### PR TITLE
⚠️  Update IPAM controller image reference

### DIFF
--- a/config/ipam/image_patch.yaml
+++ b/config/ipam/image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: quay.io/metal3-io/ip-address-manager:v0.0.6
+      - image: quay.io/metal3-io/ip-address-manager:latest
         name: manager


### PR DESCRIPTION
Currently, we have two branches to track in both CAPM3 and IPAM.

CAPM3 branches:
- **master** (for CAPI v1a4)
- **release-0.4** (for CAPI v1a3)

IPAM branches:
- **master** (for CAPI v1a4)
- **release-0.0** (for CAPI v1a3)

Currently, in both branches of CAPM3 we are pointing to use IPAM image with the tag of `0.0.6` which is a IPAM controller image used by CAPM3 v1a4/CAPI v1a3 and that needs to be changed, since we have CAPM3 and IPAM v1a4 changes in place.