### PR TITLE
🐛 Use v0.5.x tag for manager image in release-0.5 images

### DIFF
--- a/config/default/capm3/manager_image_patch.yaml
+++ b/config/default/capm3/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: quay.io/metal3-io/cluster-api-provider-metal3:main
+      - image: quay.io/metal3-io/cluster-api-provider-metal3:release-0.5
         name: manager


### PR DESCRIPTION
**What this PR does / why we need it**:
Current manager manifest is pointing to the container image with main tag
which is meant for main branch and introduces some breaking changes.
