### PR TITLE
:bug: Remove make install from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,12 +271,8 @@ set-manifest-pull-policy:
 ## --------------------------------------
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
-run: generate fmt vet install
+run: generate fmt vet 
 	go run ./main.go
-
-# Install CRDs into a cluster
-install:
-	kubectl apply -k config/crd
 
 #Deploy the BaremetalHost CRDs and CRs (for testing purposes only)
 deploy-bmo-cr:


### PR DESCRIPTION
Current way of deploying CAPM3 locally is `make run` which in turn calls `make install` and applies the CRDs only. This is no longer sufficient with webhooks picture.  So the current way of deploying CAPM3 has bugs. One solution is to remove `install` phony all-together from Makefile because this is not needed anymore. This PR removes it which fixes the bug.  
