### PR TITLE
🌱 Refactor test scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ test/e2e/_out
 /tilt.d
 tilt-settings.json
 tilt_config.json
+
+github/

--- a/Makefile
+++ b/Makefile
@@ -89,11 +89,12 @@ help:  ## Display this help
 ## Testing
 ## --------------------------------------
 
-.PHONY: testprereqs
-testprereqs: $(KUBEBUILDER) $(KUSTOMIZE)
+.PHONY: unit
+unit: ## Run unit test
+	source ./hack/fetch_ext_bins.sh; fetch_tools; setup_envs; go test -v ./controllers/... ./baremetal/... -coverprofile ./cover.out; cd api; go test -v ./... -coverprofile ./cover.out
 
 .PHONY: test
-test: testprereqs fmt lint ## Run tests
+test: fmt lint ## Run tests
 	source ./hack/fetch_ext_bins.sh; fetch_tools; setup_envs; go test -v ./controllers/... ./baremetal/... -coverprofile ./cover.out; cd api; go test -v ./... -coverprofile ./cover.out
 
 .PHONY: test-e2e
@@ -212,8 +213,11 @@ manifest-lint:
 .PHONY: modules
 modules: ## Runs go mod to ensure proper vendoring.
 	go mod tidy
+	go mod verify
 	cd $(TOOLS_DIR); go mod tidy
+	cd $(TOOLS_DIR); go mod verify
 	cd api; go mod tidy
+	cd api; go mod verify
 
 .PHONY: generate
 generate: ## Generate code

--- a/hack/fetch_ext_bins.sh
+++ b/hack/fetch_ext_bins.sh
@@ -26,17 +26,17 @@ if [[ -n "${TRACE}" ]]; then
   set -x
 fi
 
-k8s_version=1.19.2
-goarch=amd64
-goos="unknown"
+k8s_version=1.22.0
+arch=amd64
+os="unknown"
 
 if [[ "${OSTYPE}" == "linux"* ]]; then
-  goos="linux"
+  os="linux"
 elif [[ "${OSTYPE}" == "darwin"* ]]; then
-  goos="darwin"
+  os="darwin"
 fi
 
-if [[ "$goos" == "unknown" ]]; then
+if [[ "$os" == "unknown" ]]; then
   echo "OS '$OSTYPE' not supported. Aborting." >&2
   exit 1
 fi
@@ -58,9 +58,7 @@ function header_text {
   echo "$header$*$reset"
 }
 
-tmp_root=/tmp
-
-kb_root_dir=${tmp_root}/kubebuilder
+kb_root_dir="/tmp/kubebuilder"
 
 # Skip fetching and untaring the tools by setting the SKIP_FETCH_TOOLS variable
 # in your environment to any value:
@@ -71,42 +69,30 @@ kb_root_dir=${tmp_root}/kubebuilder
 # machine, but rebuild the kubebuilder and kubebuilder-bin binaries.
 SKIP_FETCH_TOOLS=${SKIP_FETCH_TOOLS:-""}
 
