### PR TITLE
🐛 Fix NPE when gateway is absent from IPPool

### DIFF
--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -605,11 +605,16 @@ func (m *DataManager) getAddressFromPool(ctx context.Context, poolName string,
 		return addresses, false, err
 	}
 
+	gateway := ipamv1.IPAddressStr("")
+	if ipAddress.Spec.Gateway != nil {
+		gateway = *ipAddress.Spec.Gateway
+	}
+
 	// get address, gateway and prefixes
 	addresses[poolName] = addressFromPool{
 		address: ipAddress.Spec.Address,
 		prefix:  ipAddress.Spec.Prefix,
-		gateway: *ipAddress.Spec.Gateway,
+		gateway: gateway,
 	}
 
 	return addresses, false, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
If the gateway is not specified in the IPPool definition or in the
subnet, the metal3data controller was hitting a
nil pointer error
