### PR TITLE
🐛  Fix node reuse test workflow in E2E

### DIFF
--- a/test/e2e/cert_rotation_test.go
+++ b/test/e2e/cert_rotation_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func cert_rotation() {
-	Logf("Start the certificate rotation test")
+	Logf("Starting certificate rotation tests")
 	By("Check if Ironic pod is running")
 	targetClusterClientSet := targetCluster.GetClientSet()
 	ironicNamespace := os.Getenv("NAMEPREFIX") + "-system"
@@ -84,7 +84,7 @@ func cert_rotation() {
 		}
 		return errors.New("Ironic pod is not in running state")
 	}, e2eConfig.GetIntervals(specName, "wait-pod-restart")...).Should(BeNil())
-	By("PASSED!")
+	By("CERTIFICATE ROTATION TESTS PASSED!")
 
 }
 

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -120,6 +120,19 @@ func annotateBmh(ctx context.Context, client client.Client, host bmo.BareMetalHo
 	Expect(helper.Patch(ctx, &host)).To(Succeed())
 }
 
+// deleteNodeReuseLabelFromHost deletes nodeReuseLabelName from the host if exists
+func deleteNodeReuseLabelFromHost(ctx context.Context, client client.Client, host bmo.BareMetalHost, nodeReuseLabelName string) {
+	helper, err := patch.NewHelper(&host, client)
+	Expect(err).NotTo(HaveOccurred())
+	labels := host.GetLabels()
+	if labels != nil {
+		if _, ok := labels[nodeReuseLabelName]; ok {
+			delete(host.Labels, nodeReuseLabelName)
+		}
+	}
+	Expect(helper.Patch(ctx, &host)).To(Succeed())
+}
+
 func scaleMachineDeployment(ctx context.Context, clusterClient client.Client, newReplicas int) {
 	machineDeployments := framework.GetMachineDeploymentsByCluster(ctx, framework.GetMachineDeploymentsByClusterInput{
 		Lister:      clusterClient,

--- a/test/e2e/node_reuse_test.go
+++ b/test/e2e/node_reuse_test.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/utils/pointer"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	kcp "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework"
@@ -25,6 +24,7 @@ import (
 )
 
 func node_reuse() {
+	Logf("Starting node reuse tests")
 	var (
 		targetClusterClient      = targetCluster.GetClient()
 		clientSet                = targetCluster.GetClientSet()
@@ -44,7 +44,7 @@ func node_reuse() {
 	controlplaneNodes := getControlplaneNodes(clientSet)
 	untaintNodes(clientSet, controlplaneNodes, controlplaneTaint)
 
-	By("Scale own machinedeployment to 0")
+	By("Scale down MachineDeployment to 0")
 	scaleMachineDeployment(ctx, targetClusterClient, 0)
 
 	Byf("Wait until the worker is scaled down and %d BMH(s) Available", numberOfWorkers)
@@ -280,6 +280,21 @@ func node_reuse() {
 		}, e2eConfig.GetIntervals(specName, "wait-cp-available")...,
 	).Should(Succeed())
 
+	By("Get MachineDeployment")
+	machineDeployments := framework.GetMachineDeploymentsByCluster(ctx, framework.GetMachineDeploymentsByClusterInput{
+		Lister:      targetClusterClient,
+		ClusterName: clusterName,
+		Namespace:   namespace,
+	})
+	Expect(len(machineDeployments)).To(Equal(1), "Expected exactly 1 MachineDeployment")
+	machineDeploy := machineDeployments[0]
+
+	By("Get Metal3MachineTemplate name for MachineDeployment")
+	m3machineTemplateName = fmt.Sprintf("%s-workers", clusterName)
+
+	By("Point to proper Metal3MachineTemplate in MachineDeployment")
+	pointMDtoM3mt(m3machineTemplateName, machineDeploy.Name, targetClusterClient)
+
 	By("Scale the worker up to 1 to start testing MachineDeployment")
 	scaleMachineDeployment(ctx, targetClusterClient, 1)
 
@@ -288,7 +303,7 @@ func node_reuse() {
 		func() int {
 			bmhs := bmo.BareMetalHostList{}
 			Expect(targetClusterClient.List(ctx, &bmhs, client.InNamespace(namespace))).To(Succeed())
-			provisionedBmhs := filterBmhsByProvisioningState(bmhs.Items, bmo.StateAvailable)
+			provisionedBmhs := filterBmhsByProvisioningState(bmhs.Items, bmo.StateProvisioned)
 			return len(provisionedBmhs)
 		}, e2eConfig.GetIntervals(specName, "wait-bmh-provisioned")...,
 	).Should(Equal(2))
@@ -308,14 +323,6 @@ func node_reuse() {
 	mdBmhBeforeUpgrade := getProvisionedBmhNamesUuids(targetClusterClient)
 
 	By("Update maxSurge/maxUnavailable fields to 0/1 in MachineDeployment test case")
-	machineDeployments := framework.GetMachineDeploymentsByCluster(ctx, framework.GetMachineDeploymentsByClusterInput{
-		Lister:      targetClusterClient,
-		ClusterName: clusterName,
-		Namespace:   namespace,
-	})
-	Expect(len(machineDeployments)).To(Equal(1), "Expected exactly 1 MachineDeployment")
-	machineDeploy := machineDeployments[0]
-
 	patch = []byte(`{
 		"spec": {
 			"strategy": {
@@ -330,15 +337,16 @@ func node_reuse() {
 	Expect(err).To(BeNil(), "Failed to patch MachineDeployment")
 
 	By("Update Metal3MachineTemplate nodeReuse field to 'True'")
-	m3machineTemplateName = fmt.Sprintf("%s-workers", clusterName)
 	updateNodeReuse(true, m3machineTemplateName, targetClusterClient)
 
-	By("List BMHs and mark all available BMHs with unhealthy annotation")
+	By("List BMHs, remove nodeReuse label from all BMHs")
 	bmhs := bmo.BareMetalHostList{}
 	Expect(targetClusterClient.List(ctx, &bmhs, client.InNamespace(namespace))).To(Succeed())
 	for _, item := range bmhs.Items {
 		if item.Status.Provisioning.State == bmo.StateAvailable {
-			annotateBmh(ctx, targetClusterClient, item, "capi.metal3.io/unhealthy", pointer.String(""))
+			// We make sure that all available BMHs are choosable by removing nodeReuse label
+			// set on them while testing KCP node reuse scenario previously.
+			deleteNodeReuseLabelFromHost(ctx, targetClusterClient, item, "infrastructure.cluster.x-k8s.io/node-reuse")
 		}
 	}
 
@@ -391,15 +399,6 @@ func node_reuse() {
 		},
 		e2eConfig.GetIntervals(specName, "wait-bmh-deprovisioning-available")...,
 	).Should(Succeed())
-
-	By("Unmark all the available BMHs with unhealthy annotation")
-	bmhs = bmo.BareMetalHostList{}
-	Expect(targetClusterClient.List(ctx, &bmhs, client.InNamespace(namespace))).To(Succeed())
-	for _, item := range bmhs.Items {
-		if item.Status.Provisioning.State == bmo.StateAvailable {
-			annotateBmh(ctx, targetClusterClient, item, "capi.metal3.io/unhealthy", nil)
-		}
-	}
 
 	By("Check if just deprovisioned BMH re-used for next provisioning")
 	Eventually(
@@ -473,7 +472,7 @@ func node_reuse() {
 		e2eConfig.GetIntervals(specName, "wait-machine-running")...,
 	).Should(Equal(numberOfAllBmh))
 
-	By("NODE_REUSE PASSED!")
+	By("NODE REUSE TESTS PASSED!")
 }
 
 func getControlplaneNodes(clientSet *kubernetes.Clientset) *corev1.NodeList {
@@ -510,6 +509,19 @@ func updateNodeReuse(nodeReuse bool, m3machineTemplateName string, clusterClient
 	// verify that nodereuse is true
 	Expect(clusterClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: m3machineTemplateName}, &m3machineTemplate)).To(Succeed())
 	Expect(m3machineTemplate.Spec.NodeReuse).To(BeTrue())
+}
+
+func pointMDtoM3mt(m3mtname, mdName string, clusterClient client.Client) {
+	md := capi.MachineDeployment{}
+	Expect(clusterClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: mdName}, &md)).To(Succeed())
+	helper, err := patch.NewHelper(&md, clusterClient)
+	Expect(err).NotTo(HaveOccurred())
+	md.Spec.Template.Spec.InfrastructureRef.Name = m3mtname
+	Expect(helper.Patch(ctx, &md)).To(Succeed())
+
+	// verify that MachineDeployment is pointing to exact m3mt where nodeReuse is enabled
+	Expect(clusterClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: mdName}, &md)).To(Succeed())
+	Expect(md.Spec.Template.Spec.InfrastructureRef.Name).To(BeEquivalentTo(fmt.Sprintf("%s-workers", clusterName)))
 }
 
 func untaintNodes(clientSet *kubernetes.Clientset, nodes *corev1.NodeList, taint *corev1.Taint) (count int) {

--- a/test/e2e/pivoting_test.go
+++ b/test/e2e/pivoting_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func pivoting() {
+	Logf("Starting pivoting tests")
 	By("Remove Ironic containers from the source cluster")
 	ephemeralCluster := os.Getenv("EPHEMERAL_CLUSTER")
 	if ephemeralCluster == "kind" {
@@ -156,7 +157,7 @@ func pivoting() {
 		return nil
 	}, e2eConfig.GetIntervals(specName, "wait-machine-running")...).Should(BeNil())
 
-	By("PASSED!")
+	By("PIVOTING TESTS PASSED!")
 }
 
 func configureIronicConfigmap(isIronicDeployed bool) {

--- a/test/e2e/remediation_test.go
+++ b/test/e2e/remediation_test.go
@@ -40,6 +40,7 @@ const (
 const defaultNamespace = "default"
 
 func test_remediation() {
+	Logf("Starting remediation tests")
 	bootstrapClient := bootstrapClusterProxy.GetClient()
 	targetClient := targetCluster.GetClient()
 	allMachinesCount := int(controlPlaneMachineCount + workerMachineCount)
@@ -280,7 +281,7 @@ func test_remediation() {
 		g.Expect(filterMachinesByPhase(machines.Items, "Running")).To(HaveLen(allMachinesCount))
 	}, e2eConfig.GetIntervals(specName, "wait-machine-remediation")...).Should(Succeed())
 
-	By("PASSED!")
+	By("REMEDIATION TESTS PASSED!")
 }
 
 type bmhToMachine struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch fixes the issue in node reuse testing workflow in e2e where:
- after testing KCP node reuse use case, we do scale down KCP to 1 and and it triggers de provisioning of BMHs to start testing MD use case, thus all BMH that were used before would have node reuse labels on them. So while testing MD case, we do not remove them and it will always chooses the same host since other BMHs have already KCP name set in node reuse label. To fix it, we remove old labels from all BMHs and then test MD use case to check if node reuse feature is working.  
- also removing marking/unmarking of BMHs with unhealthy annotation, since now when MD maxSurge field is updated with `0` it deletes the existing machine first and then recreates a new one, resulting in unneeded unhealthy annotation setting/unsetting. 
- since new m3mt has been created during remediation tests, MD was pointing to the old m3mt and tests were checking nodeReuse field in original m3mt which has no effect. This patch ensures, we do point to proper m3mt from MD first, and then scale up a worker so nodeReuse field in corresponding m3mt is respected accordingly. 
- also makes logging of starting and passing phase of the each tests more clearer with specific test name 