### PR TITLE
✨Update example generation and docs with latest CAPI v1a4 changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,12 +361,9 @@ deploy: generate-examples
 	kubectl wait --for=condition=Available --timeout=300s -n cert-manager deployment cert-manager-cainjector
 	kubectl wait --for=condition=Available --timeout=300s -n cert-manager deployment cert-manager-webhook
 	kubectl apply -f examples/_out/provider-components.yaml
-
-deploy-examples: generate-examples
-	# CRD for baremetalhosts in provider-components.yaml is not compatible
-	# with setting the status explicitly. Recreate it from metal3crds.yaml
-	kubectl delete -f examples/_out/metal3crds.yaml
 	kubectl apply -f examples/_out/metal3crds.yaml
+
+deploy-examples:
 	kubectl apply -f ./examples/_out/metal3plane.yaml
 	kubectl apply -f ./examples/_out/cluster.yaml
 	kubectl apply -f ./examples/_out/machinedeployment.yaml

--- a/config/ipam/image_patch.yaml
+++ b/config/ipam/image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: quay.io/metal3-io/ip-address-manager:latest
+      - image: quay.io/metal3-io/ip-address-manager:v0.1.0
         name: manager

--- a/config/ipam/kustomization.yaml
+++ b/config/ipam/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 # When updating the release, update also the image tag in image_patch.yaml
 resources:
-- https://github.com/metal3-io/ip-address-manager/releases/download/v0.0.6/ipam-components.yaml
+- https://github.com/metal3-io/ip-address-manager/releases/download/v0.1.0/ipam-components.yaml
 
 patchesStrategicMerge:
     - image_patch.yaml

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -302,18 +302,27 @@ instructions on launching a Minikube cluster.
 ### Deploy CAPI and CAPM3
 
 The following command will deploy the controllers from CAPI, CABPK and CAPM3 and
-the requested CRDs.
+the requested CRDs and creates BareMetalHosts custom resources. The provider
+uses the `BareMetalHost` custom resource defined by the `baremetal-operator`.
 
 ```sh
 make deploy
 ```
 
