### PR TITLE
🐛 Fix shell parameters expansion for CAPI deployment

### DIFF
--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -114,16 +114,20 @@ echo "Generated ${MACHINEDEPLOYMENT_GENERATED_FILE}"
 # Get Cert-manager provider components file
 curl -L -o "${COMPONENTS_CERT_MANAGER_GENERATED_FILE}" https://github.com/jetstack/cert-manager/releases/download/v0.13.0/cert-manager.yaml
 
+# Get enhanced envsubst version to evaluate expressions like ${VAR:=default}
+curl -L -o "${SOURCE_DIR}"/envsubst-go https://github.com/a8m/envsubst/releases/download/v1.2.0/envsubst-"$(uname -s)"-"$(uname -m)"
+chmod +x "${SOURCE_DIR}"/envsubst-go
+
 # Generate Cluster API provider components file.
-"$KUSTOMIZE" build "github.com/kubernetes-sigs/cluster-api/config/?ref=master" > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
+"$KUSTOMIZE" build "github.com/kubernetes-sigs/cluster-api/config/?ref=master" | "${SOURCE_DIR}"/envsubst-go > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
 echo "Generated ${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
 
 # Generate Kubeadm Bootstrap Provider components file.
-"$KUSTOMIZE" build "github.com/kubernetes-sigs/cluster-api/bootstrap/kubeadm/config/?ref=master" > "${COMPONENTS_KUBEADM_GENERATED_FILE}"
+"$KUSTOMIZE" build "github.com/kubernetes-sigs/cluster-api/bootstrap/kubeadm/config/?ref=master" | "${SOURCE_DIR}"/envsubst-go > "${COMPONENTS_KUBEADM_GENERATED_FILE}"
 echo "Generated ${COMPONENTS_KUBEADM_GENERATED_FILE}"
 
 # Generate Kubeadm Controlplane components file.
-"$KUSTOMIZE" build "github.com/kubernetes-sigs/cluster-api/controlplane/kubeadm/config/?ref=master" > "${COMPONENTS_CTRLPLANE_GENERATED_FILE}"
+"$KUSTOMIZE" build "github.com/kubernetes-sigs/cluster-api/controlplane/kubeadm/config/?ref=master" | "${SOURCE_DIR}"/envsubst-go > "${COMPONENTS_CTRLPLANE_GENERATED_FILE}"
 echo "Generated ${COMPONENTS_CTRLPLANE_GENERATED_FILE}"
 
 # Generate METAL3 Infrastructure Provider components file.


### PR DESCRIPTION
**What this PR does / why we need it**:
In CAPI v0.3.7+ yaml files expressions like ${PARAM:=DEFAULTVALUE} were added.
GNU envsubst can't handle such kind of expressions, so enhnaced
implementation of envsubst were used to overcome this.

**Which issue(s) this PR fixes**:
Fixes #125 
