### PR TITLE
🌱 Drop capm3:unit container image Dockerfile

### DIFF
--- a/hack/Dockerfile.unit
+++ b/hack/Dockerfile.unit
@@ -1,6 +1,0 @@
-FROM docker.io/golang:1.17
-
-WORKDIR /usr/local/kubebuilder
-COPY /hack/tools /usr/local/kubebuilder/
-RUN ./install_kustomize.sh && \
-    ./install_kubebuilder.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
Drop building capm3:unit image and instead use golang container
image for go tests in Prow. The reason for dropping this image
support is,  it has no benefit anymore but instead it brings extra
things like kubebuilder and kustomize which are not needed to be
build by shell scripts anymore because we donwload those bins via
setup_env Makefile target. This should be merged after the update
in the project-infra repo.
/hold
/cc @furkatgofurov7 @kashifest 