### PR TITLE
⚠️ Rename HasPausedAnnotation function to HasPaused

### DIFF
--- a/controllers/metal3machinetemplate_controller.go
+++ b/controllers/metal3machinetemplate_controller.go
@@ -86,7 +86,7 @@ func (r *Metal3MachineTemplateReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	// Return early if the Metal3MachineTemplate is paused.
-	if annotations.HasPausedAnnotation(metal3MachineTemplate) {
+	if annotations.HasPaused(metal3MachineTemplate) {
 		m3templateLog.Info("Metal3MachineTemplate is currently paused. Remove pause annotation to continue reconciliation.")
 		return ctrl.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR renames soon deprecated (original PR in upstream CAPI has been labeled with v1.1 milestone) `HasPausedAnnotation`
function to `HasPaused`

https://github.com/kubernetes-sigs/cluster-api/blob/release-1.1/docs/book/src/developer/providers/v1.0-to-v1.1.md#deprecation

/hold

Original issue in CAPI: https://github.com/kubernetes-sigs/cluster-api/issues/5539
