### PR TITLE
✨ Add webhook readiness and health check

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/klog/v2/klogr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -231,12 +230,12 @@ func waitForAPIs(cfg *rest.Config) error {
 }
 
 func setupChecks(mgr ctrl.Manager) {
-	if err := mgr.AddReadyzCheck("ping", healthz.Ping); err != nil {
+	if err := mgr.AddReadyzCheck("webhook", mgr.GetWebhookServer().StartedChecker()); err != nil {
 		setupLog.Error(err, "unable to create ready check")
 		os.Exit(1)
 	}
 
-	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
+	if err := mgr.AddHealthzCheck("webhook", mgr.GetWebhookServer().StartedChecker()); err != nil {
 		setupLog.Error(err, "unable to create health check")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Currently the readiness of our controller deployments does not include the webhook server. I.e., the deployment is already ready even when the webhooks are not up.

The current PR will help that the wait for readiness will also include the webhook server. This is crucial because otherwise there's a chance that clusterctl immediately fails when we try to deploy resources.

Follows: https://github.com/kubernetes-sigs/cluster-api/pull/4989