### PR TITLE
Update tilt configuration

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -12,9 +12,9 @@ settings = {
     "deploy_cert_manager": True,
     "preload_images_for_kind": True,
     "kind_cluster_name": "capm3",
-    "capi_version": "v0.4.0",
-    "cert_manager_version": "v1.1.0",
-    "kubernetes_version": "v1.18.8",
+    "capi_version": "v0.4.3",
+    "cert_manager_version": "v1.5.0",
+    "kubernetes_version": "v1.22.0",
     "enable_providers": [],
 }
 
@@ -218,7 +218,7 @@ def enable_provider(name):
         os.environ.update(substitutions)
 
         # Apply the kustomized yaml for this provider
-        yaml = str(kustomizesub(context + "/config"))
+        yaml = str(kustomizesub(context + "/config/default"))
         k8s_yaml(blob(yaml))
 
 

--- a/hack/gen_tilt_settings.sh
+++ b/hack/gen_tilt_settings.sh
@@ -36,13 +36,13 @@ function get_latest_release() {
 }
 
 CAPIRELEASEPATH="${CAPIRELEASEPATH:-https://api.github.com/repos/${CAPI_BASE_URL:-kubernetes-sigs/cluster-api}/releases}"
-export CAPIRELEASE="${CAPIRELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v0.3.")}"
+export CAPIRELEASE="${CAPIRELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v0.4.")}"
 
 cat <<EOF > tilt-settings.json
 {
   "capi_version": "${CAPIRELEASE}",
-  "cert_manager_version": "v0.16.1",
-  "kubernetes_version": "${KUBERNETES_VERSION:-v1.18.8}",
+  "cert_manager_version": "v1.5.0",
+  "kubernetes_version": "${KUBERNETES_VERSION:-v1.22.0}",
   "kustomize_substitutions": {
     "DEPLOY_KERNEL_URL": "${DEPLOY_KERNEL_URL}",
     "DEPLOY_RAMDISK_URL": "${DEPLOY_RAMDISK_URL}",

--- a/tilt_modules/cert_manager/Tiltfile
+++ b/tilt_modules/cert_manager/Tiltfile
@@ -26,7 +26,7 @@ spec:
 """
 
 # Deploys cert manager to your environment
-def deploy_cert_manager(registry="quay.io/jetstack", version="v0.16.1", load_to_kind=False, kind_cluster_name="kind"):
+def deploy_cert_manager(registry="quay.io/jetstack", version="v1.5.0", load_to_kind=False, kind_cluster_name="kind"):
     silent=True
 
     # check if cert-mamager is already installed, otherwise pre-load images & apply the manifest


### PR DESCRIPTION
Update tilt configuration
This PR updates versions of the capi, cert manager and kubernetes components. It also updates path of manifests