### PR TITLE
✨ Remove 'run' make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,10 +350,6 @@ set-manifest-pull-policy:
 ## Deploying
 ## --------------------------------------
 
-# Run against the configured Kubernetes cluster in ~/.kube/config
-run: generate fmt vet
-	go run ./main.go
-
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: generate-examples
 	kubectl apply -f examples/_out/cert-manager.yaml

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -123,7 +123,7 @@ echo "Generated ${METAL3PLANE_GENERATED_FILE}"
 echo "Generated ${MACHINEDEPLOYMENT_GENERATED_FILE}"
 
 # Get Cert-manager provider components file
-curl --fail -Ss -L -o "${COMPONENTS_CERT_MANAGER_GENERATED_FILE}" https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.yaml
+curl --fail -Ss -L -o "${COMPONENTS_CERT_MANAGER_GENERATED_FILE}" https://github.com/jetstack/cert-manager/releases/download/v1.5.0/cert-manager.yaml
 echo "Downloaded ${COMPONENTS_CERT_MANAGER_GENERATED_FILE}"
 
 # Generate Cluster API provider components file.
@@ -145,3 +145,9 @@ echo "Generated ${COMPONENTS_METAL3_GENERATED_FILE}"
 # Generate a single provider components file.
 "$KUSTOMIZE" build "${SOURCE_DIR}/provider-components" | "$ENVSUBST" > "${PROVIDER_COMPONENTS_GENERATED_FILE}"
 echo "Generated ${PROVIDER_COMPONENTS_GENERATED_FILE}"
+# The following sed makes sure the cert-manager ca inject annotation also contains
+# capm3 namePrefix for ipam-serving cert. This is a bug which has been there since
+# we use two levels of kustomization one on IPAM and then again on IPAM components
+# in CAPM3. The following is a quick fix, later once we solve it in IPAM kustomization
+# the following line would be removed
+sed -i 's/capm3-system\/ipam-serving-cert/capm3-system\/capm3-ipam-serving-cert/g' "${PROVIDER_COMPONENTS_GENERATED_FILE}"

--- a/examples/metal3crds/metal3.io_baremetalhosts.yaml
+++ b/examples/metal3crds/metal3.io_baremetalhosts.yaml
@@ -1,37 +1,12 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
   name: baremetalhosts.metal3.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.operationalStatus
-    description: Operational status
-    name: Status
-    type: string
-  - JSONPath: .status.provisioning.state
-    description: Provisioning status
-    name: Provisioning Status
-    type: string
-  - JSONPath: .spec.consumerRef.name
-    description: Consumer using this host
-    name: Consumer
-    type: string
-  - JSONPath: .spec.bmc.address
-    description: Address of management controller
-    name: BMC
-    type: string
-  - JSONPath: .status.hardwareProfile
-    description: The type of hardware detected
-    name: Hardware Profile
-    type: string
-  - JSONPath: .spec.online
-    description: Whether the host is online or not
-    name: Online
-    type: string
-  - JSONPath: .status.errorMessage
-    description: Most recent error
-    name: Error
-    type: string
   group: metal3.io
   names:
     kind: BareMetalHost
@@ -42,533 +17,1067 @@ spec:
     - bmhost
     singular: baremetalhost
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: BareMetalHost is the Schema for the baremetalhosts API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: BareMetalHostSpec defines the desired state of BareMetalHost
-          properties:
-            bmc:
-              description: How do we connect to the BMC?
-              properties:
-                address:
-                  description: Address holds the URL for accessing the controller
-                    on the network.
-                  type: string
-                credentialsName:
-                  description: The name of the secret containing the BMC credentials
-                    (requires keys "username" and "password").
-                  type: string
-                disableCertificateVerification:
-                  description: DisableCertificateVerification disables verification
-                    of server certificates when using HTTPS to connect to the BMC.
-                    This is required when the server certificate is self-signed, but
-                    is insecure because it allows a man-in-the-middle to intercept
-                    the connection.
-                  type: boolean
-              required:
-              - address
-              - credentialsName
-              type: object
-            bootMACAddress:
-              description: Which MAC address will PXE boot? This is optional for some
-                types, but required for libvirt VMs driven by vbmc.
-              pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
-              type: string
-            consumerRef:
-              description: ConsumerRef can be used to store information about something
-                that is using a host. When it is not empty, the host is considered
-                "in use".
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            description:
-              description: Description is a human-entered text used to help identify
-                the host
-              type: string
-            externallyProvisioned:
-              description: ExternallyProvisioned means something else is managing
-                the image running on the host and the operator should only manage
-                the power status and hardware inventory inspection. If the Image field
-                is filled in, this field is ignored.
-              type: boolean
-            hardwareProfile:
-              description: What is the name of the hardware profile for this host?
-                It should only be necessary to set this when inspection cannot automatically
-                determine the profile.
-              type: string
-            image:
-              description: Image holds the details of the image to be provisioned.
-              properties:
-                checksum:
-                  description: Checksum is the checksum for the image.
-                  type: string
-                url:
-                  description: URL is a location of an image to deploy.
-                  type: string
-              required:
-              - checksum
-              - url
-              type: object
-            metaData:
-              description: MetaData holds the reference to the Secret containing host
-                metadata (e.g. meta_data.json which is passed to Config Drive).
-              properties:
-                name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
-                  type: string
-                namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
-                  type: string
-              type: object
-            networkData:
-              description: NetworkData holds the reference to the Secret containing
-                network configuration (e.g content of network_data.json which is passed
-                to Config Drive).
-              properties:
-                name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
-                  type: string
-                namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
-                  type: string
-              type: object
-            online:
-              description: Should the server be online?
-              type: boolean
-            taints:
-              description: Taints is the full, authoritative list of taints to apply
-                to the corresponding Machine. This list will overwrite any modifications
-                made to the Machine on an ongoing basis.
-              items:
-                description: The node this Taint is attached to has the "effect" on
-                  any pod that does not tolerate the Taint.
+  versions:
+  - additionalPrinterColumns:
+    - description: Operational status
+      jsonPath: .status.operationalStatus
+      name: Status
+      priority: 1
+      type: string
+    - description: Provisioning status
+      jsonPath: .status.provisioning.state
+      name: State
+      type: string
+    - description: Consumer using this host
+      jsonPath: .spec.consumerRef.name
+      name: Consumer
+      type: string
+    - description: Address of management controller
+      jsonPath: .spec.bmc.address
+      name: BMC
+      priority: 1
+      type: string
+    - description: The type of hardware detected
+      jsonPath: .status.hardwareProfile
+      name: Hardware_Profile
+      priority: 1
+      type: string
+    - description: Whether the host is online or not
+      jsonPath: .spec.online
+      name: Online
+      type: string
+    - description: Type of the most recent error
+      jsonPath: .status.errorType
+      name: Error
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: BareMetalHost is the Schema for the baremetalhosts API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BareMetalHostSpec defines the desired state of BareMetalHost
+            properties:
+              automatedCleaningMode:
+                default: metadata
+                description: When set to disabled, automated cleaning will be avoided
+                  during provisioning and deprovisioning.
+                enum:
+                - metadata
+                - disabled
+                type: string
+              bmc:
+                description: How do we connect to the BMC?
                 properties:
