### PR TITLE
🌱 Don't use v1beta1 APIs of CRD

### DIFF
--- a/examples/metal3crds/metal3.io_baremetalhosts.yaml
+++ b/examples/metal3crds/metal3.io_baremetalhosts.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: baremetalhosts.metal3.io


### PR DESCRIPTION
**What this PR does / why we need it**:
I accidentally noticed that in some places we still rely on soon deprecated API versions of CRD. Don't use v1beta1 APIs of CRD which is going to be deprecated in the next release 1.22 of Kubernetes.

