### PR TITLE
🐛 Use providerID when set on metal3machine

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -71,6 +71,7 @@ type MachineManagerInterface interface {
 	Delete(context.Context) error
 	Update(context.Context) error
 	HasAnnotation() bool
+	GetProviderIDAndBMHID() (string, *string)
 	SetNodeProviderID(context.Context, string, string, ClientGetter) error
 	SetProviderID(string)
 	SetPauseAnnotation(context.Context) error
@@ -1069,6 +1070,14 @@ func (m *MachineManager) nodeAddresses(host *bmh.BareMetalHost) []capi.MachineAd
 	}
 
 	return addrs
+}
+
+func (m *MachineManager) GetProviderIDAndBMHID() (string, *string) {
+	providerID := m.Metal3Machine.Spec.ProviderID
+	if providerID == nil {
+		return "", nil
+	}
+	return *providerID, pointer.StringPtr(parseProviderID(*providerID))
 }
 
 // ClientGetter prototype

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -1923,6 +1923,40 @@ var _ = Describe("Metal3Machine manager", func() {
 		)
 	})
 
+	type testCaseGetProviderIDAndBMHID struct {
+		providerID    *string
+		expectedBMHID string
+	}
+
+	DescribeTable("Test GetProviderIDAndBMHID",
+		func(tc testCaseGetProviderIDAndBMHID) {
+			m3m := capm3.Metal3Machine{
+				Spec: capm3.Metal3MachineSpec{
+					ProviderID: tc.providerID,
+				},
+			}
+
+			machineMgr, err := NewMachineManager(nil, nil, nil, nil, &m3m, klogr.New())
+			Expect(err).NotTo(HaveOccurred())
+
+			providerID, bmhID := machineMgr.GetProviderIDAndBMHID()
+
+			if tc.providerID != nil {
+				Expect(providerID).To(Equal(*tc.providerID))
+				Expect(bmhID).NotTo(BeNil())
+				Expect(*bmhID).To(Equal(tc.expectedBMHID))
+			} else {
+				Expect(providerID).To(Equal(""))
+				Expect(bmhID).To(BeNil())
+			}
+		},
+		Entry("Empty providerID", testCaseGetProviderIDAndBMHID{}),
+		Entry("Provider ID set", testCaseGetProviderIDAndBMHID{
+			providerID:    pointer.StringPtr("metal3://abcd"),
+			expectedBMHID: "abcd",
+		}),
+	)
+
 	Describe("Test SetNodeProviderID", func() {
 		scheme := runtime.NewScheme()
 		err := capi.AddToScheme(scheme)

--- a/baremetal/mocks/zz_generated.metal3machine_manager.go
+++ b/baremetal/mocks/zz_generated.metal3machine_manager.go
@@ -176,6 +176,21 @@ func (mr *MockMachineManagerInterfaceMockRecorder) HasAnnotation() *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasAnnotation", reflect.TypeOf((*MockMachineManagerInterface)(nil).HasAnnotation))
 }
 
+// GetProviderIDAndBMHID mocks base method
+func (m *MockMachineManagerInterface) GetProviderIDAndBMHID() (string, *string) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProviderIDAndBMHID")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(*string)
+	return ret0, ret1
+}
+
+// GetProviderIDAndBMHID indicates an expected call of GetProviderIDAndBMHID
+func (mr *MockMachineManagerInterfaceMockRecorder) GetProviderIDAndBMHID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProviderIDAndBMHID", reflect.TypeOf((*MockMachineManagerInterface)(nil).GetProviderIDAndBMHID))
+}
+
 // SetNodeProviderID mocks base method
 func (m *MockMachineManagerInterface) SetNodeProviderID(arg0 context.Context, arg1, arg2 string, arg3 baremetal.ClientGetter) error {
 	m.ctrl.T.Helper()

--- a/baremetal/utils.go
+++ b/baremetal/utils.go
@@ -18,6 +18,7 @@ package baremetal
 
 import (
 	"context"
+	"strings"
 
 	// comment for go-lint
 	"github.com/go-logr/logr"
@@ -305,4 +306,8 @@ func getM3Machine(ctx context.Context, cl client.Client, mLog logr.Logger,
 		return nil, nil
 	}
 	return tmpM3Machine, nil
+}
+
+func parseProviderID(providerID string) string {
+	return strings.TrimPrefix(providerID, "metal3://")
 }

--- a/baremetal/utils_test.go
+++ b/baremetal/utils_test.go
@@ -279,14 +279,14 @@ var _ = Describe("Metal3 manager utils", func() {
 			}
 		},
 		Entry("Object does not exist", testCaseUpdate{
-			TestObject: testObject.DeepCopy(),
+			TestObject:     testObject.DeepCopy(),
 			ExistingObject: nil,
 			ExpectedError:  true,
 		}),
 		Entry("Object exists", testCaseUpdate{
-			TestObject: testObject.DeepCopy(),
+			TestObject:     testObject.DeepCopy(),
 			ExistingObject: existingObject.DeepCopy(),
-			ExpectedError: false,
+			ExpectedError:  false,
 		}),
 	)
 
