### PR TITLE
🐛 Fix the problem that "scale in" operation does not work after e2e pivoting

### DIFF
--- a/test/e2e/pivoting_test.go
+++ b/test/e2e/pivoting_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -230,10 +231,11 @@ func removeIronicContainers() {
 	}
 	dockerClient, err := docker.NewClientWithOpts()
 	Expect(err).To(BeNil(), "Unable to get docker client")
-	removeOptions := dockerTypes.ContainerRemoveOptions{
-		Force: true,
-	}
+	removeOptions := dockerTypes.ContainerRemoveOptions{}
 	for _, container := range ironicContainerList {
+		d := 1 * time.Minute
+		err = dockerClient.ContainerStop(ctx, container, &d)
+		Expect(err).To(BeNil(), "Unable to stop the container %s: %v", container, err)
 		err = dockerClient.ContainerRemove(ctx, container, removeOptions)
 		Expect(err).To(BeNil(), "Unable to delete the container %s: %v", container, err)
 	}


### PR DESCRIPTION
This PR fixes the problem that "scale in" operation does not work after e2e pivoting on Ubuntu. The problem is that the keepalived container is deleted forcefully, so it does not have time to clean the ironicendpoint IP address on the host. This leftover makes target nodes confuse and cannot connect to ironic. 