### PR TITLE
🌱 Ensure setting image tag for current release in infra components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -419,8 +419,10 @@ release-notes: $(RELEASE_NOTES_DIR) $(RELEASE_NOTES)
 
 .PHONY: release
 release:
+	@if [ -z "${RELEASE_TAG}" ]; then echo "RELEASE_TAG is not set"; exit 1; fi
 	@if ! [ -z "$$(git status --porcelain)" ]; then echo "You have uncommitted changes"; exit 1; fi
 	git checkout "${RELEASE_TAG}"
+	MANIFEST_IMG=$(CONTROLLER_IMG) MANIFEST_TAG=$(RELEASE_TAG) $(MAKE) set-manifest-image
 	$(MAKE) release-manifests
 	$(MAKE) release-notes
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We have had a release with infrastructure-components.yaml not updated
to point to the release tag image of CAPM3. `MANIFEST_IMG` ensures
to patch the infrastructure-components.yaml before publishing the release
artifacts.

Once merged, we need to backport this change to release-0.5 branch as well. 