### PR TITLE
🐛 Fix the cloud-init in the centos template

### DIFF
--- a/templates/test/cluster-template-prow-ha-centos.yaml
+++ b/templates/test/cluster-template-prow-ha-centos.yaml
@@ -182,8 +182,8 @@ spec:
         ONBOOT=yes
         USERCTL=no
         BOOTPROTO="static"
-        IPADDR={{ "{{ ds.meta_data.provisioningIP }}" }}
-        PREFIX={{ "{{ ds.meta_data.provisioningCIDR }}" }}
+        IPADDR={{ ds.meta_data.provisioningIP }}
+        PREFIX={{ ds.meta_data.provisioningCIDR }}
       path: /etc/sysconfig/network-scripts/ifcfg-ironicendpoint
       owner: root:root
       permissions: '0644'
@@ -431,8 +431,8 @@ spec:
           ONBOOT=yes
           USERCTL=no
           BOOTPROTO="static"
-          IPADDR={{ "{{ ds.meta_data.provisioningIP }}" }}
-          PREFIX={{ "{{ ds.meta_data.provisioningCIDR }}" }}
+          IPADDR={{ ds.meta_data.provisioningIP }}
+          PREFIX={{ ds.meta_data.provisioningCIDR }}
       - path: /etc/yum.repos.d/kubernetes.repo
         owner: root:root
         permissions: '0644'


### PR DESCRIPTION
This PRs fixes an issue in the Centos cluster template. This issue leads to a networking problem in the Centos target nodes. |The ptoblem is that the `ironicendpoint` bridge doesn't have IP address although it should have it. 