### PR TITLE
🌱 Add description to m3cluster NoCloudProvider boolean field

### DIFF
--- a/api/v1alpha4/metal3cluster_types.go
+++ b/api/v1alpha4/metal3cluster_types.go
@@ -32,7 +32,10 @@ const (
 type Metal3ClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	ControlPlaneEndpoint APIEndpoint `json:"controlPlaneEndpoint"`
-	NoCloudProvider      bool        `json:"noCloudProvider,omitempty"`
+	// Determines if the cluster is not to be deployed with an external cloud provider.
+	// If set to true, CAPM3 will use node labels to set providerID on the kubernetes nodes.
+	// If set to false, providerID is set on nodes by other entities and CAPM3 uses the value of the providerID on the m3m resource.
+	NoCloudProvider bool `json:"noCloudProvider,omitempty"`
 }
 
 // IsValid returns an error if the object is not valid, otherwise nil. The

--- a/api/v1alpha5/metal3cluster_types.go
+++ b/api/v1alpha5/metal3cluster_types.go
@@ -32,7 +32,10 @@ const (
 type Metal3ClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	ControlPlaneEndpoint APIEndpoint `json:"controlPlaneEndpoint"`
-	NoCloudProvider      bool        `json:"noCloudProvider,omitempty"`
+	// Determines if the cluster is not to be deployed with an external cloud provider.
+	// If set to true, CAPM3 will use node labels to set providerID on the kubernetes nodes.
+	// If set to false, providerID is set on nodes by other entities and CAPM3 uses the value of the providerID on the m3m resource.
+	NoCloudProvider bool `json:"noCloudProvider,omitempty"`
 }
 
 // IsValid returns an error if the object is not valid, otherwise nil. The

--- a/api/v1beta1/metal3cluster_types.go
+++ b/api/v1beta1/metal3cluster_types.go
@@ -33,6 +33,9 @@ type Metal3ClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
 	ControlPlaneEndpoint APIEndpoint `json:"controlPlaneEndpoint,omitempty"`
+	// Determines if the cluster is not to be deployed with an external cloud provider.
+	// If set to true, CAPM3 will use node labels to set providerID on the kubernetes nodes.
+	// If set to false, providerID is set on nodes by other entities and CAPM3 uses the value of the providerID on the m3m resource.
 	// +optional
 	NoCloudProvider bool `json:"noCloudProvider,omitempty"`
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3clusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3clusters.yaml
@@ -76,6 +76,11 @@ spec:
                 - port
                 type: object
               noCloudProvider:
+                description: Determines if the cluster is not to be deployed with
+                  an external cloud provider. If set to true, CAPM3 will use node
+                  labels to set providerID on the kubernetes nodes. If set to false,
+                  providerID is set on nodes by other entities and CAPM3 uses the
+                  value of the providerID on the m3m resource.
                 type: boolean
             required:
             - controlPlaneEndpoint
@@ -166,6 +171,11 @@ spec:
                 - port
                 type: object
               noCloudProvider:
+                description: Determines if the cluster is not to be deployed with
+                  an external cloud provider. If set to true, CAPM3 will use node
+                  labels to set providerID on the kubernetes nodes. If set to false,
+                  providerID is set on nodes by other entities and CAPM3 uses the
+                  value of the providerID on the m3m resource.
                 type: boolean
             required:
             - controlPlaneEndpoint
@@ -256,6 +266,11 @@ spec:
                 - port
                 type: object
               noCloudProvider:
+                description: Determines if the cluster is not to be deployed with
+                  an external cloud provider. If set to true, CAPM3 will use node
+                  labels to set providerID on the kubernetes nodes. If set to false,
+                  providerID is set on nodes by other entities and CAPM3 uses the
+                  value of the providerID on the m3m resource.
                 type: boolean
             type: object
           status:


### PR DESCRIPTION
Add description for NoCloudProvider
The description is visible with kubectl explain m3mcluster.spec.NoCloudProvider