### PR TITLE
🐛 Use the infrastructure components built by m3-dev-env

### DIFF
--- a/hack/e2e/environment.sh
+++ b/hack/e2e/environment.sh
@@ -31,6 +31,11 @@ export CONTROL_PLANE_MACHINE_COUNT='${CONTROL_PLANE_MACHINE_COUNT}'
 # shellcheck disable=SC2016
 export WORKER_MACHINE_COUNT='${WORKER_MACHINE_COUNT}'
 
+# The e2e test framework would itself handle the cloning. It clones all the repos that are cloned in M3-DEV-ENV expect CAPM3.
+# It would use the local CAPM3 repo where the e2e test is running. 
+# Set this variable to false to avoid the dev-env to override what the test framework cloned. 
+export FORCE_REPO_UPDATE="false"
+
 os_check
 
 if [[ "${OS}" == ubuntu ]]; then

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -61,7 +61,8 @@ providers:
     type: InfrastructureProvider
     versions:
     - name: ${CAPM3RELEASE}
-      value: "${PWD}/config/default"
+      value: "file://${HOME}/.cluster-api/overrides/infrastructure-metal3/${CAPM3RELEASE}/infrastructure-components.yaml"
+      type: "url"
     files:
     - sourcePath: "${PWD}/metadata.yaml"
       targetName: "metadata.yaml"

--- a/test/e2e/pivoting_test.go
+++ b/test/e2e/pivoting_test.go
@@ -56,6 +56,7 @@ func pivoting() {
 		InfrastructureProviders: e2eConfig.InfrastructureProviders(),
 		LogFolder:               filepath.Join(artifactFolder, "clusters", clusterName+"-pivoting"),
 	})
+
 	LogFromFile(filepath.Join(artifactFolder, "clusters", clusterName+"-pivoting", "clusterctl-init.log"))
 
 	By("Configure Ironic Configmap")


### PR DESCRIPTION
Currently, with e2e tests, the source cluster infrastructure components are initialized by the file made by m3-dev-env, while the target cluster uses the file that is built by the test framework itself. This causes a mismatch between the source and the target cluster.
This PR makes the e2e test framework use the infrastructure components issued by m3-dev-env, leading to the consistency between the source and target clusters.

Note: By default, m3-dev-env clones CAPM3 repo from upstream and build the infrastructure components from here. This behavior is not what we want in an e2e test because the components should be built from the local CAPM3 repo when the test is executed. Therefore, this PR switches the toggle that prevents m3-dev-env to clone repos. The test framework would copy the local CAPM3 repo and clone other repos to the directory where the dev-env works with. By doing that, m3-dev-env should build the infra components based on the local CAPM3 repo. 