### PR TITLE
Fix e2e calico configuration and BMO installation workflow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-logr/logr v0.4.0
 	github.com/golang/mock v1.5.0
 	github.com/gorilla/mux v1.7.3 // indirect
+	github.com/jinzhu/copier v0.3.2
 	github.com/metal3-io/baremetal-operator/apis v0.0.0-20210416073321-c927d1d8da76
 	github.com/metal3-io/cluster-api-provider-metal3/api v0.0.0-00010101000000-000000000000
 	github.com/metal3-io/ip-address-manager/api v0.0.0-20210609163946-48b0ce9a1ac0
@@ -19,6 +20,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.21.3
 	k8s.io/apimachinery v0.21.3
 	k8s.io/client-go v0.21.3
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/klog/v2 v2.9.0
 	k8s.io/kube-openapi v0.0.0-20210305164622-f622666832c1 // indirect
 	k8s.io/utils v0.0.0-20210722164352-7f3ee0f31471

--- a/go.sum
+++ b/go.sum
@@ -562,6 +562,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jinzhu/copier v0.3.2 h1:QdBOCbaouLDYaIPFfi1bKv5F5tPpeTwXe4sD0jqtz5w=
+github.com/jinzhu/copier v0.3.2/go.mod h1:24xnZezI2Yqac9J61UC6/dG/k76ttpq0DdJI3QmUvro=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -3,6 +3,8 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 
@@ -45,4 +47,25 @@ func dumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterPr
 			Name:    namespace,
 		})
 	}
+}
+
+func downloadFile(filepath string, url string) error {
+
+	// Get the data
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Create the file
+	out, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	// Write the body to file
+	_, err = io.Copy(out, resp.Body)
+	return err
 }

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -69,3 +69,7 @@ func downloadFile(filepath string, url string) error {
 	_, err = io.Copy(out, resp.Body)
 	return err
 }
+
+func Logf(format string, a ...interface{}) {
+	fmt.Fprintf(GinkgoWriter, "INFO: "+format+"\n", a...)
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Workload cluster creation", func() {
 					ControlPlaneMachineCount: pointer.Int64Ptr(3),
 					WorkerMachineCount:       pointer.Int64Ptr(1),
 				},
-				CNIManifestPath:              e2eTestsPath + cniFile,
+				CNIManifestPath:              cniFile,
 				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
 				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
 				WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
@@ -87,62 +87,39 @@ var _ = Describe("Workload cluster creation", func() {
 })
 
 func updateCalico(calicoYaml, calicoInterface string) {
-	// cniYaml, err := os.ReadFile("/tmp/calico.yaml.bk")\
 	err := downloadFile(calicoYaml, "https://docs.projectcalico.org/manifests/calico.yaml")
 	Expect(err).To(BeNil(), "Unable to download Calico manifest")
 	cniYaml, err := os.ReadFile(calicoYaml)
 	Expect(err).To(BeNil(), "Unable to read Calico manifest")
-	// TODO: Delete below
-	// podCIDR := "192.168.0.0/18"
 	podCIDR := os.Getenv("POD_CIDR")
 	cniYaml = []byte(strings.Replace(string(cniYaml), "192.168.0.0/16", podCIDR, -1))
 
 	yamlDocuments, err := splitYAML(cniYaml)
 	Expect(err).To(BeNil(), "Cannot unmarshal the calico yaml elements to golang objects")
-	// err = yaml.Unmarshal([]byte(cniYaml), yamlNode)
-
-	//TODO: check error
 	calicoNodes, err := yamlContainKeyValue(yamlDocuments, "calico-node", "metadata", "labels", "k8s-app")
 	Expect(err).To(BeNil())
-	// In this test, there should be only one document node that needs to be updated
-	calicoNode := calicoNodes[0]
+	for _, calicoNode := range calicoNodes {
+		calicoNodeSpecTemplateSpec, err := yamlFindByValue(calicoNode, "spec", "template", "spec", "containers")
+		Expect(err).To(BeNil())
+		calicoNodeContainers, err := yamlContainKeyValue(calicoNodeSpecTemplateSpec.Content, "calico-node", "name")
+		Expect(err).To(BeNil())
+		// Since we find the container by name, we expect to get only one container.
+		Expect(len(calicoNodeContainers) == 1).To(BeTrue(), "Found 0 or more than 1 container with name `calico-node`")
+		calicoNodeContainer := calicoNodeContainers[0]
+		calicoNodeContainerEnvs, err := yamlFindByValue(calicoNodeContainer, "env")
+		Expect(err).To(BeNil())
+		addItem := &yaml.Node{}
+		err = copier.CopyWithOption(addItem, calicoNodeContainerEnvs.Content[0], copier.Option{IgnoreEmpty: true, DeepCopy: true})
+		Expect(err).To(BeNil(), "Cannot copy this object")
+		addItem.Content[1].SetString("IP_AUTODETECTION_METHOD")
+		addItem.Content[3].SetString("interface=" + calicoInterface)
+		addItem.HeadComment = "Start section modified by CAPM3 e2e test framework"
+		addItem.FootComment = "End section modified by CAPM3 e2e test framework"
+		calicoNodeContainerEnvs.Content = append(calicoNodeContainerEnvs.Content, addItem)
+	}
 
-	calicoNodeSpecTemplateSpec, err := yamlFindByValue(calicoNode, "spec", "template", "spec", "containers")
-	Expect(err).To(BeNil())
-	// debugYaml, err2 := yaml.Marshal(calicoNodeSpecTemplateSpec)
-	// if err2 != nil {
-	// 	panic(err2)
-	// }
-	// fmt.Println(string(debugYaml))
-
-	calicoNodeContainers, err := yamlContainKeyValue(calicoNodeSpecTemplateSpec.Content, "calico-node", "name")
-	Expect(err).To(BeNil())
-
-	// In this test, there should be only one container in the yaml node that needs to be updated
-	calicoNodeContainer := calicoNodeContainers[0]
-	// debugYaml, err2 := yaml.Marshal(calicoNodeContainer)
-	// if err2 != nil {
-	// 	panic(err2)
-	// }
-	// fmt.Println(string(debugYaml))
-	calicoNodeContainerEnvs, err := yamlFindByValue(calicoNodeContainer, "env")
-	Expect(err).To(BeNil())
-	// debugYaml, err2 := yaml.Marshal(calicoNodeContainerEnvs)
-	// if err2 != nil {
-	// 	panic(err2)
-	// }
-	// fmt.Println(string(debugYaml))
-	addItem := &yaml.Node{}
-	copier.CopyWithOption(addItem, calicoNodeContainerEnvs.Content[0], copier.Option{IgnoreEmpty: true, DeepCopy: true})
-	addItem.Content[1].SetString("IP_AUTODETECTION_METHOD")
-	addItem.Content[3].SetString("interface=" + calicoInterface)
-	addItem.HeadComment = "Start section modified by CAPM3 e2e test framework"
-	addItem.FootComment = "End section modified by CAPM3 e2e test framework"
-	calicoNodeContainerEnvs.Content = append(calicoNodeContainerEnvs.Content, addItem)
 	yamlOut, err := printYaml(yamlDocuments)
 	Expect(err).To(BeNil())
-	// fmt.Println(string(yamlOut))
-
 	err = os.WriteFile(calicoYaml, yamlOut, 0664)
 	Expect(err).To(BeNil(), "Cannot print out the update to the file")
 }