+When a `Metal3Machine` is created, the provider looks for an available
+`BareMetalHost` object to claim and then sets it to be provisioned to fulfill the
+request expressed by the `Metal3Machine`. There’s no requirement to actually run
+the `baremetal-operator` to test the reconciliation logic of the provider.
+
+Refer to the [baremetal-operator developer
+documentation](https://github.com/metal3-io/baremetal-operator/blob/master/docs/dev-setup.md)
+for instructions and tools for creating BareMetalHost objects.
+
 ### Run the Controller locally
 
-You will first need to scale down the controller deployment :
+You will first need to scale down the controller deployment:
 
 ```sh
-kubectl scale -n capm3-system deployment.v1.apps/capm3-baremetal-operator-controller-manager --replicas 0
 kubectl scale -n capm3-system deployment.v1.apps/capm3-controller-manager --replicas 0
 ```
 
@@ -330,14 +339,12 @@ controller is doing. You can also proceed to create/update/delete
 
 ### Deploy an example cluster
 
+Make sure you run `make deploy` and wait until all pods are in `running` state
+before deploying an example cluster with:
+
 ```sh
 make deploy-examples
 ```
-
-If you want to simulate the behavior of the metal3 baremetal operator, change
-`provisioning.state` of BareMetalHost resources to `provisioned` after the
-deployment of examples. Observe how a providerID is assigned to `machine` and
-`metal3machine` resources.
 
 ### Delete the example cluster
 

--- a/examples/cluster/cluster.yaml
+++ b/examples/cluster/cluster.yaml
@@ -1,29 +1,36 @@
 ---
-apiVersion: cluster.x-k8s.io/v1alpha3
+apiVersion: cluster.x-k8s.io/v1alpha4
 kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
 spec:
   clusterNetwork:
     services:
-      cidrBlocks: ["10.96.0.0/12"]
+      cidrBlocks:
+      - 10.96.0.0/12
     pods:
-      cidrBlocks: ["192.168.0.0/16"]
+      cidrBlocks:
+      - 192.168.0.0/18
     serviceDomain: "cluster.local"
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
     kind: Metal3Cluster
     name: ${CLUSTER_NAME}
+    namespace: ${NAMESPACE}
   controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
     kind: KubeadmControlPlane
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     name: ${CLUSTER_NAME}-controlplane
+    namespace: ${NAMESPACE}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
 kind: Metal3Cluster
 metadata:
   name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
 spec:
   controlPlaneEndpoint:
-    host: 192.168.111.249
-    port: 6443
+    host: ${CLUSTER_APIENDPOINT_HOST}
+    port: ${CLUSTER_APIENDPOINT_PORT}
+  noCloudProvider: true

--- a/examples/cluster/kustomizeconfig.yaml
+++ b/examples/cluster/kustomizeconfig.yaml
@@ -1,6 +1,6 @@
 namespace:
 - kind: Cluster
   group: cluster.x-k8s.io
-  version: v1alpha3
+  version: v1alpha4
   path: spec/infrastructureRef/namespace
   create: true

--- a/examples/clusterctl-templates/clusterctl-cluster.yaml
+++ b/examples/clusterctl-templates/clusterctl-cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1alpha3
+apiVersion: cluster.x-k8s.io/v1alpha4
 kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -6,42 +6,51 @@ metadata:
 spec:
   clusterNetwork:
     services:
-      cidrBlocks: [${SERVICE_CIDR}]
+      cidrBlocks:
+      - 10.96.0.0/12
     pods:
-      cidrBlocks: [${POD_CIDR}]
+      cidrBlocks:
+      - 192.168.0.0/18
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
     kind: Metal3Cluster
     name: ${CLUSTER_NAME}
+    namespace: ${NAMESPACE}
   controlPlaneRef:
     kind: KubeadmControlPlane
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
     name: ${CLUSTER_NAME}
+    namespace: ${NAMESPACE}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
 kind: Metal3Cluster
 metadata:
   name: ${CLUSTER_NAME}
   namespace: ${NAMESPACE}
 spec:
   controlPlaneEndpoint:
-    host: ${API_ENDPOINT_HOST}
-    port: ${API_ENDPOINT_PORT}
+    host: ${CLUSTER_APIENDPOINT_HOST}
+    port: ${CLUSTER_APIENDPOINT_PORT}
   noCloudProvider: true
 ---
 kind: KubeadmControlPlane
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
 metadata:
   name: ${CLUSTER_NAME}
   namespace: ${NAMESPACE}
 spec:
   machineTemplate:
-    nodeDrainTimeout: ${NODE_DRAIN_TIMEOUT:-"0s"}
     infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
       kind: Metal3MachineTemplate
-      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
       name: ${CLUSTER_NAME}-controlplane
+      namespace: ${NAMESPACE}
+    nodeDrainTimeout: ${NODE_DRAIN_TIMEOUT:-"0s"}
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   version: ${KUBERNETES_VERSION}
   kubeadmConfigSpec:
     joinConfiguration:
@@ -57,21 +66,25 @@ spec:
           node-labels: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
 ${CTLPLANE_KUBEADM_EXTRA_CONFIG}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
 kind: Metal3MachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-controlplane
   namespace: ${NAMESPACE}
 spec:
+  nodeReuse: false
   template:
     spec:
+      automatedCleaningMode: metadata
+      dataTemplate:
+        name: ${CLUSTER_NAME}-controlplane-template
       image:
-        url: ${IMAGE_URL}
         checksum: ${IMAGE_CHECKSUM}
         checksumType: ${IMAGE_CHECKSUM_TYPE}
         format: ${IMAGE_FORMAT}
+        url: ${IMAGE_URL}
 ---
-apiVersion: cluster.x-k8s.io/v1alpha3
+apiVersion: cluster.x-k8s.io/v1alpha4
 kind: MachineDeployment
 metadata:
   name: ${CLUSTER_NAME}
@@ -98,28 +111,32 @@ spec:
       bootstrap:
         configRef:
           name: ${CLUSTER_NAME}-workers
-          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
           kind: KubeadmConfigTemplate
       infrastructureRef:
         name: ${CLUSTER_NAME}-workers
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
         kind: Metal3MachineTemplate
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
 kind: Metal3MachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-workers
   namespace: ${NAMESPACE}
 spec:
+  nodeReuse: false
   template:
     spec:
+      automatedCleaningMode: metadata
+      dataTemplate:
+        name: ${CLUSTER_NAME}-workers-template
       image:
-        url: ${IMAGE_URL}
         checksum: ${IMAGE_CHECKSUM}
         checksumType: ${IMAGE_CHECKSUM_TYPE}
         format: ${IMAGE_FORMAT}
+        url: ${IMAGE_URL}
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
 kind: KubeadmConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-workers

--- a/examples/controlplane/controlplane.yaml
+++ b/examples/controlplane/controlplane.yaml
@@ -1,5 +1,5 @@
 kind: KubeadmControlPlane
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
 metadata:
   name: ${CLUSTER_NAME}-controlplane
 spec:
@@ -7,10 +7,15 @@ spec:
     nodeDrainTimeout: ${NODE_DRAIN_TIMEOUT:-"0s"}
     infrastructureRef:
       kind: Metal3MachineTemplate
-      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
       name: ${CLUSTER_NAME}-controlplane
+      namespace: ${NAMESPACE}
   replicas: 3
-  version: v1.21.2
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
+  version: ${KUBERNETES_VERSION}
   kubeadmConfigSpec:
     initConfiguration:
       nodeRegistration:
@@ -31,20 +36,24 @@ spec:
         kubeletExtraArgs:
           cloud-provider: baremetal
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
 kind: Metal3MachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-controlplane
 spec:
+  nodeReuse: false
   template:
     spec:
+      automatedCleaningMode: metadata
       image:
-        url: "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2"
-        checksum: "97830b21ed272a3d854615beb54cf004"
+        checksum: ${IMAGE_CHECKSUM}
+        checksumType: ${IMAGE_CHECKSUM_TYPE}
+        format: ${IMAGE_FORMAT}
+        url: ${IMAGE_URL}
       dataTemplate:
         name: ${CLUSTER_NAME}-cp-metadata
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
 kind: Metal3DataTemplate
 metadata:
   name: ${CLUSTER_NAME}-cp-metadata

--- a/examples/controlplane/kustomizeconfig.yaml
+++ b/examples/controlplane/kustomizeconfig.yaml
@@ -1,12 +1,12 @@
 namespace:
 - kind: Machine
   group: cluster.x-k8s.io
-  version: v1alpha3
+  version: v1alpha4
   path: spec/infrastructureRef/namespace
   create: true
 - kind: Machine
   group: cluster.x-k8s.io
-  version: v1alpha3
+  version: v1alpha4
   path: spec/bootstrap/configRef/namespace
   create: true
 

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -24,7 +24,13 @@ KUSTOMIZE="${SOURCE_DIR}/../hack/tools/bin/kustomize"
 
 # Cluster.
 export CLUSTER_NAME="${CLUSTER_NAME:-test1}"
-export KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.16.0}"
+export KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.21.2}"
+export CLUSTER_APIENDPOINT_HOST="${CLUSTER_APIENDPOINT_HOST:-192.168.111.249}"
+export CLUSTER_APIENDPOINT_PORT="${CLUSTER_APIENDPOINT_PORT:-6443}"
+export IMAGE_URL="${IMAGE_URL:-http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.2-raw.img}"
+export IMAGE_CHECKSUM="${IMAGE_CHECKSUM:-http://172.22.0.1/images/UBUNTU_20.04_NODE_IMAGE_K8S_v1.21.2-raw.img.md5sum}"
+export IMAGE_CHECKSUM_TYPE="${IMAGE_CHECKSUM_TYPE:-md5}"
+export IMAGE_FORMAT="${IMAGE_FORMAT:-raw}"
 
 # Machine settings.
 export CONTROL_PLANE_MACHINE_TYPE="${CONTROL_PLANE_MACHINE_TYPE:-t2.medium}"