-                  effect:
-                    description: Required. The effect of the taint on pods that do
-                      not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule
-                      and NoExecute.
+                  address:
+                    description: Address holds the URL for accessing the controller
+                      on the network.
                     type: string
-                  key:
-                    description: Required. The taint key to be applied to a node.
+                  credentialsName:
+                    description: The name of the secret containing the BMC credentials
+                      (requires keys "username" and "password").
                     type: string
-                  timeAdded:
-                    description: TimeAdded represents the time at which the taint
-                      was added. It is only written for NoExecute taints.
-                    format: date-time
+                  disableCertificateVerification:
+                    description: DisableCertificateVerification disables verification
+                      of server certificates when using HTTPS to connect to the BMC.
+                      This is required when the server certificate is self-signed,
+                      but is insecure because it allows a man-in-the-middle to intercept
+                      the connection.
+                    type: boolean
+                required:
+                - address
+                - credentialsName
+                type: object
+              bootMACAddress:
+                description: Which MAC address will PXE boot? This is optional for
+                  some types, but required for libvirt VMs driven by vbmc.
+                pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
+                type: string
+              bootMode:
+                description: Select the method of initializing the hardware during
+                  boot. Defaults to UEFI.
+                enum:
+                - UEFI
+                - UEFISecureBoot
+                - legacy
+                type: string
+              consumerRef:
+                description: ConsumerRef can be used to store information about something
+                  that is using a host. When it is not empty, the host is considered
+                  "in use".
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
                     type: string
-                  value:
-                    description: Required. The taint value corresponding to the taint
-                      key.
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              customDeploy:
+                description: A custom deploy procedure.
+                properties:
+                  method:
+                    description: Custom deploy method name. This name is specific
+                      to the deploy ramdisk used. If you don't have a custom deploy
+                      ramdisk, you shouldn't use CustomDeploy.
                     type: string
                 required:
-                - effect
-                - key
+                - method
                 type: object
