### PR TITLE
✨ Add AGE column to metal3 CRDs

### DIFF
--- a/api/v1alpha5/metal3cluster_types.go
+++ b/api/v1alpha5/metal3cluster_types.go
@@ -82,6 +82,7 @@ type Metal3ClusterStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Metal3Cluster"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="metal3Cluster is Ready"
 // +kubebuilder:printcolumn:name="Error",type="string",JSONPath=".status.failureReason",description="Most recent error"
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this BMCluster belongs"

--- a/api/v1alpha5/metal3data_types.go
+++ b/api/v1alpha5/metal3data_types.go
@@ -64,6 +64,7 @@ type Metal3DataStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Metal3Data"
 // Metal3Data is the Schema for the metal3datas API
 type Metal3Data struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1alpha5/metal3dataclaim_types.go
+++ b/api/v1alpha5/metal3dataclaim_types.go
@@ -47,6 +47,7 @@ type Metal3DataClaimStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Metal3DataClaim"
 // Metal3DataClaim is the Schema for the metal3datas API
 type Metal3DataClaim struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1alpha5/metal3datatemplate_types.go
+++ b/api/v1alpha5/metal3datatemplate_types.go
@@ -460,6 +460,7 @@ type Metal3DataTemplateStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this template belongs"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Metal3DataTemplate"
 
 // Metal3DataTemplate is the Schema for the metal3datatemplates API
 type Metal3DataTemplate struct {

--- a/api/v1alpha5/metal3machine_types.go
+++ b/api/v1alpha5/metal3machine_types.go
@@ -171,6 +171,7 @@ type Metal3MachineStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Metal3Machine"
 // +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="metal3machine is Ready"
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this M3Machine belongs"

--- a/api/v1alpha5/metal3machinetemplate_types.go
+++ b/api/v1alpha5/metal3machinetemplate_types.go
@@ -33,6 +33,7 @@ type Metal3MachineTemplateSpec struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Metal3MachineTemplate"
 // +kubebuilder:resource:path=metal3machinetemplates,scope=Namespaced,categories=cluster-api,shortName=m3mt;m3machinetemplate;m3machinetemplates;metal3mt;metal3machinetemplate
 // +kubebuilder:storageversion
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3clusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3clusters.yaml
@@ -111,6 +111,10 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
+    - description: Time duration since creation of Metal3Cluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - description: metal3Cluster is Ready
       jsonPath: .status.ready
       name: Ready

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3dataclaims.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3dataclaims.yaml
@@ -132,7 +132,12 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1alpha5
+  - additionalPrinterColumns:
+    - description: Time duration since creation of Metal3DataClaim
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha5
     schema:
       openAPIV3Schema:
         description: Metal3DataClaim is the Schema for the metal3datas API

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3datas.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3datas.yaml
@@ -171,7 +171,12 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1alpha5
+  - additionalPrinterColumns:
+    - description: Time duration since creation of Metal3Data
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha5
     schema:
       openAPIV3Schema:
         description: Metal3Data is the Schema for the metal3datas API

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3datatemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3datatemplates.yaml
@@ -855,6 +855,10 @@ spec:
       jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
       name: Cluster
       type: string
+    - description: Time duration since creation of Metal3DataTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha5
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machines.yaml
@@ -371,6 +371,10 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
+    - description: Time duration since creation of Metal3Machine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - description: Provider ID
       jsonPath: .spec.providerID
       name: ProviderID

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machinetemplates.yaml
@@ -227,7 +227,12 @@ spec:
         type: object
     served: true
     storage: false
-  - name: v1alpha5
+  - additionalPrinterColumns:
+    - description: Time duration since creation of Metal3MachineTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha5
     schema:
       openAPIV3Schema:
         description: Metal3MachineTemplate is the Schema for the metal3machinetemplates
@@ -430,6 +435,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
This adds the AGE column to all our CRDs to make the printed output consistent with the built in K8s resources.

Keeping things consistent with CAPI# https://github.com/kubernetes-sigs/cluster-api/pull/5180

