### PR TITLE
Fix the kcp issue in e2e test

### DIFF
--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -83,7 +83,7 @@ variables:
 
 intervals:
   default/wait-controllers: ["3m", "10s"]
-  default/wait-cluster: ["20m", "10s"]
+  default/wait-cluster: ["20m", "30s"] # The second time to check the availibility of the cluster should happen late, so kcp object has time to be created
   default/wait-control-plane: ["30m", "10s"]
   default/wait-worker-nodes: ["30m", "10s"]
   default/wait-delete-cluster: ["20m", "10s"]


### PR DESCRIPTION
This PR aims to fix this issue: https://jenkins.nordix.org/view/Metal3/job/airship_master_e2e_v1b1_test_centos/10/console
Currently, when the CAPI e2e  framework checks the present of the cluster, it assumes that KCP is ready at the same time when the cluster object is ready. However, it may be not true because of the uncertainty of the underlying infra.
This PR makes the interval between two checks for the cluster present wider. The goal is when the cluster is checked and determined as "ready", the kcp object also has time to be ready. 
