### PR TITLE
🐛 Fix bug when cluster is not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,7 @@ docker-push-manifest: ## Push the fat manifest docker image.
 set-manifest-image:
 	$(info Updating kustomize image patch file for manager resource)
 	sed -i'' -e 's@image: .*@image: '"${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./config/manager/manager_image_patch.yaml
-	
+
 .PHONY: set-manifest-image-bmo
 set-manifest-image-bmo:
 	$(info Updating kustomize image patch file for baremetal-operator)
@@ -319,9 +319,9 @@ deploy-examples:
 	kubectl apply -f ./examples/_out/controlplane.yaml
 
 delete-examples:
-	kubectl delete -f ./examples/_out/controlplane.yaml
-	kubectl delete -f ./examples/_out/machinedeployment.yaml
-	kubectl delete -f ./examples/_out/cluster.yaml
+	kubectl delete -f ./examples/_out/machinedeployment.yaml || true
+	kubectl delete -f ./examples/_out/controlplane.yaml || true
+	kubectl delete -f ./examples/_out/cluster.yaml || true
 
 
 ## --------------------------------------

--- a/controllers/metal3datatemplate_controller_test.go
+++ b/controllers/metal3datatemplate_controller_test.go
@@ -79,7 +79,9 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				if tc.setOwnerRefError {
 					m.EXPECT().SetClusterOwnerRef(gomock.Any()).Return(errors.New(""))
 				} else {
-					m.EXPECT().SetClusterOwnerRef(gomock.Any()).Return(nil)
+					if tc.cluster != nil {
+						m.EXPECT().SetClusterOwnerRef(gomock.Any()).Return(nil)
+					}
 				}
 			}
 			if tc.m3dt != nil && !tc.m3dt.DeletionTimestamp.IsZero() && tc.reconcileDeleteError {

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -34,6 +34,12 @@ export CONTROL_PLANE_MACHINE_TYPE="${CONTROL_PLANE_MACHINE_TYPE:-t2.medium}"
 export NODE_MACHINE_TYPE="${CONTROL_PLANE_MACHINE_TYPE:-t2.medium}"
 export SSH_KEY_NAME="${SSH_KEY_NAME:-default}"
 
+# BMO settings
+export DEPLOY_KERNEL_URL="${DEPLOY_KERNEL_URL:-http://127.0.0.1:6180/images/ironic-python-agent.kernel}"
+export DEPLOY_RAMDISK_URL="${DEPLOY_RAMDISK_URL:-http://127.0.0.1:6180/images/ironic-python-agent.initramfs}"
+export IRONIC_URL="${IRONIC_URL:-http://127.0.0.1:6385/v1/}"
+export IRONIC_INSPECTOR_URL="${IRONIC_INSPECTOR_URL:-http://127.0.0.1:5050/v1/}"
+
 # Outputs.
 COMPONENTS_CERT_MANAGER_GENERATED_FILE=${OUTPUT_DIR}/cert-manager.yaml
 COMPONENTS_CLUSTER_API_GENERATED_FILE=${SOURCE_DIR}/provider-components/core-components.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
And remove the restrictions on the events triggering the reconciliation
frommetal3dataclaim to catch update events when the deletion timestamp is
set. It also improves slightly the makefile
