### PR TITLE
✨ Bump clusterctl metadata to v1beta1

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,7 +3,7 @@ kind: Metadata
 releaseSeries:
 - major: 1
   minor: 0
-  contract: v1alpha4
+  contract: v1beta1
 - major: 0
   minor: 5
   contract: v1alpha4


### PR DESCRIPTION
✨ Bump clusterctl metadata to v1beta1

**What this PR does / why we need it**: For v1beta1 support, we should bump our metadata to v1beta1