@@ -121,19 +127,19 @@ curl --fail -Ss -L -o "${COMPONENTS_CERT_MANAGER_GENERATED_FILE}" https://github
 echo "Downloaded ${COMPONENTS_CERT_MANAGER_GENERATED_FILE}"
 
 # Generate Cluster API provider components file.
-"$KUSTOMIZE" build "github.com/kubernetes-sigs/cluster-api/config/?ref=release-0.3" | "$ENVSUBST" > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
+"$KUSTOMIZE" build "github.com/kubernetes-sigs/cluster-api/config/default/?ref=master" | "$ENVSUBST" > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
 echo "Generated ${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
 
 # Generate Kubeadm Bootstrap Provider components file.
-"$KUSTOMIZE" build "github.com/kubernetes-sigs/cluster-api/bootstrap/kubeadm/config/?ref=release-0.3" | "$ENVSUBST" > "${COMPONENTS_KUBEADM_GENERATED_FILE}"
+"$KUSTOMIZE" build "github.com/kubernetes-sigs/cluster-api/bootstrap/kubeadm/config/default/?ref=master" | "$ENVSUBST" > "${COMPONENTS_KUBEADM_GENERATED_FILE}"
 echo "Generated ${COMPONENTS_KUBEADM_GENERATED_FILE}"
 
 # Generate Kubeadm Controlplane components file.
-"$KUSTOMIZE" build "github.com/kubernetes-sigs/cluster-api/controlplane/kubeadm/config/?ref=release-0.3" | "$ENVSUBST" > "${COMPONENTS_CTRLPLANE_GENERATED_FILE}"
+"$KUSTOMIZE" build "github.com/kubernetes-sigs/cluster-api/controlplane/kubeadm/config/default/?ref=master" | "$ENVSUBST" > "${COMPONENTS_CTRLPLANE_GENERATED_FILE}"
 echo "Generated ${COMPONENTS_CTRLPLANE_GENERATED_FILE}"
 
 # Generate METAL3 Infrastructure Provider components file.
-"$KUSTOMIZE" build "${SOURCE_DIR}/../config" | "$ENVSUBST" > "${COMPONENTS_METAL3_GENERATED_FILE}"
+"$KUSTOMIZE" build "${SOURCE_DIR}/../config/default" | "$ENVSUBST" > "${COMPONENTS_METAL3_GENERATED_FILE}"
 echo "Generated ${COMPONENTS_METAL3_GENERATED_FILE}"
 
 # Generate a single provider components file.

--- a/examples/machinedeployment/kustomizeconfig.yaml
+++ b/examples/machinedeployment/kustomizeconfig.yaml
@@ -1,11 +1,11 @@
 namespace:
 - kind: MachineDeployment
   group: cluster.x-k8s.io
