### PR TITLE
🌱 Set the UserAgent to "cluster-api-provider-metal3-manager"

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,7 +79,9 @@ func main() {
 
 	ctrl.SetLogger(klogr.New())
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	restConfig := ctrl.GetConfigOrDie()
+	restConfig.UserAgent = "cluster-api-provider-metal3-manager"
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                 myscheme,
 		MetricsBindAddress:     metricsAddr,
 		LeaderElection:         enableLeaderElection,


### PR DESCRIPTION
**What this PR does / why we need it**:
Set the UserAgent to "cluster-api-provider-metal3-manager".
This string is used to identify actors within a Kubernetes system; for instance, it appears in managedFields.

Currently, it is set to "manager" (if not set, UserAgent defaults to the name of the binary).

ref: [kubernetes-sigs/cluster-api#4257](https://github.com/kubernetes-sigs/cluster-api/pull/4257). 

/hold until CAPI PR is merged.

Upd: new PR has been proposed as a follow up to 4257 which is [4750](https://github.com/kubernetes-sigs/cluster-api/pull/4750) and merged in CAPI master. 

