### PR TITLE
:seedling: Improve baremetal unit test syntax part 2

### DIFF
--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -618,8 +618,8 @@ var _ = Describe("Metal3Machine manager", func() {
 
 		DescribeTable("Test ChooseHost",
 			func(tc testCaseChooseHost) {
-				c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(tc.Hosts...).Build()
-				machineMgr, err := NewMachineManager(c, nil, nil, tc.Machine,
+				fakeClient := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(tc.Hosts...).Build()
+				machineMgr, err := NewMachineManager(fakeClient, nil, nil, tc.Machine,
 					tc.M3Machine, logr.Discard(),
 				)
 				Expect(err).NotTo(HaveOccurred())
@@ -744,9 +744,11 @@ var _ = Describe("Metal3Machine manager", func() {
 
 	DescribeTable("Test Set BMH Pause Annotation",
 		func(tc testCaseSetPauseAnnotation) {
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(tc.Host, tc.M3Machine).Build()
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(
+				tc.Host,
+				tc.M3Machine).Build()
 
-			machineMgr, err := NewMachineManager(c, nil, nil, nil, tc.M3Machine, logr.Discard())
+			machineMgr, err := NewMachineManager(fakeClient, nil, nil, nil, tc.M3Machine, logr.Discard())
 			Expect(err).NotTo(HaveOccurred())
 
 			err = machineMgr.SetPauseAnnotation(context.TODO())
@@ -757,7 +759,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			}
 
 			savedHost := bmh.BareMetalHost{}
-			err = c.Get(context.TODO(),
+			err = fakeClient.Get(context.TODO(),
 				client.ObjectKey{
 					Name:      tc.Host.Name,
 					Namespace: tc.Host.Namespace,
@@ -848,8 +850,17 @@ var _ = Describe("Metal3Machine manager", func() {
 
 	DescribeTable("Test Remove BMH Pause Annotation",
 		func(tc testCaseRemovePauseAnnotation) {
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(tc.Host, tc.M3Machine, tc.Cluster).Build()
-			machineMgr, err := NewMachineManager(c, tc.Cluster, nil, nil, tc.M3Machine, logr.Discard())
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(
+				tc.Host,
+				tc.M3Machine,
+				tc.Cluster).Build()
+			machineMgr, err := NewMachineManager(fakeClient,
+				tc.Cluster,
+				nil,
+				nil,
+				tc.M3Machine,
+				logr.Discard())
+
 			Expect(err).NotTo(HaveOccurred())
 
 			err = machineMgr.RemovePauseAnnotation(context.TODO())
@@ -860,7 +871,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			}
 
 			savedHost := bmh.BareMetalHost{}
-			err = c.Get(context.TODO(),
+			err = fakeClient.Get(context.TODO(),
 				client.ObjectKey{
 					Name:      tc.Host.Name,
 					Namespace: tc.Host.Namespace,
@@ -941,14 +952,14 @@ var _ = Describe("Metal3Machine manager", func() {
 
 	DescribeTable("Test SetHostSpec",
 		func(tc testCaseSetHostSpec) {
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(tc.Host).Build()
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(tc.Host).Build()
 
 			m3mconfig, infrastructureRef := newConfig(tc.UserDataNamespace,
 				map[string]string{}, []capm3.HostSelectorRequirement{},
 			)
 			machine := newMachine("machine1", "", infrastructureRef)
 
-			machineMgr, err := NewMachineManager(c, nil, nil, machine, m3mconfig,
+			machineMgr, err := NewMachineManager(fakeClient, nil, nil, machine, m3mconfig,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -1030,14 +1041,14 @@ var _ = Describe("Metal3Machine manager", func() {
 
 	DescribeTable("Test SetHostConsumerRef",
 		func(tc testCaseSetHostSpec) {
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(tc.Host).Build()
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(tc.Host).Build()
 
 			m3mconfig, infrastructureRef := newConfig(tc.UserDataNamespace,
 				map[string]string{}, []capm3.HostSelectorRequirement{},
 			)
 			machine := newMachine("machine1", "", infrastructureRef)
 
-			machineMgr, err := NewMachineManager(c, nil, nil, machine, m3mconfig,
+			machineMgr, err := NewMachineManager(fakeClient, nil, nil, machine, m3mconfig,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -1105,7 +1116,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Namespace: "myns",
 			},
 		}
-		c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(&host).Build()
+		fakeClient := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(&host).Build()
 
 		type testCaseExists struct {
 			Machine   *capi.Machine
@@ -1115,7 +1126,7 @@ var _ = Describe("Metal3Machine manager", func() {
 
 		DescribeTable("Test Exists function",
 			func(tc testCaseExists) {
-				machineMgr, err := NewMachineManager(c, nil, nil, tc.Machine,
+				machineMgr, err := NewMachineManager(fakeClient, nil, nil, tc.Machine,
 					tc.M3Machine, logr.Discard(),
 				)
 				Expect(err).NotTo(HaveOccurred())
@@ -1157,7 +1168,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Namespace: "myns",
 			},
 		}
-		c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(&host).Build()
+		fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(&host).Build()
 
 		type testCaseGetHost struct {
 			Machine       *capi.Machine
@@ -1167,7 +1178,7 @@ var _ = Describe("Metal3Machine manager", func() {
 
 		DescribeTable("Test GetHost",
 			func(tc testCaseGetHost) {
-				machineMgr, err := NewMachineManager(c, nil, nil, tc.Machine,
+				machineMgr, err := NewMachineManager(fakeClient, nil, nil, tc.Machine,
 					tc.M3Machine, logr.Discard(),
 				)
 				Expect(err).NotTo(HaveOccurred())
@@ -1216,8 +1227,8 @@ var _ = Describe("Metal3Machine manager", func() {
 
 	DescribeTable("Test Get and Set Provider ID",
 		func(tc testCaseGetSetProviderID) {
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(tc.Host).Build()
-			machineMgr, err := NewMachineManager(c, nil, nil, tc.Machine,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(tc.Host).Build()
+			machineMgr, err := NewMachineManager(fakeClient, nil, nil, tc.Machine,
 				tc.M3Machine, logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -1308,11 +1319,11 @@ var _ = Describe("Metal3Machine manager", func() {
 				Namespace: "myns",
 			},
 		}
-		c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(&host).Build()
+		fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(&host).Build()
 
 		DescribeTable("Test small functions",
 			func(tc testCaseSmallFunctions) {
-				machineMgr, err := NewMachineManager(c, nil, nil, tc.Machine,
+				machineMgr, err := NewMachineManager(fakeClient, nil, nil, tc.Machine,
 					tc.M3Machine, logr.Discard(),
 				)
 				Expect(err).NotTo(HaveOccurred())
@@ -1369,8 +1380,8 @@ var _ = Describe("Metal3Machine manager", func() {
 
 	DescribeTable("Test EnsureAnnotation",
 		func(tc testCaseEnsureAnnotation) {
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(tc.M3Machine).Build()
-			machineMgr, err := NewMachineManager(c, nil, nil, &tc.Machine,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(tc.M3Machine).Build()
+			machineMgr, err := NewMachineManager(fakeClient, nil, nil, &tc.Machine,
 				tc.M3Machine, logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -1464,9 +1475,9 @@ var _ = Describe("Metal3Machine manager", func() {
 			if tc.BMCSecret != nil {
 				objects = append(objects, tc.BMCSecret)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
 
-			machineMgr, err := NewMachineManager(c, nil, nil, tc.Machine,
+			machineMgr, err := NewMachineManager(fakeClient, nil, nil, tc.Machine,
 				tc.M3Machine, logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -1488,7 +1499,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				}
 				host := bmh.BareMetalHost{}
 
-				err := c.Get(context.TODO(), key, &host)
+				err := fakeClient.Get(context.TODO(), key, &host)
 				Expect(err).NotTo(HaveOccurred())
 
 				name := ""
@@ -1517,7 +1528,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					Name:      tc.M3Machine.Status.UserData.Name,
 					Namespace: tc.M3Machine.Status.UserData.Namespace,
 				}
-				err = c.Get(context.TODO(), key, &tmpBootstrapSecret)
+				err = fakeClient.Get(context.TODO(), key, &tmpBootstrapSecret)
 				if tc.ExpectSecretDeleted {
 					Expect(err).To(HaveOccurred())
 					Expect(apierrors.IsNotFound(err)).To(BeTrue())
@@ -1528,7 +1539,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			if tc.ExpectedPausedAnnotationDeleted {
 				// get the saved host
 				savedHost := bmh.BareMetalHost{}
-				err = c.Get(context.TODO(),
+				err = fakeClient.Get(context.TODO(),
 					client.ObjectKey{
 						Name:      tc.Host.Name,
 						Namespace: tc.Host.Namespace,
@@ -1542,7 +1553,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			if tc.ExpectClusterLabelDeleted {
 				// get the saved host
 				savedHost := bmh.BareMetalHost{}
-				err = c.Get(context.TODO(),
+				err = fakeClient.Get(context.TODO(),
 					client.ObjectKey{
 						Name:      tc.Host.Name,
 						Namespace: tc.Host.Namespace,
@@ -1552,7 +1563,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Expect(err).NotTo(HaveOccurred())
 				// get the BMC credential
 				savedCred := corev1.Secret{}
-				err = c.Get(context.TODO(),
+				err = fakeClient.Get(context.TODO(),
 					client.ObjectKey{
 						Name:      savedHost.Spec.BMC.CredentialsName,
 						Namespace: savedHost.Namespace,
@@ -1568,7 +1579,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			}
 			if tc.NodeReuseEnabled {
 				m3mTemplate := capm3.Metal3MachineTemplate{}
-				err = c.Get(context.TODO(),
+				err = fakeClient.Get(context.TODO(),
 					client.ObjectKey{
 						Name:      tc.M3Machine.ObjectMeta.GetAnnotations()[capi.TemplateClonedFromNameAnnotation],
 						Namespace: tc.M3Machine.Namespace,
@@ -1820,9 +1831,9 @@ var _ = Describe("Metal3Machine manager", func() {
 
 		DescribeTable("Test UpdateMachineStatus",
 			func(tc testCaseUpdateMachineStatus) {
-				c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(&tc.M3Machine).Build()
+				fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(&tc.M3Machine).Build()
 
-				machineMgr, err := NewMachineManager(c, nil, nil, tc.Machine,
+				machineMgr, err := NewMachineManager(fakeClient, nil, nil, tc.Machine,
 					&tc.M3Machine, logr.Discard(),
 				)
 				Expect(err).NotTo(HaveOccurred())
@@ -1835,7 +1846,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					Namespace: tc.M3Machine.ObjectMeta.Namespace,
 				}
 				m3machine := capm3.Metal3Machine{}
-				err = c.Get(context.TODO(), key, &m3machine)
+				err = fakeClient.Get(context.TODO(), key, &m3machine)
 				Expect(err).NotTo(HaveOccurred())
 
 				if tc.M3Machine.Status.Addresses != nil {
@@ -2039,8 +2050,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			func(tc testCaseNodeAddress) {
 				var nodeAddresses []capi.MachineAddress
 
-				c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).Build()
-				machineMgr, err := NewMachineManager(c, nil, nil, &tc.Machine,
+				fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).Build()
+				machineMgr, err := NewMachineManager(fakeClient, nil, nil, &tc.Machine,
 					&tc.M3Machine, logr.Discard(),
 				)
 				Expect(err).NotTo(HaveOccurred())
@@ -2135,12 +2146,12 @@ var _ = Describe("Metal3Machine manager", func() {
 	)
 
 	Describe("Test SetNodeProviderID", func() {
-		scheme := runtime.NewScheme()
-		err := capi.AddToScheme(scheme)
+		s := runtime.NewScheme()
+		err := capi.AddToScheme(s)
 		if err != nil {
 			log.Printf("AddToScheme failed: %v", err)
 		}
-		err = bmh.AddToScheme(scheme)
+		err = bmh.AddToScheme(s)
 		if err != nil {
 			log.Printf("AddToScheme failed: %v", err)
 		}
@@ -2154,15 +2165,15 @@ var _ = Describe("Metal3Machine manager", func() {
 
 		DescribeTable("Test SetNodeProviderID",
 			func(tc testCaseSetNodePoviderID) {
-				c := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+				fakeClient := fakeclient.NewClientBuilder().WithScheme(s).Build()
 				corev1Client := clientfake.NewSimpleClientset(&tc.Node).CoreV1()
-				mockCapiClientGetter := func(ctx context.Context, c client.Client, cluster *capi.Cluster) (
+				m := func(ctx context.Context, client client.Client, cluster *capi.Cluster) (
 					clientcorev1.CoreV1Interface, error,
 				) {
 					return corev1Client, nil
 				}
 
-				machineMgr, err := NewMachineManager(c, newCluster(clusterName),
+				machineMgr, err := NewMachineManager(fakeClient, newCluster(clusterName),
 					newMetal3Cluster(metal3ClusterName, bmcOwnerRef,
 						&capm3.Metal3ClusterSpec{NoCloudProvider: true}, nil,
 					),
@@ -2171,7 +2182,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				err = machineMgr.SetNodeProviderID(context.TODO(), tc.HostID,
-					tc.ExpectedProviderID, mockCapiClientGetter,
+					tc.ExpectedProviderID, m,
 				)
 
 				if tc.ExpectedError {
@@ -2243,9 +2254,9 @@ var _ = Describe("Metal3Machine manager", func() {
 			if tc.Secret != nil {
 				objects = append(objects, tc.Secret)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
 
-			machineMgr, err := NewMachineManager(c, nil, nil, tc.Machine,
+			machineMgr, err := NewMachineManager(fakeClient, nil, nil, tc.Machine,
 				tc.M3Machine, logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -2283,7 +2294,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					Name:      tc.M3Machine.Status.UserData.Name,
 					Namespace: tc.M3Machine.Namespace,
 				}
-				err = c.Get(context.TODO(), key, &tmpBootstrapSecret)
+				err = fakeClient.Get(context.TODO(), key, &tmpBootstrapSecret)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(tmpBootstrapSecret.Data["userData"])).To(Equal("FooBar\n"))
 				Expect(len(tmpBootstrapSecret.OwnerReferences)).To(BeEquivalentTo(1))
@@ -2448,9 +2459,9 @@ var _ = Describe("Metal3Machine manager", func() {
 			if tc.BMCSecret != nil {
 				objects = append(objects, tc.BMCSecret)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
 
-			machineMgr, err := NewMachineManager(c, nil, nil, tc.Machine,
+			machineMgr, err := NewMachineManager(fakeClient, nil, nil, tc.Machine,
 				tc.M3Machine, logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -2469,7 +2480,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			}
 			// get the saved host
 			savedHost := bmh.BareMetalHost{}
-			err = c.Get(context.TODO(),
+			err = fakeClient.Get(context.TODO(),
 				client.ObjectKey{
 					Name:      tc.Host.Name,
 					Namespace: tc.Host.Namespace,
@@ -2486,7 +2497,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			if tc.ExpectClusterLabel {
 				// get the BMC credential
 				savedCred := corev1.Secret{}
-				err = c.Get(context.TODO(),
+				err = fakeClient.Get(context.TODO(),
 					client.ObjectKey{
 						Name:      savedHost.Spec.BMC.CredentialsName,
 						Namespace: savedHost.Namespace,
@@ -2645,9 +2656,9 @@ var _ = Describe("Metal3Machine manager", func() {
 				tc.M3Machine,
 				tc.Machine,
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
 
-			machineMgr, err := NewMachineManager(c, nil, nil, tc.Machine,
+			machineMgr, err := NewMachineManager(fakeClient, nil, nil, tc.Machine,
 				tc.M3Machine, logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -2960,8 +2971,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			if tc.DataClaim != nil {
 				objects = append(objects, tc.DataClaim)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
-			machineMgr, err := NewMachineManager(c, nil, nil, tc.Machine, tc.M3Machine,
+			fakeCleint := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			machineMgr, err := NewMachineManager(fakeCleint, nil, nil, tc.Machine, tc.M3Machine,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -2985,7 +2996,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			}
 			if tc.expectClaim {
 				dataTemplate := capm3.Metal3DataClaim{}
-				err = c.Get(context.TODO(),
+				err = fakeCleint.Get(context.TODO(),
 					client.ObjectKey{
 						Name:      tc.M3Machine.Name,
 						Namespace: tc.M3Machine.Namespace,
@@ -3073,8 +3084,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			if tc.Data != nil {
 				objects = append(objects, tc.Data)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
-			machineMgr, err := NewMachineManager(c, nil, nil, tc.Machine, tc.M3Machine,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			machineMgr, err := NewMachineManager(fakeClient, nil, nil, tc.Machine, tc.M3Machine,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -3258,8 +3269,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			if tc.DataClaim != nil {
 				objects = append(objects, tc.DataClaim)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
-			machineMgr, err := NewMachineManager(c, nil, nil, tc.Machine, tc.M3Machine,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			machineMgr, err := NewMachineManager(fakeClient, nil, nil, tc.Machine, tc.M3Machine,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -3288,7 +3299,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				return
 			}
 			dataTemplate := capm3.Metal3DataClaim{}
-			err = c.Get(context.TODO(),
+			err = fakeClient.Get(context.TODO(),
 				client.ObjectKey{
 					Name:      tc.M3Machine.Name,
 					Namespace: tc.M3Machine.Namespace,
@@ -3348,9 +3359,9 @@ var _ = Describe("Metal3Machine manager", func() {
 	}
 	DescribeTable("Test NodeReuseLabelExists",
 		func(tc testCaseNodeReuseLabelExists) {
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(tc.Host).Build()
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(tc.Host).Build()
 
-			machineMgr, err := NewMachineManager(c, nil, nil, nil,
+			machineMgr, err := NewMachineManager(fakeClient, nil, nil, nil,
 				nil, logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -3397,8 +3408,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			if tc.Machine != nil {
 				objects = append(objects, tc.Machine)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
-			machineMgr, err := NewMachineManager(c, nil, nil, tc.Machine,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			machineMgr, err := NewMachineManager(fakeClient, nil, nil, tc.Machine,
 				nil, logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -3475,11 +3486,11 @@ var _ = Describe("Metal3Machine manager", func() {
 			if tc.expectedMachineSet != nil {
 				objects = append(objects, tc.expectedMachineSet)
 			}
-			for _, ms := range tc.MachineSets {
-				objects = append(objects, ms)
+			for _, machineSets := range tc.MachineSets {
+				objects = append(objects, machineSets)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
-			machineMgr, err := NewMachineSetManager(c, tc.Machine,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			machineMgr, err := NewMachineSetManager(fakeClient, tc.Machine,
 				tc.MachineSets, tc.expectedMachineSet, logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -3491,8 +3502,8 @@ var _ = Describe("Metal3Machine manager", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 			machineSetObjects := capi.MachineSetList{}
-			for ms := range machineSetObjects.Items {
-				tc.expectedMachineSet = &machineSetObjects.Items[ms]
+			for machineSets := range machineSetObjects.Items {
+				tc.expectedMachineSet = &machineSetObjects.Items[machineSets]
 				Expect(result).To(Equal(tc.expectedMachineSet))
 			}
 			if tc.expectedMD {
@@ -3528,11 +3539,11 @@ var _ = Describe("Metal3Machine manager", func() {
 	DescribeTable("Test GetMachineSet",
 		func(tc testCaseGetMachineSet) {
 			objects := []client.Object{}
-			for _, ms := range tc.MachineSets {
-				objects = append(objects, ms)
+			for _, machineSets := range tc.MachineSets {
+				objects = append(objects, machineSets)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
-			machineMgr, err := NewMachineSetManager(c, tc.Machine,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			machineMgr, err := NewMachineSetManager(fakeClient, tc.Machine,
 				tc.MachineSets, nil, logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -3545,8 +3556,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			}
 			machineSetObjects := capi.MachineSetList{}
 
-			for ms := range machineSetObjects.Items {
-				tc.expectedMachineSet = &machineSetObjects.Items[ms]
+			for machineSetObject := range machineSetObjects.Items {
+				tc.expectedMachineSet = &machineSetObjects.Items[machineSetObject]
 				Expect(result).To(Equal(tc.expectedMachineSet))
 			}
 		},

--- a/baremetal/metal3machinetemplate_manager_test.go
+++ b/baremetal/metal3machinetemplate_manager_test.go
@@ -46,8 +46,8 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 				tc.M3MachineTemplate,
 				tc.M3MachineList,
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithRuntimeObjects(objects...).Build()
-			templateMgr, err := NewMachineTemplateManager(c, tc.M3MachineTemplate,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithRuntimeObjects(objects...).Build()
+			templateMgr, err := NewMachineTemplateManager(fakeClient, tc.M3MachineTemplate,
 				tc.M3MachineList, logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -62,7 +62,7 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 					Namespace: m3m.Namespace,
 				}
 				updatedM3M := capm3.Metal3Machine{}
-				err = c.Get(context.TODO(), key, &updatedM3M)
+				err = fakeClient.Get(context.TODO(), key, &updatedM3M)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(updatedM3M.Spec.AutomatedCleaningMode).To(Equal(tc.ExpectedValue))
 			}

--- a/baremetal/metal3remediation_manager_test.go
+++ b/baremetal/metal3remediation_manager_test.go
@@ -51,8 +51,8 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 		DescribeTable("Test NewRemediationManager",
 			func(tc testCaseRemediationManager) {
-				_, err := NewRemediationManager(fakeClient, tc.Metal3Remediation, tc.Metal3Machine, tc.Machine,
-					logr.Discard(),
+				_, err := NewRemediationManager(fakeClient, tc.Metal3Remediation,
+					tc.Metal3Machine, tc.Machine, logr.Discard(),
 				)
 				if tc.ExpectSuccess {
 					Expect(err).NotTo(HaveOccurred())
@@ -288,9 +288,9 @@ var _ = Describe("Metal3Remediation manager", func() {
 				},
 			}
 
-			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(&host).Build()
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(&host).Build()
 
-			remediationMgr, err := NewRemediationManager(c, nil, tc.M3Machine, nil,
+			remediationMgr, err := NewRemediationManager(fakeClient, nil, tc.M3Machine, nil,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This commit tries to align the unit test syntax with CAPI's
syntax.