### PR TITLE
Parameterize docker registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 # Build the manager binary on golang image
-FROM registry.hub.docker.com/library/golang:1.15.3 as builder
+ARG OVERRIDE_DOCKER_HUB_REGISTRY=${OVERRIDE_DOCKER_HUB_REGISTRY:-"registry.hub.docker.com"}
+
+FROM "${OVERRIDE_DOCKER_HUB_REGISTRY}/"library/golang:1.15.3 as builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,9 @@ RBAC_ROOT ?= $(MANIFEST_ROOT)/rbac
 # Allow overriding the imagePullPolicy
 PULL_POLICY ?= IfNotPresent
 
+# Default Image pull registry
+OVERRIDE_DOCKER_HUB_REGISTRY ?= "registry.hub.docker.com"
+
 ## --------------------------------------
 ## Help
 ## --------------------------------------
@@ -261,7 +264,7 @@ generate-examples: $(KUSTOMIZE) clean-examples ## Generate examples configuratio
 
 .PHONY: docker-build
 docker-build: ## Build the docker image for controller-manager
-	docker build --network=host --pull --build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	docker build --network=host --pull --build-arg ARCH=$(ARCH) --build-arg OVERRIDE_DOCKER_HUB_REGISTRY=${OVERRIDE_DOCKER_HUB_REGISTRY} . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
 	MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) $(MAKE) set-manifest-image
 	$(MAKE) set-manifest-pull-policy
 

--- a/hack/Dockerfile.unit
+++ b/hack/Dockerfile.unit
@@ -1,4 +1,6 @@
-FROM registry.hub.docker.com/library/golang:1.15.3
+ARG OVERRIDE_DOCKER_HUB_REGISTRY=${OVERRIDE_DOCKER_HUB_REGISTRY:-"registry.hub.docker.com"}
+
+FROM "${OVERRIDE_DOCKER_HUB_REGISTRY}/"library/golang:1.15.3
 
 WORKDIR /usr/local/kubebuilder
 COPY /hack/tools /usr/local/kubebuilder/


### PR DESCRIPTION
This PR parameterizes the docker registry for building images.
Which registry is used determined by the following variable, with the give default value.
Exporting the variables per Dockerfile allows this repo to be independent of metal3-dev-env
This has an effect when using Makefile and the value is overridden.

export OVERRIDE_DOCKER_HUB_REGISTRY=${OVERRIDE_DOCKER_HUB_REGISTRY:-"registry.hub.docker.com"}

If you wish to use a different registry, please assign value in a HOST:PORT/path format.