### PR TITLE
🐛 Untaint the CP node once upgraded

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -89,7 +89,7 @@ source "${REPO_ROOT}/hack/ensure-kustomize.sh"
 
 # This will run the tests with env variabls defined in environment.sh
 # or exported by metal3-dev-env scripts
-${M3_DEV_ENV_PATH}/scripts/run_command.sh make e2e-tests
+SKIP_CLEANUP=true ${M3_DEV_ENV_PATH}/scripts/run_command.sh make e2e-tests || sleep infinity
 
 pushd ${M3_DEV_ENV_PATH} || exit 1
 make clean

--- a/test/e2e/node_reuse_test.go
+++ b/test/e2e/node_reuse_test.go
@@ -331,9 +331,9 @@ func node_reuse() {
 	bmhs := bmo.BareMetalHostList{}
 	Expect(targetClusterClient.List(ctx, &bmhs, client.InNamespace(namespace))).To(Succeed())
 	for _, item := range bmhs.Items {
-		if item.Status.Provisioning.State == bmo.StateAvailable {
-			annotateBmh(ctx, targetClusterClient, item, "capi.metal3.io/unhealthy", pointer.String(""))
-		}
+		// if item.Status.Provisioning.State == bmo.StateAvailable {
+		annotateBmh(ctx, targetClusterClient, item, "capi.metal3.io/unhealthy", pointer.String(""))
+		//}
 	}
 
 	Byf("Upgrade the MachineDeployment k8s version from %s to %s ", kubernetesVersion, upgradedK8sVersion)
@@ -390,9 +390,9 @@ func node_reuse() {
 	bmhs = bmo.BareMetalHostList{}
 	Expect(targetClusterClient.List(ctx, &bmhs, client.InNamespace(namespace))).To(Succeed())
 	for _, item := range bmhs.Items {
-		if item.Status.Provisioning.State == bmo.StateAvailable {
-			annotateBmh(ctx, targetClusterClient, item, "capi.metal3.io/unhealthy", nil)
-		}
+		//if item.Status.Provisioning.State == bmo.StateAvailable {
+		annotateBmh(ctx, targetClusterClient, item, "capi.metal3.io/unhealthy", nil)
+		//}
 	}
 
 	By("Check if just deprovisioned BMH re-used for next provisioning")


### PR DESCRIPTION
Sometime CP nodes wait for the new upgraded node to be untainted to start deprovisioning so this PR untaint nodes as soon as they upgraded 