### PR TITLE
🌱 parameterize providerID parts in tests

### DIFF
--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -35,6 +35,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientfake "k8s.io/client-go/kubernetes/fake"
 	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2/klogr"
@@ -55,7 +56,8 @@ const (
 	kcpName                   = "kcp-pool1"
 )
 
-var ProviderID = fmt.Sprintf("%s12345ID6789", ProviderIDPrefix)
+var Bmhuid = types.UID("4d25a2c2-46e4-11ec-81d3-0242ac130003")
+var ProviderID = fmt.Sprintf("metal3://%s", Bmhuid)
 
 var testImageDiskFormat = pointer.StringPtr("raw")
 
@@ -1259,7 +1261,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
-					UID:       "12345ID6789",
+					UID:       Bmhuid,
 				},
 				Status: bmh.BareMetalHostStatus{
 					Provisioning: bmh.ProvisionStatus{
@@ -1279,7 +1281,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
-					UID:       "12345ID6789",
+					UID:       Bmhuid,
 				},
 				Status: bmh.BareMetalHostStatus{
 					Provisioning: bmh.ProvisionStatus{
@@ -2126,8 +2128,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		},
 		Entry("Empty providerID", testCaseGetProviderIDAndBMHID{}),
 		Entry("Provider ID set", testCaseGetProviderIDAndBMHID{
-			providerID:    pointer.StringPtr(fmt.Sprintf("%sabcd", ProviderIDPrefix)),
-			expectedBMHID: "abcd",
+			providerID:    pointer.StringPtr(ProviderID),
+			expectedBMHID: string(Bmhuid),
 		}),
 	)
 
@@ -2189,36 +2191,36 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 			Entry("Set target ProviderID, No matching node", testCaseSetNodePoviderID{
 				Node:               v1.Node{},
-				HostID:             "abcd",
+				HostID:             string(Bmhuid),
 				ExpectedError:      true,
-				ExpectedProviderID: fmt.Sprintf("%sabcd", ProviderIDPrefix),
+				ExpectedProviderID: ProviderID,
 			}),
 			Entry("Set target ProviderID, matching node", testCaseSetNodePoviderID{
 				Node: v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							ProviderLabelPrefix: "abcd",
+							ProviderLabelPrefix: string(bmhuid),
 						},
 					},
 				},
-				HostID:             "abcd",
+				HostID:             string(bmhuid),
 				ExpectedError:      false,
-				ExpectedProviderID: fmt.Sprintf("%sabcd", ProviderIDPrefix),
+				ExpectedProviderID: fmt.Sprintf("%s%s", ProviderIDPrefix, string(bmhuid)),
 			}),
 			Entry("Set target ProviderID, providerID set", testCaseSetNodePoviderID{
 				Node: v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							ProviderLabelPrefix: "abcd",
+							ProviderLabelPrefix: string(Bmhuid),
 						},
 					},
 					Spec: v1.NodeSpec{
-						ProviderID: fmt.Sprintf("%sabcd", ProviderIDPrefix),
+						ProviderID: ProviderID,
 					},
 				},
-				HostID:             "abcd",
+				HostID:             string(Bmhuid),
 				ExpectedError:      false,
-				ExpectedProviderID: fmt.Sprintf("%sabcd", ProviderIDPrefix),
+				ExpectedProviderID: ProviderID,
 			}),
 		)
 	})

--- a/controllers/metal3machine_controller_integration_test.go
+++ b/controllers/metal3machine_controller_integration_test.go
@@ -47,7 +47,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-var providerID = fmt.Sprintf("%s/foo/bar", baremetal.ProviderIDPrefix)
+var bmhuid = types.UID("63856098-4b80-11ec-81d3-0242ac130003")
+
+var providerID = fmt.Sprintf("%s%s", baremetal.ProviderIDPrefix, bmhuid)
 
 var bootstrapDataSecretName = "testdatasecret"
 