-  version: v1alpha3
+  version: v1alpha4
   path: spec/template/spec/infrastructureRef/namespace
   create: true
 - kind: MachineDeployment
   group: cluster.x-k8s.io
-  version: v1alpha3
+  version: v1alpha4
   path: spec/template/spec/bootstrap/configRef/namespace
   create: true

--- a/examples/machinedeployment/machinedeployment.yaml
+++ b/examples/machinedeployment/machinedeployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1alpha3
+apiVersion: cluster.x-k8s.io/v1alpha4
 kind: MachineDeployment
 metadata:
   name: ${CLUSTER_NAME}-md-0
@@ -24,27 +24,31 @@ spec:
       bootstrap:
         configRef:
           name: ${CLUSTER_NAME}-md-0
-          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
           kind: KubeadmConfigTemplate
       infrastructureRef:
         name: ${CLUSTER_NAME}-md-0
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
         kind: Metal3MachineTemplate
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
 kind: Metal3MachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
 spec:
+  nodeReuse: false
   template:
     spec:
+      automatedCleaningMode: metadata
       image:
-        url: "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2"
-        checksum: "97830b21ed272a3d854615beb54cf004"
+        checksum: ${IMAGE_CHECKSUM}
+        checksumType: ${IMAGE_CHECKSUM_TYPE}
+        format: ${IMAGE_FORMAT}
+        url: ${IMAGE_URL}
       dataTemplate:
         name: ${CLUSTER_NAME}-md-metadata
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
 kind: Metal3DataTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-metadata
@@ -131,7 +135,7 @@ spec:
       dns:
         - 8.8.8.8
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
 kind: KubeadmConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0

--- a/examples/metal3plane/hosts.yaml
+++ b/examples/metal3plane/hosts.yaml
@@ -13,10 +13,12 @@ kind: BareMetalHost
 metadata:
   name: metal3-0
 spec:
-  online: false
+  automatedCleaningMode: metadata
+  online: true
   bmc:
     address: ipmi://192.168.122.10:6233
     credentialsName: demo-externally-provisioned-secret
+  bootMode: legacy
 status:
   errorMessage: ""
   errorCount: 0
@@ -24,7 +26,7 @@ status:
     credentials:
       name: demo-externally-provisioned-secret
       namespace: default
-    credentialsVersion: "879"
+    credentialsVersion: "879" 
   hardware:
     cpu:
       arch: x86_64
@@ -46,12 +48,13 @@ status:
       rotational: true
       serialNumber: drive-scsi0-0-0-0
       sizeBytes: 53687091200
+      type: HDD
       vendor: QEMU
     systemVendor:
       manufacturer: QEMU
       productName: Standard PC (Q35 + ICH9, 2009)
       serialNumber: ""
-    hostname: master-0
+    hostname: metal3-0
     nics:
     - ip: 172.22.0.11
       mac: 00:28:19:1f:79:4d
@@ -70,7 +73,7 @@ status:
   hardwareProfile: unknown
   operationalStatus: OK
   operationHistory: {}
-  poweredOn: false
+  poweredOn: true
   triedCredentials:
     credentials:
       name: demo-externally-provisioned-secret
@@ -78,9 +81,12 @@ status:
     credentialsVersion: "879"
   provisioning:
     ID: be02cfb3-7b24-47c7-b9b8-d69207d86f1e
+    bootMode: legacy
     image:
       checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
       url: http://172.22.0.1/images/centos-updated.qcow2
+    rootDeviceHints:
+      deviceName: /dev/sda
     state: ready
 ---
 apiVersion: metal3.io/v1alpha1
@@ -88,10 +94,12 @@ kind: BareMetalHost
 metadata:
   name: metal3-1
 spec:
-  online: false
+  automatedCleaningMode: metadata
+  online: true
   bmc:
-    address: ipmi://192.168.122.11:6233
+    address: redfish+http://192.168.111.1:8000/redfish/v1/Systems/0a2e3d8c-e230-4511-845a-ccb12e0b71f4
     credentialsName: demo-externally-provisioned-secret
+  bootMode: legacy
 status:
   errorMessage: ""
   errorCount: 0
@@ -121,12 +129,13 @@ status:
       rotational: true
       serialNumber: drive-scsi0-0-0-0
       sizeBytes: 53687091200
+      type: HDD
       vendor: QEMU
     systemVendor:
       manufacturer: QEMU
       productName: Standard PC (Q35 + ICH9, 2009)
       serialNumber: ""
-    hostname: master-0
+    hostname: metal3-1
     nics:
     - ip: 172.22.0.11
       mac: 00:28:19:1f:79:4d
@@ -145,7 +154,7 @@ status:
   hardwareProfile: unknown
   operationalStatus: OK
   operationHistory: {}
-  poweredOn: false
+  poweredOn: true
   triedCredentials:
     credentials:
       name: demo-externally-provisioned-secret
