### PR TITLE
🐛 Fix bug that BMH NetworkData and MetaData cleaned on deprovisioning when they should not

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -506,15 +506,15 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 			host.Spec.Image = nil
 			bmhUpdated = true
 		}
-		if host.Spec.UserData != nil {
+		if m.Metal3Machine.Status.UserData != nil && host.Spec.UserData != nil {
 			host.Spec.UserData = nil
 			bmhUpdated = true
 		}
-		if host.Spec.MetaData != nil {
+		if m.Metal3Machine.Status.MetaData != nil && host.Spec.MetaData != nil {
 			host.Spec.MetaData = nil
 			bmhUpdated = true
 		}
-		if host.Spec.NetworkData != nil {
+		if m.Metal3Machine.Status.NetworkData != nil && host.Spec.NetworkData != nil {
 			host.Spec.NetworkData = nil
 			bmhUpdated = true
 		}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #196 
