### PR TITLE
🌱 utils/IsPuased is deprecated, instead use util/annotations/IsPaused

### DIFF
--- a/controllers/metal3cluster_controller.go
+++ b/controllers/metal3cluster_controller.go
@@ -30,6 +30,7 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -100,7 +101,7 @@ func (r *Metal3ClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 	clusterLog = clusterLog.WithValues("cluster", cluster.Name)
 
 	// Return early if BMCluster or Cluster is paused.
-	if util.IsPaused(cluster, metal3Cluster) {
+	if annotations.IsPaused(cluster, metal3Cluster) {
 		clusterLog.Info("reconciliation is paused for this object")
 		return ctrl.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
 	}

--- a/controllers/metal3data_controller.go
+++ b/controllers/metal3data_controller.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -96,7 +97,7 @@ func (r *Metal3DataReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, rerr 
 		metadataLog = metadataLog.WithValues("cluster", cluster.Name)
 
 		// Return early if the Metadata or Cluster is paused.
-		if util.IsPaused(cluster, capm3Metadata) {
+		if annotations.IsPaused(cluster, capm3Metadata) {
 			metadataLog.Info("reconciliation is paused for this object")
 			return ctrl.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
 		}

--- a/controllers/metal3datatemplate_controller.go
+++ b/controllers/metal3datatemplate_controller.go
@@ -26,7 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
-	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -113,7 +113,7 @@ func (r *Metal3DataTemplateReconciler) Reconcile(req ctrl.Request) (_ ctrl.Resul
 			return ctrl.Result{}, err
 		}
 		// Return early if the Metadata or Cluster is paused.
-		if util.IsPaused(cluster, capm3DataTemplate) {
+		if annotations.IsPaused(cluster, capm3DataTemplate) {
 			metadataLog.Info("reconciliation is paused for this object")
 			return ctrl.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
 		}

--- a/controllers/metal3labelsync_controller.go
+++ b/controllers/metal3labelsync_controller.go
@@ -36,6 +36,7 @@ import (
 	k8strings "k8s.io/utils/strings"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -167,7 +168,7 @@ func (r *Metal3LabelSyncReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, 
 	}
 	controllerLog.V(5).Info(fmt.Sprintf("Found Metal3Cluster %v/%v", metal3Cluster.Name, metal3Cluster.Namespace))
 
-	if util.IsPaused(cluster, metal3Cluster) {
+	if annotations.IsPaused(cluster, metal3Cluster) {
 		controllerLog.Info("Cluster and/or Metal3Cluster are currently paused. Remove pause to continue reconciliation.")
 		return ctrl.Result{RequeueAfter: bmhSyncInterval}, nil
 	}

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -32,6 +32,7 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -174,7 +175,7 @@ func (r *Metal3MachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 	}
 
 	// Return early if the M3Machine or Cluster is paused.
-	if util.IsPaused(cluster, capm3Machine) {
+	if annotations.IsPaused(cluster, capm3Machine) {
 		machineLog.Info("reconciliation is paused for this object")
 		return ctrl.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
utils/`IsPuased()`helper function is deprecated and moved to [util/annotations/IsPaused](https://github.com/kubernetes-sigs/cluster-api/blob/v0.3.7-rc.1/util/annotations/paused.go#L25). This patch updates the references to that helper func.
