### PR TITLE
✨ Add nodeDrainTimeout for example cluster template

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -204,6 +204,12 @@ This is the URL of the md5sum of the image to deploy. For example:
 
 `IMAGE_CHECKSUM="http://192.168.0.1/ubuntu.qcow2.md5sum"`
 
+#### NODE_DRAIN_TIMEOUT
+
+This variable sets the nodeDrainTimout for cluster, controlplane and machinedeployment template. Users can set desired value in seconds ("300s") or minutes ("5m"). If it is not set, default value will be "0s" which will not make any change in the current deployment. For example:
+
+`NODE_DRAIN_TIMEOUT="300s"`
+
 #### CTLPLANE_KUBEADM_EXTRA_CONFIG
 
 This contains the extra configuration to pass in KubeadmControlPlane. It is

--- a/examples/clusterctl-templates/clusterctl-cluster.yaml
+++ b/examples/clusterctl-templates/clusterctl-cluster.yaml
@@ -35,6 +35,7 @@ metadata:
   name: ${CLUSTER_NAME}
   namespace: ${NAMESPACE}
 spec:
+  nodeDrainTimeout: ${NODE_DRAIN_TIMEOUT:-"0s"}
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   version: ${KUBERNETES_VERSION}
   infrastructureTemplate:
@@ -90,6 +91,7 @@ spec:
         cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
         nodepool: nodepool-0
     spec:
+      nodeDrainTimeout: ${NODE_DRAIN_TIMEOUT:-"0s"}
       clusterName: ${CLUSTER_NAME}
       version: ${KUBERNETES_VERSION}
       bootstrap:

--- a/examples/controlplane/controlplane.yaml
+++ b/examples/controlplane/controlplane.yaml
@@ -3,6 +3,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 metadata:
   name: ${CLUSTER_NAME}-controlplane
 spec:
+  nodeDrainTimeout: ${NODE_DRAIN_TIMEOUT:-"0s"}
   replicas: 3
   version: v1.17.0
   infrastructureTemplate:

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -33,6 +33,7 @@ export KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.16.0}"
 export CONTROL_PLANE_MACHINE_TYPE="${CONTROL_PLANE_MACHINE_TYPE:-t2.medium}"
 export NODE_MACHINE_TYPE="${CONTROL_PLANE_MACHINE_TYPE:-t2.medium}"
 export SSH_KEY_NAME="${SSH_KEY_NAME:-default}"
+export NODE_DRAIN_TIMEOUT="${NODE_DRAIN_TIMEOUT:-"0s"}"
 
 # BMO settings
 export DEPLOY_KERNEL_URL="${DEPLOY_KERNEL_URL:-http://127.0.0.1:6180/images/ironic-python-agent.kernel}"

--- a/examples/machinedeployment/machinedeployment.yaml
+++ b/examples/machinedeployment/machinedeployment.yaml
@@ -18,6 +18,7 @@ spec:
         cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
         nodepool: nodepool-0
     spec:
+      nodeDrainTimeout: ${NODE_DRAIN_TIMEOUT:-"0s"}
       clusterName: ${CLUSTER_NAME}
       version: ${KUBERNETES_VERSION}
       bootstrap:


### PR DESCRIPTION
**What this PR does / why we need it**: This PR will add the nodeDrainTimeout configuration option in cluster, controlplane and worker example template. As to not affect existing deployments, made the default value to be `0s` and the user can override it with desired value.
