### PR TITLE
🐛 Use proper infrastructure var in e2e conf

### DIFF
--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -79,7 +79,7 @@ variables:
   KUBERNETES_VERSION: "${KUBERNETES_VERSION}"
   UPGRADED_K8S_VERSION: "${UPGRADED_K8S_VERSION}"
   CNI: "./data/cni/calico/calico.yaml"
-  APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha5"
+  APIVersion: "infrastructure.cluster.x-k8s.io/${CAPM3_VERSION}"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]


### PR DESCRIPTION
This PR updates left out e2e conf file to refer to latest infrastructure provider API version which will be used later in remediation e2e test. 