### PR TITLE
Delete the container Ironic-inspector-watch-log from the e2e test 

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -43,8 +43,6 @@ var _ = Describe("Workload cluster creation", func() {
 			flavorSuffix = ""
 			updateCalico(cniFile, "enp2s0")
 		}
-		// Quick fix to solve ipam nameprefix problem
-		replaceIpamCertAnnotation()
 
 		Expect(e2eConfig).ToNot(BeNil(), "Invalid argument. e2eConfig can't be nil when calling %s spec", specName)
 		Expect(clusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. clusterctlConfigPath must be an existing file when calling %s spec", specName)
@@ -91,16 +89,6 @@ var _ = Describe("Workload cluster creation", func() {
 		})
 	})
 })
-
-func replaceIpamCertAnnotation() {
-	filename := os.Getenv("PWD") + "/../../_artifacts/repository/infrastructure-metal3/v0.5.0/components.yaml"
-	component, err := os.ReadFile(filename)
-	Expect(err).To(BeNil(), "Unable to read infrastruture component")
-	org := "capm3-system/ipam-serving-cert"
-	dst := "capm3-system/capm3-ipam-serving-cert"
-	component = []byte(strings.Replace(string(component), org, dst, -1))
-	Expect(os.WriteFile(filename, component, 0666)).To(Succeed(), "Unable to write to file")
-}
 
 func updateCalico(calicoYaml, calicoInterface string) {
 	err := downloadFile(calicoYaml, "https://docs.projectcalico.org/manifests/calico.yaml")

--- a/test/e2e/pivoting_test.go
+++ b/test/e2e/pivoting_test.go
@@ -239,7 +239,6 @@ func removeIronicContainers() {
 		"mariadb",
 		"ironic-endpoint-keepalived",
 		"ironic-log-watch",
-		"ironic-inspector-log-watch",
 	}
 	dockerClient, err := docker.NewClientWithOpts()
 	Expect(err).To(BeNil(), "Unable to get docker client")


### PR DESCRIPTION
Recently, the container ironic-inspector-log-watch has been removed from BMO in https://github.com/metal3-io/baremetal-operator/pull/945. This cause an error for the e2e test. This PR aims to fix it by removing this container so the e2e test would no longer try to stop it. 