### PR TITLE
🐛Fix node reuse workflow in E2E in release-0.5 branch

### DIFF
--- a/test/e2e/cert_rotation_test.go
+++ b/test/e2e/cert_rotation_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func cert_rotation() {
-	Logf("Start the certificate rotation test")
+	Logf("Starting certificate rotation tests")
 	By("Check if Ironic pod is running")
 	targetClusterClientSet := targetCluster.GetClientSet()
 	ironicNamespace := os.Getenv("NAMEPREFIX") + "-system"
@@ -82,7 +82,7 @@ func cert_rotation() {
 		}
 		return errors.New("Ironic pod is not in running state")
 	}, e2eConfig.GetIntervals(specName, "wait-pod-restart")...).Should(BeNil())
-	By("PASSED!")
+	By("CERTIFICATE ROTATION TESTS PASSED!")
 
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 )
@@ -22,7 +22,7 @@ var (
 	specName                 = "metal3"
 	namespace                = "metal3"
 	flavorSuffix             string
-	cluster                  *clusterv1.Cluster
+	cluster                  *capi.Cluster
 	clusterName              = "test1"
 	clusterctlLogFolder      string
 	cniFile                  string

--- a/test/e2e/pivoting_test.go
+++ b/test/e2e/pivoting_test.go
@@ -17,7 +17,7 @@ import (
 	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1alpha5"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha4"
 
 	dockerTypes "github.com/docker/docker/api/types"
 	docker "github.com/docker/docker/client"
@@ -28,6 +28,7 @@ import (
 )
 
 func pivoting() {
+	Logf("Starting pivoting tests")
 	By("Remove Ironic containers from the source cluster")
 	ephemeralCluster := os.Getenv("EPHEMERAL_CLUSTER")
 	if ephemeralCluster == "kind" {
@@ -144,7 +145,7 @@ func pivoting() {
 
 	By("Check if machines become running.")
 	Eventually(func() error {
-		machines := &clusterv1.MachineList{}
+		machines := &capi.MachineList{}
 		if err := targetCluster.GetClient().List(ctx, machines, client.InNamespace(namespace)); err != nil {
 			return err
 		}
@@ -156,7 +157,7 @@ func pivoting() {
 		return nil
 	}, e2eConfig.GetIntervals(specName, "wait-machine-running")...).Should(BeNil())
 
-	By("PASSED!")
+	By("PIVOTING TESTS PASSED!")
 }
 
 func configureIronicConfigmap(isIronicDeployed bool) {

--- a/test/e2e/remediation_test.go
+++ b/test/e2e/remediation_test.go
@@ -14,7 +14,7 @@ import (
 	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1alpha5"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha4"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
@@ -40,6 +40,7 @@ const (
 const defaultNamespace = "default"
 
 func test_remediation() {
+	Logf("Starting remediation tests")
 	bootstrapClient := bootstrapClusterProxy.GetClient()
 	targetClient := targetCluster.GetClient()
 	allMachinesCount := int(controlPlaneMachineCount + workerMachineCount)
@@ -174,7 +175,7 @@ func test_remediation() {
 
 	By("Waiting for all Machines to be Running")
 	Eventually(func(g Gomega) error {
-		machines := clusterv1.MachineList{}
+		machines := capi.MachineList{}
 		g.Expect(bootstrapClient.List(ctx, &machines, client.InNamespace(namespace))).To(Succeed())
 		g.Expect(filterMachinesByPhase(machines.Items, "Running")).To(HaveLen(allMachinesCount))
 		return nil
@@ -228,7 +229,7 @@ func test_remediation() {
 	Expect(bootstrapClient.Create(ctx, newM3MachineTemplate)).To(Succeed(), "Failed to create new Metal3MachineTemplate")
 
 	By("Pointing MachineDeployment to the new Metal3MachineTemplate")
-	deployment := clusterv1.MachineDeployment{}
+	deployment := capi.MachineDeployment{}
 	Expect(bootstrapClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: clusterName}, &deployment)).To(Succeed())
 
 	helper, err := patch.NewHelper(&deployment, bootstrapClient)
@@ -275,12 +276,12 @@ func test_remediation() {
 
 	Byf("Waiting for all %d machines to be Running", allMachinesCount)
 	Eventually(func(g Gomega) {
-		machines := clusterv1.MachineList{}
+		machines := capi.MachineList{}
 		g.Expect(bootstrapClient.List(ctx, &machines, client.InNamespace(namespace))).To(Succeed())
 		g.Expect(filterMachinesByPhase(machines.Items, "Running")).To(HaveLen(allMachinesCount))
 	}, e2eConfig.GetIntervals(specName, "wait-machine-remediation")...).Should(Succeed())
 
-	By("PASSED!")
+	By("REMEDIATION TESTS PASSED!")
 }
 
 type bmhToMachine struct {
@@ -507,7 +508,7 @@ func cleanObjectMeta(om *metav1.ObjectMeta) {
 }
 
 // Get the machine object given its object name.
-func getMachine(ctx context.Context, c client.Client, name client.ObjectKey) (result clusterv1.Machine) {
+func getMachine(ctx context.Context, c client.Client, name client.ObjectKey) (result capi.Machine) {
 	Expect(c.Get(ctx, name, &result)).To(Succeed())
 	return
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch fixes the issue in node reuse testing workflow in e2e tests of release-0.5 branch where:
- after testing KCP node reuse use case, we do scale down KCP to 1 and and it triggers de provisioning of BMHs to start testing MD use case, thus all BMH that were used before would have node reuse labels on them. So while testing MD case, we do not remove them and it will always chooses the same host since other BMHs have already KCP name set in node reuse label. To fix it, we remove old labels from all BMHs and then test MD use case to check if node reuse feature is working.  
- also removing marking/unmarking of BMHs with unhealthy annotation, since now when MD maxSurge field is updated with `0` it deletes the existing machine first and then recreates a new one, resulting in unneeded unhealthy annotation setting/unsetting. 
- since new m3mt has been created during remediation tests, MD was pointing to the old m3mt and tests were checking nodeReuse field in original m3mt which has no effect. This patch ensures, we do point to proper m3mt from MD first, and then scale up a worker so nodeReuse field in corresponding m3mt is respected accordingly. 
- also makes logging of starting and passing phase of the each tests more clearer with specific test name 