### PR TITLE
🌱 Remove deprecated ioutil usage

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -24,7 +23,7 @@ func Logf(format string, a ...interface{}) {
 }
 
 func LogFromFile(logFile string) {
-	data, err := ioutil.ReadFile(logFile)
+	data, err := os.ReadFile(logFile)
 	Expect(err).To(BeNil(), "No log file found")
 	Logf(string(data))
 }

--- a/test/e2e/pivoting_test.go
+++ b/test/e2e/pivoting_test.go
@@ -3,7 +3,7 @@ package e2e
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -216,12 +216,12 @@ func installIronicBMO(targetCluster framework.ClusterProxy, isIronic, isBMO stri
 	Expect(er).To(BeNil(), "Cannot get the stderr from the command")
 	err := cmd.Start()
 	Expect(err).To(BeNil(), "Failed to deploy Ironic")
-	data, er := ioutil.ReadAll(outputPipe)
+	data, er := io.ReadAll(outputPipe)
 	Expect(er).To(BeNil(), "Cannot get the stdout from the command")
 	if len(data) > 0 {
 		Logf("Output of the shell: %s\n", string(data))
 	}
-	errorData, er := ioutil.ReadAll(errorPipe)
+	errorData, er := io.ReadAll(errorPipe)
 	Expect(er).To(BeNil(), "Cannot get the stderr from the command")
 	err = cmd.Wait()
 	if len(errorData) > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
We are now targeting go1.16. Starting with this release, the ioutils
package is now deprecated [0]. This updates usage of ioutils calls for
the new recommended io and os equivalents.

[0] [doc/go1.16#ioutil](https://golang.org/doc/go1.16#ioutil)

