### PR TITLE
🐛 Use providerID when set on metal3machine

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -75,6 +75,7 @@ type MachineManagerInterface interface {
 	Delete(context.Context) error
 	Update(context.Context) error
 	HasAnnotation() bool
+	GetProviderIDAndBMHID() (string, *string)
 	SetNodeProviderID(context.Context, string, string, ClientGetter) error
 	SetProviderID(string)
 }
@@ -924,6 +925,14 @@ func (m *MachineManager) nodeAddresses(host *bmh.BareMetalHost) []capi.MachineAd
 	}
 
 	return addrs
+}
+
+func (m *MachineManager) GetProviderIDAndBMHID() (string, *string) {
+	providerID := m.Metal3Machine.Spec.ProviderID
+	if providerID == nil {
+		return "", nil
+	}
+	return *providerID, pointer.StringPtr(parseProviderID(*providerID))
 }
 
 // ClientGetter prototype

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -1565,6 +1565,40 @@ var _ = Describe("Metal3Machine manager", func() {
 		)
 	})
 
+	type testCaseGetProviderIDAndBMHID struct {
+		providerID    *string
+		expectedBMHID string
+	}
+
+	DescribeTable("Test GetProviderIDAndBMHID",
+		func(tc testCaseGetProviderIDAndBMHID) {
+			m3m := capm3.Metal3Machine{
+				Spec: capm3.Metal3MachineSpec{
+					ProviderID: tc.providerID,
+				},
+			}
+
+			machineMgr, err := NewMachineManager(nil, nil, nil, nil, &m3m, klogr.New())
+			Expect(err).NotTo(HaveOccurred())
+
+			providerID, bmhID := machineMgr.GetProviderIDAndBMHID()
+
+			if tc.providerID != nil {
+				Expect(providerID).To(Equal(*tc.providerID))
+				Expect(bmhID).NotTo(BeNil())
+				Expect(*bmhID).To(Equal(tc.expectedBMHID))
+			} else {
+				Expect(providerID).To(Equal(""))
+				Expect(bmhID).To(BeNil())
+			}
+		},
+		Entry("Empty providerID", testCaseGetProviderIDAndBMHID{}),
+		Entry("Provider ID set", testCaseGetProviderIDAndBMHID{
+			providerID:    pointer.StringPtr("metal3://abcd"),
+			expectedBMHID: "abcd",
+		}),
+	)
+
 	Describe("Test SetNodeProviderID", func() {
 		scheme := runtime.NewScheme()
 		err := capi.AddToScheme(scheme)

--- a/baremetal/mocks/zz_generated.metal3machine_manager.go
+++ b/baremetal/mocks/zz_generated.metal3machine_manager.go
@@ -175,6 +175,21 @@ func (mr *MockMachineManagerInterfaceMockRecorder) HasAnnotation() *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasAnnotation", reflect.TypeOf((*MockMachineManagerInterface)(nil).HasAnnotation))
 }
 
+// GetProviderIDAndBMHID mocks base method
+func (m *MockMachineManagerInterface) GetProviderIDAndBMHID() (string, *string) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProviderIDAndBMHID")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(*string)
+	return ret0, ret1
+}
+
+// GetProviderIDAndBMHID indicates an expected call of GetProviderIDAndBMHID
+func (mr *MockMachineManagerInterfaceMockRecorder) GetProviderIDAndBMHID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProviderIDAndBMHID", reflect.TypeOf((*MockMachineManagerInterface)(nil).GetProviderIDAndBMHID))
+}
+
 // SetNodeProviderID mocks base method
 func (m *MockMachineManagerInterface) SetNodeProviderID(arg0 context.Context, arg1, arg2 string, arg3 baremetal.ClientGetter) error {
 	m.ctrl.T.Helper()

--- a/baremetal/utils.go
+++ b/baremetal/utils.go
@@ -18,6 +18,7 @@ package baremetal
 
 import (
 	"context"
+	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -75,4 +76,8 @@ func patchIfFound(ctx context.Context, helper *patch.Helper, host runtime.Object
 		}
 	}
 	return err
+}
+
+func parseProviderID(providerID string) string {
+	return strings.TrimPrefix(providerID, "metal3://")
 }

--- a/baremetal/utils_test.go
+++ b/baremetal/utils_test.go
@@ -228,4 +228,9 @@ var _ = Describe("Metal3 manager utils", func() {
 			CreateObject:   true,
 		}),
 	)
+
+	It("Parses the providerID properly", func() {
+		Expect(parseProviderID("metal3://abcd")).To(Equal("abcd"))
+		Expect(parseProviderID("foo://abcd")).To(Equal("foo://abcd"))
+	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of always creating it from BMH UID.
Currently, after pivoting, the BMH UID has changed so the
provider IDs do not match anymore since we always used the BMH UID.
Instead, use the providerID if set in the Metal3Machine already to
avoid this issue.

**Which issue(s) this PR fixes** :
Fixes #88 
