### PR TITLE
✨ Generate providerID as a combination of BMH and M3M resources

### DIFF
--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -2461,7 +2461,7 @@ var _ = Describe("Metal3Data manager", func() {
 							},
 							{
 								Key:   "provideruid",
-								Value: fmt.Sprintf("%s_11111111", bmhuid),
+								Value: fmt.Sprintf("%s_%s", bmhuid, m3muidOctet),
 							},
 						},
 						ObjectNames: []capm3.MetaDataObjectName{
@@ -2667,7 +2667,7 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			expectedMetaData: map[string]string{
 				"String-1":     "String-1",
-				"provideruid":  fmt.Sprintf("%s_11111111", bmhuid),
+				"provideruid":  fmt.Sprintf("%s_%s", bmhuid, m3muidOctet),
 				"ObjectName-1": "machine-abc",
 				"ObjectName-2": "metal3machine-abc",
 				"ObjectName-3": "bmh-abc",

--- a/baremetal/mocks/zz_generated.metal3machine_manager.go
+++ b/baremetal/mocks/zz_generated.metal3machine_manager.go
@@ -126,12 +126,13 @@ func (mr *MockMachineManagerInterfaceMockRecorder) GetBaremetalHostID(arg0 inter
 }
 
 // GetProviderIDAndBMHID mocks base method.
-func (m *MockMachineManagerInterface) GetProviderIDAndBMHID() (string, *string) {
+func (m *MockMachineManagerInterface) GetProviderIDAndBMHID() (string, *string, string) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetProviderIDAndBMHID")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(*string)
-	return ret0, ret1
+	ret2, _ := ret[2].(string)
+	return ret0, ret1, ret2
 }
 
 // GetProviderIDAndBMHID indicates an expected call of GetProviderIDAndBMHID.
@@ -221,7 +222,7 @@ func (mr *MockMachineManagerInterfaceMockRecorder) SetFinalizer() *gomock.Call {
 }
 
 // SetNodeProviderID mocks base method.
-func (m *MockMachineManagerInterface) SetNodeProviderID(arg0 context.Context, arg1, arg2 string, arg3 baremetal.ClientGetter) error {
+func (m *MockMachineManagerInterface) SetNodeProviderID(arg0 context.Context, arg1 string, arg2 *string, arg3 baremetal.ClientGetter) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetNodeProviderID", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -22,19 +22,19 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
 	_ "github.com/go-logr/logr"
 	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -44,6 +44,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
+var m3muid = types.UID("11111111-9845-4321-1234-c74be387f57c")
+var bmhuid = types.UID("22222222-9845-4c48-9e49-c74be387f57c")
+var m3muidOctet = "11111111"
+var provideruid = fmt.Sprintf("%s_%s", bmhuid, m3muidOctet)
+var providerID = fmt.Sprintf("metal3://%s", provideruid)
+
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
@@ -52,11 +58,7 @@ const (
 	clusterName       = "testCluster"
 	metal3ClusterName = "testmetal3Cluster"
 	namespaceName     = "testNameSpace"
-	m3muid            = "11111111-9845-4321-1234-c74be387f57c"
-	bmhuid            = "22222222-9845-4c48-9e49-c74be387f57c"
 )
-
-var provideruid = fmt.Sprintf("%s_11111111", bmhuid)
 
 func TestManagers(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -237,8 +237,7 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 			"failed to update BaremetalHost", errType,
 		)
 	}
-
-	providerID, bmhID := machineMgr.GetProviderIDAndBMHID()
+	providerID, bmhID, m3mUID := machineMgr.GetProviderIDAndBMHID()
 	if bmhID == nil {
 		bmhID, err = machineMgr.GetBaremetalHostID(ctx)
 		if err != nil {
@@ -247,12 +246,14 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 			)
 		}
 		if bmhID != nil {
-			providerID = fmt.Sprintf("%s%s", baremetal.ProviderIDPrefix, *bmhID)
+			provideruid := baremetal.BuildProviderIDToNodes(*bmhID, m3mUID)
+			providerID = fmt.Sprintf("%s%s", baremetal.ProviderIDPrefix, provideruid)
+
 		}
 	}
 	if bmhID != nil {
 		// Set the providerID on the node if no Cloud provider
-		err = machineMgr.SetNodeProviderID(ctx, *bmhID, providerID, r.CapiClientGetter)
+		err = machineMgr.SetNodeProviderID(ctx, *bmhID, &providerID, r.CapiClientGetter)
 		if err != nil {
 			return checkMachineError(machineMgr, err,
 				"failed to set the target node providerID", errType,

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -25,16 +25,21 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"fmt"
+
 	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
+
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
+
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -58,6 +63,12 @@ const (
 	metal3machineName = "testmetal3machine"
 	namespaceName     = "testNameSpace"
 )
+
+var m3muid = types.UID("33333333-9845-4321-1234-c74be387f57c")
+var bmhuid = types.UID("44444444-9845-4c48-9e49-c74be387f57c")
+var m3muidOctet = "33333333"
+var provideruid = fmt.Sprintf("%s_%s", bmhuid, m3muidOctet)
+var providerID = fmt.Sprintf("metal3://%s", provideruid)
 
 func init() {
 	klog.InitFlags(nil)


### PR DESCRIPTION
Generate providerID as a combination of BareMetalHost UID and dynamic part of the Metal3Machine resource.

As we have it now, the providerID takes the value of the BMH uid, making it static for the life time of a metal3-dev-env deployment. The purpose of this PR is to make the provider ID unique per kubernetes node (CP or worker), deployment.

Verification:

1. scale out and upgrade succeeds with Legacy Label
2. scale out and upgrade succeeds with new Label
3. Given existing legacy (capm3 and kcp):
    upgrading capm3, scaling out results in legacy providerID. Also, upgrading results legacy providerID
4. Given existing legacy (capm3 and KCT):
    upgrading capm3 and KCT, scaling out results in new providerID. Also, upgrading results new providerID
  