@@ -237,8 +239,8 @@ var _ = Describe("Reconcile metal3machine", func() {
 			}
 			if tc.CheckBMProviderID {
 				if tc.CheckBMProviderIDUnchanged {
-					Expect(testBMmachine.Spec.ProviderID).NotTo(Equal(pointer.StringPtr(fmt.Sprintf("%s%s", baremetal.ProviderIDPrefix,
-						string(testBMHost.ObjectMeta.UID)))))
+					Expect(testBMmachine.Spec.ProviderID).NotTo(Equal(fmt.Sprintf("%s%s", baremetal.ProviderIDPrefix,
+						string(testBMHost.ObjectMeta.UID))))
 				} else {
 					Expect(testBMmachine.Spec.ProviderID).To(Equal(pointer.StringPtr(fmt.Sprintf("%s%s", baremetal.ProviderIDPrefix,
 						string(testBMHost.ObjectMeta.UID)))))
@@ -542,7 +544,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 					newMetal3Machine(
 						metal3machineName, m3mMetaWithAnnotation(),
 						&capm3.Metal3MachineSpec{
-							ProviderID: pointer.StringPtr(fmt.Sprintf("%sabcd", baremetal.ProviderIDPrefix)),
+							ProviderID: pointer.StringPtr(providerID),
 							Image: capm3.Image{
 								Checksum: "abcd",
 								URL:      "abcd",
@@ -630,7 +632,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "bmh-0",
 							Labels: map[string]string{
-								baremetal.ProviderLabelPrefix: "54db7dd5-269a-4d94-a12a-c4eafcecb8e7",
+								baremetal.ProviderLabelPrefix: string(bmhuid),
 							},
 						},
 						Spec: v1.NodeSpec{},

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -18,7 +18,7 @@ package controllers
 
 import (
 	"context"
-	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -110,7 +110,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		m.EXPECT().GetBaremetalHostID(context.TODO()).Return(nil,
 			errors.New("Failed"),
 		)
-		m.EXPECT().SetProviderID("abc").MaxTimes(0)
+		m.EXPECT().SetProviderID(bmhuid).MaxTimes(0)
 		m.EXPECT().SetError(gomock.Any(), gomock.Any())
 		return m
 	}
@@ -120,11 +120,11 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		if tc.GetProviderIDFails {
 			m.EXPECT().GetProviderIDAndBMHID().Return("", nil)
 			m.EXPECT().GetBaremetalHostID(context.TODO()).Return(
-				pointer.StringPtr("abc"), nil,
+				pointer.StringPtr(string(bmhuid)), nil,
 			)
 		} else {
 			m.EXPECT().GetProviderIDAndBMHID().Return(
-				fmt.Sprintf("%sabc", baremetal.ProviderIDPrefix), pointer.StringPtr("abc"),
+				providerID, pointer.StringPtr(string(bmhuid)),
 			)
 			m.EXPECT().GetBaremetalHostID(context.TODO()).MaxTimes(0)
 		}
@@ -132,18 +132,18 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		// if we fail to set it on the node, we do not go further
 		if tc.SetNodeProviderIDFails {
 			m.EXPECT().
-				SetNodeProviderID(context.TODO(), "abc", fmt.Sprintf("%sabc", baremetal.ProviderIDPrefix), nil).
+				SetNodeProviderID(context.TODO(), string(bmhuid), providerID, nil).
 				Return(errors.New("Failed"))
-			m.EXPECT().SetProviderID("abc").MaxTimes(0)
+			m.EXPECT().SetProviderID(string(bmhuid)).MaxTimes(0)
 			m.EXPECT().SetError(gomock.Any(), gomock.Any())
 			return m
 		}
 
 		// we successfully set it on the node
 		m.EXPECT().
-			SetNodeProviderID(context.TODO(), "abc", fmt.Sprintf("%sabc", baremetal.ProviderIDPrefix), nil).
+			SetNodeProviderID(context.TODO(), string(bmhuid), providerID, nil).
 			Return(nil)
-		m.EXPECT().SetProviderID(fmt.Sprintf("%sabc", baremetal.ProviderIDPrefix))
+		m.EXPECT().SetProviderID(providerID)
 
 		// We did not get an id (got nil), so we'll requeue and not go further
 	} else {
@@ -151,7 +151,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		m.EXPECT().GetBaremetalHostID(context.TODO()).Return(nil, nil)
 
 		m.EXPECT().
-			SetNodeProviderID(context.TODO(), "abc", fmt.Sprintf("%sabc", baremetal.ProviderIDPrefix), nil).
+			SetNodeProviderID(context.TODO(), bmhuid, providerID, nil).
 			MaxTimes(0)
 	}
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -366,7 +366,7 @@ func newBareMetalHost(spec *bmh.BareMetalHostSpec,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bmh-0",
 			Namespace: namespaceName,
-			UID:       "54db7dd5-269a-4d94-a12a-c4eafcecb8e7",
+			UID:       bmhuid,
 		},
 		Spec:   *spec,
 		Status: *status,


### PR DESCRIPTION
The providerID generation is changing by https://github.com/metal3-io/cluster-api-provider-metal3/pull/324. 
Tests also need to change. However, providerID and related objects ids are scattered throughout the tests.


This PR centralizes definition of providerID related objects. This is required before modifying existing providerID related tests.