### PR TITLE
🌱 Use generic folder name for all volume mounted folders under hack scripts

### DIFF
--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -36,9 +36,9 @@ if [ "${IS_CONTAINER}" != "false" ]; then
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:rw,z" \
+    --volume "${PWD}:/capm3:rw,z" \
     --entrypoint sh \
-    --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
+    --workdir /capm3 \
     docker.io/golang:1.17 \
-    /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/codegen.sh
+    /capm3/hack/codegen.sh
 fi;

--- a/hack/gofmt.sh
+++ b/hack/gofmt.sh
@@ -25,9 +25,9 @@ if [ "${IS_CONTAINER}" != "false" ]; then
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:ro,z" \
+    --volume "${PWD}:/capm3:ro,z" \
     --entrypoint sh \
-    --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
+    --workdir /capm3 \
     docker.io/golang:1.17 \
-    /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/gofmt.sh
+    /capm3/hack/gofmt.sh
 fi;

--- a/hack/golint.sh
+++ b/hack/golint.sh
@@ -14,9 +14,9 @@ if [ "${IS_CONTAINER}" != "false" ]; then
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:ro,z" \
+    --volume "${PWD}:/capm3:ro,z" \
     --entrypoint sh \
-    --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
+    --workdir /capm3 \
     docker.io/golang:1.17 \
-    /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/golint.sh
+    /capm3/hack/golint.sh
 fi;

--- a/hack/govet.sh
+++ b/hack/govet.sh
@@ -14,9 +14,9 @@ if [ "${IS_CONTAINER}" != "false" ]; then
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:ro,z" \
+    --volume "${PWD}:/capm3:ro,z" \
     --entrypoint sh \
-    --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
+    --workdir /capm3 \
     docker.io/golang:1.17 \
-    /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/govet.sh
+    /capm3/hack/govet.sh
 fi;

--- a/hack/manifestlint.sh
+++ b/hack/manifestlint.sh
@@ -25,9 +25,9 @@ if [ "${IS_CONTAINER}" != "false" ]; then
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/workdir:ro,z" \
+    --volume "${PWD}:/capm3:ro,z" \
     --entrypoint sh \
-    --workdir /workdir \
+    --workdir /capm3 \
     garethr/kubeval:latest \
-    /workdir/hack/manifestlint.sh "${@}"
+    /capm3/hack/manifestlint.sh "${@}"
 fi;

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -11,9 +11,9 @@ if [ "${IS_CONTAINER}" != "false" ]; then
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/workdir:ro,z" \
+    --volume "${PWD}:/capm3:ro,z" \
     --entrypoint sh \
-    --workdir /workdir \
+    --workdir /capm3 \
     docker.io/pipelinecomponents/markdownlint:latest \
-    /workdir/hack/markdownlint.sh "${@}"
+    /capm3/hack/markdownlint.sh "${@}"
 fi;

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -11,9 +11,9 @@ if [ "${IS_CONTAINER}" != "false" ]; then
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/workdir:ro,z" \
+    --volume "${PWD}:/capm3:ro,z" \
     --entrypoint sh \
-    --workdir /workdir \
+    --workdir /capm3 \
     docker.io/koalaman/shellcheck-alpine:stable \
-    /workdir/hack/shellcheck.sh "${@}"
+    /capm3/hack/shellcheck.sh "${@}"
 fi;

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -14,9 +14,9 @@ if [ "${IS_CONTAINER}" != "false" ]; then
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:ro,z" \
+    --volume "${PWD}:/capm3:ro,z" \
     --entrypoint sh \
-    --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
+    --workdir /capm3 \
     docker.io/golang:1.17 \
-    /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/unit.sh "${@}"
+    /capm3/hack/unit.sh "${@}"
 fi;


### PR DESCRIPTION
**What this PR does / why we need it**:
We folder names that would be used eventually while mounting a volume inside the container while using hack/scripts are scattered all over the repo (in some places used as `workdir` and in some `go/src/github.com/metal3-io/cluster-api-provider-metal3`). This PR cleans that a bit and uses a single folder name under all over the hack scripts. 

Similar changes have been done in [IPAM](https://github.com/metal3-io/ip-address-manager/pull/80) repo some time ago. 
