### PR TITLE
✨ Add support for TLS with custom CA certificate in BMO

### DIFF
--- a/config/bmo/kustomization.yaml
+++ b/config/bmo/kustomization.yaml
@@ -13,11 +13,18 @@ configMapGenerator:
   - DEPLOY_RAMDISK_URL=${DEPLOY_RAMDISK_URL}
   - IRONIC_ENDPOINT=${IRONIC_URL}
   - IRONIC_INSPECTOR_ENDPOINT=${IRONIC_INSPECTOR_URL}
+  - IRONIC_CACERT_FILE=/opt/metal3/certs/ca/tls.crt
   name: ironic-bmo-configmap
+
+secretGenerator:
+- name: ironic-cacert
+  literals:
+  - tls.crt=${IRONIC_CA_CERT_B64:-""}
 
 patchesStrategicMerge:
 - bmo_image_patch.yaml
 - bmo_pull_policy.yaml
+- secret_mount.yaml
 
 configurations:
 - kustomizeconfig.yaml

--- a/config/bmo/secret_mount.yaml
+++ b/config/bmo/secret_mount.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metal3-baremetal-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: baremetal-operator
+        volumeMounts:
+          - name: cacert
+            mountPath: "/opt/metal3/${IRONIC_NO_CA_CERT:-certs}/ca/"
+            readOnly: true
+      volumes:
+      - name: cacert
+        secret:
+          secretName: ironic-cacert

--- a/config/default/namespace.yaml
+++ b/config/default/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: system
+  name: capm3-system

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,30 +26,75 @@ additional information on the `move` process.
 
 #### Environment variables
 
+There are some required variables :
+
+- DEPLOY_KERNEL_URL
+- DEPLOY_RAMDISK_URL
+- IRONIC_URL
+- IRONIC_INSPECTOR_URL
+- IRONIC_CA_CERT_B64 **or** IRONIC_NO_CA_CERT
+
 ##### DEPLOY_KERNEL_URL
 
 This is the URL of the kernel to deploy. For example:
 
-`DEPLOY_KERNEL_URL="http://172.22.0.1:6180/images/ironic-python-agent.kernel"`
+```sh
+  export DEPLOY_KERNEL_URL="http://172.22.0.1:6180/images/ironic-python-agent.kernel"`
+```
 
 ##### DEPLOY_RAMDISK_URL
 
 This is the URL of the ramdisk to deploy. For example:
 
-`DEPLOY_RAMDISK_URL="http://172.22.0.1:6180/images/ironic-python-agent.initramfs"`
+```sh
+  export DEPLOY_RAMDISK_URL="http://172.22.0.1:6180/images/ironic-python-agent.initramfs"`
+```
 
 ##### IRONIC_URL
 
 This is the URL of the ironic endpoint. For example:
 
-`IRONIC_URL="http://172.22.0.1:6385/v1/"`
+```sh
+  export IRONIC_URL="http://172.22.0.1:6385/v1/"`
+```
 
 ##### IRONIC_INSPECTOR_URL
 
 This is the URL of the ironic inspector endpoint.
 For example:
 
-`IRONIC_INSPECTOR_URL="http://172.22.0.1:5050/v1/"`
+```sh
+  export IRONIC_INSPECTOR_URL="http://172.22.0.1:5050/v1/"`
+```
+
+##### IRONIC_CA_CERT_B64
+
+This contains the CA certificate for Ironic, encoded in Base 64. It defaults to
+an empty string in case you do not want to provide a CA certificate. Setting
+this variable is optional, but either this variable or `IRONIC_NO_CA_CERT` must
+be set.
+
+```sh
+  export IRONIC_CA_CERT_B64="LS0tLS1C..."
+```
+
+The content of this variable must be string without line wraps. It can be
+generated as follows :
+
+```sh
+  export IRONIC_CA_CERT_B64="$(cat ca.crt | base64 -w 0)"
+```
+
+##### IRONIC_NO_CA_CERT
+
+Do not use a dedicated CA certificate for Ironic API. Any value provided in
+this variable disables additional CA certificate validation. To provide a CA
+certificate, leave this variable unset. If unset, then `IRONIC_CA_CERT_B64`
+must be set.
+
+```sh
+  export IRONIC_NO_BASIC_AUTH="true"
+```
 
 #### Cluster templates variables
 

--- a/hack/tools/install_kustomize.sh
+++ b/hack/tools/install_kustomize.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ARCH=amd64
-MINIMUM_KUSTOMIZE_VERSION=3.5.5
+MINIMUM_KUSTOMIZE_VERSION=3.8.2
 
 # Ensure the kustomize tool exists and is a viable version, or installs it
 verify_kustomize_version() {


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit modifies the config folder to deploy BMO with a
custom CA cert to interact with Ironic. The CA cert must be
provided as a base64 encoded string without line wrap in
the IRONIC_CA_CERT_B64 environment variable for clusterctl

