### PR TITLE
🌱 Use errors.Errorf() instead of fmt.Errorf()

### DIFF
--- a/api/v1alpha3/metal3cluster_types.go
+++ b/api/v1alpha3/metal3cluster_types.go
@@ -17,8 +17,7 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 )
@@ -49,7 +48,7 @@ func (s *Metal3ClusterSpec) IsValid() error {
 	}
 
 	if len(missing) > 0 {
-		return fmt.Errorf("Missing fields from Spec: %v", missing)
+		return errors.Errorf("Missing fields from Spec: %v", missing)
 	}
 	return nil
 }

--- a/api/v1alpha3/metal3machine_types.go
+++ b/api/v1alpha3/metal3machine_types.go
@@ -17,8 +17,7 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
@@ -63,7 +62,7 @@ func (s *Metal3MachineSpec) IsValid() error {
 		missing = append(missing, "Image.Checksum")
 	}
 	if len(missing) > 0 {
-		return fmt.Errorf("Missing fields from ProviderSpec: %v", missing)
+		return errors.Errorf("Missing fields from ProviderSpec: %v", missing)
 	}
 	return nil
 }

--- a/api/v1alpha4/metal3cluster_types.go
+++ b/api/v1alpha4/metal3cluster_types.go
@@ -17,8 +17,7 @@ limitations under the License.
 package v1alpha4
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 )
@@ -49,7 +48,7 @@ func (s *Metal3ClusterSpec) IsValid() error {
 	}
 
 	if len(missing) > 0 {
-		return fmt.Errorf("Missing fields from Spec: %v", missing)
+		return errors.Errorf("Missing fields from Spec: %v", missing)
 	}
 	return nil
 }

--- a/api/v1alpha4/metal3machine_types.go
+++ b/api/v1alpha4/metal3machine_types.go
@@ -17,8 +17,7 @@ limitations under the License.
 package v1alpha4
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
@@ -76,7 +75,7 @@ func (s *Metal3MachineSpec) IsValid() error {
 		missing = append(missing, "Image.Checksum")
 	}
 	if len(missing) > 0 {
-		return fmt.Errorf("Missing fields from ProviderSpec: %v", missing)
+		return errors.Errorf("Missing fields from ProviderSpec: %v", missing)
 	}
 	return nil
 }

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -615,7 +615,7 @@ func (m *MachineManager) Update(ctx context.Context) error {
 		return err
 	}
 	if host == nil {
-		return fmt.Errorf("host not found for machine %s", m.Machine.Name)
+		return errors.Errorf("host not found for machine %s", m.Machine.Name)
 	}
 
 	if err := m.WaitForM3Metadata(ctx); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Replaces `fmt.Errorf()` with  `errors.Errorf()` for the sake of handling errors consistently.
