### PR TITLE
✨ Fix clusterctl init issue and failing upgrade ironic containers tests in E2E

### DIFF
--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -15,54 +15,52 @@ images:
     loadBehavior: mustLoad
 
 providers:
-  - name: cluster-api
-    type: CoreProvider
-    versions:
-      - name: ${CAPIRELEASE}
-        # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPIRELEASE}/core-components.yaml"
-        type: "url"
-        files:
-        - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-        replacements:
-          - old: "imagePullPolicy: Always"
-            new: "imagePullPolicy: IfNotPresent"
-          - old: "--leader-elect"
-            new: "--leader-elect=false"
-  - name: kubeadm
-    type: BootstrapProvider
-    versions:
-      - name: ${CAPIRELEASE}
-        # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPIRELEASE}/bootstrap-components.yaml"
-        type: "url"
-        files:
-        - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-        replacements:
-          - old: "imagePullPolicy: Always"
-            new: "imagePullPolicy: IfNotPresent"
-          - old: "--leader-elect"
-            new: "--leader-elect=false"
-  - name: kubeadm
-    type: ControlPlaneProvider
-    versions:
-      - name: ${CAPIRELEASE}
-        # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPIRELEASE}/control-plane-components.yaml"
-        type: "url"
-        files:
-        - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-        replacements:
-          - old: "imagePullPolicy: Always"
-            new: "imagePullPolicy: IfNotPresent"
-          - old: "--leader-elect"
-            new: "--leader-elect=false"
-  - name: metal3
-    type: InfrastructureProvider
-    versions:
-    - name: ${CAPM3RELEASE}
-      value: "file://${HOME}/.cluster-api/overrides/infrastructure-metal3/${CAPM3RELEASE}/infrastructure-components.yaml"
-      type: "url"
+- name: cluster-api
+  type: CoreProvider
+  versions:
+  - name: v1.1.0
+    # Use manifest from source files
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.0-beta.1/core-components.yaml"
+    type: "url"
+    contract: v1beta1
+    files:
+      - sourcePath: "../data/shared/v1beta1/metadata.yaml"
+    replacements:
+      - old: "--leader-elect"
+        new: "--leader-elect=false"
+- name: kubeadm
+  type: BootstrapProvider
+  versions:
+  - name: v1.1.0
+    # Use manifest from source files
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.0-beta.1/bootstrap-components.yaml"
+    type: "url"
+    contract: v1beta1
+    files:
+      - sourcePath: "../data/shared/v1beta1/metadata.yaml"
+    replacements:
+      - old: "--leader-elect"
+        new: "--leader-elect=false"
+- name: kubeadm
+  type: ControlPlaneProvider
+  versions:
+  - name: v1.1.0
+    # Use manifest from source files
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.0-beta.1/control-plane-components.yaml"
+    type: "url"
+    contract: v1beta1
+    files:
+      - sourcePath: "../data/shared/v1beta1/metadata.yaml"
+    replacements:
+      - old: "--leader-elect"
+        new: "--leader-elect=false"
+- name: metal3
+  type: InfrastructureProvider
+  versions:
+  - name: v1.0.0
+    value: "file://${HOME}/.cluster-api/overrides/infrastructure-metal3/v1.0.0/infrastructure-components.yaml"
+    type: "url"
+    contract: v1beta1
     files:
     - sourcePath: "${PWD}/metadata.yaml"
       targetName: "metadata.yaml"
@@ -84,6 +82,9 @@ variables:
   IRONIC_NAMESPACE: "${IRONIC_NAMESPACE:-baremetal-operator-system}"
   CONTAINER_REGISTRY: "${CONTAINER_REGISTRY:-quay.io}"
   IRONIC_IMAGE_TAG: "${IRONIC_IMAGE_TAG:-master}"
+  CAPIRELEASE: "${CAPIRELEASE}"
+  CAPM3RELEASE: "${CAPM3RELEASE}"
+  CONFIG_FILE_PATH: "${HOME}/.cluster-api/overrides/clusterctl.yaml"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -82,6 +82,7 @@ variables:
   IRONIC_NAMESPACE: "${IRONIC_NAMESPACE:-baremetal-operator-system}"
   CONTAINER_REGISTRY: "${CONTAINER_REGISTRY:-quay.io}"
   IRONIC_IMAGE_TAG: "${IRONIC_IMAGE_TAG:-master}"
+  MARIADB_IMAGE_TAG: "${MARIADB_IMAGE_TAG:-main}"
   CAPIRELEASE: "${CAPIRELEASE}"
   CAPM3RELEASE: "${CAPM3RELEASE}"
   CONFIG_FILE_PATH: "${HOME}/.cluster-api/overrides/clusterctl.yaml"

--- a/test/e2e/pivoting_test.go
+++ b/test/e2e/pivoting_test.go
@@ -49,12 +49,16 @@ func pivoting() {
 
 	By("Initialize Provider component in target cluster")
 	clusterctl.Init(ctx, clusterctl.InitInput{
-		KubeconfigPath:          targetCluster.GetKubeconfigPath(),
-		ClusterctlConfigPath:    clusterctlConfigPath,
-		CoreProvider:            config.ClusterAPIProviderName,
-		BootstrapProviders:      []string{config.KubeadmBootstrapProviderName},
-		ControlPlaneProviders:   []string{config.KubeadmControlPlaneProviderName},
-		InfrastructureProviders: e2eConfig.InfrastructureProviders(),
+		KubeconfigPath: targetCluster.GetKubeconfigPath(),
+		// TODO (furkat), to uplift CAPI to v1.1.0-beta.1 pre-release
+		// in pivoting tests we are pointing to overrides folder as ClusterctlConfigPath.
+		// We have to revert this to point to e2e ClusterctlConfigPath once there is an
+		// actual latest release with v1.1.X tag.
+		ClusterctlConfigPath:    os.Getenv("CONFIG_FILE_PATH"),
+		CoreProvider:            config.ClusterAPIProviderName + ":" + os.Getenv("CAPIRELEASE"),
+		BootstrapProviders:      []string{config.KubeadmBootstrapProviderName + ":" + os.Getenv("CAPIRELEASE")},
+		ControlPlaneProviders:   []string{config.KubeadmControlPlaneProviderName + ":" + os.Getenv("CAPIRELEASE")},
+		InfrastructureProviders: []string{config.Metal3ProviderName + ":" + os.Getenv("CAPM3RELEASE")},
 		LogFolder:               filepath.Join(artifactFolder, "clusters", clusterName+"-pivoting"),
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Tackles 2 issues:
1. after uplifting to capi  v1.1.0-beta.1 pre-release, pivoting e2e tests started failing during initializing provider components in target cluster, with not being able to fetch releases tagged with a valid semantic version. And that is fixed by pointing to overrides folder during pivoting tests now;
2. backports  https://github.com/metal3-io/cluster-api-provider-metal3/commit/efe3e356afa1183da401fe774d43f751db444e44 which fixes failing mariadb container upgrade in main branch.
