### PR TITLE
🌱 Move maelk to emeritus_approvers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,13 +3,14 @@
 approvers:
  - hardys
  - kashifest
- - maelk
  - furkatgofurov7
  - Xenwar
 
- 
 reviewers:
  - fmuyassarov
  - jan-est
  - namnx228
  - smoshiur1237
+
+emeritus_approvers:
+ - maelk


### PR DESCRIPTION
Maël's focus has shifted from this project to other tasks thus the
OWNERS list has to be modified accordingly.