-              type: array
-            userData:
-              description: UserData holds the reference to the Secret containing the
-                user data to be passed to the host before it boots.
-              properties:
-                name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
-                  type: string
-                namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
-                  type: string
-              type: object
-          required:
-          - online
-          type: object
-        status:
-          description: BareMetalHostStatus defines the observed state of BareMetalHost
-          properties:
-            errorMessage:
-              description: the last error message reported by the provisioning subsystem
-              type: string
-            errorType:
-              description: ErrorType indicates the type of failure encountered when
-                the OperationalStatus is OperationalStatusError
-              enum:
-              - registration error
-              - inspection error
-              - provisioning error
-              - power management error
-              type: string
-            goodCredentials:
-              description: the last credentials we were able to validate as working
-              properties:
-                credentials:
-                  description: SecretReference represents a Secret Reference. It has
-                    enough information to retrieve secret in any namespace
+              description:
+                description: Description is a human-entered text used to help identify
+                  the host
+                type: string
+              externallyProvisioned:
+                description: ExternallyProvisioned means something else is managing
+                  the image running on the host and the operator should only manage
+                  the power status and hardware inventory inspection. If the Image
+                  field is filled in, this field is ignored.
+                type: boolean
+              firmware:
+                description: BIOS configuration for bare metal server
+                properties:
+                  simultaneousMultithreadingEnabled:
+                    description: 'Allows a single physical processor core to appear
+                      as several logical processors. This supports following options:
+                      true, false.'
+                    enum:
+                    - true
+                    - false
+                    type: boolean
+                  sriovEnabled:
+                    description: 'SR-IOV support enables a hypervisor to create virtual
+                      instances of a PCI-express device, potentially increasing performance.
+                      This supports following options: true, false.'
+                    enum:
+                    - true
+                    - false
+                    type: boolean
+                  virtualizationEnabled:
+                    description: 'Supports the virtualization of platform hardware.
+                      This supports following options: true, false.'
+                    enum:
+                    - true
+                    - false
+                    type: boolean
+                type: object
+              hardwareProfile:
+                description: What is the name of the hardware profile for this host?
+                  It should only be necessary to set this when inspection cannot automatically
+                  determine the profile.
+                type: string
+              image:
+                description: Image holds the details of the image to be provisioned.
+                properties:
+                  checksum:
+                    description: Checksum is the checksum for the image.
+                    type: string
+                  checksumType:
+                    description: ChecksumType is the checksum algorithm for the image.
+                      e.g md5, sha256, sha512
+                    enum:
+                    - md5
+                    - sha256
+                    - sha512
+                    type: string
+                  format:
+                    description: DiskFormat contains the format of the image (raw,
+                      qcow2, ...). Needs to be set to raw for raw images streaming.
+                      Note live-iso means an iso referenced by the url will be live-booted
+                      and not deployed to disk, and in this case the checksum options
+                      are not required and if specified will be ignored.
+                    enum:
+                    - raw
+                    - qcow2
+                    - vdi
+                    - vmdk
+                    - live-iso
+                    type: string
+                  url:
+                    description: URL is a location of an image to deploy.
+                    type: string
+                required:
+                - url
+                type: object
+              metaData:
+                description: MetaData holds the reference to the Secret containing
+                  host metadata (e.g. meta_data.json which is passed to Config Drive).
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+              networkData:
+                description: NetworkData holds the reference to the Secret containing
+                  network configuration (e.g content of network_data.json which is
+                  passed to Config Drive).
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+              online:
+                description: Should the server be online?
+                type: boolean
+              raid:
+                description: RAID configuration for bare metal server
+                properties:
+                  hardwareRAIDVolumes:
+                    description: The list of logical disks for hardware RAID, if rootDeviceHints
+                      isn't used, first volume is root volume. You can set the value
+                      of this field to `[]` to clear all the hardware RAID configurations.
+                    items:
+                      description: HardwareRAIDVolume defines the desired configuration
+                        of volume in hardware RAID
+                      properties:
+                        level:
+                          description: 'RAID level for the logical disk. The following
+                            levels are supported: 0;1;2;5;6;1+0;5+0;6+0.'
+                          enum:
+                          - "0"
+                          - "1"
+                          - "2"
+                          - "5"
+                          - "6"
+                          - 1+0
+                          - 5+0
+                          - 6+0
+                          type: string
+                        name:
+                          description: Name of the volume. Should be unique within
+                            the Node. If not specified, volume name will be auto-generated.
+                          maxLength: 64
+                          type: string
+                        numberOfPhysicalDisks:
+                          description: Integer, number of physical disks to use for
+                            the logical disk. Defaults to minimum number of disks
+                            required for the particular RAID level.
+                          minimum: 1
+                          type: integer
+                        rotational:
+                          description: Select disks with only rotational or solid-state
+                            storage
+                          type: boolean
+                        sizeGibibytes:
+                          description: Size (Integer) of the logical disk to be created
+                            in GiB. If unspecified or set be 0, the maximum capacity
+                            of disk will be used for logical disk.
+                          minimum: 0
+                          type: integer
+                      required:
+                      - level
+                      type: object
+                    nullable: true
+                    type: array
+                  softwareRAIDVolumes:
+                    description: The list of logical disks for software RAID, if rootDeviceHints
+                      isn't used, first volume is root volume. If HardwareRAIDVolumes
+                      is set this item will be invalid. The number of created Software
+                      RAID devices must be 1 or 2. If there is only one Software RAID
+                      device, it has to be a RAID-1. If there are two, the first one
+                      has to be a RAID-1, while the RAID level for the second one
+                      can be 0, 1, or 1+0. As the first RAID device will be the deployment
+                      device, enforcing a RAID-1 reduces the risk of ending up with
+                      a non-booting node in case of a disk failure. Software RAID
+                      will always be deleted.
+                    items:
+                      description: SoftwareRAIDVolume defines the desired configuration
+                        of volume in software RAID
+                      properties:
+                        level:
+                          description: 'RAID level for the logical disk. The following
+                            levels are supported: 0;1;1+0.'
+                          enum:
+                          - "0"
+                          - "1"
+                          - 1+0
+                          type: string
+                        physicalDisks:
+                          description: A list of device hints, the number of items
+                            should be greater than or equal to 2.
+                          items:
+                            description: RootDeviceHints holds the hints for specifying
+                              the storage location for the root filesystem for the
+                              image.
+                            properties:
+                              deviceName:
+                                description: A Linux device name like "/dev/vda".
+                                  The hint must match the actual value exactly.
+                                type: string
+                              hctl:
+                                description: A SCSI bus address like 0:0:0:0. The
+                                  hint must match the actual value exactly.
+                                type: string
+                              minSizeGigabytes:
+                                description: The minimum size of the device in Gigabytes.
+                                minimum: 0
+                                type: integer
+                              model:
+                                description: A vendor-specific device identifier.
+                                  The hint can be a substring of the actual value.
+                                type: string
+                              rotational:
+                                description: True if the device should use spinning
+                                  media, false otherwise.
+                                type: boolean
+                              serialNumber:
+                                description: Device serial number. The hint must match
+                                  the actual value exactly.
+                                type: string
+                              vendor:
+                                description: The name of the vendor or manufacturer
+                                  of the device. The hint can be a substring of the
+                                  actual value.
+                                type: string
+                              wwn:
+                                description: Unique storage identifier. The hint must
+                                  match the actual value exactly.
+                                type: string
+                              wwnVendorExtension:
+                                description: Unique vendor storage identifier. The
+                                  hint must match the actual value exactly.
+                                type: string
+                              wwnWithExtension:
+                                description: Unique storage identifier with the vendor
+                                  extension appended. The hint must match the actual
+                                  value exactly.
+                                type: string
+                            type: object
+                          minItems: 2
+                          type: array
+                        sizeGibibytes:
+                          description: Size (Integer) of the logical disk to be created
+                            in GiB. If unspecified or set be 0, the maximum capacity
+                            of disk will be used for logical disk.
+                          minimum: 0
+                          type: integer
+                      required:
+                      - level
+                      type: object
+                    maxItems: 2
+                    nullable: true
+                    type: array
+                type: object
+              rootDeviceHints:
+                description: Provide guidance about how to choose the device for the
+                  image being provisioned.
+                properties:
+                  deviceName:
+                    description: A Linux device name like "/dev/vda". The hint must
+                      match the actual value exactly.
+                    type: string
+                  hctl:
+                    description: A SCSI bus address like 0:0:0:0. The hint must match
+                      the actual value exactly.
+                    type: string
+                  minSizeGigabytes:
+                    description: The minimum size of the device in Gigabytes.
+                    minimum: 0
+                    type: integer
+                  model:
+                    description: A vendor-specific device identifier. The hint can
+                      be a substring of the actual value.
+                    type: string
+                  rotational:
+                    description: True if the device should use spinning media, false
+                      otherwise.
+                    type: boolean
+                  serialNumber:
+                    description: Device serial number. The hint must match the actual
+                      value exactly.
+                    type: string
+                  vendor:
+                    description: The name of the vendor or manufacturer of the device.
+                      The hint can be a substring of the actual value.
+                    type: string
+                  wwn:
+                    description: Unique storage identifier. The hint must match the
+                      actual value exactly.
+                    type: string
+                  wwnVendorExtension:
+                    description: Unique vendor storage identifier. The hint must match
+                      the actual value exactly.
+                    type: string
+                  wwnWithExtension:
+                    description: Unique storage identifier with the vendor extension
+                      appended. The hint must match the actual value exactly.
+                    type: string
+                type: object
+              taints:
+                description: Taints is the full, authoritative list of taints to apply
+                  to the corresponding Machine. This list will overwrite any modifications
+                  made to the Machine on an ongoing basis.
+                items:
+                  description: The node this Taint is attached to has the "effect"
+                    on any pod that does not tolerate the Taint.
                   properties:
