### PR TITLE
🌱Add an option to choose the cluster template from metal3-dev-env

### DIFF
--- a/hack/e2e/environment.sh
+++ b/hack/e2e/environment.sh
@@ -30,6 +30,11 @@ export CONTROL_PLANE_MACHINE_COUNT=${CONTROL_PLANE_MACHINE_COUNT:-3}
 # shellcheck disable=SC2016
 export WORKER_MACHINE_COUNT=${WORKER_MACHINE_COUNT:-1}
 
+# These two variables below are required to render the cluster template dynamically from the metal3-dev-env.
+# This template is used by default, but users can change to use the static templates by changing the flavor. 
+export NUM_OF_MASTER_REPLICAS=${CONTROL_PLANE_MACHINE_COUNT}
+export NUM_OF_WORKER_REPLICAS=${WORKER_MACHINE_COUNT}
+
 # The e2e test framework would itself handle the cloning. It clones all the repos that are cloned in M3-DEV-ENV expect CAPM3.
 # It would use the local CAPM3 repo where the e2e test is running. 
 # Set this variable to false to avoid the dev-env to override what the test framework cloned. 

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -55,6 +55,18 @@ REPO_ROOT=$(realpath "$REPO_ROOT")
 rm -rf "${M3PATH}/cluster-api-provider-metal3" # To avoid 'permission denied' error when overriding .git/
 cp -R "${REPO_ROOT}" "${M3PATH}/" 
 make launch_mgmt_cluster verify
+# Generate the cluster template from metal3-dev-env
+if [ -f "${PWD}/scripts/generate-template.sh"  ]; then
+  ./scripts/generate-template.sh
+  DEV_ENV_CLUSTER_TEMPLATE="${REPO_ROOT}/templates/test/cluster-template-prow-ha-m3-dev-env.yaml"
+  TEMPLATE_DIR_SRC="vm-setup/roles/v1aX_integration_test/files/manifests/"
+  echo -n > "${DEV_ENV_CLUSTER_TEMPLATE}"
+  # shellcheck disable=SC2045
+  for file in $(ls -d ${TEMPLATE_DIR_SRC}*); do
+    echo "---" >> "${DEV_ENV_CLUSTER_TEMPLATE}"
+    cat "$file" >> "${DEV_ENV_CLUSTER_TEMPLATE}"
+  done
+fi
 popd
 
 SSH_PUB_KEY_CONTENT=$(cat "$HOME/.ssh/id_rsa.pub")

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -66,10 +66,14 @@ providers:
     files:
     - sourcePath: "${PWD}/metadata.yaml"
       targetName: "metadata.yaml"
-    - sourcePath: "${PWD}/test/e2e/_out/cluster-template-prow-ha.yaml"
-      targetName: "cluster-template-ha.yaml"
-    - sourcePath: "${PWD}/test/e2e/_out/cluster-template-prow-ha-centos.yaml"
-      targetName: "cluster-template-ha-centos.yaml"
+    # In the future, we can use the two commented templates below if we can find a way to make the e2e test less dependant on the dev-env.
+    # If someone wants to run the e2e test with a custom template instead of the one from the dev-env, they can modify and use the two templates.
+    # - sourcePath: "${PWD}/test/e2e/_out/cluster-template-prow-ha.yaml"
+    #   targetName: "cluster-template-ha.yaml"
+    # - sourcePath: "${PWD}/test/e2e/_out/cluster-template-prow-ha-centos.yaml"
+    #   targetName: "cluster-template-ha-centos.yaml"
+    - sourcePath: "${PWD}/test/e2e/_out/cluster-template-prow-ha-m3-dev-env.yaml"
+      targetName: "cluster-template-ha-m3-dev-env.yaml"
 
 variables:
   KUBERNETES_VERSION: "${KUBERNETES_VERSION}"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -37,12 +37,11 @@ var _ = Describe("Workload cluster creation", func() {
 		cniFile = "/tmp/calico.yaml"
 		osType := strings.ToLower(os.Getenv("OS"))
 		Expect(osType).ToNot(Equal(""))
+		flavorSuffix = "-m3-dev-env"
 
 		if osType == "centos" {
-			flavorSuffix = "-centos"
 			updateCalico(cniFile, "eth1")
 		} else {
-			flavorSuffix = ""
 			updateCalico(cniFile, "enp2s0")
 		}
 


### PR DESCRIPTION
This PR allows the e2e tests to apply the cluster template from metal3-dev-env.
