### PR TITLE
🌱 Drop Jaakko from the OWNERS list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -11,5 +11,4 @@ approvers:
  
 reviewers:
  - fmuyassarov
- - Jaakko-Os
  - jan-est


### PR DESCRIPTION
**What this PR does / why we need it**:
Drop @Jaakko-Os as he is no longer in Metal3 project. Thanks for your work @Jaakko-Os !