-                    name:
-                      description: Name is unique within a namespace to reference
-                        a secret resource.
+                    effect:
+                      description: Required. The effect of the taint on pods that
+                        do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule
+                        and NoExecute.
                       type: string
-                    namespace:
-                      description: Namespace defines the space within which the secret
-                        name must be unique.
+                    key:
+                      description: Required. The taint key to be applied to a node.
                       type: string
-                  type: object
-                credentialsVersion:
-                  type: string
-              type: object
-            hardware:
-              description: The hardware discovered to exist on the host.
-              properties:
-                cpu:
-                  description: CPU describes one processor on the host.
-                  properties:
-                    arch:
+                    timeAdded:
+                      description: TimeAdded represents the time at which the taint
+                        was added. It is only written for NoExecute taints.
+                      format: date-time
                       type: string
-                    clockMegahertz:
-                      description: ClockSpeed is a clock speed in MHz
-                    count:
-                      type: integer
-                    flags:
-                      items:
-                        type: string
-                      type: array
-                    model:
+                    value:
+                      description: The taint value corresponding to the taint key.
                       type: string
                   required:
-                  - arch
-                  - clockMegahertz
-                  - count
-                  - flags
-                  - model
+                  - effect
+                  - key
                   type: object
-                firmware:
-                  description: Firmware describes the firmware on the host.
-                  properties:
-                    bios:
-                      description: The BIOS for this firmware
+                type: array
+              userData:
+                description: UserData holds the reference to the Secret containing
+                  the user data to be passed to the host before it boots.
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+            required:
+            - online
+            type: object
+          status:
+            description: BareMetalHostStatus defines the observed state of BareMetalHost
+            properties:
+              errorCount:
+                default: 0
+                description: ErrorCount records how many times the host has encoutered
+                  an error since the last successful operation
+                type: integer
+              errorMessage:
+                description: the last error message reported by the provisioning subsystem
+                type: string
+              errorType:
+                description: ErrorType indicates the type of failure encountered when
+                  the OperationalStatus is OperationalStatusError
+                enum:
+                - provisioned registration error
+                - registration error
+                - inspection error
+                - preparation error
+                - provisioning error
+                - power management error
+                type: string
+              goodCredentials:
+                description: the last credentials we were able to validate as working
+                properties:
+                  credentials:
+                    description: SecretReference represents a Secret Reference. It
+                      has enough information to retrieve secret in any namespace
+                    properties:
+                      name:
+                        description: Name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: Namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                  credentialsVersion:
+                    type: string
+                type: object
+              hardware:
+                description: The hardware discovered to exist on the host.
+                properties:
+                  cpu:
+                    description: CPU describes one processor on the host.
+                    properties:
+                      arch:
+                        type: string
+                      clockMegahertz:
+                        description: ClockSpeed is a clock speed in MHz
+                        format: double
+                        type: number
+                      count:
+                        type: integer
+                      flags:
+                        items:
+                          type: string
+                        type: array
+                      model:
+                        type: string
+                    type: object
+                  firmware:
+                    description: Firmware describes the firmware on the host.
+                    properties:
+                      bios:
+                        description: The BIOS for this firmware
+                        properties:
+                          date:
+                            description: The release/build date for this BIOS
+                            type: string
+                          vendor:
+                            description: The vendor name for this BIOS
+                            type: string
+                          version:
+                            description: The version of the BIOS
+                            type: string
+                        type: object
+                    type: object
+                  hostname:
+                    type: string
+                  nics:
+                    items:
+                      description: NIC describes one network interface on the host.
                       properties:
