### PR TITLE
✨ Use grouping feature of Tilt to add CAPM3 label

### DIFF
--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -3,7 +3,15 @@
     "config": {
         "image": "quay.io/metal3-io/cluster-api-provider-metal3",
         "live_reload_deps": [
-            "api", "baremetal", "config", "controllers", "go.mod", "go.sum", "main.go"
-        ]
+            "api",
+            "baremetal",
+            "config",
+            "controllers",
+            "go.mod",
+            "go.sum",
+            "main.go"
+        ],
+        "label": "CAPM3",
+        "manager_name": "capm3-controller-manager"
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Update tilt-provider.json to add CAPM3 label in Tilt UX. This [grouping feature](https://blog.tilt.dev/2021/08/09/resource-grouping.html) is supported in tilt version >= v0.22.2.
This patch provides two different grouping strategies:

- by controllers
- and local binaries

See [CAPI](https://github.com/kubernetes-sigs/cluster-api/pull/5217) PR for grouping resources in Tilt.
Also, the corresponding controller and binary will be grouped under 'CAPM3' group label as shown in the local Tilt setup using BMO,CAPM3&IPAM controllers.

![CAPM3](https://user-images.githubusercontent.com/40443040/147975022-615fe044-2a62-4cf2-80c1-73df84a95149.png)

Related patches in: [IPAM](https://github.com/metal3-io/ip-address-manager/pull/83)&[BMO](https://github.com/metal3-io/baremetal-operator/pull/1061).

/hold needs local testing
