### PR TITLE
🌱 Use explicit path for conversion-gen output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,16 @@ export GOPROXY
 export GO111MODULE=on
 
 # Directories.
+# Full directory of where the Makefile resides
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 TOOLS_DIR := hack/tools
 TOOLS_BIN_DIR := $(TOOLS_DIR)/bin
 BIN_DIR := bin
+
+# Set --output-base for conversion-gen if we are not within GOPATH
+ifneq ($(abspath $(ROOT_DIR)),$(shell go env GOPATH)/src/sigs.k8s.io/cluster-api-provider-metal3)
+	CONVERSION_GEN_OUTPUT_BASE := --output-base=$(ROOT_DIR)
+endif
 
 # Binaries.
 CLUSTERCTL := $(BIN_DIR)/clusterctl
@@ -230,7 +237,7 @@ generate-go: $(CONTROLLER_GEN) $(MOCKGEN) $(CONVERSION_GEN) $(KUBEBUILDER) $(KUS
 
 	$(CONVERSION_GEN) \
 		--input-dirs=./api/v1alpha3 \
-		--output-file-base=zz_generated.conversion \
+		--output-file-base=zz_generated.conversion  $(CONVERSION_GEN_OUTPUT_BASE) \
 		--go-header-file=./hack/boilerplate/boilerplate.generatego.txt
 
 .PHONY: generate-manifests


### PR DESCRIPTION
 **What this PR does / why we need it**:
 Make sure that even if someone clones cluster-api-provider-metal3 outside of `GOPATH` is running `make generate` generated files lands in the same place where `make generate` was executed.
This issue was started in CAPI issue: https://github.com/kubernetes-sigs/cluster-api/issues/4185 and was fixed in https://github.com/kubernetes-sigs/cluster-api/pull/4349. This PR is doing the same changes for CAPM3. 
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