@@ -153,9 +162,12 @@ status:
     credentialsVersion: "879"
   provisioning:
     ID: be02cfb3-7b24-47c7-b9b8-d69207d86f10
+    bootMode: legacy
     image:
       checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
       url: http://172.22.0.1/images/centos-updated.qcow2
+    rootDeviceHints:
+      deviceName: /dev/sda  
     state: ready
 ---
 apiVersion: metal3.io/v1alpha1
@@ -163,10 +175,12 @@ kind: BareMetalHost
 metadata:
   name: metal3-2
 spec:
-  online: false
+  automatedCleaningMode: metadata
+  online: true
   bmc:
     address: ipmi://192.168.122.12:6233
     credentialsName: demo-externally-provisioned-secret
+  bootMode: legacy
 status:
   errorMessage: ""
   errorCount: 0
@@ -196,12 +210,13 @@ status:
       rotational: true
       serialNumber: drive-scsi0-0-0-0
       sizeBytes: 53687091200
+      type: HDD
       vendor: QEMU
     systemVendor:
       manufacturer: QEMU
       productName: Standard PC (Q35 + ICH9, 2009)
       serialNumber: ""
-    hostname: master-0
+    hostname: metal3-2
     nics:
     - ip: 172.22.0.11
       mac: 00:28:19:1f:79:4d
@@ -220,7 +235,7 @@ status:
   hardwareProfile: unknown
   operationalStatus: OK
   operationHistory: {}
-  poweredOn: false
+  poweredOn: true
   triedCredentials:
     credentials:
       name: demo-externally-provisioned-secret
@@ -228,9 +243,12 @@ status:
     credentialsVersion: "879"
   provisioning:
     ID: be02cfb3-7b24-47c7-b9b8-d69207d86f11
+    bootMode: legacy
     image:
       checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
       url: http://172.22.0.1/images/centos-updated.qcow2
+    rootDeviceHints:
+      deviceName: /dev/sda
     state: ready
 ---
 apiVersion: metal3.io/v1alpha1
@@ -238,10 +256,12 @@ kind: BareMetalHost
 metadata:
   name: metal3-3
 spec:
-  online: false
+  automatedCleaningMode: metadata
+  online: true
   bmc:
     address: ipmi://192.168.122.13:6233
     credentialsName: demo-externally-provisioned-secret
+  bootMode: legacy
 status:
   errorMessage: ""
   errorCount: 0
@@ -271,12 +291,13 @@ status:
       rotational: true
       serialNumber: drive-scsi0-0-0-0
       sizeBytes: 53687091200
+      type: HDD
       vendor: QEMU
     systemVendor:
       manufacturer: QEMU
       productName: Standard PC (Q35 + ICH9, 2009)
       serialNumber: ""
-    hostname: master-0
+    hostname: metal3-3
     nics:
     - ip: 172.22.0.11
       mac: 00:28:19:1f:79:4d
@@ -295,7 +316,7 @@ status:
   hardwareProfile: unknown
   operationalStatus: OK
   operationHistory: {}
-  poweredOn: false
+  poweredOn: true
   triedCredentials:
     credentials:
       name: demo-externally-provisioned-secret
@@ -303,9 +324,12 @@ status:
     credentialsVersion: "879"
   provisioning:
     ID: be02cfb3-7b24-47c7-b9b8-d69207d86f12
+    bootMode: legacy
     image:
       checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
       url: http://172.22.0.1/images/centos-updated.qcow2
+    rootDeviceHints:
+      deviceName: /dev/sda
     state: ready
 ---
 apiVersion: metal3.io/v1alpha1
@@ -313,10 +337,12 @@ kind: BareMetalHost
 metadata:
   name: metal3-4
 spec:
-  online: false
+  automatedCleaningMode: metadata
+  online: true
   bmc:
     address: ipmi://192.168.122.14:6233
     credentialsName: demo-externally-provisioned-secret
+  bootMode: legacy
 status:
   errorMessage: ""
   errorCount: 0
@@ -346,12 +372,13 @@ status:
       rotational: true
       serialNumber: drive-scsi0-0-0-0
       sizeBytes: 53687091200
+      type: HDD
       vendor: QEMU
     systemVendor:
       manufacturer: QEMU
       productName: Standard PC (Q35 + ICH9, 2009)
       serialNumber: ""
-    hostname: master-0
+    hostname: metal3-4
     nics:
     - ip: 172.22.0.11
       mac: 00:28:19:1f:79:4d
@@ -370,7 +397,7 @@ status:
   hardwareProfile: unknown
   operationalStatus: OK
   operationHistory: {}
-  poweredOn: false
+  poweredOn: true
   triedCredentials:
     credentials:
       name: demo-externally-provisioned-secret
@@ -378,9 +405,12 @@ status:
     credentialsVersion: "879"
   provisioning:
     ID: be02cfb3-7b24-47c7-b9b8-d69207d86f13
+    bootMode: legacy
     image:
       checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
       url: http://172.22.0.1/images/centos-updated.qcow2
