### PR TITLE
🐛 Fix compilation issues in e2e tests

### DIFF
--- a/test/e2e/node_reuse_test.go
+++ b/test/e2e/node_reuse_test.go
@@ -58,7 +58,7 @@ func nodeReuse() {
 	untaintNodes(clientSet, controlplaneNodes, controlplaneTaint)
 
 	By("Scale down MachineDeployment to 0")
-	scaleMachineDeployment(ctx, targetClusterClient, 0)
+	scaleMachineDeployment(ctx, targetClusterClient, clusterName, namespace,0)
 
 	Byf("Wait until the worker is scaled down and %d BMH(s) Available", numberOfWorkers)
 	Eventually(
@@ -293,7 +293,7 @@ func nodeReuse() {
 	pointMDtoM3mt(m3machineTemplateName, machineDeploy.Name, targetClusterClient)
 
 	By("Scale the worker up to 1 to start testing MachineDeployment")
-	scaleMachineDeployment(ctx, targetClusterClient, 1)
+	scaleMachineDeployment(ctx, targetClusterClient, clusterName, namespace, 1)
 
 	Byf("Wait until %d more BMH becomes provisioned", numberOfWorkers)
 	Eventually(

--- a/test/e2e/remediation_test.go
+++ b/test/e2e/remediation_test.go
@@ -132,7 +132,7 @@ func remediation() {
 	}, e2eConfig.GetIntervals(specName, "wait-machine-remediation")...).Should(Succeed())
 
 	By("Scaling up machine deployment to 3 replicas")
-	scaleMachineDeployment(ctx, bootstrapClient, 3)
+	scaleMachineDeployment(ctx, bootstrapClient, clusterName, namespace, 3)
 
 	By("Waiting for one BMH to start provisioning")
 	Eventually(func(g Gomega) error {
@@ -180,7 +180,7 @@ func remediation() {
 	}, e2eConfig.GetIntervals(specName, "wait-machine-remediation")...)
 
 	By("Scaling machine deployment down to 1")
-	scaleMachineDeployment(ctx, bootstrapClient, 1)
+	scaleMachineDeployment(ctx, bootstrapClient, clusterName, namespace, 1)
 
 	By("Waiting for 2 BMHs to be in Available state")
 	Eventually(func(g Gomega) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

Some global variables were defined in the *_test.go files but referenced in "normal" files. This is causing compilation errors since *_test.go files are not included in a normal build (only in go test).

