### PR TITLE
🐛 Add CAPI metadata.yaml to the e2e

### DIFF
--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -22,6 +22,8 @@ providers:
         # Use manifest from source files
         value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPIRELEASE}/core-components.yaml"
         type: "url"
+        files:
+        - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
@@ -34,6 +36,8 @@ providers:
         # Use manifest from source files
         value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPIRELEASE}/bootstrap-components.yaml"
         type: "url"
+        files:
+        - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
@@ -46,6 +50,8 @@ providers:
         # Use manifest from source files
         value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPIRELEASE}/control-plane-components.yaml"
         type: "url"
+        files:
+        - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"

--- a/test/e2e/data/shared/v1alpha4/metadata.yaml
+++ b/test/e2e/data/shared/v1alpha4/metadata.yaml
@@ -1,0 +1,9 @@
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+- major: 0
+  minor: 4
+  contract: v1alpha4
+- major: 0
+  minor: 3
+  contract: v1alpha3  


### PR DESCRIPTION
This PR adds CAPI metadata.yaml to the e2e folder, so the [problem](https://pastebin.com/CKtTspda) with `clusterctl init` can be solved. This `metadata.yaml` differs from the one in the root directory. It documents the release series of cluster-api provider, so it is the file located in the root directory of cluster-api repo. 

```
failed to run clusterctl init
    Unexpected error:
        <*errors.withStack | 0xc001656870>: {
            error: <*errors.withMessage | 0xc0008fb2e0>{
                cause: <*errors.withStack | 0xc001656840>{
                    error: <*errors.withMessage | 0xc0008fb2c0>{
                        cause: <*fs.PathError | 0xc000b8a000>{
                            Op: "stat",
                            Path: "/home/****/tested_repo/_artifacts/repository/cluster-api/v0.4.0/metadata.yaml",
                            Err: <syscall.Errno>0x2,
                        },
                        msg: "failed to read file \"/home/****/tested_repo/_artifacts/repository/cluster-api/v0.4.0/metadata.yaml\" from local release v0.4.0",
                    },
                    stack: [0x193fcc5, 0x193c7d6, 0x194d904, 0x194d1be, 0x1976742, 0x197df55, 0x1a00bfc, 0x1a05aa8, 0x78b123, 0x78ad3c, 0x78a307, 0x790e2f, 0x7904d2, 0x7b90b1, 0x7b8bc7, 0x7b83b7, 0x7baac6, 0x7c8178, 0x7c7e27, 0x19ff3b8, 0x527c2f, 0x4744e1],
                },
                msg: "failed to read \"metadata.yaml\" from the repository for provider \"cluster-api\"",
            },
            stack: [0x193c91d, 0x194d904, 0x194d1be, 0x1976742, 0x197df55, 0x1a00bfc, 0x1a05aa8, 0x78b123, 0x78ad3c, 0x78a307, 0x790e2f, 0x7904d2, 0x7b90b1, 0x7b8bc7, 0x7b83b7, 0x7baac6, 0x7c8178, 0x7c7e27, 0x19ff3b8, 0x527c2f, 0x4744e1],
        }
        failed to read "metadata.yaml" from the repository for provider "cluster-api": failed to read file "/home/****/tested_repo/_artifacts/repository/cluster-api/v0.4.0/metadata.yaml" from local release v0.4.0: stat /home/****/tested_repo/_artifacts/repository/cluster-api/v0.4.0/metadata.yaml: no such file or directory
    occurred
```