### PR TITLE
:bug: Multiple updates operation on the BMH #33

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -327,6 +327,11 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 		return err
 	}
 
+	err = m.updateObject(ctx, host)
+	if err != nil {
+		return err
+	}
+
 	err = m.ensureAnnotation(ctx, host)
 	if err != nil {
 		if _, ok := err.(HasRequeueAfterError); !ok {
@@ -606,6 +611,11 @@ func (m *MachineManager) Update(ctx context.Context) error {
 		return err
 	}
 
+	err = m.updateObject(ctx, host)
+	if err != nil {
+		return err
+	}
+
 	err = m.ensureAnnotation(ctx, host)
 	if err != nil {
 		return err
@@ -745,7 +755,6 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmh.BareMetalHost, er
 // consumerRefMatches returns a boolean based on whether the consumer
 // reference and bare metal machine metadata match
 func consumerRefMatches(consumer *corev1.ObjectReference, bmmachine *capm3.Metal3Machine) bool {
-
 	if consumer.Name != bmmachine.Name {
 		return false
 	}
@@ -844,7 +853,8 @@ func (m *MachineManager) setHostSpec(ctx context.Context, host *bmh.BareMetalHos
 		return err
 	}
 	host.OwnerReferences = hostOwnerReferences
-	return m.updateObject(ctx, host)
+
+	return nil
 }
 
 // ensureAnnotation makes sure the machine has an annotation that references the

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -813,38 +813,29 @@ var _ = Describe("Metal3Machine manager", func() {
 			err = machineMgr.setHostSpec(context.TODO(), tc.Host)
 			Expect(err).NotTo(HaveOccurred())
 
-			// get the saved host
-			savedHost := bmh.BareMetalHost{}
-			err = c.Get(context.TODO(),
-				client.ObjectKey{
-					Name:      tc.Host.Name,
-					Namespace: tc.Host.Namespace,
-				},
-				&savedHost,
-			)
 			Expect(err).NotTo(HaveOccurred())
 
 			// validate the saved host
-			Expect(savedHost.Spec.ConsumerRef).NotTo(BeNil())
-			Expect(savedHost.Spec.ConsumerRef.Name).To(Equal(bmmconfig.Name))
-			Expect(savedHost.Spec.ConsumerRef.Namespace).
+			Expect(tc.Host.Spec.ConsumerRef).NotTo(BeNil())
+			Expect(tc.Host.Spec.ConsumerRef.Name).To(Equal(bmmconfig.Name))
+			Expect(tc.Host.Spec.ConsumerRef.Namespace).
 				To(Equal(bmmconfig.Namespace))
-			Expect(savedHost.Spec.ConsumerRef.Kind).To(Equal("Metal3Machine"))
-			Expect(savedHost.Spec.Online).To(BeTrue())
+			Expect(tc.Host.Spec.ConsumerRef.Kind).To(Equal("Metal3Machine"))
+			Expect(tc.Host.Spec.Online).To(BeTrue())
 			if tc.ExpectedImage == nil {
-				Expect(savedHost.Spec.Image).To(BeNil())
+				Expect(tc.Host.Spec.Image).To(BeNil())
 			} else {
-				Expect(*savedHost.Spec.Image).To(Equal(*tc.ExpectedImage))
+				Expect(*tc.Host.Spec.Image).To(Equal(*tc.ExpectedImage))
 			}
 			if tc.ExpectUserData {
-				Expect(savedHost.Spec.UserData).NotTo(BeNil())
-				Expect(savedHost.Spec.UserData.Namespace).
+				Expect(tc.Host.Spec.UserData).NotTo(BeNil())
+				Expect(tc.Host.Spec.UserData.Namespace).
 					To(Equal(tc.ExpectedUserDataNamespace))
-				Expect(savedHost.Spec.UserData.Name).To(Equal(testUserDataSecretName))
+				Expect(tc.Host.Spec.UserData.Name).To(Equal(testUserDataSecretName))
 			} else {
-				Expect(savedHost.Spec.UserData).To(BeNil())
+				Expect(tc.Host.Spec.UserData).To(BeNil())
 			}
-			_, err = machineMgr.FindOwnerRef(savedHost.OwnerReferences)
+			_, err = machineMgr.FindOwnerRef(tc.Host.OwnerReferences)
 			Expect(err).NotTo(HaveOccurred())
 		},
 		Entry("User data has explicit alternate namespace", testCaseSetHostSpec{

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -202,6 +202,11 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 		if err != nil {
 			return checkError(err, "failed to associate the Metal3Machine to a BaremetalHost")
 		}
+	} else {
+		err := machineMgr.Update(ctx)
+		if err != nil {
+			return checkError(err, "failed to update BaremetalHost")
+		}
 	}
 
 	bmhID, err := machineMgr.GetBaremetalHostID(ctx)
@@ -219,7 +224,6 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 		machineMgr.SetProviderID(providerID)
 	}
 
-	err = machineMgr.Update(ctx)
 	return ctrl.Result{}, err
 }
 

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -85,11 +85,13 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		if tc.AssociateFails {
 			m.EXPECT().Associate(context.TODO()).Return(errors.New("Failed"))
 			m.EXPECT().GetBaremetalHostID(context.TODO()).MaxTimes(0)
-			m.EXPECT().Update(context.TODO()).MaxTimes(0)
 			return m
 		} else {
 			m.EXPECT().Associate(context.TODO()).Return(nil)
 		}
+		m.EXPECT().Update(context.TODO()).MaxTimes(0)
+	} else {
+		m.EXPECT().Update(context.TODO())
 	}
 
 	// if node is now associated, if getting the ID fails, we do not go further
@@ -97,7 +99,6 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		m.EXPECT().GetBaremetalHostID(context.TODO()).Return(nil,
 			errors.New("Failed"),
 		)
-		m.EXPECT().Update(context.TODO()).MaxTimes(0)
 		m.EXPECT().SetProviderID("abc").MaxTimes(0)
 		return m
 	}
@@ -114,7 +115,6 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 				SetNodeProviderID(context.TODO(), "abc", "metal3://abc", nil).
 				Return(errors.New("Failed"))
 			m.EXPECT().SetProviderID("abc").MaxTimes(0)
-			m.EXPECT().Update(context.TODO()).MaxTimes(0)
 			return m
 		}
 
@@ -133,8 +133,6 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 			MaxTimes(0)
 	}
 
-	// last call
-	m.EXPECT().Update(context.TODO())
 	return m
 }
 


### PR DESCRIPTION

**What this PR does / why we need it**:
Currently, CAPM3 can execute multiple update operations on the BMH. This is problematic because the update triggers a reconcile of the BMH while we still process the BMH, regularly ending in a conflict, triggering a requeue.
 
Fixes #33
