### PR TITLE
✨ PR prevents the use of BMH annotated as unhealthy

### DIFF
--- a/api/v1alpha4/common_types.go
+++ b/api/v1alpha4/common_types.go
@@ -20,6 +20,11 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 )
 
+const (
+	// UnhealthyAnnotation is the annotation that sets unhealthy status of BMH
+	UnhealthyAnnotation = "capi.metal3.io/unhealthy"
+)
+
 // APIEndpoint represents a reachable Kubernetes API endpoint.
 type APIEndpoint struct {
 	// Host is the hostname on which the API server is serving.

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -808,13 +808,18 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmh.BareMetalHost, *p
 		default:
 			continue
 		}
-		// continue if BaremetalHost is paused
+
+		// continue if BaremetalHost is paused or marked with UnhealthyAnnotation
 		annotations := host.GetAnnotations()
 		if annotations != nil {
 			if _, ok := annotations[bmh.PausedAnnotation]; ok {
 				continue
 			}
+			if _, ok := annotations[capm3.UnhealthyAnnotation]; ok {
+				continue
+			}
 		}
+
 		if labelSelector.Matches(labels.Set(host.ObjectMeta.Labels)) {
 			m.Log.Info("Host matched hostSelector for Metal3Machine", "host", host.Name)
 			availableHosts = append(availableHosts, &hosts.Items[i])

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -496,6 +496,13 @@ var _ = Describe("Metal3Machine manager", func() {
 				Labels:    map[string]string{"key1": "value1"},
 			},
 		}
+		hostWithUnhealthyAnnotation := bmh.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "hostWithUnhealthyAnnotation",
+				Namespace:   "myns",
+				Annotations: map[string]string{capm3.UnhealthyAnnotation: "unhealthy"},
+			},
+		}
 
 		m3mconfig, infrastructureRef := newConfig("", map[string]string{},
 			[]capm3.HostSelectorRequirement{},
@@ -561,6 +568,14 @@ var _ = Describe("Metal3Machine manager", func() {
 				testCaseChooseHost{
 					Machine:          newMachine("machine1", "", infrastructureRef2),
 					Hosts:            []runtime.Object{&discoveredHost, &host2, &host1},
+					M3Machine:        m3mconfig2,
+					ExpectedHostName: host2.Name,
+				},
+			),
+			Entry("Ignore hostWithUnhealthyAnnotation and pick host2, which lacks a ConsumerRef",
+				testCaseChooseHost{
+					Machine:          newMachine("machine1", "", infrastructureRef2),
+					Hosts:            []runtime.Object{&hostWithUnhealthyAnnotation, &host1, &host2},
 					M3Machine:        m3mconfig2,
 					ExpectedHostName: host2.Name,
 				},


### PR DESCRIPTION
This PR adds the new `UnhealthyAnnotation = "capi.metal3.io/unhealthy"` and PR prevents the unhealthy BMH from being selected as the host for metal3machine. With new annotation users can mark BMH as unhealthy. 
