### PR TITLE
🌱 Fix example manifests generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ kubeconfig
 bin/*
 hack/tools/bin/*
 examples/_out/*
+examples/envsubst-go
 examples/provider-components/*-components.yaml
 out/*
 

--- a/Makefile
+++ b/Makefile
@@ -334,8 +334,8 @@ deploy: generate-examples
 	kubectl wait --for=condition=Available --timeout=300s -n cert-manager deployment cert-manager-webhook
 	kubectl apply -f examples/_out/provider-components.yaml
 
-deploy-examples:
-	kubectl apply -f ./examples/metal3plane/hosts.yaml
+deploy-examples: generate-examples
+	kubectl apply -f ./examples/_out/metal3plane.yaml
 	kubectl apply -f ./examples/_out/cluster.yaml
 	kubectl apply -f ./examples/_out/machinedeployment.yaml
 	kubectl apply -f ./examples/_out/controlplane.yaml
@@ -344,7 +344,7 @@ delete-examples:
 	kubectl delete -f ./examples/_out/machinedeployment.yaml || true
 	kubectl delete -f ./examples/_out/controlplane.yaml || true
 	kubectl delete -f ./examples/_out/cluster.yaml || true
-	kubectl delete -f ./examples/metal3plane/hosts.yaml || true
+	kubectl delete -f ./examples/_out/metal3plane.yaml || true
 
 
 ## --------------------------------------

--- a/examples/metal3plane/hosts.yaml
+++ b/examples/metal3plane/hosts.yaml
@@ -19,6 +19,7 @@ spec:
     credentialsName: demo-externally-provisioned-secret
 status:
   errorMessage: ""
+  errorCount: 0
   goodCredentials:
     credentials:
       name: demo-externally-provisioned-secret
@@ -93,6 +94,7 @@ spec:
     credentialsName: demo-externally-provisioned-secret
 status:
   errorMessage: ""
+  errorCount: 0
   goodCredentials:
     credentials:
       name: demo-externally-provisioned-secret
@@ -167,6 +169,7 @@ spec:
     credentialsName: demo-externally-provisioned-secret
 status:
   errorMessage: ""
+  errorCount: 0
   goodCredentials:
     credentials:
       name: demo-externally-provisioned-secret
@@ -241,6 +244,7 @@ spec:
     credentialsName: demo-externally-provisioned-secret
 status:
   errorMessage: ""
+  errorCount: 0
   goodCredentials:
     credentials:
       name: demo-externally-provisioned-secret
@@ -315,6 +319,7 @@ spec:
     credentialsName: demo-externally-provisioned-secret
 status:
   errorMessage: ""
+  errorCount: 0
   goodCredentials:
     credentials:
       name: demo-externally-provisioned-secret
@@ -389,6 +394,7 @@ spec:
     credentialsName: demo-externally-provisioned-secret
 status:
   errorMessage: ""
+  errorCount: 0
   goodCredentials:
     credentials:
       name: demo-externally-provisioned-secret
@@ -463,6 +469,7 @@ spec:
     credentialsName: demo-externally-provisioned-secret
 status:
   errorMessage: ""
+  errorCount: 0
   goodCredentials:
     credentials:
       name: demo-externally-provisioned-secret
@@ -537,6 +544,7 @@ spec:
     credentialsName: demo-externally-provisioned-secret
 status:
   errorMessage: ""
+  errorCount: 0
   goodCredentials:
     credentials:
       name: demo-externally-provisioned-secret
@@ -611,6 +619,7 @@ spec:
     credentialsName: demo-externally-provisioned-secret
 status:
   errorMessage: ""
+  errorCount: 0
   goodCredentials:
     credentials:
       name: demo-externally-provisioned-secret
@@ -685,6 +694,7 @@ spec:
     credentialsName: demo-externally-provisioned-secret
 status:
   errorMessage: ""
+  errorCount: 0
   goodCredentials:
     credentials:
       name: demo-externally-provisioned-secret

--- a/examples/provider-components/image_versions_patch.yaml
+++ b/examples/provider-components/image_versions_patch.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-controller-manager
+  namespace: capi-webhook-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          image: gcr.io/k8s-staging-cluster-api/cluster-api-controller:v0.3.16
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-controller-manager
+  namespace: capi-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          image: gcr.io/k8s-staging-cluster-api/cluster-api-controller:v0.3.16
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-kubeadm-bootstrap-controller-manager
+  namespace: capi-webhook-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          image: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:v0.3.16
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-kubeadm-bootstrap-controller-manager
+  namespace: capi-kubeadm-bootstrap-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          image: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:v0.3.16
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-kubeadm-control-plane-controller-manager
+  namespace: capi-kubeadm-control-plane-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          image: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller:v0.3.16
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-kubeadm-control-plane-controller-manager
+  namespace: capi-webhook-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          image: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller:v0.3.16
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-kubeadm-bootstrap-controller-manager
+  namespace: capi-webhook-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          image: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:v0.3.16

--- a/examples/provider-components/kustomization.yaml
+++ b/examples/provider-components/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - infrastructure-components.yaml
 patchesStrategicMerge:
 - manager_tolerations_patch.yaml
+- image_versions_patch.yaml

--- a/hack/ensure-kustomize.sh
+++ b/hack/ensure-kustomize.sh
@@ -31,7 +31,7 @@ verify_kustomize_version() {
       if ! [ -d "${GOPATH_BIN}" ]; then
         mkdir -p "${GOPATH_BIN}"
       fi
-      curl -sLo "${GOPATH_BIN}/kustomize" https://github.com/kubernetes-sigs/kustomize/releases/download/${MINIMUM_KUSTOMIZE_VERSION}/kustomize_${MINIMUM_KUSTOMIZE_VERSION}_linux_amd64
+      curl --fail -SsL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${MINIMUM_KUSTOMIZE_VERSION}/kustomize_${MINIMUM_KUSTOMIZE_VERSION}_linux_amd64.tar.gz | tar -xz -C "${GOPATH_BIN}"
       chmod +x "${GOPATH_BIN}/kustomize"
     else
       echo "Missing required binary in path: kustomize"


### PR DESCRIPTION
**What this PR does / why we need it**:
- fixes the `examples/generate.sh` script to successfully generate example manifests. It also pins the versions of images used in example manifests to avoid breaking compatibility with the manifests.
- updates `ensure-kustomize.sh` to use an up-to-date URL for downloading kustomize

This allows generating examples and running `make deploy`, which is a step in a good direction. There is still an issue with `capm3-baremetal-operator-controller-manager` not receiving basic auth credentials, which will be addressed in a future PR.

I will squash the commits after review.