### PR TITLE
🐛 Remove vulnerable import k8s.io/kubernetes v1.13.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	k8s.io/apimachinery v0.21.4
 	k8s.io/client-go v0.21.4
 	k8s.io/klog/v2 v2.9.0
-	k8s.io/kubernetes v1.13.0
 	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a
 	sigs.k8s.io/cluster-api v0.4.4
 	sigs.k8s.io/cluster-api/test v0.4.4

--- a/go.sum
+++ b/go.sum
@@ -1425,7 +1425,6 @@ k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAG
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 h1:vEx13qjvaZ4yfObSSXW7BrMc/KQBBT/Jyee8XtLf4x0=
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=
 k8s.io/kubectl v0.21.4/go.mod h1:rRYB5HeScoGQKxZDQmus17pTSVIuqfm0D31ApET/qSM=
-k8s.io/kubernetes v1.13.0 h1:qTfB+u5M92k2fCCCVP2iuhgwwSOv1EkAkvQY1tQODD8=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/metrics v0.21.4/go.mod h1:uhWoVuVumUMSeCa1B1p2tm4Y4XuZIg0n24QEtB54wuA=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=

--- a/test/e2e/node_reuse_test.go
+++ b/test/e2e/node_reuse_test.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/kubernetes/pkg/util/taints"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	kcp "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha4"
@@ -517,8 +516,7 @@ func untaintNodes(clientSet *kubernetes.Clientset, nodes *corev1.NodeList, taint
 	count = 0
 	for i := range nodes.Items {
 		Logf("Untainting node %v ...", nodes.Items[i].Name)
-		newNode, changed, err := taints.RemoveTaint(&nodes.Items[i], taint)
-		Expect(err).To(BeNil(), "Failed to remove taint")
+		newNode, changed := removeTaint(&nodes.Items[i], taint)
 		if changed {
 			node, err := clientSet.CoreV1().Nodes().Update(ctx, newNode, metav1.UpdateOptions{})
 			Expect(err).To(BeNil(), "Failed to update nodes")
@@ -527,6 +525,44 @@ func untaintNodes(clientSet *kubernetes.Clientset, nodes *corev1.NodeList, taint
 		}
 	}
 	return
+}
+
+func removeTaint(node *corev1.Node, taint *corev1.Taint) (*corev1.Node, bool) {
+	newNode := node.DeepCopy()
+	nodeTaints := newNode.Spec.Taints
+	if len(nodeTaints) == 0 {
+		return newNode, false
+	}
+
+	if !taintExists(nodeTaints, taint) {
+		return newNode, false
+	}
+
+	newTaints, _ := deleteTaint(nodeTaints, taint)
+	newNode.Spec.Taints = newTaints
+	return newNode, true
+}
+
+func taintExists(taints []corev1.Taint, taintToFind *corev1.Taint) bool {
+	for _, taint := range taints {
+		if taint.MatchTaint(taintToFind) {
+			return true
+		}
+	}
+	return false
+}
+
+func deleteTaint(taints []corev1.Taint, taintToDelete *corev1.Taint) ([]corev1.Taint, bool) {
+	newTaints := []corev1.Taint{}
+	deleted := false
+	for i := range taints {
+		if taintToDelete.MatchTaint(&taints[i]) {
+			deleted = true
+			continue
+		}
+		newTaints = append(newTaints, taints[i])
+	}
+	return newTaints, deleted
 }
 
 func filterMachinesByStatusPhase(machines []clusterv1.Machine, phase clusterv1.MachinePhase) (result []clusterv1.Machine) {


### PR DESCRIPTION
This change refactors node_reuse tainting workflow to remove vulnerable import k8s.io/kubernetes v1.13.0
The `k8s.io/kubernetes v1.13.0` import results in following security vulnerability 
https://github.com/advisories/GHSA-f5f7-6478-qm6p
https://github.com/advisories/GHSA-vw47-mr44-3jf9
https://github.com/advisories/GHSA-74j8-88mm-7496

This PR intends to remove the import

