### PR TITLE
🌱 Bump the Golang version to 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary on golang image
-FROM registry.hub.docker.com/library/golang:1.15.3 as builder
+FROM registry.hub.docker.com/library/golang:1.16 as builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy

--- a/Tiltfile
+++ b/Tiltfile
@@ -198,7 +198,7 @@ def validate_auth():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.15.3 as tilt-helper
+FROM golang:1.16 as tilt-helper
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/cluster-api-provider-metal3
 
-go 1.15
+go 1.16
 
 require (
 	cloud.google.com/go v0.74.0 // indirect

--- a/hack/Dockerfile.unit
+++ b/hack/Dockerfile.unit
@@ -1,4 +1,4 @@
-FROM registry.hub.docker.com/library/golang:1.15.3
+FROM registry.hub.docker.com/library/golang:1.16
 
 WORKDIR /usr/local/kubebuilder
 COPY /hack/tools /usr/local/kubebuilder/

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -39,6 +39,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:rw,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
-    registry.hub.docker.com/library/golang:1.15.3 \
+    registry.hub.docker.com/library/golang:1.16 \
     /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/codegen.sh
 fi;

--- a/hack/gofmt.sh
+++ b/hack/gofmt.sh
@@ -24,6 +24,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:ro,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
-    registry.hub.docker.com/library/golang:1.15.3 \
+    registry.hub.docker.com/library/golang:1.16 \
     /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/gofmt.sh
 fi;

--- a/hack/golint.sh
+++ b/hack/golint.sh
@@ -17,6 +17,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:ro,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
-    registry.hub.docker.com/library/golang:1.15.3 \
+    registry.hub.docker.com/library/golang:1.16 \
     /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/gofmt.sh
 fi;

--- a/hack/govet.sh
+++ b/hack/govet.sh
@@ -17,6 +17,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:ro,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
-    registry.hub.docker.com/library/golang:1.15.3 \
+    registry.hub.docker.com/library/golang:1.16 \
     /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/govet.sh
 fi;


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump the Golang version to [1.16](https://blog.golang.org/go1.16)