### PR TITLE
TLS and Basic auth vars for capm3 v0.4.1 release

### DIFF
--- a/examples/clusterctl-templates/example_variables.rc
+++ b/examples/clusterctl-templates/example_variables.rc
@@ -10,6 +10,9 @@ export IMAGE_URL="http://192.168.0.1/ubuntu.qcow2"
 export IMAGE_CHECKSUM="http://192.168.0.1/ubuntu.qcow2.md5sum"
 export IMAGE_CHECKSUM_TYPE="md5"
 export IMAGE_FORMAT="qcow2"
+export IRONIC_NO_CA_CERT=true
+export IRONIC_NO_BASIC_AUTH=true
+export IRONIC_INSPECTOR_NO_BASIC_AUTH=true
 export CTLPLANE_KUBEADM_EXTRA_CONFIG="
     preKubeadmCommands:
       - ip link set dev enp2s0 up


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Add missing TLS and Basic auth related vars which are required for the clusterctl deployment.

