### PR TITLE
Give an option for NOT deploying bmh resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -348,7 +348,8 @@ set-manifest-pull-policy:
 # Deploy the BaremetalHost CRDs and CRs (for testing purposes only)
 deploy-bmo-cr:
 	kubectl apply -f examples/metal3crds/metal3.io_baremetalhosts.yaml
-	kubectl apply -f "${METAL3_BMH_CRS}"
+##	ignore error when bmh resource creation is not run yet, relevant when metal3-dev-env uses tilt ephemeral cluster
+	kubectl apply -f "${METAL3_BMH_CRS}" || true
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: generate-examples


### PR DESCRIPTION
When running tilt, the bmh resources will be not be generated in time.
This commit removes the functionality of deploying bmh resources from empty files
This has no effect when running make from capm3.