### PR TITLE
:seedling: Uplift kube-rbac-proxy to v0.8.0

### DIFF
--- a/config/manager/manager_auth_proxy_patch.yaml
+++ b/config/manager/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
Taking in changes as CAPI release-0.3 https://github.com/kubernetes-sigs/cluster-api/pull/4639