### PR TITLE
🌱 Update DockerHub registry path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary on golang image
-FROM registry.hub.docker.com/library/golang:1.16 as builder
+FROM docker.io/golang:1.16 as builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy

--- a/hack/Dockerfile.unit
+++ b/hack/Dockerfile.unit
@@ -1,4 +1,4 @@
-FROM registry.hub.docker.com/library/golang:1.16
+FROM docker.io/golang:1.16
 
 WORKDIR /usr/local/kubebuilder
 COPY /hack/tools /usr/local/kubebuilder/

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -38,6 +38,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:rw,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
-    registry.hub.docker.com/library/golang:1.16 \
+    docker.io/golang:1.16 \
     /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/codegen.sh
 fi;

--- a/hack/gofmt.sh
+++ b/hack/gofmt.sh
@@ -28,6 +28,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:ro,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
-    registry.hub.docker.com/library/golang:1.16 \
+    docker.io/golang:1.16 \
     /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/gofmt.sh
 fi;

--- a/hack/golint.sh
+++ b/hack/golint.sh
@@ -17,6 +17,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:ro,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
-    registry.hub.docker.com/library/golang:1.16 \
+    docker.io/golang:1.16 \
     /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/golint.sh
 fi;

--- a/hack/govet.sh
+++ b/hack/govet.sh
@@ -17,6 +17,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:ro,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
-    registry.hub.docker.com/library/golang:1.16 \
+    docker.io/golang:1.16 \
     /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/govet.sh
 fi;

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -14,6 +14,6 @@ else
     --volume "${PWD}:/workdir:ro,z" \
     --entrypoint sh \
     --workdir /workdir \
-    registry.hub.docker.com/pipelinecomponents/markdownlint:latest \
+    docker.io/pipelinecomponents/markdownlint:latest \
     /workdir/hack/markdownlint.sh "${@}"
 fi;

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -14,6 +14,6 @@ else
     --volume "${PWD}:/workdir:ro,z" \
     --entrypoint sh \
     --workdir /workdir \
-    registry.hub.docker.com/koalaman/shellcheck-alpine:stable \
+    docker.io/koalaman/shellcheck-alpine:stable \
     /workdir/hack/shellcheck.sh "${@}"
 fi;


### PR DESCRIPTION
**What this PR does / why we need it**:

The registry path for DockerHub https://registry.hub.docker.com/v2/ returns a 404. Docker/Podman make a GET request to this path before pulling the image, and they're failing at this step. Whether DockerHub have deprecated or changed the behaviour of their registry is unclear.

Updating the paths to docker.io resolves this issue and allows Docker image pulling once more.
