### PR TITLE
🏃 Remove code generation from unit test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,11 +175,6 @@ generate-go: $(CONTROLLER_GEN) $(MOCKGEN) $(CONVERSION_GEN) $(KUBEBUILDER) $(KUS
 		paths=./api/... \
 		object:headerFile=./hack/boilerplate/boilerplate.generatego.txt
 
-	$(CONVERSION_GEN) \
-		--input-dirs=./api/v1alpha2 \
-		--output-file-base=zz_generated.conversion \
-		--go-header-file=./hack/boilerplate/boilerplate.generatego.txt
-
 	$(MOCKGEN) \
 	  -destination=./baremetal/mocks/zz_generated.metal3cluster_manager.go \
 	  -source=./baremetal/metal3cluster_manager.go \
@@ -193,6 +188,37 @@ generate-go: $(CONTROLLER_GEN) $(MOCKGEN) $(CONVERSION_GEN) $(KUBEBUILDER) $(KUS
 		-package=baremetal_mocks \
 		-copyright_file=./hack/boilerplate/boilerplate.generatego.txt \
 		MachineManagerInterface
+
+	$(MOCKGEN) \
+	  -destination=./baremetal/mocks/zz_generated.metal3datatemplate_manager.go \
+	  -source=./baremetal/metal3datatemplate_manager.go \
+		-package=baremetal_mocks \
+		-copyright_file=./hack/boilerplate/boilerplate.generatego.txt \
+		DataTemplateManagerInterface
+
+	$(MOCKGEN) \
+	  -destination=./baremetal/mocks/zz_generated.metal3data_manager.go \
+	  -source=./baremetal/metal3data_manager.go \
+		-package=baremetal_mocks \
+		-copyright_file=./hack/boilerplate/boilerplate.generatego.txt \
+		DataManagerInterface
+
+	$(MOCKGEN) \
+	  -destination=./baremetal/mocks/zz_generated.manager_factory.go \
+	  -source=./baremetal/manager_factory.go \
+		-package=baremetal_mocks \
+		-copyright_file=./hack/boilerplate/boilerplate.generatego.txt \
+		ManagerFactoryInterface
+
+	$(CONVERSION_GEN) \
+		--input-dirs=./api/v1alpha2 \
+		--output-file-base=zz_generated.conversion \
+		--go-header-file=./hack/boilerplate/boilerplate.generatego.txt
+
+	$(CONVERSION_GEN) \
+		--input-dirs=./api/v1alpha3 \
+		--output-file-base=zz_generated.conversion \
+		--go-header-file=./hack/boilerplate/boilerplate.generatego.txt
 
 .PHONY: generate-manifests
 generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
@@ -208,7 +234,7 @@ generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
 		rbac:roleName=manager-role
 
 .PHONY: generate-examples
-generate-examples: clean-examples ## Generate examples configurations to run a cluster.
+generate-examples: $(KUSTOMIZE) clean-examples ## Generate examples configurations to run a cluster.
 	./examples/generate.sh
 
 ## --------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ help:  ## Display this help
 testprereqs: $(KUBEBUILDER) $(KUSTOMIZE)
 
 .PHONY: test
-test: testprereqs generate fmt lint ## Run tests
+test: testprereqs fmt lint ## Run tests
 	source ./hack/fetch_ext_bins.sh; fetch_tools; setup_envs; go test -v ./api/... ./controllers/... ./baremetal/... -coverprofile ./cover.out
 
 .PHONY: test-integration
@@ -162,80 +162,6 @@ vet:
 modules: ## Runs go mod to ensure proper vendoring.
 	go mod tidy
 	cd $(TOOLS_DIR); go mod tidy
-
-.PHONY: generate
-generate: ## Generate code
-	$(MAKE) generate-go
-	$(MAKE) generate-manifests
-
-.PHONY: generate-go
-generate-go: $(CONTROLLER_GEN) $(MOCKGEN) $(CONVERSION_GEN) $(KUBEBUILDER) $(KUSTOMIZE) ## Runs Go related generate targets
-	go generate ./...
-	$(CONTROLLER_GEN) \
-		paths=./api/... \
-		object:headerFile=./hack/boilerplate/boilerplate.generatego.txt
-
-	$(MOCKGEN) \
-	  -destination=./baremetal/mocks/zz_generated.metal3cluster_manager.go \
-	  -source=./baremetal/metal3cluster_manager.go \
-		-package=baremetal_mocks \
-		-copyright_file=./hack/boilerplate/boilerplate.generatego.txt \
-		ClusterManagerInterface
-
-	$(MOCKGEN) \
-	  -destination=./baremetal/mocks/zz_generated.metal3machine_manager.go \
-	  -source=./baremetal/metal3machine_manager.go \
-		-package=baremetal_mocks \
-		-copyright_file=./hack/boilerplate/boilerplate.generatego.txt \
-		MachineManagerInterface
-
-	$(MOCKGEN) \
-	  -destination=./baremetal/mocks/zz_generated.metal3datatemplate_manager.go \
-	  -source=./baremetal/metal3datatemplate_manager.go \
-		-package=baremetal_mocks \
-		-copyright_file=./hack/boilerplate/boilerplate.generatego.txt \
-		DataTemplateManagerInterface
-
-	$(MOCKGEN) \
-	  -destination=./baremetal/mocks/zz_generated.metal3data_manager.go \
-	  -source=./baremetal/metal3data_manager.go \
-		-package=baremetal_mocks \
-		-copyright_file=./hack/boilerplate/boilerplate.generatego.txt \
-		DataManagerInterface
-
-	$(MOCKGEN) \
-	  -destination=./baremetal/mocks/zz_generated.manager_factory.go \
-	  -source=./baremetal/manager_factory.go \
-		-package=baremetal_mocks \
-		-copyright_file=./hack/boilerplate/boilerplate.generatego.txt \
-		ManagerFactoryInterface
-
-	$(CONVERSION_GEN) \
-		--input-dirs=./api/v1alpha2 \
-		--output-file-base=zz_generated.conversion \
-		--go-header-file=./hack/boilerplate/boilerplate.generatego.txt
-
-	$(CONVERSION_GEN) \
-		--input-dirs=./api/v1alpha3 \
-		--output-file-base=zz_generated.conversion \
-		--go-header-file=./hack/boilerplate/boilerplate.generatego.txt
-
-.PHONY: generate-manifests
-generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
-	$(CONTROLLER_GEN) \
-		paths=./api/... \
-		crd:crdVersions=v1 \
-		output:crd:dir=$(CRD_ROOT) \
-		output:webhook:dir=$(WEBHOOK_ROOT) \
-		webhook
-	$(CONTROLLER_GEN) \
-		paths=./controllers/... \
-		output:rbac:dir=$(RBAC_ROOT) \
-		rbac:roleName=manager-role
-
-.PHONY: generate-examples
-generate-examples: $(KUSTOMIZE) clean-examples ## Generate examples configurations to run a cluster.
-	./examples/generate.sh
 
 ## --------------------------------------
 ## Docker

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,54 @@ modules: ## Runs go mod to ensure proper vendoring.
 	go mod tidy
 	cd $(TOOLS_DIR); go mod tidy
 
+.PHONY: generate
+generate: ## Generate code
+	$(MAKE) generate-go
+	$(MAKE) generate-manifests
+
+.PHONY: generate-go
+generate-go: $(CONTROLLER_GEN) $(MOCKGEN) $(CONVERSION_GEN) $(KUBEBUILDER) $(KUSTOMIZE) ## Runs Go related generate targets
+	go generate ./...
+	$(CONTROLLER_GEN) \
+		paths=./api/... \
+		object:headerFile=./hack/boilerplate/boilerplate.generatego.txt
+
+	$(CONVERSION_GEN) \
+		--input-dirs=./api/v1alpha2 \
+		--output-file-base=zz_generated.conversion \
+		--go-header-file=./hack/boilerplate/boilerplate.generatego.txt
+
+	$(MOCKGEN) \
+	  -destination=./baremetal/mocks/zz_generated.metal3cluster_manager.go \
+	  -source=./baremetal/metal3cluster_manager.go \
+		-package=baremetal_mocks \
+		-copyright_file=./hack/boilerplate/boilerplate.generatego.txt \
+		ClusterManagerInterface
+
+	$(MOCKGEN) \
+	  -destination=./baremetal/mocks/zz_generated.metal3machine_manager.go \
+	  -source=./baremetal/metal3machine_manager.go \
+		-package=baremetal_mocks \
+		-copyright_file=./hack/boilerplate/boilerplate.generatego.txt \
+		MachineManagerInterface
+
+.PHONY: generate-manifests
+generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
+	$(CONTROLLER_GEN) \
+		paths=./api/... \
+		crd:crdVersions=v1 \
+		output:crd:dir=$(CRD_ROOT) \
+		output:webhook:dir=$(WEBHOOK_ROOT) \
+		webhook
+	$(CONTROLLER_GEN) \
+		paths=./controllers/... \
+		output:rbac:dir=$(RBAC_ROOT) \
+		rbac:roleName=manager-role
+
+.PHONY: generate-examples
+generate-examples: clean-examples ## Generate examples configurations to run a cluster.
+	./examples/generate.sh
+
 ## --------------------------------------
 ## Docker
 ## --------------------------------------

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -1,4 +1,3 @@
-
 #!/bin/sh
 
 set -eux

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -19,7 +19,7 @@ if [ "${IS_CONTAINER}" != "false" ]; then
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:ro,z" \
+    --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:rw,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
     registry.hub.docker.com/library/golang:1.13.7 \

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -3,6 +3,7 @@
 set -eux
 
 IS_CONTAINER=${IS_CONTAINER:-false}
+ARTIFACTS=${ARTIFACTS:-/tmp}
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
@@ -10,7 +11,12 @@ if [ "${IS_CONTAINER}" != "false" ]; then
   mkdir /tmp/unit
   cp -r ./* /tmp/unit
   cd /tmp/unit
-  make generate 
+  INPUT_FILES="api/v1alpha2/zz_generated.*.go api/v1alpha2/zz_generated.*.go api/v1alpha4/zz_generated.*.go baremetal/mocks/zz_generated.*.go"
+  cksum $INPUT_FILES > "$ARTIFACTS/lint.cksums.before"
+  export VERBOSE="--verbose"
+  make generate
+  cksum $INPUT_FILES > "$ARTIFACTS/lint.cksums.after"
+  diff "$ARTIFACTS/lint.cksums.before" "$ARTIFACTS/lint.cksums.after"
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -7,10 +7,9 @@ ARTIFACTS=${ARTIFACTS:-/tmp}
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
+  eval "$(go env)"
+  cd "${GOPATH}"/src/github.com/metal3-io/cluster-api-provider-metal3
   export XDG_CACHE_HOME=/tmp/.cache
-  mkdir /tmp/unit
-  cp -r ./* /tmp/unit
-  cd /tmp/unit
   INPUT_FILES="api/v1alpha2/zz_generated.*.go api/v1alpha3/zz_generated.*.go api/v1alpha4/zz_generated.*.go baremetal/mocks/zz_generated.*.go"
   cksum $INPUT_FILES > "$ARTIFACTS/lint.cksums.before"
   export VERBOSE="--verbose"

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -1,0 +1,23 @@
+
+#!/bin/sh
+
+set -eux
+
+IS_CONTAINER=${IS_CONTAINER:-false}
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+  export XDG_CACHE_HOME=/tmp/.cache
+  mkdir /tmp/unit
+  cp -r ./* /tmp/unit
+  cd /tmp/unit
+  make generate 
+else
+  "${CONTAINER_RUNTIME}" run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:ro,z" \
+    --entrypoint sh \
+    --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
+    registry.hub.docker.com/library/golang:1.13.7 \
+    /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/codegen.sh
+fi;

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -11,7 +11,7 @@ if [ "${IS_CONTAINER}" != "false" ]; then
   mkdir /tmp/unit
   cp -r ./* /tmp/unit
   cd /tmp/unit
-  INPUT_FILES="api/v1alpha2/zz_generated.*.go api/v1alpha2/zz_generated.*.go api/v1alpha4/zz_generated.*.go baremetal/mocks/zz_generated.*.go"
+  INPUT_FILES="api/v1alpha2/zz_generated.*.go api/v1alpha3/zz_generated.*.go api/v1alpha4/zz_generated.*.go baremetal/mocks/zz_generated.*.go"
   cksum $INPUT_FILES > "$ARTIFACTS/lint.cksums.before"
   export VERBOSE="--verbose"
   make generate

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -11,10 +11,10 @@ if [ "${IS_CONTAINER}" != "false" ]; then
   cd "${GOPATH}"/src/github.com/metal3-io/cluster-api-provider-metal3
   export XDG_CACHE_HOME=/tmp/.cache
   INPUT_FILES="api/v1alpha2/zz_generated.*.go api/v1alpha3/zz_generated.*.go api/v1alpha4/zz_generated.*.go baremetal/mocks/zz_generated.*.go"
-  cksum $INPUT_FILES > "$ARTIFACTS/lint.cksums.before"
+  cksum "$INPUT_FILES" > "$ARTIFACTS/lint.cksums.before"
   export VERBOSE="--verbose"
   make generate
-  cksum $INPUT_FILES > "$ARTIFACTS/lint.cksums.after"
+  cksum "$INPUT_FILES" > "$ARTIFACTS/lint.cksums.after"
   diff "$ARTIFACTS/lint.cksums.before" "$ARTIFACTS/lint.cksums.after"
 else
   "${CONTAINER_RUNTIME}" run --rm \

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -7,14 +7,16 @@ ARTIFACTS=${ARTIFACTS:-/tmp}
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
+  export XDG_CACHE_HOME=/tmp/.cache
   eval "$(go env)"
   cd "${GOPATH}"/src/github.com/metal3-io/cluster-api-provider-metal3
-  export XDG_CACHE_HOME=/tmp/.cache
   INPUT_FILES="api/v1alpha2/zz_generated.*.go api/v1alpha3/zz_generated.*.go api/v1alpha4/zz_generated.*.go baremetal/mocks/zz_generated.*.go"
-  cksum "$INPUT_FILES" > "$ARTIFACTS/lint.cksums.before"
+  # shellcheck disable=SC2086
+  cksum $INPUT_FILES > "$ARTIFACTS/lint.cksums.before"
   export VERBOSE="--verbose"
   make generate
-  cksum "$INPUT_FILES" > "$ARTIFACTS/lint.cksums.after"
+  # shellcheck disable=SC2086
+  cksum $INPUT_FILES > "$ARTIFACTS/lint.cksums.after"
   diff "$ARTIFACTS/lint.cksums.before" "$ARTIFACTS/lint.cksums.after"
 else
   "${CONTAINER_RUNTIME}" run --rm \


### PR DESCRIPTION
generate-go script is taking lot of time in unit tests and everytime it generates the code which is not required for unit tests, so removing generate-go from unit.

Fixes #13 