+    rootDeviceHints:
+      deviceName: /dev/sda
     state: ready
 ---
 apiVersion: metal3.io/v1alpha1
@@ -388,10 +418,12 @@ kind: BareMetalHost
 metadata:
   name: metal3-5
 spec:
-  online: false
+  automatedCleaningMode: metadata
+  online: true
   bmc:
     address: ipmi://192.168.122.15:6233
     credentialsName: demo-externally-provisioned-secret
+  bootMode: legacy
 status:
   errorMessage: ""
   errorCount: 0
@@ -421,12 +453,13 @@ status:
       rotational: true
       serialNumber: drive-scsi0-0-0-0
       sizeBytes: 53687091200
+      type: HDD
       vendor: QEMU
     systemVendor:
       manufacturer: QEMU
       productName: Standard PC (Q35 + ICH9, 2009)
       serialNumber: ""
-    hostname: master-0
+    hostname: metal3-5
     nics:
     - ip: 172.22.0.11
       mac: 00:28:19:1f:79:4d
@@ -445,7 +478,7 @@ status:
   hardwareProfile: unknown
   operationalStatus: OK
   operationHistory: {}
-  poweredOn: false
+  poweredOn: true
   triedCredentials:
     credentials:
       name: demo-externally-provisioned-secret
@@ -453,9 +486,12 @@ status:
     credentialsVersion: "879"
   provisioning:
     ID: be02cfb3-7b24-47c7-b9b8-d69207d86f14
+    bootMode: legacy
     image:
       checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
       url: http://172.22.0.1/images/centos-updated.qcow2
+    rootDeviceHints:
+      deviceName: /dev/sda
     state: ready
 ---
 apiVersion: metal3.io/v1alpha1
@@ -463,10 +499,12 @@ kind: BareMetalHost
 metadata:
   name: metal3-6
 spec:
-  online: false
+  automatedCleaningMode: metadata
+  online: true
   bmc:
-    address: ipmi://192.168.122.16:6233
+    address: redfish+http://192.168.111.1:8000/redfish/v1/Systems/0a2e3d8c-e230-4511-845a-ccb12e0b71f5
     credentialsName: demo-externally-provisioned-secret
+  bootMode: legacy
 status:
   errorMessage: ""
   errorCount: 0
@@ -496,12 +534,13 @@ status:
       rotational: true
       serialNumber: drive-scsi0-0-0-0
       sizeBytes: 53687091200
+      type: HDD
       vendor: QEMU
     systemVendor:
       manufacturer: QEMU
       productName: Standard PC (Q35 + ICH9, 2009)
       serialNumber: ""
-    hostname: master-0
+    hostname: metal3-6
     nics:
     - ip: 172.22.0.11
       mac: 00:28:19:1f:79:4d
@@ -520,7 +559,7 @@ status:
   hardwareProfile: unknown
   operationalStatus: OK
   operationHistory: {}
-  poweredOn: false
+  poweredOn: true
   triedCredentials:
     credentials:
       name: demo-externally-provisioned-secret
@@ -528,9 +567,12 @@ status:
     credentialsVersion: "879"
   provisioning:
     ID: be02cfb3-7b24-47c7-b9b8-d69207d86f15
+    bootMode: legacy
     image:
       checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
       url: http://172.22.0.1/images/centos-updated.qcow2
+    rootDeviceHints:
+      deviceName: /dev/sda 
     state: ready
 ---
 apiVersion: metal3.io/v1alpha1
@@ -538,10 +580,12 @@ kind: BareMetalHost
 metadata:
   name: metal3-7
 spec:
-  online: false
+  automatedCleaningMode: metadata
+  online: true
   bmc:
     address: ipmi://192.168.122.17:6233
     credentialsName: demo-externally-provisioned-secret
+  bootMode: legacy
 status:
   errorMessage: ""
   errorCount: 0
@@ -571,12 +615,13 @@ status:
       rotational: true
       serialNumber: drive-scsi0-0-0-0
       sizeBytes: 53687091200
+      type: HDD
       vendor: QEMU
     systemVendor:
       manufacturer: QEMU
       productName: Standard PC (Q35 + ICH9, 2009)
       serialNumber: ""
-    hostname: master-0
+    hostname: metal3-7
     nics:
     - ip: 172.22.0.11
       mac: 00:28:19:1f:79:4d
@@ -595,7 +640,7 @@ status:
   hardwareProfile: unknown
   operationalStatus: OK
   operationHistory: {}
-  poweredOn: false
+  poweredOn: true
   triedCredentials:
     credentials:
       name: demo-externally-provisioned-secret
@@ -603,9 +648,12 @@ status:
     credentialsVersion: "879"
   provisioning:
     ID: be02cfb3-7b24-47c7-b9b8-d69207d86f16
+    bootMode: legacy
     image:
       checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
       url: http://172.22.0.1/images/centos-updated.qcow2
+    rootDeviceHints:
+      deviceName: /dev/sda
     state: ready
 ---
 apiVersion: metal3.io/v1alpha1
