### PR TITLE
🐛 Fixes missing copyright header

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds missing copyright header to the `suite_test.go` file.

