### PR TITLE
✨ Add BMO inject-ca-from custom patching

### DIFF
--- a/config/bmo/bmo_inject_ca_patch.yaml
+++ b/config/bmo/bmo_inject_ca_patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: "/metadata/annotations/cert-manager.io~1inject-ca-from"
+  value: capm3-system/capm3-baremetal-operator-serving-cert

--- a/config/bmo/bmo_patch_cert_dns.yaml
+++ b/config/bmo/bmo_patch_cert_dns.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: "/spec/dnsNames/0"
+  value: capm3-baremetal-operator-webhook-service.capm3-system.svc

--- a/config/bmo/kustomization.yaml
+++ b/config/bmo/kustomization.yaml
@@ -22,5 +22,26 @@ patchesStrategicMerge:
 - bmo_pull_policy_patch.yaml
 - secret_mount_patch.yaml
 
+patchesJson6902:
+  - target:
+      group: cert-manager.io
+      version: v1
+      kind: Certificate
+      name: baremetal-operator-serving-cert
+      namespace: baremetal-operator-system
+    path: bmo_patch_cert_dns.yaml
+  - target:
+      group: admissionregistration.k8s.io
+      version: v1
+      kind: ValidatingWebhookConfiguration
+      name: baremetal-operator-validating-webhook-configuration
+    path: bmo_inject_ca_patch.yaml
+  - target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: baremetalhosts.metal3.io
+    path: bmo_inject_ca_patch.yaml
+
 configurations:
 - kustomizeconfig.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is backport of https://github.com/metal3-io/cluster-api-provider-metal3/pull/223. This PR is not needed in master because BMO is decoupled from CAPM3 resources. However, this patch is needed in this branch to enable validating webhook of BMO.
