### PR TITLE
⚠️ Default LeaderElectionResourceLock to leases

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -7,26 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - configmaps/status
-  verbs:
-  - get
-  - update
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - events
   verbs:
   - create

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -86,18 +87,19 @@ func main() {
 	restConfig := ctrl.GetConfigOrDie()
 	restConfig.UserAgent = "cluster-api-provider-metal3-manager"
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
-		Scheme:                 myscheme,
-		MetricsBindAddress:     metricsBindAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaseDuration:          &leaderElectionLeaseDuration,
-		RenewDeadline:          &leaderElectionRenewDeadline,
-		RetryPeriod:            &leaderElectionRetryPeriod,
-		LeaderElectionID:       "controller-leader-election-capm3",
-		SyncPeriod:             &syncPeriod,
-		Port:                   webhookPort,
-		CertDir:                webhookCertDir,
-		HealthProbeBindAddress: healthAddr,
-		Namespace:              watchNamespace,
+		Scheme:                     myscheme,
+		MetricsBindAddress:         metricsBindAddr,
+		LeaseDuration:              &leaderElectionLeaseDuration,
+		RenewDeadline:              &leaderElectionRenewDeadline,
+		RetryPeriod:                &leaderElectionRetryPeriod,
+		LeaderElection:             enableLeaderElection,
+		LeaderElectionID:           "controller-leader-election-capm3",
+		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
+		SyncPeriod:                 &syncPeriod,
+		Port:                       webhookPort,
+		CertDir:                    webhookCertDir,
+		HealthProbeBindAddress:     healthAddr,
+		Namespace:                  watchNamespace,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
**What this PR does / why we need it**:
Controller runtime sets by default leader-election-resource-lock to ConfigMapsLeasesResourceLock since v0.7 so consumers can do smooth transitions: https://github.com/kubernetes-sigs/controller-runtime/blob/1730628f118be1128787012c164379e6ac46c75f/pkg/manager/manager.go#L143-L156

Configmap updates to keep the lease alive result in large memory hits for any component that caches/syncs configmaps, particularly the apiserver. Furthermore, it requires additional rbac for controllers. This PR defaults our controller to leases and
should mitigate overwhelming the apiserver in a large management cluster and avoid additional rbac.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #383
please refer to kubernetes-sigs/cluster-api#5388 and https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/providers/v1alpha4-to-v1beta1.md#warning-leaderelectionresourcelock-change-warning

/hold
