### PR TITLE
Define makefile target for running ci-e2e.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,14 +97,9 @@ testprereqs: $(KUBEBUILDER) $(KUSTOMIZE)
 test: testprereqs fmt lint ## Run tests
 	source ./hack/fetch_ext_bins.sh; fetch_tools; setup_envs; go test -v ./controllers/... ./baremetal/... -coverprofile ./cover.out; cd api; go test -v ./... -coverprofile ./cover.out
 
-.PHONY: test-integration
-test-integration: ## Run integration tests
-	source ./hack/fetch_ext_bins.sh; fetch_tools; setup_envs; go test -v -tags=integration ./test/integration/...
-
 .PHONY: test-e2e
-test-e2e: ## Run e2e tests
-	PULL_POLICY=IfNotPresent $(MAKE) docker-build
-	go test -v -tags=e2e -timeout=1h ./test/e2e/... -args --managerImage $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+test-e2e: ## Run e2e tests with capi e2e testing framework
+	./scripts/ci-e2e.sh
 
 GINKGO_NOCOLOR ?= false
 ARTIFACTS ?= $(ROOT_DIR)/_artifacts
@@ -114,7 +109,7 @@ SKIP_CLEANUP ?= false
 SKIP_CREATE_MGMT_CLUSTER ?= true
 
 .PHONY: e2e-tests
-e2e-tests: ## Run e2e tests with capi e2e testing framework
+e2e-tests: ## This target should be called from scripts/ci-e2e.sh
 	docker pull quay.io/metal3-io/cluster-api-provider-metal3
 	docker pull quay.io/metal3-io/baremetal-operator
 	docker pull quay.io/metal3-io/ip-address-manager

--- a/docs/e2e-test.md
+++ b/docs/e2e-test.md
@@ -16,7 +16,7 @@ This doc gives short instructions how to run e2e tests. For the developing e2e t
 Run e2e tests with
 
 ```sh
-./scripts/ci-e2e.sh
+make test-e2e
 ```
 
 ## Cleanup

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -31,7 +31,7 @@ M3_DEV_ENV_BRANCH=master
 M3_DEV_ENV_PATH="${WORKING_DIR}"/metal3-dev-env
 clone_repo "${M3_DEV_ENV_REPO}" "${M3_DEV_ENV_BRANCH}" "${M3_DEV_ENV_PATH}"
 
-cp "${REPO_ROOT}"/hack/e2e/config_ubuntu.sh ${M3_DEV_ENV_PATH}
+cp "${REPO_ROOT}"/hack/e2e/config_ubuntu.sh "${M3_DEV_ENV_PATH}/config_$(whoami).sh"
 
 pushd ${M3_DEV_ENV_PATH} || exit 1
 make || exit 1

--- a/templates/test/cluster-template-prow-ha.yaml
+++ b/templates/test/cluster-template-prow-ha.yaml
@@ -191,7 +191,7 @@ spec:
   #rolloutStrategy:
   #  rollingUpdate:
   #    maxSurge: 1
-  version: v1.21.0
+  version: v1.21.2
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: Metal3MachineTemplate
@@ -204,10 +204,10 @@ spec:
       dataTemplate:
         name: test1-controlplane-template
       image:
-        checksum: http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.0-raw.img.md5sum
+        checksum: http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.2-raw.img.md5sum
         checksumType: md5
         format: raw
-        url: http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.0-raw.img
+        url: http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.2-raw.img
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: Metal3DataTemplate
@@ -287,7 +287,7 @@ spec:
         kind: Metal3MachineTemplate
         name: test1-workers
       nodeDrainTimeout: 0s
-      version: v1.21.0
+      version: v1.21.2
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: Metal3MachineTemplate
@@ -300,10 +300,10 @@ spec:
       dataTemplate:
         name: test1-workers-template
       image:
-        checksum: http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.0-raw.img.md5sum
+        checksum: http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.2-raw.img.md5sum
         checksumType: md5
         format: raw
-        url: http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.0-raw.img
+        url: http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.2-raw.img
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: Metal3DataTemplate

--- a/templates/test/cluster-template-prow-single-master.yaml
+++ b/templates/test/cluster-template-prow-single-master.yaml
@@ -188,7 +188,7 @@ spec:
       sudo: ALL=(ALL) NOPASSWD:ALL
   nodeDrainTimeout: 0s
   replicas: 1
-  version: v1.21.0
+  version: v1.21.2
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: Metal3MachineTemplate
@@ -201,10 +201,10 @@ spec:
       dataTemplate:
         name: test1-controlplane-template
       image:
-        checksum: http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.0-raw.img.md5sum
+        checksum: http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.2-raw.img.md5sum
         checksumType: md5
         format: raw
-        url: http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.0-raw.img
+        url: http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.2-raw.img
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: Metal3DataTemplate
@@ -284,7 +284,7 @@ spec:
         kind: Metal3MachineTemplate
         name: test1-workers
       nodeDrainTimeout: 0s
-      version: v1.21.0
+      version: v1.21.2
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: Metal3MachineTemplate
@@ -297,10 +297,10 @@ spec:
       dataTemplate:
         name: test1-workers-template
       image:
-        checksum: http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.0-raw.img.md5sum
+        checksum: http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.2-raw.img.md5sum
         checksumType: md5
         format: raw
-        url: http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.0-raw.img
+        url: http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.2-raw.img
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: Metal3DataTemplate

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -18,9 +18,9 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v0.3.12
+      - name: v0.3.17
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.12/core-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.17/core-components.yaml"
         type: "url"
         replacements:
           - old: "imagePullPolicy: Always"
@@ -30,9 +30,9 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-      - name: v0.3.12
+      - name: v0.3.17
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.12/bootstrap-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.17/bootstrap-components.yaml"
         type: "url"
         replacements:
           - old: "imagePullPolicy: Always"
@@ -42,9 +42,9 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-      - name: v0.3.12
+      - name: v0.3.17
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.12/control-plane-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.17/control-plane-components.yaml"
         type: "url"
         replacements:
           - old: "imagePullPolicy: Always"
@@ -54,7 +54,7 @@ providers:
   - name: metal3
     type: InfrastructureProvider
     versions:
-    - name: v0.4.1
+    - name: v0.4.2
       value: "${PWD}/config"
     files:
     - sourcePath: "${PWD}/metadata.yaml"
@@ -65,7 +65,7 @@ providers:
       targetName: "cluster-template-ha.yaml"
 
 variables:
-  KUBERNETES_VERSION: "v1.21.0"
+  KUBERNETES_VERSION: "v1.21.2"
   CNI: "./data/cni/calico/calico.yaml"
 
 intervals:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a Makefile target that calls e2e tests wrapper script. This gives more uniformity to the way we start tests.