### PR TITLE
🌱 Update go mod and image patch kustomization for the IPAM

### DIFF
--- a/config/ipam/image_patch.yaml
+++ b/config/ipam/image_patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: quay.io/metal3-io/ip-address-manager:v0.0.5
+      - image: quay.io/metal3-io/ip-address-manager:v0.0.6
         name: manager
 ---
 apiVersion: apps/v1
@@ -21,5 +21,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: quay.io/metal3-io/ip-address-manager:v0.0.5
+      - image: quay.io/metal3-io/ip-address-manager:v0.0.6
         name: manager

--- a/config/ipam/kustomization.yaml
+++ b/config/ipam/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 # When updating the release, update also the image tag in image_patch.yaml
 resources:
-- https://github.com/metal3-io/ip-address-manager/releases/download/v0.0.5/ipam-components.yaml
+- https://github.com/metal3-io/ip-address-manager/releases/download/v0.0.6/ipam-components.yaml
 
 patchesStrategicMerge:
     - image_patch.yaml

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/googleapis/gnostic v0.5.4 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/metal3-io/baremetal-operator/apis v0.0.0-20210416073321-c927d1d8da76
-	github.com/metal3-io/ip-address-manager v0.0.5
+	github.com/metal3-io/ip-address-manager v0.0.6
 	github.com/onsi/ginkgo v1.16.1
 	github.com/onsi/gomega v1.11.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -435,8 +435,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/metal3-io/baremetal-operator/apis v0.0.0-20210416073321-c927d1d8da76 h1:ozvVlGJWJhbKSRLtS3llaJg3WKSIWYE9UPnbnex4Lo4=
 github.com/metal3-io/baremetal-operator/apis v0.0.0-20210416073321-c927d1d8da76/go.mod h1:b2uTLrpVxUWaXRhQeaONl8jOjPxSjtdmjCNKlgsoGI0=
-github.com/metal3-io/ip-address-manager v0.0.5 h1:MMfZTc/2ZbFHASufYanlbIlRXHMBjnjVWSZPCQXqLYA=
-github.com/metal3-io/ip-address-manager v0.0.5/go.mod h1:OU3VFLTSv0z0bIKS3imN/ufB9gLFwvN1vQ/U7SAO/dI=
+github.com/metal3-io/ip-address-manager v0.0.6 h1:kTzU02EfEtxmGkICoMUODAQTGU7vJkzr8OpZuqt/5uc=
+github.com/metal3-io/ip-address-manager v0.0.6/go.mod h1:OU3VFLTSv0z0bIKS3imN/ufB9gLFwvN1vQ/U7SAO/dI=
 github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2/go.mod h1:g4cOPxcjV0oFq3qwpjSA30LReKD8AoIfwAY9VvG35NY=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.3/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=


### PR DESCRIPTION
**What this PR does / why we need it**:
IPAM [v0.0.6 release](https://github.com/metal3-io/ip-address-manager/releases/tag/v0.0.6) is out, this patch updates go modules and configuration files accordingly in release-0.4 branch. 
