### PR TITLE
🌱 Update kind & kubectl & k8s & CAPI versions

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -12,7 +12,7 @@ settings = {
     "deploy_cert_manager": True,
     "preload_images_for_kind": True,
     "kind_cluster_name": "capm3",
-    "capi_version": "v0.3.9",
+    "capi_version": "v0.3.14",
     "cert_manager_version": "v0.16.1",
     "kubernetes_version": "v1.18.8",
     "enable_providers": [],

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 GOPATH_BIN="$(go env GOPATH)/bin/"
-MINIMUM_KIND_VERSION=v0.8.1
+MINIMUM_KIND_VERSION=v0.9.0
 
 # Ensure the kind tool exists and is a viable version, or installs it
 verify_kind_version() {

--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 GOPATH_BIN="$(go env GOPATH)/bin/"
-MINIMUM_KUBECTL_VERSION=v1.15.0
+MINIMUM_KUBECTL_VERSION=v1.19.0
 
 # Ensure the kubectl tool exists and is a viable version, or installs it
 verify_kubectl_version() {

--- a/hack/fetch_ext_bins.sh
+++ b/hack/fetch_ext_bins.sh
@@ -26,7 +26,7 @@ if [[ -n "${TRACE}" ]]; then
   set -x
 fi
 
-k8s_version=1.16.4
+k8s_version=1.19.2
 goarch=amd64
 goos="unknown"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates:

- kind version to [v0.9.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0) to align with [CAPI](https://github.com/kubernetes-sigs/cluster-api/blob/master/hack/ensure-kind.sh)
- kubectl version to [v1.19.0](https://github.com/kubernetes/kubectl/releases/tag/v0.19.0) to align with [CAPI](https://github.com/kubernetes-sigs/cluster-api/blob/master/hack/ensure-kubectl.sh)
- k8s version to [1.19.2](https://github.com/kubernetes/kubernetes/releases/tag/v1.19.2) to align with [CAPI](https://github.com/kubernetes-sigs/cluster-api/blob/master/scripts/fetch_ext_bins.sh)
- CAPI version in Tiltfile