### PR TITLE
✨ Pin calico version to v3.21.0

### DIFF
--- a/hack/e2e/environment.sh
+++ b/hack/e2e/environment.sh
@@ -54,3 +54,7 @@ source "${M3_DEV_ENV_PATH}/scripts/feature_tests/feature_test_vars.sh"
 # shellcheck disable=SC1091
 # shellcheck disable=SC1090
 source "${M3_DEV_ENV_PATH}/scripts/feature_tests/node_reuse/node_reuse_vars.sh"
+
+# Pin Calico version
+export CALICO_PATCH_RELEASE="v3.21.0"
+export CALICO_MINOR_RELEASE="v3.21"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -235,10 +236,18 @@ func validateGlobals(specName string) {
 }
 
 func updateCalico(calicoYaml, calicoInterface string) {
-	err := downloadFile(calicoYaml, "https://docs.projectcalico.org/manifests/calico.yaml")
+	calicoManifestURL := fmt.Sprintf("https://docs.projectcalico.org/archive/%s/manifests/calico.yaml", os.Getenv("CALICO_MINOR_RELEASE"))
+	err := downloadFile(calicoYaml, calicoManifestURL)
 	Expect(err).To(BeNil(), "Unable to download Calico manifest")
 	cniYaml, err := os.ReadFile(calicoYaml)
 	Expect(err).To(BeNil(), "Unable to read Calico manifest")
+
+	Logf("Replace the calico version with the pinned one")
+	regex := regexp.MustCompile("image: docker.io/calico/(.+):v(.+)")
+	replacement := fmt.Sprintf("image: docker.io/calico/$1:%s", os.Getenv("CALICO_PATCH_RELEASE"))
+	cniYaml = []byte(regex.ReplaceAllString(string(cniYaml), replacement))
+
+	Logf("Replace the default CIDR with the one set in $POD_CIDR")
 	podCIDR := os.Getenv("POD_CIDR")
 	cniYaml = []byte(strings.Replace(string(cniYaml), "192.168.0.0/16", podCIDR, -1))
 


### PR DESCRIPTION
This PR pins the calico version used ine2e test to v3.21.0 which is the same as the default calico version in Metal3-dev-env. Pinning calico version helps to avoid the docker rate limit issue because in CI this calico version is baked into the node image. 