### PR TITLE
🌱 Remove omitempty fields and add optional tag to some status fields in v1beta1 types.

### DIFF
--- a/api/v1beta1/metal3cluster_types.go
+++ b/api/v1beta1/metal3cluster_types.go
@@ -31,7 +31,8 @@ const (
 // Metal3ClusterSpec defines the desired state of Metal3Cluster.
 type Metal3ClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
-	ControlPlaneEndpoint APIEndpoint `json:"controlPlaneEndpoint"`
+	// +optional
+	ControlPlaneEndpoint APIEndpoint `json:"controlPlaneEndpoint,omitempty"`
 	// +optional
 	NoCloudProvider bool `json:"noCloudProvider,omitempty"`
 }
@@ -75,6 +76,7 @@ type Metal3ClusterStatus struct {
 	// Baremetal case, it does not mean anything for now as no infrastructure
 	// steps need to be performed. Required by Cluster API. Set to True by the
 	// metal3Cluster controller after creation.
+	// +optional
 	Ready bool `json:"ready"`
 }
 

--- a/api/v1beta1/metal3data_types.go
+++ b/api/v1beta1/metal3data_types.go
@@ -58,7 +58,7 @@ type Metal3DataSpec struct {
 type Metal3DataStatus struct {
 	// Ready is a flag set to True if the secrets were rendered properly
 	// +optional
-	Ready bool `json:"ready,omitempty"`
+	Ready bool `json:"ready"`
 
 	// ErrorMessage contains the error message
 	// +optional

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3clusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3clusters.yaml
@@ -257,8 +257,6 @@ spec:
                 type: object
               noCloudProvider:
                 type: boolean
-            required:
-            - controlPlaneEndpoint
             type: object
           status:
             description: Metal3ClusterStatus defines the observed state of Metal3Cluster.
@@ -282,8 +280,6 @@ spec:
                   no infrastructure steps need to be performed. Required by Cluster
                   API. Set to True by the metal3Cluster controller after creation.
                 type: boolean
-            required:
-            - ready
             type: object
         type: object
     served: true


### PR DESCRIPTION
This PR will remove remove `omitempty` field and add `optional` tag to some status fields in v1beta1 types. It follows [CAPI PR](https://github.com/kubernetes-sigs/cluster-api/pull/5305). 
PR can be merged after #361 gets in.