-                        date:
-                          description: The release/build date for this BIOS
+                        ip:
+                          description: The IP address of the interface. This will
+                            be an IPv4 or IPv6 address if one is present.  If both
+                            IPv4 and IPv6 addresses are present in a dual-stack environment,
+                            two nics will be output, one with each IP.
+                          type: string
+                        mac:
+                          description: The device MAC address
+                          pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
+                          type: string
+                        model:
+                          description: The vendor and product IDs of the NIC, e.g.
+                            "0x8086 0x1572"
+                          type: string
+                        name:
+                          description: The name of the network interface, e.g. "en0"
+                          type: string
+                        pxe:
+                          description: Whether the NIC is PXE Bootable
+                          type: boolean
+                        speedGbps:
+                          description: The speed of the device in Gigabits per second
+                          type: integer
+                        vlanId:
+                          description: The untagged VLAN ID
+                          format: int32
+                          maximum: 4094
+                          minimum: 0
+                          type: integer
+                        vlans:
+                          description: The VLANs available
+                          items:
+                            description: VLAN represents the name and ID of a VLAN
+                            properties:
+                              id:
+                                description: VLANID is a 12-bit 802.1Q VLAN identifier
+                                format: int32
+                                maximum: 4094
+                                minimum: 0
+                                type: integer
+                              name:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  ramMebibytes:
+                    type: integer
+                  storage:
+                    items:
+                      description: Storage describes one storage device (disk, SSD,
+                        etc.) on the host.
+                      properties:
+                        hctl:
+                          description: The SCSI location of the device
+                          type: string
+                        model:
+                          description: Hardware model
+                          type: string
+                        name:
+                          description: The Linux device name of the disk, e.g. "/dev/sda".
+                            Note that this may not be stable across reboots.
+                          type: string
+                        rotational:
+                          description: Whether this disk represents rotational storage.
+                            This field is not recommended for usage, please prefer
+                            using 'Type' field instead, this field will be deprecated
+                            eventually.
+                          type: boolean
+                        serialNumber:
+                          description: The serial number of the device
+                          type: string
+                        sizeBytes:
+                          description: The size of the disk in Bytes
+                          format: int64
+                          type: integer
+                        type:
+                          description: 'Device type, one of: HDD, SSD, NVME.'
+                          enum:
+                          - HDD
+                          - SSD
+                          - NVME
                           type: string
                         vendor:
-                          description: The vendor name for this BIOS
+                          description: The name of the vendor of the device
                           type: string
-                        version:
-                          description: The version of the BIOS
+                        wwn:
+                          description: The WWN of the device
                           type: string
-                      required:
-                      - date
-                      - vendor
-                      - version
+                        wwnVendorExtension:
+                          description: The WWN Vendor extension of the device
+                          type: string
+                        wwnWithExtension:
+                          description: The WWN with the extension
+                          type: string
                       type: object
-                  required:
-                  - bios
-                  type: object
-                hostname:
-                  type: string
-                nics:
-                  items:
-                    description: NIC describes one network interface on the host.
+                    type: array
+                  systemVendor:
+                    description: HardwareSystemVendor stores details about the whole
+                      hardware system.
                     properties:
-                      ip:
-                        description: The IP address of the device
+                      manufacturer:
                         type: string
-                      mac:
-                        description: The device MAC addr
-                        pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
+                      productName:
                         type: string
-                      model:
-                        description: The name of the model, e.g. "virt-io"
+                      serialNumber:
                         type: string
-                      name:
-                        description: The name of the NIC, e.g. "nic-1"
-                        type: string
-                      pxe:
-                        description: Whether the NIC is PXE Bootable
-                        type: boolean
-                      speedGbps:
-                        description: The speed of the device
-                        type: integer
-                      vlanId:
-                        description: The untagged VLAN ID
-                        format: int32
-                        type: integer
-                      vlans:
-                        description: The VLANs available
-                        items:
-                          description: VLAN represents the name and ID of a VLAN
-                          properties:
-                            id:
-                              description: VLANID is a 12-bit 802.1Q VLAN identifier
-                              format: int32
-                              type: integer
-                            name:
-                              type: string
-                          required:
-                          - id
-                          type: object
-                        type: array
-                    required:
-                    - ip
-                    - mac
-                    - model
-                    - name
-                    - pxe
-                    - speedGbps
-                    - vlanId
                     type: object
-                  type: array
-                ramMebibytes:
-                  type: integer
-                storage:
-                  items:
-                    description: Storage describes one storage device (disk, SSD,
-                      etc.) on the host.
+                type: object
+              hardwareProfile:
+                description: The name of the profile matching the hardware details.
+                type: string
+              lastUpdated:
+                description: LastUpdated identifies when this status was last observed.
+                format: date-time
+                type: string
+              operationHistory:
+                description: OperationHistory holds information about operations performed
+                  on this host.
+                properties:
+                  deprovision:
+                    description: OperationMetric contains metadata about an operation
+                      (inspection, provisioning, etc.) used for tracking metrics.
                     properties:
