### PR TITLE
Fix CAPM3 name under GOPATH src

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -53,7 +53,7 @@ clone_repos
 REPO_ROOT=$(realpath "$REPO_ROOT") 
 # Copy the current CAPM3 repo to the Go source directory
 rm -rf "${M3PATH}/cluster-api-provider-metal3" # To avoid 'permission denied' error when overriding .git/
-cp -R "${REPO_ROOT}" "${M3PATH}/" 
+cp -R "${REPO_ROOT}" "${M3PATH}/cluster-api-provider-metal3/" 
 make launch_mgmt_cluster verify
 popd
 


### PR DESCRIPTION
This PR forces naming cluster-api-provider-metal3 in go/src since the cloned repo might have different name (e.g on the CI the cloned cluster-api-provider-metal3 is named tested_repo) 