--- a/test/e2e/yaml.go
+++ b/test/e2e/yaml.go
@@ -23,7 +23,7 @@ func yamlContainKeyValue(yamlNodes []*yaml.Node, value string, keys ...string) (
 		}
 	}
 	if len(foundNode) == 0 {
-		return nil, errors.New("Cannot found the appropriated yaml node")
+		return nil, errors.New("Could not find the appropriate yaml node")
 	}
 	return foundNode, nil
 }
@@ -42,7 +42,7 @@ func yamlFindByValue(node *yaml.Node, values ...string) (*yaml.Node, error) {
 			return targetNode, nil
 		}
 	}
-	return nil, errors.New("Cannot found the appropriated yaml node")
+	return nil, errors.New("Could not find the appropriate yaml node")
 }
 
 func splitYAML(resources []byte) ([]*yaml.Node, error) {

--- a/test/e2e/yaml.go
+++ b/test/e2e/yaml.go
@@ -1,0 +1,77 @@
+package e2e
+
+import (
+	"bytes"
+	"errors"
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+func yamlContainKeyValue(yamlNodes []*yaml.Node, value string, keys ...string) ([]*yaml.Node, error) {
+	if yamlNodes == nil {
+		return nil, errors.New("Input list of yaml node is null")
+	}
+	foundNode := []*yaml.Node{}
+	for _, obj := range yamlNodes {
+		if obj.Kind == yaml.DocumentNode {
+			obj = obj.Content[0] // We can ignore the document node and focus on the block-mapping node.
+		}
+		field, err := yamlFindByValue(obj, keys...)
+		if err == nil && field.Value == value {
+			foundNode = append(foundNode, obj)
+		}
+	}
+	if len(foundNode) == 0 {
+		return nil, errors.New("Cannot found the appropriated yaml node")
+	}
+	return foundNode, nil
+}
+
+func yamlFindByValue(node *yaml.Node, values ...string) (*yaml.Node, error) {
+	if node == nil {
+		return nil, errors.New("Input yaml node is null")
+	}
+	value := values[0]
+	for i, child := range node.Content {
+		if child.Value == value {
+			targetNode := node.Content[i+1]
+			if len(values[1:]) > 0 {
+				return yamlFindByValue(targetNode, values[1:]...)
+			}
+			return targetNode, nil
+		}
+	}
+	return nil, errors.New("Cannot found the appropriated yaml node")
+}
+
+func splitYAML(resources []byte) ([]*yaml.Node, error) {
+
+	dec := yaml.NewDecoder(bytes.NewReader(resources))
+	listDocument := []*yaml.Node{}
+	for {
+		var value yaml.Node
+		err := dec.Decode(&value)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		listDocument = append(listDocument, &value)
+	}
+
+	return listDocument, nil
+}
+
+func printYaml(listDocument []*yaml.Node) ([]byte, error) {
+	var out []byte
+	for _, doc := range listDocument {
+		marshalDoc, err := yaml.Marshal(doc)
+		if err != nil {
+			return nil, err
+		}
+		out = append(append(out, []byte("\n---\n")...), marshalDoc...)
+	}
+	return out, nil
+}


### PR DESCRIPTION
This PR Does the following things:
- Fix the issue calico issue in the target cluster of e2e tests. It downloads the calico manifests, then update the yaml file. 
- Print out the log of some shell commands running in e2e tests.
- In pivoting test, run `clusterctl init` before installing BMO because now this installation requires to have cert-manager.