### PR TITLE
🌱 Allow fetching repo tags when checking in GitHub Actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
     tags:
     - "v0.*.*"
 
-name: Main
+name: release
 
 jobs:
   build:
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Install go
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch ensures that we fetch all history for all tags
and branches when checking out with GitHub actions.