### PR TITLE
🐛 Automated cleaning bug fix in machine template controller

### DIFF
--- a/baremetal/metal3machinetemplate_manager.go
+++ b/baremetal/metal3machinetemplate_manager.go
@@ -89,8 +89,8 @@ func (m *MachineTemplateManager) UpdateAutomatedCleaningMode(ctx context.Context
 	if len(matchedM3Machines) > 0 {
 		for _, m3m := range matchedM3Machines {
 			// don't synchronize AutomatedCleaningMode between metal3MachineTemplate
-			// and metal3Machine if unset in metal3Machine.
-			if m3m.Spec.AutomatedCleaningMode != nil {
+			// and metal3Machine if unset in metal3MachineTemplate.
+			if m.Metal3MachineTemplate.Spec.Template.Spec.AutomatedCleaningMode != nil {
 
 				m3m.Spec.AutomatedCleaningMode = m.Metal3MachineTemplate.Spec.Template.Spec.AutomatedCleaningMode
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Due to this bug,  `automatedCleaning` will not be synchronized between
metal3MachineTemplate and metal3Machine when set. Because we are
verifying it from the metal3Machine which should be the metal3MachineTemplate.
