### PR TITLE
🐛 Remove capm3- prefix from root kustomize

### DIFF
--- a/config/default/capm3/kustomization.yaml
+++ b/config/default/capm3/kustomization.yaml
@@ -1,5 +1,6 @@
 # Adds namespace to all resources.
 namespace: capm3-system
+namePrefix: capm3-
 
 resources:
   - namespace.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,4 +1,3 @@
-namePrefix: capm3-
 
 commonLabels:
   cluster.x-k8s.io/provider: "infrastructure-metal3"


### PR DESCRIPTION
Adding `capm3-` prefix in root kustomize adds `capm3- `prefix on ipam objects as well. This created issue in IPAM kustomization since the cert-mnanager/ca-inject-from annotation doesn't get updated. This PR only keeps `capm3-` prefix for capm3 objects.

