### PR TITLE
🌱Use providerID and providerLabel prefixes

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -61,6 +61,8 @@ const (
 	bmRoleControlPlane  = "control-plane"
 	bmRoleNode          = "node"
 	PausedAnnotationKey = "metal3.io/capm3"
+	ProviderIDPrefix    = "metal3://"
+	ProviderLabelPrefix = "metal3.io/uuid"
 )
 
 // MachineManagerInterface is an interface for a MachineManager
@@ -1226,7 +1228,7 @@ func (m *MachineManager) SetNodeProviderID(ctx context.Context, bmhID, providerI
 		return errors.Wrap(err, "Error creating a remote client")
 	}
 
-	nodeLabel := fmt.Sprintf("metal3.io/uuid=%v", bmhID)
+	nodeLabel := fmt.Sprintf("%s=%v", ProviderLabelPrefix, bmhID)
 	nodes, nodesCount, err := m.getNodesWithLabel(ctx, nodeLabel, clientFactory)
 	if err != nil {
 		m.Log.Info("error retrieving node, requeuing")

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -55,7 +55,7 @@ const (
 	kcpName                   = "kcp-pool1"
 )
 
-var ProviderID = "metal3://12345ID6789"
+var ProviderID = fmt.Sprintf("%s12345ID6789", ProviderIDPrefix)
 
 var testImageDiskFormat = pointer.StringPtr("raw")
 
@@ -1233,7 +1233,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				return
 			}
 
-			providerID := fmt.Sprintf("metal3://%s", *bmhID)
+			providerID := fmt.Sprintf("%s%s", ProviderIDPrefix, *bmhID)
 			Expect(*tc.M3Machine.Spec.ProviderID).To(Equal(providerID))
 		},
 		Entry("Set ProviderID, empty annotations", testCaseGetSetProviderID{
@@ -2126,7 +2126,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		},
 		Entry("Empty providerID", testCaseGetProviderIDAndBMHID{}),
 		Entry("Provider ID set", testCaseGetProviderIDAndBMHID{
-			providerID:    pointer.StringPtr("metal3://abcd"),
+			providerID:    pointer.StringPtr(fmt.Sprintf("%sabcd", ProviderIDPrefix)),
 			expectedBMHID: "abcd",
 		}),
 	)
@@ -2191,34 +2191,34 @@ var _ = Describe("Metal3Machine manager", func() {
 				Node:               v1.Node{},
 				HostID:             "abcd",
 				ExpectedError:      true,
-				ExpectedProviderID: "metal3://abcd",
+				ExpectedProviderID: fmt.Sprintf("%sabcd", ProviderIDPrefix),
 			}),
 			Entry("Set target ProviderID, matching node", testCaseSetNodePoviderID{
 				Node: v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"metal3.io/uuid": "abcd",
+							ProviderLabelPrefix: "abcd",
 						},
 					},
 				},
 				HostID:             "abcd",
 				ExpectedError:      false,
-				ExpectedProviderID: "metal3://abcd",
+				ExpectedProviderID: fmt.Sprintf("%sabcd", ProviderIDPrefix),
 			}),
 			Entry("Set target ProviderID, providerID set", testCaseSetNodePoviderID{
 				Node: v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"metal3.io/uuid": "abcd",
+							ProviderLabelPrefix: "abcd",
 						},
 					},
 					Spec: v1.NodeSpec{
-						ProviderID: "metal3://abcd",
+						ProviderID: fmt.Sprintf("%sabcd", ProviderIDPrefix),
 					},
 				},
 				HostID:             "abcd",
 				ExpectedError:      false,
-				ExpectedProviderID: "metal3://abcd",
+				ExpectedProviderID: fmt.Sprintf("%sabcd", ProviderIDPrefix),
 			}),
 		)
 	})

--- a/baremetal/utils.go
+++ b/baremetal/utils.go
@@ -308,5 +308,5 @@ func getM3Machine(ctx context.Context, cl client.Client, mLog logr.Logger,
 }
 
 func parseProviderID(providerID string) string {
-	return strings.TrimPrefix(providerID, "metal3://")
+	return strings.TrimPrefix(providerID, ProviderIDPrefix)
 }

