### PR TITLE
🐛 Fix Namespace handling

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -59,6 +59,9 @@ const (
 	bmRoleNode          = "node"
 	userDataFinalizer   = "metal3machine.infrastructure.cluster.x-k8s.io/userData"
 	pausedAnnotationKey = "metal3.io/capm3"
+
+	// metal3SecretType defines the type of secret created by metal3
+	metal3SecretType corev1.SecretType = "infrastructure.cluster.x-k8s.io/secret"
 )
 
 // MachineManagerInterface is an interface for a ClusterManager
@@ -346,42 +349,27 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 func (m *MachineManager) GetUserData(ctx context.Context, host *bmh.BareMetalHost) error {
 	var err error
 	var decodedUserDataBytes []byte
-	// if datasecretname is set and BaremetalHost and Machine are in the same
-	// namespace, just pass the reference
-	if m.Machine.Spec.Bootstrap.DataSecretName != nil &&
-		host.Namespace == m.Machine.Namespace {
+
+	// if datasecretname is set just pass the reference
+	if m.Machine.Spec.Bootstrap.DataSecretName != nil {
 		m.Metal3Machine.Spec.UserData = &corev1.SecretReference{
 			Name:      *m.Machine.Spec.Bootstrap.DataSecretName,
 			Namespace: m.Machine.Namespace,
 		}
 		return nil
 
-	} else if m.Machine.Spec.Bootstrap.DataSecretName != nil &&
-		host.Namespace != m.Machine.Namespace {
-		// If they are in different namespaces, create a new secret in BMH namespace
-		capiBootstrapSecret := corev1.Secret{}
-		capikey := client.ObjectKey{
-			Name:      *m.Machine.Spec.Bootstrap.DataSecretName,
-			Namespace: m.Machine.Namespace,
-		}
-		err := m.client.Get(ctx, capikey, &capiBootstrapSecret)
-		if err != nil {
-			return err
-		}
-		decodedUserDataBytes = capiBootstrapSecret.Data["value"]
-
 	} else if m.Machine.Spec.Bootstrap.Data == nil {
 		// If we do not have DataSecretName or Data then exit
 		return nil
 
-	} else if m.Machine.Spec.Bootstrap.Data != nil {
-		// If we have Data, use it
-		decodedUserData := *m.Machine.Spec.Bootstrap.Data
-		// decode the base64 cloud-config
-		decodedUserDataBytes, err = base64.StdEncoding.DecodeString(decodedUserData)
-		if err != nil {
-			return err
-		}
+	}
+
+	// If we have Data, use it
+	decodedUserData := *m.Machine.Spec.Bootstrap.Data
+	// decode the base64 cloud-config
+	decodedUserDataBytes, err = base64.StdEncoding.DecodeString(decodedUserData)
+	if err != nil {
+		return err
 	}
 
 	bootstrapSecret := &corev1.Secret{
@@ -391,7 +379,7 @@ func (m *MachineManager) GetUserData(ctx context.Context, host *bmh.BareMetalHos
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.Metal3Machine.Name + "-user-data",
-			Namespace: host.Namespace,
+			Namespace: m.Metal3Machine.Namespace,
 			Labels: map[string]string{
 				capi.ClusterLabelName: m.Machine.Spec.ClusterName,
 			},
@@ -409,13 +397,13 @@ func (m *MachineManager) GetUserData(ctx context.Context, host *bmh.BareMetalHos
 		Data: map[string][]byte{
 			"userData": decodedUserDataBytes,
 		},
-		Type: "Opaque",
+		Type: metal3SecretType,
 	}
 
 	tmpBootstrapSecret := corev1.Secret{}
 	key := client.ObjectKey{
 		Name:      m.Metal3Machine.Name + "-user-data",
-		Namespace: host.Namespace,
+		Namespace: m.Metal3Machine.Namespace,
 	}
 	err = m.client.Get(ctx, key, &tmpBootstrapSecret)
 	if err == nil {
@@ -434,7 +422,7 @@ func (m *MachineManager) GetUserData(ctx context.Context, host *bmh.BareMetalHos
 	}
 	m.Metal3Machine.Spec.UserData = &corev1.SecretReference{
 		Name:      m.Metal3Machine.Name + "-user-data",
-		Namespace: host.Namespace,
+		Namespace: m.Metal3Machine.Namespace,
 	}
 
 	return nil
@@ -536,17 +524,15 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 			delete(host.Annotations, bmh.PausedAnnotation)
 		}
 
-		// Delete created secret, if data was set without DataSecretName or if
-		// BareMetalHost and Machine are in different namespaces.
-		if (m.Machine.Spec.Bootstrap.DataSecretName == nil &&
-			m.Machine.Spec.Bootstrap.Data != nil) ||
-			(m.Machine.Spec.Bootstrap.DataSecretName != nil &&
-				m.Machine.Namespace != host.Namespace) {
+		// Delete created secret, if data was set without DataSecretName but with
+		// Data
+		if m.Machine.Spec.Bootstrap.DataSecretName == nil &&
+			m.Machine.Spec.Bootstrap.Data != nil {
 			m.Log.Info("Deleting User data secret for machine")
 			tmpBootstrapSecret := corev1.Secret{}
 			key := client.ObjectKey{
-				Name:      m.Metal3Machine.Name + "-user-data",
-				Namespace: host.Namespace,
+				Name:      m.Metal3Machine.Spec.UserData.Name,
+				Namespace: m.Metal3Machine.Namespace,
 			}
 			err = m.client.Get(ctx, key, &tmpBootstrapSecret)
 			if err != nil && !apierrors.IsNotFound(err) {
@@ -688,8 +674,9 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmh.BareMetalHost, er
 
 	// get list of BMH
 	hosts := bmh.BareMetalHostList{}
+	// without this ListOption, all namespaces would be including in the listing
 	opts := &client.ListOptions{
-		Namespace: m.Machine.Namespace,
+		Namespace: m.Metal3Machine.Namespace,
 	}
 
 	err := m.client.List(ctx, &hosts, opts)
@@ -821,7 +808,7 @@ func (m *MachineManager) setHostLabel(ctx context.Context, host *bmh.BareMetalHo
 
 // setHostSpec will ensure the host's Spec is set according to the machine's
 // details. It will then update the host via the kube API. If UserData does not
-// include a Namespace, it will default to the Machine's namespace.
+// include a Namespace, it will default to the Metal3Machine's namespace.
 func (m *MachineManager) setHostSpec(ctx context.Context, host *bmh.BareMetalHost) error {
 
 	// We only want to update the image setting if the host does not
@@ -838,7 +825,7 @@ func (m *MachineManager) setHostSpec(ctx context.Context, host *bmh.BareMetalHos
 		}
 		host.Spec.UserData = m.Metal3Machine.Spec.UserData
 		if host.Spec.UserData != nil && host.Spec.UserData.Namespace == "" {
-			host.Spec.UserData.Namespace = m.Machine.Namespace
+			host.Spec.UserData.Namespace = host.Namespace
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the use of namespaces when referring to objects. It was inconsistent and sometimes wrong. It includes :

- Use ConfigRef namespace if available for userdata secret
- refer to userdata namespace instead of host namespace


**Which issue(s) this PR fixes** :
Fixes #29 
