### PR TITLE
Fix incorrect use of variable kb_root_dir

### DIFF
--- a/hack/fetch_ext_bins.sh
+++ b/hack/fetch_ext_bins.sh
@@ -77,9 +77,9 @@ function prepare_staging_dir {
   if [[ -z "${SKIP_FETCH_TOOLS}" ]]; then
     rm -rf "${kb_root_dir}"
   else
-    rm -f "${kb_root_dir}/kubebuilder/bin/kubebuilder"
-    rm -f "${kb_root_dir}/kubebuilder/bin/kubebuilder-gen"
-    rm -f "${kb_root_dir}/kubebuilder/bin/vendor.tar.gz"
+    rm -f "${kb_root_dir}/bin/kubebuilder"
+    rm -f "${kb_root_dir}/bin/kubebuilder-gen"
+    rm -f "${kb_root_dir}/bin/vendor.tar.gz"
   fi
 }
 
@@ -105,8 +105,8 @@ function setup_envs {
   header_text "setting up env vars"
 
   # Setup env vars
-  export PATH=/tmp/kubebuilder/bin:$PATH
-  export TEST_ASSET_KUBECTL=/tmp/kubebuilder/bin/kubectl
-  export TEST_ASSET_KUBE_APISERVER=/tmp/kubebuilder/bin/kube-apiserver
-  export TEST_ASSET_ETCD=/tmp/kubebuilder/bin/etcd
+  export PATH=${kb_root_dir}/bin:$PATH
+  export TEST_ASSET_KUBECTL=${kb_root_dir}/bin/kubectl
+  export TEST_ASSET_KUBE_APISERVER=${kb_root_dir}/bin/kube-apiserver
+  export TEST_ASSET_ETCD=${kb_root_dir}/bin/etcd
 }


### PR DESCRIPTION
  1. bin is under kb_root_dir, not kb_root_dir/kubebuilder
  2. Make full use of $kb_root_dir instead of specify /tmp/kubebuilder directly

Signed-off-by: Ma Xinjian <maxj.fnst@cn.fujitsu.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
