### PR TITLE
Remove secret generation of ironic CA cert in BMO.

### DIFF
--- a/config/bmo/secrets.yaml
+++ b/config/bmo/secrets.yaml
@@ -1,12 +1,4 @@
 apiVersion: v1
-data:
-  tls.crt: ${IRONIC_CA_CERT_B64:-""}
-kind: Secret
-metadata:
-  name: ironic-cacert
-type: Opaque
----
-apiVersion: v1
 stringData:
   password: ${IRONIC_PASSWORD:-""}
   username: ${IRONIC_USERNAME:-""}


### PR DESCRIPTION
This PR will remove the secret generation of ironic CA certificate in BMO and use the same CA certificate secret name generated by cert-manager in ironic deployment. This PR is needed to able to run the [PR#859](https://github.com/metal3-io/baremetal-operator/pull/859) in BMO.

