### PR TITLE
Fix e2e tests

### DIFF
--- a/templates/test/cluster-template-prow-ha-centos.yaml
+++ b/templates/test/cluster-template-prow-ha-centos.yaml
@@ -77,7 +77,7 @@ spec:
           cgroup-driver: systemd
           container-runtime: remote
           container-runtime-endpoint: unix:///var/run/crio/crio.sock
-          feature-gates: AllAlpha=false,RunAsGroup=true
+          feature-gates: AllAlpha=false
           node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
           provider-id: metal3://{{ ds.meta_data.uuid }}
           runtime-request-timeout: 5m
@@ -88,7 +88,7 @@ spec:
           cgroup-driver: systemd
           container-runtime: remote
           container-runtime-endpoint: unix:///var/run/crio/crio.sock
-          feature-gates: AllAlpha=false,RunAsGroup=true
+          feature-gates: AllAlpha=false
           node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
           provider-id: metal3://{{ ds.meta_data.uuid }}
           runtime-request-timeout: 5m
@@ -459,7 +459,7 @@ spec:
             cgroup-driver: systemd
             container-runtime: remote
             container-runtime-endpoint: unix:///var/run/crio/crio.sock
-            feature-gates: AllAlpha=false,RunAsGroup=true
+            feature-gates: AllAlpha=false
             node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
             provider-id: metal3://{{ ds.meta_data.uuid }}
             runtime-request-timeout: 5m

--- a/templates/test/cluster-template-prow-ha.yaml
+++ b/templates/test/cluster-template-prow-ha.yaml
@@ -152,7 +152,7 @@ spec:
           cgroup-driver: systemd
           container-runtime: remote
           container-runtime-endpoint: unix:///var/run/crio/crio.sock
-          feature-gates: AllAlpha=false,RunAsGroup=true
+          feature-gates: AllAlpha=false
           node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
           provider-id: metal3://{{ ds.meta_data.uuid }}
           runtime-request-timeout: 5m
@@ -164,7 +164,7 @@ spec:
           cgroup-driver: systemd
           container-runtime: remote
           container-runtime-endpoint: unix:///var/run/crio/crio.sock
-          feature-gates: AllAlpha=false,RunAsGroup=true
+          feature-gates: AllAlpha=false
           node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
           provider-id: metal3://{{ ds.meta_data.uuid }}
           runtime-request-timeout: 5m
@@ -384,7 +384,7 @@ spec:
             cgroup-driver: systemd
             container-runtime: remote
             container-runtime-endpoint: unix:///var/run/crio/crio.sock
-            feature-gates: AllAlpha=false,RunAsGroup=true
+            feature-gates: AllAlpha=false
             node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
             provider-id: metal3://{{ ds.meta_data.uuid }}
             runtime-request-timeout: 5m

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -43,6 +43,8 @@ var _ = Describe("Workload cluster creation", func() {
 			flavorSuffix = ""
 			updateCalico(cniFile, "enp2s0")
 		}
+		// Quick fix to solve ipam nameprefix problem
+		replaceIpamCertAnnotation()
 
 		Expect(e2eConfig).ToNot(BeNil(), "Invalid argument. e2eConfig can't be nil when calling %s spec", specName)
 		Expect(clusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. clusterctlConfigPath must be an existing file when calling %s spec", specName)
@@ -89,6 +91,16 @@ var _ = Describe("Workload cluster creation", func() {
 		})
 	})
 })
+
+func replaceIpamCertAnnotation() {
+	filename := os.Getenv("PWD") + "/../../_artifacts/repository/infrastructure-metal3/v0.5.0/components.yaml"
+	component, err := os.ReadFile(filename)
+	Expect(err).To(BeNil(), "Unable to read infrastruture component")
+	org := "capm3-system/ipam-serving-cert"
+	dst := "capm3-system/capm3-ipam-serving-cert"
+	component = []byte(strings.Replace(string(component), org, dst, -1))
+	Expect(os.WriteFile(filename, component, 0666)).To(Succeed(), "Unable to write to file")
+}
 
 func updateCalico(calicoYaml, calicoInterface string) {
 	err := downloadFile(calicoYaml, "https://docs.projectcalico.org/manifests/calico.yaml")


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes e2e tests by:

- removing unnecessary `RunAsGroup=true` field to keep up a consistency with m3-dev-env templates
- adding a workaround for nameprefix issue in IPAM kustomization

