### PR TITLE
🐛 Fix bug with missing checkout to a tag during releasing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Export RELEASE_TAG var
+        run:  echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
       - name: checkout code
         uses: actions/checkout@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -395,6 +395,7 @@ release-notes: $(RELEASE_NOTES_DIR) $(RELEASE_NOTES)
 .PHONY: release
 release:
 	@if ! [ -z "$$(git status --porcelain)" ]; then echo "You have uncommitted changes"; exit 1; fi
+	git checkout "${RELEASE_TAG}"
 	$(MAKE) release-manifests
 	$(MAKE) release-notes
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to make sure that we checkout to the correct branch/tag
before we go to release, because otherwise we use wrong tag
version as the prior one.