### PR TITLE
:seedling: apply our own rules for host availability

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -788,7 +788,7 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmh.BareMetalHost, *p
 		if host.GetDeletionTimestamp() != nil {
 			continue
 		}
-		if host.HasError() {
+		if host.Status.ErrorMessage != "" {
 			continue
 		}
 		switch host.Status.Provisioning.State {

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -782,7 +782,13 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmh.BareMetalHost, *p
 			helper, err := patch.NewHelper(&hosts.Items[i], m.client)
 			return &hosts.Items[i], helper, err
 		}
-		if !host.Available() {
+		if host.Spec.ConsumerRef != nil {
+			continue
+		}
+		if host.GetDeletionTimestamp() != nil {
+			continue
+		}
+		if host.HasError() {
 			continue
 		}
 		switch host.Status.Provisioning.State {


### PR DESCRIPTION
Do not rely on the host's Available() method to decide when a host can
be selected for provisioning.