### PR TITLE
✨ Add internal logging mechanism for e2e test framework

### DIFF
--- a/test/e2e/internal/log/log.go
+++ b/test/e2e/internal/log/log.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package log implements test framework logging.
+package log
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+)
+
+func Logf(format string, a ...interface{}) {
+	fmt.Fprintf(GinkgoWriter, "INFO: "+format+"\n", a...)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an internal log for the e2e tests. The reason is that we cannot use the [log](https://github.com/kubernetes-sigs/cluster-api/blob/test/v0.4.0/test/framework/internal/log/log.go) from the cluster-api e2e test framework before the package is [internal](https://pkg.go.dev/cmd/go#hdr-Internal_Directories). 

