### PR TITLE
:bug: Fix Next version in clusterctl-settings.json

### DIFF
--- a/clusterctl-settings.json
+++ b/clusterctl-settings.json
@@ -2,6 +2,6 @@
   "name": "infrastructure-metal3",
   "config": {
     "componentsFile": "infrastructure-components.yaml",
-    "nextVersion": "v0.3.0"
+    "nextVersion": "v0.4.0"
   }
 }


### PR DESCRIPTION
PR #11  changed the next-version to v0.3.0, it should not point to the release version , but something else. This PR fixes this issue. 