### PR TITLE
✨ Update IPAM reference in CAPM3

### DIFF
--- a/config/ipam/image_patch.yaml
+++ b/config/ipam/image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: quay.io/metal3-io/ip-address-manager:v0.1.0
+      - image: quay.io/metal3-io/ip-address-manager:v0.1.1
         name: manager

--- a/config/ipam/kustomization.yaml
+++ b/config/ipam/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 # When updating the release, update also the image tag in image_patch.yaml
 resources:
-- https://github.com/metal3-io/ip-address-manager/releases/download/v0.1.0/ipam-components.yaml
+- https://github.com/metal3-io/ip-address-manager/releases/download/v0.1.1/ipam-components.yaml
 
 patchesStrategicMerge:
     - image_patch.yaml


### PR DESCRIPTION
IPAM v0.1.1 release is out. This PR updates IPAM references with the same in CAPM3. 