### PR TITLE
🌱 Revert Add golint and generate test in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ env:
     - TARGET=markdownlint
     - TARGET=govet
     - TARGET=gofmt
-    - TARGET=golint
-    - TARGET=codegen
 
 script:
 - ./hack/${TARGET}.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
This reverts https://github.com/metal3-io/cluster-api-provider-metal3/pull/192 as Prow cluster is back on track and disables unit & linting test.