### PR TITLE
Fix the flaky issue that one machine is failed instead of running

### DIFF
--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -88,7 +88,7 @@ intervals:
   default/wait-worker-nodes: ["30m", "10s"]
   default/wait-delete-cluster: ["20m", "10s"]
   default/wait-machine-upgrade: ["50m", "10s"]
-  default/wait-machine-remediation: ["30m", "10s"]
+  default/wait-machine-remediation: ["40m", "10s"]
   default/wait-vm-state: ["10m", "100ms"]
   default/monitor-vm-state: ["1m", "500ms"]
   default/monitor-provisioning: ["5m", "500ms"]


### PR DESCRIPTION
Currently, if the underlying infrastructure is unstable, the last check of remediation test will fail because one machine fails to be provisioned (it is in `failed` status, instead). 
```
kubectl get machine -A
NAMESPACE   NAME                    CLUSTER   NODENAME                PROVIDERID                                      PHASE     AGE   VERSION
metal3      test1-59d669478-q2mx9   test1     test1-59d669478-q2mx9   metal3://1cc3e4c3-a47c-458a-ac93-370e9554c760   Running   24h   v1.22.2
metal3      test1-8lfg4             test1     test1-8lfg4             metal3://31fb8362-f232-46ed-8f4c-d70de9b31b1d   Running   24h   v1.22.2
metal3      test1-9hrk7             test1     test1-9hrk7             metal3://96dfa070-c71f-497f-8c2c-e9218c73bbba   Running   24h   v1.22.2
metal3      test1-zxlpq             test1     test1-zxlpq             metal3://a8f24e01-44ef-48b0-9258-77f3b17aa044   Failed    24h   v1.22.2
```

This PR deletes the failed machine, so a new machine can be created and can reach the provisioned status. 