@@ -323,14 +323,14 @@ var _ = Describe("Metal3 manager utils", func() {
 			}
 		},
 		Entry("Object does not exist", testCaseUpdate{
-			TestObject: testObject.DeepCopy(),
+			TestObject:     testObject.DeepCopy(),
 			ExistingObject: nil,
 			ExpectedError:  false,
 		}),
 		Entry("Object exists", testCaseUpdate{
-			TestObject: testObject.DeepCopy(),
+			TestObject:     testObject.DeepCopy(),
 			ExistingObject: existingObject.DeepCopy(),
-			ExpectedError: true,
+			ExpectedError:  true,
 		}),
 	)
 
@@ -731,4 +731,9 @@ var _ = Describe("Metal3 manager utils", func() {
 			ExpectEmpty: true,
 		}),
 	)
+
+	It("Parses the providerID properly", func() {
+		Expect(parseProviderID("metal3://abcd")).To(Equal("abcd"))
+		Expect(parseProviderID("foo://abcd")).To(Equal("foo://abcd"))
+	})
 })

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -232,19 +232,24 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 		}
 	}
 
-	bmhID, err := machineMgr.GetBaremetalHostID(ctx)
-	if err != nil {
-		return checkMachineError(machineMgr, err,
-			"failed to get the providerID for the metal3machine", errType,
-		)
+	providerID, bmhID := machineMgr.GetProviderIDAndBMHID()
+	if bmhID == nil {
+		bmhID, err = machineMgr.GetBaremetalHostID(ctx)
+		if err != nil {
+			return checkMachineError(machineMgr, err,
+				"failed to get the providerID for the metal3machine", errType,
+			)
+		}
+		if bmhID != nil {
+			providerID = fmt.Sprintf("metal3://%s", *bmhID)
+		}
 	}
 	if bmhID != nil {
-		providerID := fmt.Sprintf("metal3://%s", *bmhID)
 		// Set the providerID on the node if no Cloud provider
 		err = machineMgr.SetNodeProviderID(ctx, *bmhID, providerID, r.CapiClientGetter)
 		if err != nil {
 			return checkMachineError(machineMgr, err,
-				"failed to get the providerID for the metal3machine", errType,
+				"failed to set the target node providerID", errType,
 			)
 		}
 		// Make sure Spec.ProviderID is set and mark the capm3Machine ready

--- a/controllers/metal3machine_controller_integration_test.go
+++ b/controllers/metal3machine_controller_integration_test.go
@@ -154,22 +154,23 @@ func machineWithBootstrap() *clusterv1.Machine {
 var _ = Describe("Reconcile metal3machine", func() {
 
 	type TestCaseReconcile struct {
-		Objects                 []runtime.Object
-		TargetObjects           []runtime.Object
-		ErrorExpected           bool
-		RequeueExpected         bool
-		ErrorReasonExpected     bool
-		ErrorReason             capierrors.MachineStatusError
-		ErrorType               error
-		ExpectedRequeueDuration time.Duration
-		LabelExpected           bool
-		ClusterInfraReady       bool
-		CheckBMFinalizer        bool
-		CheckBMState            bool
-		CheckBMProviderID       bool
-		CheckBootStrapReady     bool
-		CheckBMHostCleaned      bool
-		CheckBMHostProvisioned  bool
+		Objects                    []runtime.Object
+		TargetObjects              []runtime.Object
+		ErrorExpected              bool
+		RequeueExpected            bool
+		ErrorReasonExpected        bool
+		ErrorReason                capierrors.MachineStatusError
+		ErrorType                  error
+		ExpectedRequeueDuration    time.Duration
+		LabelExpected              bool
+		ClusterInfraReady          bool
+		CheckBMFinalizer           bool
+		CheckBMState               bool
+		CheckBMProviderID          bool
+		CheckBMProviderIDUnchanged bool
+		CheckBootStrapReady        bool
+		CheckBMHostCleaned         bool
+		CheckBMHostProvisioned     bool
 	}
 
 	DescribeTable("Reconcile tests",
@@ -234,8 +235,13 @@ var _ = Describe("Reconcile metal3machine", func() {
 				Expect(testBMmachine.Status.Ready).To(BeTrue())
 			}
 			if tc.CheckBMProviderID {
-				Expect(testBMmachine.Spec.ProviderID).To(Equal(pointer.StringPtr(fmt.Sprintf("metal3://%s",
-					string(testBMHost.ObjectMeta.UID)))))
+				if tc.CheckBMProviderIDUnchanged {
+					Expect(testBMmachine.Spec.ProviderID).NotTo(Equal(pointer.StringPtr(fmt.Sprintf("metal3://%s",
+						string(testBMHost.ObjectMeta.UID)))))
+				} else {
+					Expect(testBMmachine.Spec.ProviderID).To(Equal(pointer.StringPtr(fmt.Sprintf("metal3://%s",
+						string(testBMHost.ObjectMeta.UID)))))
+				}
 			}
 			if tc.CheckBootStrapReady {
 				Expect(testmachine.Status.BootstrapReady).To(BeTrue())
@@ -525,6 +531,35 @@ var _ = Describe("Reconcile metal3machine", func() {
 				CheckBMFinalizer:    true,
 				CheckBMProviderID:   true,
 				CheckBootStrapReady: true,
+			},
+		),
+		//Given: Machine(with Bootstrap data), M3Machine (Annotation Given, provider ID set), BMH (provisioned)
+		//Expected: No Error, BMH.Spec.ProviderID is set properly (unchanged)
+		Entry("Should set ProviderID when bootstrap data is available, ProviderID is given, BMH is provisioned",
+			TestCaseReconcile{
+				Objects: []runtime.Object{
+					newMetal3Machine(
+						metal3machineName, m3mMetaWithAnnotation(),
+						&infrav1.Metal3MachineSpec{
+							ProviderID: pointer.StringPtr("metal3://abcd"),
+							Image: infrav1.Image{
+								Checksum: "abcd",
+								URL:      "abcd",
+							},
+						}, nil, false,
+					),
+					machineWithBootstrap(),
+					newCluster(clusterName, nil, nil),
+					newMetal3Cluster(metal3ClusterName, nil, nil, nil, false),
+					newBareMetalHost(nil, nil),
+				},
+				ErrorExpected:              false,
+				RequeueExpected:            false,
+				ClusterInfraReady:          true,
+				CheckBMFinalizer:           true,
+				CheckBMProviderID:          true,
+				CheckBootStrapReady:        true,
+				CheckBMProviderIDUnchanged: true,
 			},
 		),
 		//Given: Machine(with Bootstrap data), M3Machine (Annotation Given, no provider ID), BMH (provisioning)


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of always creating it from BMH UID.
Currently, after pivoting, the BMH UID has changed so the
provider IDs do not match anymore since we always used the BMH UID.
Instead, use the providerID if set in the Metal3Machine already to
avoid this issue.

**Which issue(s) this PR fixes** :
Fixes #88 