+                      end:
+                        format: date-time
+                        nullable: true
+                        type: string
+                      start:
+                        format: date-time
+                        nullable: true
+                        type: string
+                    type: object
+                  inspect:
+                    description: OperationMetric contains metadata about an operation
+                      (inspection, provisioning, etc.) used for tracking metrics.
+                    properties:
+                      end:
+                        format: date-time
+                        nullable: true
+                        type: string
+                      start:
+                        format: date-time
+                        nullable: true
+                        type: string
+                    type: object
+                  provision:
+                    description: OperationMetric contains metadata about an operation
+                      (inspection, provisioning, etc.) used for tracking metrics.
+                    properties:
+                      end:
+                        format: date-time
+                        nullable: true
+                        type: string
+                      start:
+                        format: date-time
+                        nullable: true
+                        type: string
+                    type: object
+                  register:
+                    description: OperationMetric contains metadata about an operation
+                      (inspection, provisioning, etc.) used for tracking metrics.
+                    properties:
+                      end:
+                        format: date-time
+                        nullable: true
+                        type: string
+                      start:
+                        format: date-time
+                        nullable: true
+                        type: string
+                    type: object
+                type: object
+              operationalStatus:
+                description: OperationalStatus holds the status of the host
+                enum:
+                - ""
+                - OK
+                - discovered
+                - error
+                - delayed
+                - detached
+                type: string
+              poweredOn:
+                description: indicator for whether or not the host is powered on
+                type: boolean
+              provisioning:
+                description: Information tracked by the provisioner.
+                properties:
+                  ID:
+                    description: The machine's UUID from the underlying provisioning
+                      tool
+                    type: string
+                  bootMode:
+                    description: BootMode indicates the boot mode used to provision
+                      the node
+                    enum:
+                    - UEFI
+                    - UEFISecureBoot
+                    - legacy
+                    type: string
+                  customDeploy:
+                    description: Custom deploy procedure applied to the host.
+                    properties:
+                      method:
+                        description: Custom deploy method name. This name is specific
+                          to the deploy ramdisk used. If you don't have a custom deploy
+                          ramdisk, you shouldn't use CustomDeploy.
+                        type: string
+                    required:
+                    - method
+                    type: object
+                  firmware:
+                    description: The Bios set by the user
+                    properties:
+                      simultaneousMultithreadingEnabled:
+                        description: 'Allows a single physical processor core to appear
+                          as several logical processors. This supports following options:
+                          true, false.'
+                        enum:
+                        - true
+                        - false
+                        type: boolean
+                      sriovEnabled:
+                        description: 'SR-IOV support enables a hypervisor to create
+                          virtual instances of a PCI-express device, potentially increasing
+                          performance. This supports following options: true, false.'
+                        enum:
+                        - true
+                        - false
+                        type: boolean
+                      virtualizationEnabled:
+                        description: 'Supports the virtualization of platform hardware.
+                          This supports following options: true, false.'
+                        enum:
+                        - true
+                        - false
+                        type: boolean
+                    type: object
+                  image:
+                    description: Image holds the details of the last image successfully
+                      provisioned to the host.
+                    properties:
+                      checksum:
+                        description: Checksum is the checksum for the image.
+                        type: string
+                      checksumType:
+                        description: ChecksumType is the checksum algorithm for the
+                          image. e.g md5, sha256, sha512
+                        enum:
+                        - md5
+                        - sha256
+                        - sha512
+                        type: string
+                      format:
+                        description: DiskFormat contains the format of the image (raw,
+                          qcow2, ...). Needs to be set to raw for raw images streaming.
+                          Note live-iso means an iso referenced by the url will be
+                          live-booted and not deployed to disk, and in this case the
+                          checksum options are not required and if specified will
+                          be ignored.
+                        enum:
+                        - raw
+                        - qcow2
+                        - vdi
+                        - vmdk
+                        - live-iso
+                        type: string
+                      url:
+                        description: URL is a location of an image to deploy.
+                        type: string
+                    required:
+                    - url
+                    type: object
+                  raid:
+                    description: The Raid set by the user
+                    properties:
+                      hardwareRAIDVolumes:
+                        description: The list of logical disks for hardware RAID,
+                          if rootDeviceHints isn't used, first volume is root volume.
+                          You can set the value of this field to `[]` to clear all
+                          the hardware RAID configurations.
+                        items:
+                          description: HardwareRAIDVolume defines the desired configuration
+                            of volume in hardware RAID
+                          properties:
+                            level:
+                              description: 'RAID level for the logical disk. The following
+                                levels are supported: 0;1;2;5;6;1+0;5+0;6+0.'
+                              enum:
+                              - "0"
+                              - "1"
+                              - "2"
+                              - "5"
+                              - "6"
+                              - 1+0
+                              - 5+0
+                              - 6+0
+                              type: string
+                            name:
+                              description: Name of the volume. Should be unique within
+                                the Node. If not specified, volume name will be auto-generated.
+                              maxLength: 64
+                              type: string
+                            numberOfPhysicalDisks:
+                              description: Integer, number of physical disks to use
+                                for the logical disk. Defaults to minimum number of
+                                disks required for the particular RAID level.
+                              minimum: 1
+                              type: integer
+                            rotational:
+                              description: Select disks with only rotational or solid-state
+                                storage
+                              type: boolean
+                            sizeGibibytes:
+                              description: Size (Integer) of the logical disk to be
+                                created in GiB. If unspecified or set be 0, the maximum
+                                capacity of disk will be used for logical disk.
+                              minimum: 0
+                              type: integer
+                          required:
+                          - level
+                          type: object
+                        nullable: true
+                        type: array
+                      softwareRAIDVolumes:
+                        description: The list of logical disks for software RAID,
+                          if rootDeviceHints isn't used, first volume is root volume.
+                          If HardwareRAIDVolumes is set this item will be invalid.
+                          The number of created Software RAID devices must be 1 or
+                          2. If there is only one Software RAID device, it has to
+                          be a RAID-1. If there are two, the first one has to be a
+                          RAID-1, while the RAID level for the second one can be 0,
+                          1, or 1+0. As the first RAID device will be the deployment
+                          device, enforcing a RAID-1 reduces the risk of ending up
+                          with a non-booting node in case of a disk failure. Software
+                          RAID will always be deleted.
+                        items:
+                          description: SoftwareRAIDVolume defines the desired configuration
+                            of volume in software RAID
+                          properties:
+                            level:
+                              description: 'RAID level for the logical disk. The following
+                                levels are supported: 0;1;1+0.'
+                              enum:
+                              - "0"
+                              - "1"
+                              - 1+0
+                              type: string
+                            physicalDisks:
+                              description: A list of device hints, the number of items
+                                should be greater than or equal to 2.
+                              items:
+                                description: RootDeviceHints holds the hints for specifying
+                                  the storage location for the root filesystem for
+                                  the image.
+                                properties:
+                                  deviceName:
+                                    description: A Linux device name like "/dev/vda".
+                                      The hint must match the actual value exactly.
+                                    type: string
+                                  hctl:
+                                    description: A SCSI bus address like 0:0:0:0.
+                                      The hint must match the actual value exactly.
+                                    type: string
+                                  minSizeGigabytes:
+                                    description: The minimum size of the device in
+                                      Gigabytes.
+                                    minimum: 0
+                                    type: integer
+                                  model:
+                                    description: A vendor-specific device identifier.
+                                      The hint can be a substring of the actual value.
+                                    type: string
+                                  rotational:
+                                    description: True if the device should use spinning
+                                      media, false otherwise.
+                                    type: boolean
+                                  serialNumber:
+                                    description: Device serial number. The hint must
+                                      match the actual value exactly.
+                                    type: string
+                                  vendor:
+                                    description: The name of the vendor or manufacturer
+                                      of the device. The hint can be a substring of
+                                      the actual value.
+                                    type: string
+                                  wwn:
+                                    description: Unique storage identifier. The hint
+                                      must match the actual value exactly.
+                                    type: string
+                                  wwnVendorExtension:
+                                    description: Unique vendor storage identifier.
+                                      The hint must match the actual value exactly.
+                                    type: string
+                                  wwnWithExtension:
+                                    description: Unique storage identifier with the
+                                      vendor extension appended. The hint must match
+                                      the actual value exactly.
+                                    type: string
+                                type: object
+                              minItems: 2
+                              type: array
+                            sizeGibibytes:
+                              description: Size (Integer) of the logical disk to be
+                                created in GiB. If unspecified or set be 0, the maximum
+                                capacity of disk will be used for logical disk.
+                              minimum: 0
+                              type: integer
+                          required:
+                          - level
+                          type: object
+                        maxItems: 2
+                        nullable: true
+                        type: array
+                    type: object
+                  rootDeviceHints:
+                    description: The RootDevicehints set by the user
+                    properties:
+                      deviceName:
+                        description: A Linux device name like "/dev/vda". The hint
+                          must match the actual value exactly.
+                        type: string
                       hctl:
