### PR TITLE
:bug: Fix clusterctl-settings.json file

### DIFF
--- a/clusterctl-settings.json
+++ b/clusterctl-settings.json
@@ -1,7 +1,7 @@
 {
-  "name": "infrastructure-baremetal",
+  "name": "infrastructure-metal3",
   "config": {
     "componentsFile": "infrastructure-components.yaml",
-    "nextVersion": "v0.4.0"
+    "nextVersion": "v0.3.0"
   }
 }


### PR DESCRIPTION
This small PR updates clusterctl-settings.json with correct name of the provider i.e. metal3 and also corrects the version of release. 