### PR TITLE
✨ Add Support for Ironic Basic auth in deployment templates

### DIFF
--- a/config/bmo/kustomization.yaml
+++ b/config/bmo/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - github.com/metal3-io/baremetal-operator/deploy/operator/?ref=master
 - github.com/metal3-io/baremetal-operator/deploy/crds/?ref=master
 - github.com/metal3-io/baremetal-operator/deploy/rbac/?ref=master
+- secrets.yaml
 
 configMapGenerator:
 - behavior: create
@@ -15,11 +16,6 @@ configMapGenerator:
   - IRONIC_INSPECTOR_ENDPOINT=${IRONIC_INSPECTOR_URL}
   - IRONIC_CACERT_FILE=/opt/metal3/certs/ca/tls.crt
   name: ironic-bmo-configmap
-
-secretGenerator:
-- name: ironic-cacert
-  literals:
-  - tls.crt=${IRONIC_CA_CERT_B64:-""}
 
 patchesStrategicMerge:
 - bmo_image_patch.yaml

--- a/config/bmo/kustomization.yaml
+++ b/config/bmo/kustomization.yaml
@@ -13,11 +13,18 @@ configMapGenerator:
   - DEPLOY_RAMDISK_URL=${DEPLOY_RAMDISK_URL}
   - IRONIC_ENDPOINT=${IRONIC_URL}
   - IRONIC_INSPECTOR_ENDPOINT=${IRONIC_INSPECTOR_URL}
+  - IRONIC_CACERT_FILE=/opt/metal3/certs/ca/tls.crt
   name: ironic-bmo-configmap
+
+secretGenerator:
+- name: ironic-cacert
+  literals:
+  - tls.crt=${IRONIC_CA_CERT_B64:-""}
 
 patchesStrategicMerge:
 - bmo_image_patch.yaml
 - bmo_pull_policy.yaml
+- secret_mount.yaml
 
 configurations:
 - kustomizeconfig.yaml

--- a/config/bmo/secret_mount.yaml
+++ b/config/bmo/secret_mount.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metal3-baremetal-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: baremetal-operator
+        volumeMounts:
+          - name: cacert
+            mountPath: "/opt/metal3/${IRONIC_NO_CA_CERT:-certs}/ca/"
+            readOnly: true
+      volumes:
+      - name: cacert
+        secret:
+          secretName: ironic-cacert

--- a/config/bmo/secret_mount.yaml
+++ b/config/bmo/secret_mount.yaml
@@ -11,7 +11,19 @@ spec:
           - name: cacert
             mountPath: "/opt/metal3/${IRONIC_NO_CA_CERT:-certs}/ca/"
             readOnly: true
+          - name: ironic-credentials
+            mountPath: "/opt/metal3/${IRONIC_NO_BASIC_AUTH:-auth}/ironic"
+            readOnly: true
+          - name: ironic-inspector-credentials
+            mountPath: "/opt/metal3/${IRONIC_INSPECTOR_NO_BASIC_AUTH:-auth}/ironic-inspector"
+            readOnly: true
       volumes:
       - name: cacert
         secret:
           secretName: ironic-cacert
+      - name: ironic-credentials
+        secret:
+          secretName: ironic-credentials
+      - name: ironic-inspector-credentials
+        secret:
+          secretName: ironic-inspector-credentials

--- a/config/bmo/secrets.yaml
+++ b/config/bmo/secrets.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+data:
+  tls.crt: ${IRONIC_CA_CERT_B64:-""}
+kind: Secret
+metadata:
+  name: ironic-cacert
+type: Opaque
+---
+apiVersion: v1
+stringData:
+  password: ${IRONIC_PASSWORD:-""}
+  username: ${IRONIC_USERNAME:-""}
+kind: Secret
+metadata:
+  name: ironic-credentials
+type: Opaque
+---
+apiVersion: v1
+stringData:
+  password: ${IRONIC_INSPECTOR_PASSWORD:-""}
+  username: ${IRONIC_INSPECTOR_USERNAME:-""}
+kind: Secret
+metadata:
+  name: ironic-inspector-credentials
+type: Opaque

--- a/config/default/namespace.yaml
+++ b/config/default/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: system
+  name: capm3-system

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,30 +26,75 @@ additional information on the `move` process.
 
 #### Environment variables
 
+There are some required variables :
+
+- DEPLOY_KERNEL_URL
+- DEPLOY_RAMDISK_URL
+- IRONIC_URL
+- IRONIC_INSPECTOR_URL
+- IRONIC_CA_CERT_B64 **or** IRONIC_NO_CA_CERT
+
 ##### DEPLOY_KERNEL_URL
 
 This is the URL of the kernel to deploy. For example:
 
-`DEPLOY_KERNEL_URL="http://172.22.0.1:6180/images/ironic-python-agent.kernel"`
+```sh
+  export DEPLOY_KERNEL_URL="http://172.22.0.1:6180/images/ironic-python-agent.kernel"`
+```
 
 ##### DEPLOY_RAMDISK_URL
 
 This is the URL of the ramdisk to deploy. For example:
 
-`DEPLOY_RAMDISK_URL="http://172.22.0.1:6180/images/ironic-python-agent.initramfs"`
+```sh
+  export DEPLOY_RAMDISK_URL="http://172.22.0.1:6180/images/ironic-python-agent.initramfs"`
+```
 
 ##### IRONIC_URL
 
 This is the URL of the ironic endpoint. For example:
 