--- a/baremetal/utils_test.go
+++ b/baremetal/utils_test.go
@@ -19,6 +19,7 @@ package baremetal
 import (
 	"context"
 
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -736,7 +737,7 @@ var _ = Describe("Metal3 manager utils", func() {
 	)
 
 	It("Parses the providerID properly", func() {
-		Expect(parseProviderID("metal3://abcd")).To(Equal("abcd"))
+		Expect(parseProviderID(fmt.Sprintf("%sabcd", ProviderIDPrefix))).To(Equal("abcd"))
 		Expect(parseProviderID("foo://abcd")).To(Equal("foo://abcd"))
 	})
 })

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -247,7 +247,7 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 			)
 		}
 		if bmhID != nil {
-			providerID = fmt.Sprintf("metal3://%s", *bmhID)
+			providerID = fmt.Sprintf("%s%s", baremetal.ProviderIDPrefix, *bmhID)
 		}
 	}
 	if bmhID != nil {

--- a/controllers/metal3machine_controller_integration_test.go
+++ b/controllers/metal3machine_controller_integration_test.go
@@ -47,7 +47,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-var providerID = "metal3:///foo/bar"
+var providerID = fmt.Sprintf("%s/foo/bar", baremetal.ProviderIDPrefix)
 
 var bootstrapDataSecretName = "testdatasecret"
 
@@ -237,10 +237,10 @@ var _ = Describe("Reconcile metal3machine", func() {
 			}
 			if tc.CheckBMProviderID {
 				if tc.CheckBMProviderIDUnchanged {
-					Expect(testBMmachine.Spec.ProviderID).NotTo(Equal(pointer.StringPtr(fmt.Sprintf("metal3://%s",
+					Expect(testBMmachine.Spec.ProviderID).NotTo(Equal(pointer.StringPtr(fmt.Sprintf("%s%s", baremetal.ProviderIDPrefix,
 						string(testBMHost.ObjectMeta.UID)))))
 				} else {
-					Expect(testBMmachine.Spec.ProviderID).To(Equal(pointer.StringPtr(fmt.Sprintf("metal3://%s",
+					Expect(testBMmachine.Spec.ProviderID).To(Equal(pointer.StringPtr(fmt.Sprintf("%s%s", baremetal.ProviderIDPrefix,
 						string(testBMHost.ObjectMeta.UID)))))
 				}
 			}
@@ -542,7 +542,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 					newMetal3Machine(
 						metal3machineName, m3mMetaWithAnnotation(),
 						&capm3.Metal3MachineSpec{
-							ProviderID: pointer.StringPtr("metal3://abcd"),
+							ProviderID: pointer.StringPtr(fmt.Sprintf("%sabcd", baremetal.ProviderIDPrefix)),
 							Image: capm3.Image{
 								Checksum: "abcd",
 								URL:      "abcd",
@@ -630,7 +630,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "bmh-0",
 							Labels: map[string]string{
-								"metal3.io/uuid": "54db7dd5-269a-4d94-a12a-c4eafcecb8e7",
+								baremetal.ProviderLabelPrefix: "54db7dd5-269a-4d94-a12a-c4eafcecb8e7",
 							},
 						},
 						Spec: v1.NodeSpec{},

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -18,7 +18,7 @@ package controllers
 
 import (
 	"context"
-
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -124,7 +124,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 			)
 		} else {
 			m.EXPECT().GetProviderIDAndBMHID().Return(
-				"metal3://abc", pointer.StringPtr("abc"),
+				fmt.Sprintf("%sabc", baremetal.ProviderIDPrefix), pointer.StringPtr("abc"),
 			)
 			m.EXPECT().GetBaremetalHostID(context.TODO()).MaxTimes(0)
 		}
@@ -132,7 +132,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		// if we fail to set it on the node, we do not go further
 		if tc.SetNodeProviderIDFails {
 			m.EXPECT().
-				SetNodeProviderID(context.TODO(), "abc", "metal3://abc", nil).
+				SetNodeProviderID(context.TODO(), "abc", fmt.Sprintf("%sabc", baremetal.ProviderIDPrefix), nil).
 				Return(errors.New("Failed"))
 			m.EXPECT().SetProviderID("abc").MaxTimes(0)
 			m.EXPECT().SetError(gomock.Any(), gomock.Any())
@@ -141,9 +141,9 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 
 		// we successfully set it on the node
 		m.EXPECT().
-			SetNodeProviderID(context.TODO(), "abc", "metal3://abc", nil).
+			SetNodeProviderID(context.TODO(), "abc", fmt.Sprintf("%sabc", baremetal.ProviderIDPrefix), nil).
 			Return(nil)
-		m.EXPECT().SetProviderID("metal3://abc")
+		m.EXPECT().SetProviderID(fmt.Sprintf("%sabc", baremetal.ProviderIDPrefix))
 
 		// We did not get an id (got nil), so we'll requeue and not go further
 	} else {
@@ -151,7 +151,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		m.EXPECT().GetBaremetalHostID(context.TODO()).Return(nil, nil)
 
 		m.EXPECT().
-			SetNodeProviderID(context.TODO(), "abc", "metal3://abc", nil).
+			SetNodeProviderID(context.TODO(), "abc", fmt.Sprintf("%sabc", baremetal.ProviderIDPrefix), nil).
 			MaxTimes(0)
 	}
 


### PR DESCRIPTION
Use providerID and providerLabel prefixes

This PR parameterizes the providerID and providerID labels with `metal3://` and `metal3.io/uuid` respectively.
This is required in order to change the providerID generation logic. 