### PR TITLE
Restore the BMO config map and add more logs to the e2e pivoting test

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -16,6 +17,16 @@ import (
 
 func Byf(format string, a ...interface{}) {
 	By(fmt.Sprintf(format, a...))
+}
+
+func Logf(format string, a ...interface{}) {
+	fmt.Fprintf(GinkgoWriter, "INFO: "+format+"\n", a...)
+}
+
+func LogFromFile(logFile string) {
+	data, err := ioutil.ReadFile(logFile)
+	Expect(err).To(BeNil(), "No log file found")
+	Logf(string(data))
 }
 
 func dumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterProxy framework.ClusterProxy, artifactFolder string, namespace string, cluster *clusterv1.Cluster, intervalsGetter func(spec, key string) []interface{}, clusterName, clusterctlLogFolder string, skipCleanup bool) {
@@ -68,8 +79,4 @@ func downloadFile(filepath string, url string) error {
 	// Write the body to file
 	_, err = io.Copy(out, resp.Body)
 	return err
-}
-
-func Logf(format string, a ...interface{}) {
-	fmt.Fprintf(GinkgoWriter, "INFO: "+format+"\n", a...)
 }

--- a/test/e2e/pivoting_test.go
+++ b/test/e2e/pivoting_test.go
@@ -68,6 +68,8 @@ func pivoting() {
 	By("Install Ironic in the target cluster")
 	installIronicBMO(targetCluster, "true", "false")
 
+	By("Restore original BMO configmap")
+	restoreBMOConfigmap()
 	By("Reinstate Ironic Configmap")
 	configureIronicConfigmap(false)
 
@@ -172,6 +174,15 @@ func configureIronicConfigmap(isIronicDeployed bool) {
 		err := cmd.Run()
 		Expect(err).To(BeNil(), "Cannot run mv command")
 	}
+}
+
+func restoreBMOConfigmap() {
+	bmoPath := "BMOPATH"
+	bmoConfigmap := fmt.Sprintf("%s/config/default/ironic.env", os.Getenv(bmoPath))
+	backupBmoConfigmap := fmt.Sprintf("%s/config/default/ironic.env.orig", os.Getenv(bmoPath))
+	cmd := exec.Command("mv", backupBmoConfigmap, bmoConfigmap)
+	_ = cmd.Run()
+	// Accept the error of this cmd because there might be no backup file to restore
 }
 
 func installIronicBMO(targetCluster framework.ClusterProxy, isIronic, isBMO string) {

--- a/test/e2e/pivoting_test.go
+++ b/test/e2e/pivoting_test.go
@@ -56,6 +56,7 @@ func pivoting() {
 		InfrastructureProviders: e2eConfig.InfrastructureProviders(),
 		LogFolder:               filepath.Join(artifactFolder, "clusters", clusterName+"-pivoting"),
 	})
+	LogFromFile(filepath.Join(artifactFolder, "clusters", clusterName+"-pivoting", "clusterctl-init.log"))
 
 	By("Configure Ironic Configmap")
 	configureIronicConfigmap(true)
@@ -97,6 +98,7 @@ func pivoting() {
 		ToKubeconfigPath:     targetCluster.GetKubeconfigPath(),
 		Namespace:            namespace,
 	})
+	LogFromFile(filepath.Join(artifactFolder, "clusters", clusterName+"-bootstrap", "clusterctl-move.log"))
 
 	pivotingCluster := framework.DiscoveryAndWaitForCluster(ctx, framework.DiscoveryAndWaitForClusterInput{
 		Getter:    targetCluster.GetClient(),


### PR DESCRIPTION
This PR fixes the issue with the e2e pivoting test which is the same as the PR on m3-dev-env: https://github.com/metal3-io/metal3-dev-env/pull/765