### PR TITLE
:running: update baremetalhost crd to include boot mode field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/mailru/easyjson v0.7.1 // indirect
 	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a // indirect
 	github.com/mdempsky/maligned v0.0.0-20180708014732-6e39bd26a8c8 // indirect
-	github.com/metal3-io/baremetal-operator v0.0.0-20200707051855-4d4d033a8059
+	github.com/metal3-io/baremetal-operator v0.0.0-20200715105701-3207e795cae5
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -773,6 +773,8 @@ github.com/metal3-io/baremetal-operator v0.0.0-20200617072321-b35c5e9bceba h1:1v
 github.com/metal3-io/baremetal-operator v0.0.0-20200617072321-b35c5e9bceba/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=
 github.com/metal3-io/baremetal-operator v0.0.0-20200707051855-4d4d033a8059 h1:Ek7eFJ4t3TS3aosP/FHGhQX9DEm2Z53tnNnHwE/A2Kc=
 github.com/metal3-io/baremetal-operator v0.0.0-20200707051855-4d4d033a8059/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=
+github.com/metal3-io/baremetal-operator v0.0.0-20200715105701-3207e795cae5 h1:jjO0p4ptm+PIFdOFXqpaVyjsrMMLeVM657ZYbxmdHes=
+github.com/metal3-io/baremetal-operator v0.0.0-20200715105701-3207e795cae5/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=
 github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2/go.mod h1:g4cOPxcjV0oFq3qwpjSA30LReKD8AoIfwAY9VvG35NY=
 github.com/miekg/dns v0.0.0-20181005163659-0d29b283ac0f/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the version of BMO we use so we get the newer BareMetalHost with
the additional field for the boot mode. This prevents the controller from
overwriting the host with partial data and losing the user-configured
value for booting the host.

**Which issue(s) this PR fixes**

Implements https://github.com/metal3-io/metal3-docs/blob/master/design/baremetal-operator/implicit-boot-mode.md