-function prepare_staging_dir {
-  header_text "preparing staging dir"
-
-  if [[ -z "${SKIP_FETCH_TOOLS}" ]]; then
-    rm -rf "${kb_root_dir}"
-  else
-    rm -f "${kb_root_dir}/bin/kubebuilder"
-    rm -f "${kb_root_dir}/bin/kubebuilder-gen"
-    rm -f "${kb_root_dir}/bin/vendor.tar.gz"
-  fi
-}
-
-# fetch k8s API gen tools and make it available under kb_root_dir/bin.
+# Download the tarball containing  etcd, k8s API server and
+# kubelet binaries and store them under kb_root_dir/bin.
 function fetch_tools {
   if [[ -n "$SKIP_FETCH_TOOLS" ]]; then
     return 0
   fi
 
-  header_text "fetching tools"
-  kb_tools_archive_name="kubebuilder-tools-${k8s_version}-${goos}-${goarch}.tar.gz"
-  kb_tools_download_url="https://storage.googleapis.com/kubebuilder-tools/${kb_tools_archive_name}"
+  mkdir -p "${kb_root_dir}"
+  header_text "fetching binaries"
+  kb_tools_archive_name="envtest-bins.tar.gz"
+  kb_tools_download_url=https://go.kubebuilder.io/test-tools/"${k8s_version}"/"${os}"/"${arch}"
+  kb_tools_archive_path="/tmp/${kb_tools_archive_name}"
 
-  kb_tools_archive_path="${tmp_root}/${kb_tools_archive_name}"
   if [[ ! -f ${kb_tools_archive_path} ]]; then
-    curl -fsL ${kb_tools_download_url} -o "${kb_tools_archive_path}"
+    curl -sSLo "${kb_tools_archive_path}" "${kb_tools_download_url}"
   fi
-  tar -zvxf "${kb_tools_archive_path}" -C "${tmp_root}/"
+  tar -C "${kb_root_dir}/" --strip-components=1 -zvxf "${kb_tools_archive_path}"
   rm "${kb_tools_archive_path}"
 }
 
 function setup_envs {
   header_text "setting up env vars"
-
-  # Setup env vars
-  export PATH=${kb_root_dir}/bin:$PATH
-  export TEST_ASSET_KUBECTL=${kb_root_dir}/bin/kubectl
-  export TEST_ASSET_KUBE_APISERVER=${kb_root_dir}/bin/kube-apiserver
-  export TEST_ASSET_ETCD=${kb_root_dir}/bin/etcd
+  # Export binaries path"
+  export PATH="${kb_root_dir}/bin:$PATH"
+  export SKIP_FETCH_TOOLS=1
+  export KUBEBUILDER_ASSETS="${kb_root_dir}/bin/"
 }

--- a/hack/tools/install_kubebuilder.sh
+++ b/hack/tools/install_kubebuilder.sh
@@ -2,14 +2,10 @@
 
 [[ -f bin/kubebuilder ]] && exit 0
 
-version=2.2.0
-arch=amd64
+# kubebuilder version
+kb_version=3.2.0
 
 mkdir -p ./bin
-curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_linux_${arch}.tar.gz"
-
-tar -zxvf kubebuilder_${version}_linux_${arch}.tar.gz
-mv kubebuilder_${version}_linux_${arch}/bin/* bin
-
-rm kubebuilder_${version}_linux_${arch}.tar.gz
-rm -r kubebuilder_${version}_linux_${arch}
+cd ./bin || exit
+curl -L -o kubebuilder "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${kb_version}/kubebuilder_$(go env GOOS)_$(go env GOARCH)"
+chmod +x kubebuilder

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -11,7 +11,7 @@ if [ "${IS_CONTAINER}" != "false" ]; then
   cp -r . /tmp/unit
   cp -r /usr/local/kubebuilder/bin /tmp/unit/hack/tools
   cd /tmp/unit
-  make test
+  make unit
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \


### PR DESCRIPTION
**What this PR does / why we need it**:
We have been seeing quite many flakiness in the unit test scripts. 
This is a first set of patches that will be trying to fix that flakiness.

1. When running make generate, some of the autogenerated code ends up
in github/ dir, which should be outside of staging area. This patch
adds github/ dir to .gitignore, so that we don't accidentally submit
a PR with those changes included.

2. Current `install_kubebuilder.sh` script downloads a tarball containing
other binaries apart from kubebuilder, such as etcd, kube-apiserver
and kubectl. We use kubebuilder binary only when running make generate
target, meaning there is no need to set up a test k8s env with those
binaries. Those are only needed to setup a fake k8s env while unit
testing, via make unit/test target.

3. Delete kubebuilder & kustomize installation when running go tests.
We currenrty install them on every single run of `test/unit` test
run, and in fact go test doesn't require them to perform tests.

4. Run `go mod verify` after tidy to ensure go.sum matches with
downloaded packages.