### PR TITLE
Add StateAvailable provision state

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -418,7 +418,7 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 		switch host.Status.Provisioning.State {
 		case bmh.StateRegistrationError, bmh.StateRegistering,
 			bmh.StateMatchProfile, bmh.StateInspecting,
-			bmh.StateReady, bmh.StateNone:
+			bmh.StateReady, bmh.StateAvailable, bmh.StateNone:
 			// Host is not provisioned
 			waiting = false
 		case bmh.StateExternallyProvisioned:

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -1186,6 +1186,17 @@ var _ = Describe("Metal3Machine manager", func() {
 				ExpectSecretDeleted: true,
 			},
 		),
+		Entry("Consumer ref should be removed, BMH state is available", testCaseDelete{
+			Host: newBareMetalHost("myhost", bmhSpecNoImg(), bmh.StateAvailable,
+				bmhStatus(), false, false,
+			),
+			Machine: newMachine("mymachine", "", nil),
+			BMMachine: newMetal3Machine("mybmmachine", nil, bmmSecret(), nil,
+				bmmObjectMetaWithValidAnnotations(),
+			),
+			Secret:              newSecret(),
+			ExpectSecretDeleted: true,
+		}),
 		Entry("Consumer ref should be removed", testCaseDelete{
 			Host: newBareMetalHost("myhost", bmhSpecNoImg(), bmh.StateReady,
 				bmhStatus(), false, false,

--- a/controllers/metal3machine_controller_integration_test.go
+++ b/controllers/metal3machine_controller_integration_test.go
@@ -416,6 +416,42 @@ var _ = Describe("Reconcile metal3machine", func() {
 			},
 		),
 		//Given: Machine has Bootstrap data available while BMMachine has no Host Annotation
+		// BMH is in available state
+		//Expected: Requeue Expected
+		//			BMHost.Spec.Image = BMmachine.Spec.Image,
+		// 			BMHost.Spec.UserData is populated
+		// 			Expect BMHost.Spec.ConsumerRef.Name = BMmachine.Name
+		Entry("Should set BMH Spec in correct state and requeue when all objects are available but no annotation, BMH state is available",
+			TestCaseReconcile{
+				Objects: []runtime.Object{
+
+					newMetal3Machine(
+						metal3machineName, bmmMetaWithOwnerRef(), &infrav1.Metal3MachineSpec{
+							Image: infrav1.Image{
+								Checksum: "abcd",
+								URL:      "abcd",
+							},
+						}, nil, false,
+					),
+					machineWithBootstrap(),
+					newCluster(clusterName, nil, nil),
+					newMetal3Cluster(metal3ClusterName, nil, nil, nil, false),
+					newBareMetalHost(nil, &bmh.BareMetalHostStatus{
+						Provisioning: bmh.ProvisionStatus{
+							State: bmh.StateAvailable,
+						},
+					}),
+				},
+				ErrorExpected:           false,
+				RequeueExpected:         true,
+				ExpectedRequeueDuration: requeueAfter,
+				ClusterInfraReady:       true,
+				CheckBMFinalizer:        true,
+				CheckBootStrapReady:     true,
+				CheckBMHostProvisioned:  true,
+			},
+		),
+		//Given: Machine has Bootstrap data available while BMMachine has no Host Annotation
 		// BMH is in ready state
 		//Expected: Requeue Expected
 		//			BMHost.Spec.Image = BMmachine.Spec.Image,


### PR DESCRIPTION
Follow up for BMO [PR 427 ](https://github.com/metal3-io/baremetal-operator/pull/427)
Required for the completion of BMO  [PR 340](https://github.com/metal3-io/baremetal-operator/pull/340)
In this PR, added StateAvialabel to  CAPBM  case statement
After this is merged, BMO  [PR 340](https://github.com/metal3-io/baremetal-operator/pull/340)  need to be merged and then clean up in CAPBM to remove StateReady 
Fixes [#315](https://github.com/metal3-io/baremetal-operator/issues/315)
