### PR TITLE
🌱 Modify Metal3Machine association order

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -371,47 +371,7 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 		return err
 	}
 
-	if m.Metal3Machine.Spec.DataTemplate != nil {
-		// Requeue to get the DataTemplate output. We need to requeue to trigger the
-		// wait on the Metal3DataTemplate
-		if err := m.WaitForM3Metadata(ctx); err != nil {
-			return err
-		}
-
-		// If the requeue is not needed, then get the updated host and set the host
-		// specs
-		host, helper, err = m.getHost(ctx)
-		if err != nil {
-			m.SetError("Failed to get the BaremetalHost for the Metal3Machine",
-				capierrors.CreateMachineError,
-			)
-			return err
-		}
-
-		if err = m.setHostSpec(ctx, host); err != nil {
-			if _, ok := err.(HasRequeueAfterError); !ok {
-				m.SetError("Failed to set the BaremetalHost Specs",
-					capierrors.CreateMachineError,
-				)
-			}
-			return err
-		}
-
-		// Update the BMH object.
-		err = helper.Patch(ctx, host)
-		if err != nil {
-			if aggr, ok := err.(kerrors.Aggregate); ok {
-				for _, kerr := range aggr.Errors() {
-					if apierrors.IsConflict(kerr) {
-						return &RequeueAfterError{}
-					}
-				}
-			}
-			return err
-		}
-	}
-
-	m.Log.Info("Finished creating machine")
+	m.Log.Info("Finished associating machine")
 	return nil
 }
 

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -2309,8 +2309,6 @@ var _ = Describe("Metal3Machine manager", func() {
 		Host               *bmh.BareMetalHost
 		M3Machine          *capm3.Metal3Machine
 		BMCSecret          *corev1.Secret
-		DataTemplate       *capm3.Metal3DataTemplate
-		Data               *capm3.Metal3Data
 		ExpectRequeue      bool
 		ExpectClusterLabel bool
 		ExpectOwnerRef     bool
@@ -2324,12 +2322,6 @@ var _ = Describe("Metal3Machine manager", func() {
 			}
 			if tc.Host != nil {
 				objects = append(objects, tc.Host)
-			}
-			if tc.DataTemplate != nil {
-				objects = append(objects, tc.DataTemplate)
-			}
-			if tc.Data != nil {
-				objects = append(objects, tc.Data)
 			}
 			if tc.BMCSecret != nil {
 				objects = append(objects, tc.BMCSecret)
@@ -2465,7 +2457,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Host:               newBareMetalHost("myhost", bmhSpecBMC(), bmh.StateNone, nil, false, false),
 				BMCSecret:          newBMCSecret("mycredentials", false),
 				ExpectClusterLabel: true,
-				ExpectRequeue:      true,
+				ExpectRequeue:      false,
 				ExpectOwnerRef:     true,
 			},
 		),
@@ -2491,25 +2483,8 @@ var _ = Describe("Metal3Machine manager", func() {
 						RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: "myns"},
 					}, nil,
 				),
-				Host:      newBareMetalHost("myhost", bmhSpecBMC(), bmh.StateNone, nil, false, false),
-				BMCSecret: newBMCSecret("mycredentials", false),
-				Data: &capm3.Metal3Data{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abcd-0",
-						Namespace: "myns",
-					},
-					Spec: capm3.Metal3DataSpec{
-						MetaData: &corev1.SecretReference{
-							Name: "metadata",
-						},
-						NetworkData: &corev1.SecretReference{
-							Name: "networkdata",
-						},
-					},
-					Status: capm3.Metal3DataStatus{
-						Ready: true,
-					},
-				},
+				Host:               newBareMetalHost("myhost", bmhSpecBMC(), bmh.StateNone, nil, false, false),
+				BMCSecret:          newBMCSecret("mycredentials", false),
 				ExpectClusterLabel: true,
 				ExpectRequeue:      false,
 				ExpectOwnerRef:     true,

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -85,13 +85,14 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		return m
 	}
 
-	m.EXPECT().AssociateM3Metadata(context.TODO()).Return(nil)
 	// Bootstrap data is ready and node is not annotated, i.e. not associated
 	m.EXPECT().HasAnnotation().Return(tc.Annotated)
 	if !tc.Annotated {
 		// if associate fails, we do not go further
 		if tc.AssociateFails {
 			m.EXPECT().Associate(context.TODO()).Return(errors.New("Failed"))
+			m.EXPECT().AssociateM3Metadata(context.TODO()).MaxTimes(0)
+			m.EXPECT().Update(context.TODO()).MaxTimes(0)
 			m.EXPECT().GetProviderIDAndBMHID().MaxTimes(0)
 			m.EXPECT().GetBaremetalHostID(context.TODO()).MaxTimes(0)
 			m.EXPECT().SetError(gomock.Any(), gomock.Any())
@@ -99,10 +100,10 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		} else {
 			m.EXPECT().Associate(context.TODO()).Return(nil)
 		}
-		m.EXPECT().Update(context.TODO()).MaxTimes(0)
-	} else {
-		m.EXPECT().Update(context.TODO())
 	}
+
+	m.EXPECT().AssociateM3Metadata(context.TODO()).Return(nil)
+	m.EXPECT().Update(context.TODO())
 
 	// if node is now associated, if getting the ID fails, we do not go further
 	if tc.GetBMHIDFails {


### PR DESCRIPTION
**What this PR does / why we need it**:
​This PR waits for a BMH to be available and associated before creating the Metal3DataClaim. This ensures that the previous node
is properly deleted before giving an index to the new one (in case of scale-in upgrade).
