### PR TITLE
:bug: Modify deploy-bmo-cr in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,8 +280,8 @@ install:
 
 #Deploy the BaremetalHost CRDs and CRs (for testing purposes only)
 deploy-bmo-cr:
-	kubectl apply -f ./examples/_out/metal3crds.yaml
-	kubectl apply -f ./examples/_out/metal3plane.yaml
+	kubectl apply -f ./examples/metal3crds/metal3.io_baremetalhosts.yaml
+	kubectl apply -f ./examples/metal3plane/hosts.yaml
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: generate-examples


### PR DESCRIPTION
`deploy-bmo-cr` in Makefile deploys bmo CRDs and CRs from examples/_out, while it is not generated before `make generate-examples` or `make deploy`. This PR modifies the `deploy-bmo-cr` to deploy the bmo CRD and CR from examples directory. 