-`IRONIC_URL="http://172.22.0.1:6385/v1/"`
+```sh
+  export IRONIC_URL="http://172.22.0.1:6385/v1/"`
+```
 
 ##### IRONIC_INSPECTOR_URL
 
 This is the URL of the ironic inspector endpoint.
 For example:
 
-`IRONIC_INSPECTOR_URL="http://172.22.0.1:5050/v1/"`
+```sh
+  export IRONIC_INSPECTOR_URL="http://172.22.0.1:5050/v1/"`
+```
+
+##### IRONIC_CA_CERT_B64
+
+This contains the CA certificate for Ironic, encoded in Base 64. It defaults to
+an empty string in case you do not want to provide a CA certificate. Setting
+this variable is optional, but either this variable or `IRONIC_NO_CA_CERT` must
+be set.
+
+```sh
+  export IRONIC_CA_CERT_B64="LS0tLS1C..."
+```
+
+The content of this variable must be string without line wraps. It can be
+generated as follows :
+
+```sh
+  export IRONIC_CA_CERT_B64="$(cat ca.crt | base64 -w 0)"
+```
+
+##### IRONIC_NO_CA_CERT
+
+Do not use a dedicated CA certificate for Ironic API. Any value provided in
+this variable disables additional CA certificate validation. To provide a CA
+certificate, leave this variable unset. If unset, then `IRONIC_CA_CERT_B64`
+must be set.
+
+```sh
+  export IRONIC_NO_BASIC_AUTH="true"
+```
 
 #### Cluster templates variables
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,6 +33,9 @@ There are some required variables :
 - IRONIC_URL
 - IRONIC_INSPECTOR_URL
 - IRONIC_CA_CERT_B64 **or** IRONIC_NO_CA_CERT
+- IRONIC_NO_BASIC_AUTH **or** IRONIC_USERNAME and IRONIC_PASSWORD
+- IRONIC_INSPECTOR_NO_BASIC_AUTH **or** IRONIC_INSPECTOR_USERNAME and
+  IRONIC_INSPECTOR_PASSWORD
 
 ##### DEPLOY_KERNEL_URL
 
@@ -94,6 +97,63 @@ must be set.
 
 ```sh
   export IRONIC_NO_BASIC_AUTH="true"
+```
+
+##### IRONIC_USERNAME
+
+Username for Ironic basic auth. Optional, but either this variable or
+`IRONIC_NO_BASIC_AUTH` must be set.
+
+```sh
+  export IRONIC_USERNAME="<username>"
+```
+
+##### IRONIC_PASSWORD
+
+Password for Ironic basic auth. Optional, but either this variable or
+`IRONIC_NO_BASIC_AUTH` must be set.
+
+```sh
+  export IRONIC_PASSWORD="<password>"
+```
+
+##### IRONIC_NO_BASIC_AUTH
+
+Disables basic authentication for Ironic API. Any value provided in this
+variable disables authentication. To enable authentication, leave this variable
+unset. If unset, then `IRONIC_USERNAME` and `IRONIC_PASSWORD` must be set.
+
+```sh
+  export IRONIC_NO_BASIC_AUTH="true"
+```
+
+##### IRONIC_INSPECTOR_USERNAME
+
+Username for Ironic inspector basic auth. Optional, but either this variable or
+`IRONIC_INSPECTOR_NO_BASIC_AUTH` must be set.
+
+```sh
+  export IRONIC_INSPECTOR_USERNAME="<username>"
+```
+
+##### IRONIC_INSPECTOR_PASSWORD
+
+Password for Ironic inspector basic auth. Optional, but either this variable or
+`IRONIC_INSPECTOR_NO_BASIC_AUTH` must be set.
+
+```sh
+  export IRONIC_INSPECTOR_PASSWORD="<password>"
+```
+
+##### IRONIC_INSPECTOR_NO_BASIC_AUTH
+
+Disables basic authentication for Ironic inspector API. Any value provided in
+this variable disables authentication. To enable authentication, leave this
+variable unset. If unset, then `IRONIC_INSPECTOR_USERNAME` and
+`IRONIC_INSPECTOR_PASSWORD` must be set.
+
+```sh
+  export IRONIC_INSPECTOR_NO_BASIC_AUTH="true"
 ```
 
 #### Cluster templates variables

--- a/hack/tools/install_kustomize.sh
+++ b/hack/tools/install_kustomize.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ARCH=amd64
-MINIMUM_KUSTOMIZE_VERSION=3.5.5
+MINIMUM_KUSTOMIZE_VERSION=3.8.2
 
 # Ensure the kustomize tool exists and is a viable version, or installs it
 verify_kustomize_version() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for basic authentication towards Ironic and Ironic inspector.

Based on #133 