@@ -613,10 +661,12 @@ kind: BareMetalHost
 metadata:
   name: metal3-8
 spec:
-  online: false
+  automatedCleaningMode: metadata
+  online: true
   bmc:
     address: ipmi://192.168.122.18:6233
     credentialsName: demo-externally-provisioned-secret
+  bootMode: legacy
 status:
   errorMessage: ""
   errorCount: 0
@@ -646,12 +696,13 @@ status:
       rotational: true
       serialNumber: drive-scsi0-0-0-0
       sizeBytes: 53687091200
+      type: HDD
       vendor: QEMU
     systemVendor:
       manufacturer: QEMU
       productName: Standard PC (Q35 + ICH9, 2009)
       serialNumber: ""
-    hostname: master-0
+    hostname: metal3-8
     nics:
     - ip: 172.22.0.11
       mac: 00:28:19:1f:79:4d
@@ -670,7 +721,7 @@ status:
   hardwareProfile: unknown
   operationalStatus: OK
   operationHistory: {}
-  poweredOn: false
+  poweredOn: true
   triedCredentials:
     credentials:
       name: demo-externally-provisioned-secret
@@ -678,9 +729,12 @@ status:
     credentialsVersion: "879"
   provisioning:
     ID: be02cfb3-7b24-47c7-b9b8-d69207d86f17
+    bootMode: legacy
     image:
       checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
       url: http://172.22.0.1/images/centos-updated.qcow2
+    rootDeviceHints:
+      deviceName: /dev/sda
     state: ready
 ---
 apiVersion: metal3.io/v1alpha1
@@ -688,10 +742,12 @@ kind: BareMetalHost
 metadata:
   name: metal3-9
 spec:
-  online: false
+  automatedCleaningMode: metadata
+  online: true
   bmc:
     address: ipmi://192.168.122.19:6233
     credentialsName: demo-externally-provisioned-secret
+  bootMode: legacy
 status:
   errorMessage: ""
   errorCount: 0
@@ -721,12 +777,13 @@ status:
       rotational: true
       serialNumber: drive-scsi0-0-0-0
       sizeBytes: 53687091200
+      type: HDD
       vendor: QEMU
     systemVendor:
       manufacturer: QEMU
       productName: Standard PC (Q35 + ICH9, 2009)
       serialNumber: ""
-    hostname: master-0
+    hostname: metal3-9
     nics:
     - ip: 172.22.0.11
       mac: 00:28:19:1f:79:4d
@@ -745,7 +802,7 @@ status:
   hardwareProfile: unknown
   operationalStatus: OK
   operationHistory: {}
-  poweredOn: false
+  poweredOn: true
   triedCredentials:
     credentials:
       name: demo-externally-provisioned-secret
@@ -753,7 +810,10 @@ status:
     credentialsVersion: "879"
   provisioning:
     ID: be02cfb3-7b24-47c7-b9b8-d69207d86f18
+    bootMode: legacy
     image:
       checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
       url: http://172.22.0.1/images/centos-updated.qcow2
+    rootDeviceHints:
+      deviceName: /dev/sda
     state: ready

--- a/examples/provider-components/image_versions_patch.yaml
+++ b/examples/provider-components/image_versions_patch.yaml
@@ -2,37 +2,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: capi-controller-manager
-  namespace: capi-webhook-system
-spec:
-  template:
-    spec:
-      containers:
-        - name: manager
-          image: gcr.io/k8s-staging-cluster-api/cluster-api-controller:v0.3.16
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: capi-controller-manager
   namespace: capi-system
 spec:
   template:
     spec:
       containers:
         - name: manager
-          image: gcr.io/k8s-staging-cluster-api/cluster-api-controller:v0.3.16
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: capi-kubeadm-bootstrap-controller-manager
-  namespace: capi-webhook-system
-spec:
-  template:
-    spec:
-      containers:
-        - name: manager
-          image: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:v0.3.16
+          image: gcr.io/k8s-staging-cluster-api/cluster-api-controller:master
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -44,7 +20,7 @@ spec:
     spec:
       containers:
         - name: manager
-          image: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:v0.3.16
+          image: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:master
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -56,28 +32,5 @@ spec:
     spec:
       containers:
         - name: manager
-          image: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller:v0.3.16
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: capi-kubeadm-control-plane-controller-manager
-  namespace: capi-webhook-system
-spec:
-  template:
-    spec:
-      containers:
-        - name: manager
-          image: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller:v0.3.16
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: capi-kubeadm-bootstrap-controller-manager
-  namespace: capi-webhook-system
-spec:
-  template:
-    spec:
-      containers:
-        - name: manager
-          image: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:v0.3.16
+          image: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller:master
+

--- a/go.sum
+++ b/go.sum
@@ -44,17 +44,21 @@ github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9mo
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v10.8.1+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
+github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest v0.9.6/go.mod h1:/FALq9T/kS7b5J5qsQ+RSTUdAmGFqi0vUdVNNx8q630=
 github.com/Azure/go-autorest/autorest v0.11.1/go.mod h1:JFgpikqFJ/MleTTxwepExTKnFUKKszPS8UavbQYUMuw=