-                        description: The SCSI location of the device
+                        description: A SCSI bus address like 0:0:0:0. The hint must
+                          match the actual value exactly.
                         type: string
+                      minSizeGigabytes:
+                        description: The minimum size of the device in Gigabytes.
+                        minimum: 0
+                        type: integer
                       model:
-                        description: Hardware model
-                        type: string
-                      name:
-                        description: A name for the disk, e.g. "disk 1 (boot)"
+                        description: A vendor-specific device identifier. The hint
+                          can be a substring of the actual value.
                         type: string
                       rotational:
-                        description: Whether this disk represents rotational storage
+                        description: True if the device should use spinning media,
+                          false otherwise.
                         type: boolean
                       serialNumber:
-                        description: The serial number of the device
+                        description: Device serial number. The hint must match the
+                          actual value exactly.
                         type: string
-                      sizeBytes:
-                        description: The size of the disk in Bytes
-                        format: int64
-                        type: integer
                       vendor:
-                        description: The name of the vendor of the device
+                        description: The name of the vendor or manufacturer of the
+                          device. The hint can be a substring of the actual value.
                         type: string
                       wwn:
-                        description: The WWN of the device
+                        description: Unique storage identifier. The hint must match
+                          the actual value exactly.
                         type: string
                       wwnVendorExtension:
-                        description: The WWN Vendor extension of the device
+                        description: Unique vendor storage identifier. The hint must
+                          match the actual value exactly.
                         type: string
                       wwnWithExtension:
-                        description: The WWN with the extension
+                        description: Unique storage identifier with the vendor extension
+                          appended. The hint must match the actual value exactly.
                         type: string
-                    required:
-                    - name
-                    - rotational
-                    - serialNumber
-                    - sizeBytes
                     type: object
