### PR TITLE
🐛 Force deletion of BMH attributes when deleting m3m

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -496,10 +496,30 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 			}
 		}
 
-		if host.Spec.Image != nil || host.Spec.Online || host.Spec.UserData != nil {
+		bmhUpdated := false
+
+		if host.Spec.Image != nil {
 			host.Spec.Image = nil
-			host.Spec.Online = false
+			bmhUpdated = true
+		}
+		if host.Spec.UserData != nil {
 			host.Spec.UserData = nil
+			bmhUpdated = true
+		}
+		if host.Spec.MetaData != nil {
+			host.Spec.MetaData = nil
+			bmhUpdated = true
+		}
+		if host.Spec.NetworkData != nil {
+			host.Spec.NetworkData = nil
+			bmhUpdated = true
+		}
+		if host.Spec.Online {
+			host.Spec.Online = false
+			bmhUpdated = true
+		}
+
+		if bmhUpdated {
 			if err := patchIfFound(ctx, helper, host); err != nil {
 				if _, ok := err.(HasRequeueAfterError); !ok {
 					m.setError("Failed to delete Metal3Machine",


### PR DESCRIPTION
**What this PR does / why we need it**:

When deleting the Metal3machine, the userData used to provision might
already be deleted and absent from the status of the metal3machine,
causing the metal3machine not to be deleted since the BMH still has the
userData set. This patch forces the deletion of the userData and similar.