+github.com/Azure/go-autorest/autorest v0.11.12 h1:gI8ytXbxMfI+IVbI9mP2JGCTXIuhHLgRlvQ9X4PsnHE=
 github.com/Azure/go-autorest/autorest v0.11.12/go.mod h1:eipySxLmqSyC5s5k1CLupqet0PSENBEDP93LQ9a8QYw=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=
 github.com/Azure/go-autorest/autorest/adal v0.8.2/go.mod h1:ZjhuQClTqx435SRJ2iMlOxPYt3d2C/T/7TiQCVZSn3Q=
 github.com/Azure/go-autorest/autorest/adal v0.9.0/go.mod h1:/c022QCutn2P7uY+/oQWWNcK9YU+MH96NgK+jErpbcg=
+github.com/Azure/go-autorest/autorest/adal v0.9.5 h1:Y3bBUV4rTuxenJJs41HU3qmqsb+auo+a3Lz+PlJPpL0=
 github.com/Azure/go-autorest/autorest/adal v0.9.5/go.mod h1:B7KF7jKIeC9Mct5spmyCB/A8CG/sEz1vwIRGv/bbw7A=
 github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=
 github.com/Azure/go-autorest/autorest/date v0.2.0/go.mod h1:vcORJHLJEh643/Ioh9+vPmf1Ij9AEBM5FuBIXLmIy0g=
+github.com/Azure/go-autorest/autorest/date v0.3.0 h1:7gUk1U5M/CQbp9WoqinNzJar+8KY+LPI6wiWrP/myHw=
 github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
 github.com/Azure/go-autorest/autorest/mocks v0.1.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
 github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
@@ -62,8 +66,10 @@ github.com/Azure/go-autorest/autorest/mocks v0.3.0/go.mod h1:a8FDP3DYzQ4RYfVAxAN
 github.com/Azure/go-autorest/autorest/mocks v0.4.0/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
+github.com/Azure/go-autorest/logger v0.2.0 h1:e4RVHVZKC5p6UANLJHkM4OfR1UKZPj8Wt8Pcx+3oqrE=
 github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
+github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -318,9 +324,11 @@ github.com/evanphx/json-patch/v5 v5.2.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2Vvl
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.12.0 h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
+github.com/form3tech-oss/jwt-go v3.2.3+incompatible h1:7ZaBxOI7TMoYBfyA3cQHErNNyAWIKUMIwqxEtgHOs5c=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -511,6 +519,7 @@ github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gosuri/uitable v0.0.4 h1:IG2xLKRvErL3uhY6e1BylFzG+aJiwQviDDTfOKeKTpY=
 github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -606,6 +615,7 @@ github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7
 github.com/markbates/pkger v0.17.1/go.mod h1:0JoVlrol20BSywW79rN3kdFFsE5xYM+rSCQDXbLhiuI=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
@@ -613,6 +623,7 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -629,6 +640,7 @@ github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceT
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
+github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
@@ -638,6 +650,7 @@ github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxd
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
@@ -768,6 +781,7 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
@@ -1458,6 +1472,7 @@ k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAG
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=
 k8s.io/kube-openapi v0.0.0-20210305164622-f622666832c1 h1:bKbnE878105Y2291CtM1YO9XIQJe/QsG2SRx6vxQmDI=
 k8s.io/kube-openapi v0.0.0-20210305164622-f622666832c1/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=
+k8s.io/kubectl v0.21.2 h1:9XPCetvOMDqrIZZXb1Ei+g8t6KrIp9ENJaysQjUuLiE=
 k8s.io/kubectl v0.21.2/go.mod h1:PgeUclpG8VVmmQIl8zpLar3IQEpFc9mrmvlwY3CK1xo=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/metrics v0.21.2/go.mod h1:wzlOINZMCtWq8dR9gHlyaOemmYlOpAoldEIXE82gAhI=


### PR DESCRIPTION
**What this PR does / why we need it**:
This is on top of #167, and will be rebased once 167 is merged. Updates examples/docs folders accordingly to CAPI v1a4 uplift.  
This PR makes sure to run example generation files properly and also updates documentation accordingly to be compatible with the latest CAPI v1a4 API version. 
Upd: rebased on top of 167. 

**Note:** For example generation  changes this PR expects and assumes that we will have a new release of IPAM from the **master** branch that is compatible with CAPI v1a4. This was tested with [ipam-components.yaml](https://github.com/metal3-io/cluster-api-provider-metal3/blob/master/config/ipam/kustomization.yaml#L6) build manually out of IPAM master branch since it is as is pointing to v0.6.0 yaml which is the IPAM release that is not compatible with CAPI v1a4. 
**Upd2.:** new IPAM release out and this PR points to ipam-components.yaml from latest CAPI v1a4 compatible IPAM release v0.1.0. 