### PR TITLE
:bug: Change shortnames to m3c and m3m

### DIFF
--- a/api/v1alpha2/metal3cluster_types.go
+++ b/api/v1alpha2/metal3cluster_types.go
@@ -128,7 +128,7 @@ type Metal3ClusterStatus struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:path=metal3clusters,scope=Namespaced,categories=cluster-api,shortName=bmc;bmcluster
+// +kubebuilder:resource:path=metal3clusters,scope=Namespaced,categories=cluster-api,shortName=m3c;m3cluster
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="metal3Cluster is Ready"

--- a/api/v1alpha2/metal3machine_types.go
+++ b/api/v1alpha2/metal3machine_types.go
@@ -132,7 +132,7 @@ type Metal3MachineStatus struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:path=metal3machines,scope=Namespaced,categories=cluster-api,shortName=bmm;bmmachine
+// +kubebuilder:resource:path=metal3machines,scope=Namespaced,categories=cluster-api,shortName=m3m;m3machine
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID"

--- a/api/v1alpha3/metal3cluster_types.go
+++ b/api/v1alpha3/metal3cluster_types.go
@@ -79,7 +79,7 @@ type Metal3ClusterStatus struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:path=metal3clusters,scope=Namespaced,categories=cluster-api,shortName=bmc;bmcluster
+// +kubebuilder:resource:path=metal3clusters,scope=Namespaced,categories=cluster-api,shortName=m3c;m3cluster
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true

--- a/api/v1alpha3/metal3machine_types.go
+++ b/api/v1alpha3/metal3machine_types.go
@@ -18,6 +18,7 @@ package v1alpha3
 
 import (
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
@@ -131,7 +132,7 @@ type Metal3MachineStatus struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:path=metal3machines,scope=Namespaced,categories=cluster-api,shortName=bmm;bmmachine
+// +kubebuilder:resource:path=metal3machines,scope=Namespaced,categories=cluster-api,shortName=m3m;m3machine
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3clusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3clusters.yaml
@@ -16,8 +16,8 @@ spec:
     listKind: Metal3ClusterList
     plural: metal3clusters
     shortNames:
-    - bmc
-    - bmcluster
+    - m3c
+    - m3cluster
     singular: metal3cluster
   scope: Namespaced
   versions:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machines.yaml
@@ -16,8 +16,8 @@ spec:
     listKind: Metal3MachineList
     plural: metal3machines
     shortNames:
-    - bmm
-    - bmmachine
+    - m3m
+    - m3machine
     singular: metal3machine
   scope: Namespaced
   versions:


### PR DESCRIPTION
This PR changes the shortname for metal3cluster and metal3machine to m3c and m3m respectively