### PR TITLE
🐛 Remove unnecessary and buggy step in e2e remediation test

### DIFF
--- a/test/e2e/remediation_test.go
+++ b/test/e2e/remediation_test.go
@@ -74,10 +74,8 @@ func test_remediation() {
 	Logf("Marking a BMH '%s' for reboot", workerBmh.GetName())
 	annotateBmh(ctx, bootstrapClient, workerBmh, rebootAnnotation, pointer.String(""))
 	waitForVmsState([]string{vmName}, shutoff, specName)
-	waitForNodeStatus(ctx, targetClient, client.ObjectKey{Namespace: defaultNamespace, Name: workerNodeName}, v1.ConditionUnknown, specName)
 	waitForVmsState([]string{vmName}, running, specName)
 	waitForNodeStatus(ctx, targetClient, client.ObjectKey{Namespace: defaultNamespace, Name: workerNodeName}, v1.ConditionTrue, specName)
-	monitorNodesStatusGlobalConsistently(ctx, targetClient, defaultNamespace, []string{workerNodeName}, v1.ConditionTrue, specName)
 
 	By("Power cycling worker node")
 	powerCycle(ctx, bootstrapClient, targetClient, bmhToMachineSlice{{
@@ -420,20 +418,6 @@ func waitForVmsState(vmNames []string, state vmState, specName string) {
 func monitorNodesStatus(g Gomega, ctx context.Context, c client.Client, namespace string, names []string, status v1.ConditionStatus, specName string) {
 	Byf("Ensuring Nodes %v consistently have ready=%s status", names, status)
 	g.Consistently(
-		func() error {
-			for _, node := range names {
-				if err := assertNodeStatus(ctx, c, client.ObjectKey{Namespace: namespace, Name: node}, status); err != nil {
-					return err
-				}
-			}
-			return nil
-		}, e2eConfig.GetIntervals(specName, "monitor-vm-state")...).Should(Succeed())
-}
-
-// monitorNodesStatusGlobalConsistently call Consistently instead of g.Consistently
-func monitorNodesStatusGlobalConsistently(ctx context.Context, c client.Client, namespace string, names []string, status v1.ConditionStatus, specName string) {
-	Byf("Ensuring Nodes %v consistently have ready=%s status", names, status)
-	Consistently(
 		func() error {
 			for _, node := range names {
 				if err := assertNodeStatus(ctx, c, client.ObjectKey{Namespace: namespace, Name: node}, status); err != nil {


### PR DESCRIPTION
This PR fixes this issue: 
```bash
• Failure [1432.664 seconds]                                                                                                                                                                           
Workload cluster creation                                                                                                                                                                              
/home/slintes/cluster-api-provider-metal3/test/e2e/e2e_test.go:34                                                                                                                                      
  Creating a highly available control-plane cluster                                                                                                                                                   
  /home/slintes/cluster-api-provider-metal3/test/e2e/e2e_test.go:57                                                                                                                                   
    Should create a cluster with 3 control-plane and 1 worker nodes [It]                                                                                                                              
    /home/slintes/cluster-api-provider-metal3/test/e2e/e2e_test.go:58                                                                                                                                 
                                                                                                                                                                                                      
    Timed out after 600.008s.                                                                                                                                                                         
    Expected success, but got an error:                                                                                                                                                               
        <*errors.errorString | 0xc000c3ac10>: {                                                                                                                                                       
            s: "Node test1-5569b575bd-8hp2l has status 'True', should have 'Unknown'",                                                                                                                
        }                                                                                                                                                                                             
        Node test1-5569b575bd-8hp2l has status 'True', should have 'Unknown'                                                                                                                          
                                                                                                                                                                                                      
    /home/slintes/cluster-api-provider-metal3/test/e2e/remediation_test.go:469                                                                                                                        
                                                                                                                                                                                                      
    Full Stack Trace                                                                                                                                                                                  
    github.com/metal3-io/cluster-api-provider-metal3/test/e2e.waitForNodeStatus(0x220bd60, 0xc000126018, 0x2223430, 0xc0004b8000, 0x1f6acbd, 0x7, 0xc0008ab698, 0x16, 0x1f6a8db, 0x7, ...)            
        /home/slintes/cluster-api-provider-metal3/test/e2e/remediation_test.go:469 +0x292                                                                                                             
    github.com/metal3-io/cluster-api-provider-metal3/test/e2e.test_remediation()                                                                                                                      
        /home/slintes/cluster-api-provider-metal3/test/e2e/remediation_test.go:77 +0xb18
```
This issue happens when a k8s node restarts too fast, so it cannot get into the status `unknown`. A node can have this status only if it is unreachable for at least [40 seconds](https://kubernetes.io/docs/concepts/architecture/nodes/#condition).  
Also, the check that ensure the node has status `Unknown` after its VM shutdowns seems to be not necessary. Therefore, removing this check should be the best fix for the issue.