### PR TITLE
🌱 Opt for a more inclusive Other PR category

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
-<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->
+<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->
 
 **What this PR does / why we need it**:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ All code PR must be labeled with one of
 - ✨ (:sparkles:, minor or feature additions)
 - 🐛 (:bug:, patch and bugfixes)
 - 📖 (:book:, documentation or proposals)
-- 🏃 (:running:, other)
+- 🌱 (:seedling:, minor or other)
 
 All changes must be code reviewed. Coding conventions and standards are
 explained in the official [developer

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -71,7 +71,7 @@ a:
 - Non-breaking feature: :sparkles: (`:sparkles:`)
 - Patch fix: :bug: (`:bug:`)
 - Docs: :book: (`:book:`)
-- Infra/Tests/Other: :running: (`:running:`)
+- Infra/Tests/Other: :seedling: (`:seedling:`)
 
 You can also use the equivalent emoji directly, since GitHub doesn't
 render the `:xyz:` aliases in PR titles.

--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -39,7 +39,7 @@ const (
 	bugs          = ":bug: Bug Fixes"
 	documentation = ":book: Documentation"
 	warning       = ":warning: Breaking Changes"
-	other         = ":running: Others"
+	other         = ":seedling: Others"
 	unknown       = ":question: Sort these by hand"
 )
 
@@ -134,7 +134,12 @@ func run() int {
 			key = documentation
 			body = strings.TrimPrefix(body, ":book:")
 			body = strings.TrimPrefix(body, "📖")
+		case strings.HasPrefix(body, ":seedling:"), strings.HasPrefix(body, "🌱"):
+			key = other
+			body = strings.TrimPrefix(body, ":seedling:")
+			body = strings.TrimPrefix(body, "🌱")
 		case strings.HasPrefix(body, ":running:"), strings.HasPrefix(body, "🏃"):
+			// This has been deprecated in favor of :seedling:
 			key = other
 			body = strings.TrimPrefix(body, ":running:")
 			body = strings.TrimPrefix(body, "🏃")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the emoji used for the "Other" PR category to make it more inclusive