-                  type: array
-                systemVendor:
-                  description: HardwareSystemVendor stores details about the whole
-                    hardware system.
-                  properties:
-                    manufacturer:
-                      type: string
-                    productName:
-                      type: string
-                    serialNumber:
-                      type: string
-                  required:
-                  - manufacturer
-                  - productName
-                  - serialNumber
-                  type: object
-              required:
-              - cpu
-              - firmware
-              - hostname
-              - nics
-              - ramMebibytes
-              - storage
-              - systemVendor
-              type: object
-            hardwareProfile:
-              description: The name of the profile matching the hardware details.
-              type: string
-            lastUpdated:
-              description: LastUpdated identifies when this status was last observed.
-              format: date-time
-              type: string
-            operationHistory:
-              description: OperationHistory holds information about operations performed
-                on this host.
-              properties:
-                deprovision:
-                  description: OperationMetric contains metadata about an operation
-                    (inspection, provisioning, etc.) used for tracking metrics.
-                  properties:
-                    end:
-                      format: date-time
-                      nullable: true
-                      type: string
-                    start:
-                      format: date-time
-                      nullable: true
-                      type: string
-                  type: object
-                inspect:
-                  description: OperationMetric contains metadata about an operation
-                    (inspection, provisioning, etc.) used for tracking metrics.
-                  properties:
-                    end:
-                      format: date-time
-                      nullable: true
-                      type: string
-                    start:
-                      format: date-time
-                      nullable: true
-                      type: string
-                  type: object
-                provision:
-                  description: OperationMetric contains metadata about an operation
-                    (inspection, provisioning, etc.) used for tracking metrics.
-                  properties:
-                    end:
-                      format: date-time
-                      nullable: true
-                      type: string
-                    start:
-                      format: date-time
-                      nullable: true
-                      type: string
-                  type: object
-                register:
-                  description: OperationMetric contains metadata about an operation
-                    (inspection, provisioning, etc.) used for tracking metrics.
-                  properties:
-                    end:
-                      format: date-time
-                      nullable: true
-                      type: string
-                    start:
-                      format: date-time
-                      nullable: true
-                      type: string
-                  type: object
-              type: object
-            operationalStatus:
-              description: OperationalStatus holds the status of the host
-              enum:
-              - ""
-              - OK
-              - discovered
-              - error
-              type: string
-            poweredOn:
-              description: indicator for whether or not the host is powered on
-              type: boolean
-            provisioning:
-              description: Information tracked by the provisioner.
-              properties:
-                ID:
-                  description: The machine's UUID from the underlying provisioning
-                    tool
-                  type: string
-                image:
-                  description: Image holds the details of the last image successfully
-                    provisioned to the host.
-                  properties:
-                    checksum:
-                      description: Checksum is the checksum for the image.
-                      type: string
-                    url:
-                      description: URL is a location of an image to deploy.
-                      type: string
-                  required:
-                  - checksum
-                  - url
-                  type: object
-                state:
-                  description: An indiciator for what the provisioner is doing with
-                    the host.
-                  type: string
-              required:
-              - ID
-              - state
-              type: object
-            triedCredentials:
-              description: the last credentials we sent to the provisioning backend
-              properties:
-                credentials:
-                  description: SecretReference represents a Secret Reference. It has
-                    enough information to retrieve secret in any namespace
-                  properties:
-                    name:
-                      description: Name is unique within a namespace to reference
-                        a secret resource.
-                      type: string
-                    namespace:
-                      description: Namespace defines the space within which the secret
-                        name must be unique.
-                      type: string
-                  type: object
-                credentialsVersion:
-                  type: string
-              type: object
-          required:
-          - errorMessage
-          - hardwareProfile
-          - operationHistory
-          - operationalStatus
-          - poweredOn
-          - provisioning
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+                  state:
+                    description: An indiciator for what the provisioner is doing with
+                      the host.
+                    type: string
+                required:
+                - ID
+                - state
+                type: object
+              triedCredentials:
+                description: the last credentials we sent to the provisioning backend
+                properties:
+                  credentials:
+                    description: SecretReference represents a Secret Reference. It
+                      has enough information to retrieve secret in any namespace
+                    properties:
+                      name:
+                        description: Name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: Namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                  credentialsVersion:
+                    type: string
+                type: object
+            required:
+            - errorCount
+            - errorMessage
+            - hardwareProfile
+            - operationalStatus
+            - poweredOn
+            - provisioning
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/cluster-api/hack/tools
 go 1.15
 
 require (
-	github.com/drone/envsubst v1.0.3-0.20200804185402-58bc65f69603
+	github.com/drone/envsubst v1.0.3
 	github.com/golang/mock v1.5.0
 	github.com/golangci/golangci-lint v1.40.0
 	github.com/jteeuwen/go-bindata v3.0.7+incompatible

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -169,8 +169,8 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
-github.com/drone/envsubst v1.0.3-0.20200804185402-58bc65f69603 h1:PMzPM0wCHDrXlO7TlEq5lqlhGKHEgSnUR4YMSEVKrQ0=
-github.com/drone/envsubst v1.0.3-0.20200804185402-58bc65f69603/go.mod h1:N2jZmlMufstn1KEqvbHjw40h1KyTmnVzHcSc9bFiJ2g=
+github.com/drone/envsubst v1.0.3 h1:PCIBwNDYjs50AsLZPYdfhSATKaRg/FJmDc2D6+C2x8g=
+github.com/drone/envsubst v1.0.3/go.mod h1:N2jZmlMufstn1KEqvbHjw40h1KyTmnVzHcSc9bFiJ2g=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustmop/soup v1.1.2-0.20190516214245-38228baa104e/go.mod h1:CgNC6SGbT+Xb8wGGvzilttZL1mc5sQ/5KkcxsZttMIk=


### PR DESCRIPTION
This PR removes run make target from Makefile since after the uplift to v1alpha5 version, it is not feasible to run go code only anymore. For local development and testing, Tilt is recommended instead.

This PR also updates the BMH CRDs to keep it up to date.

This PR also uplifts the envsubst module in tools.
