### PR TITLE
🐛 Remove capm3- prefix from root kustomize

### DIFF
--- a/config/bmo/kustomization.yaml
+++ b/config/bmo/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+namePrefix: capm3-
+
 namespace: capm3-system
 resources:
 - https://raw.githubusercontent.com/metal3-io/baremetal-operator/master/config/render/capm3.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namePrefix: capm3-
 # Adds namespace to all resources.
 namespace: capm3-system
 

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -1,4 +1,3 @@
-namePrefix: capm3-
 
 commonLabels:
   cluster.x-k8s.io/provider: "infrastructure-metal3"

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,3 +1,5 @@
+
+namePrefix: capm3-
 namespace: capi-webhook-system
 
 resources:


### PR DESCRIPTION
Adding capm3- prefix in root kustomize adds capm3- prefix on ipam objects as well. This created issue in IPAM kustomization since the cert-mnanager/ca-inject-from annotation doesn't get updated. This PR
only keeps capm3- prefix for capm3 objects.
