### PR TITLE
:seedling: Improve baremetal unit test syntax part 3

### DIFF
--- a/baremetal/metal3cluster_manager_test.go
+++ b/baremetal/metal3cluster_manager_test.go
@@ -371,10 +371,10 @@ func newBMClusterSetup(tc testCaseBMClusterManager) (*ClusterManager, error) {
 	if tc.BMCluster != nil {
 		objects = append(objects, tc.BMCluster)
 	}
-	c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
 
 	return &ClusterManager{
-		client:        c,
+		client:        fakeClient,
 		Metal3Cluster: tc.BMCluster,
 		Cluster:       tc.Cluster,
 		Log:           logr.Discard(),
@@ -393,10 +393,10 @@ func descendantsSetup(tc descendantsTestCase) *ClusterManager {
 	for _, machine := range tc.Machines {
 		objects = append(objects, machine)
 	}
-	c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
 
 	return &ClusterManager{
-		client:        c,
+		client:        fakeClient,
 		Metal3Cluster: bmCluster,
 		Cluster:       cluster,
 		Log:           logr.Discard(),

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -124,8 +124,8 @@ var _ = Describe("Metal3Data manager", func() {
 			if tc.m3m != nil {
 				objects = append(objects, tc.m3m)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
-			dataMgr, err := NewDataManager(c, tc.m3d,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			dataMgr, err := NewDataManager(fakeClient, tc.m3d,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -205,8 +205,8 @@ var _ = Describe("Metal3Data manager", func() {
 			if tc.networkdataSecret != nil {
 				objects = append(objects, tc.networkdataSecret)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
-			dataMgr, err := NewDataManager(c, tc.m3d,
+			faskeClient := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			dataMgr, err := NewDataManager(faskeClient, tc.m3d,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -229,7 +229,7 @@ var _ = Describe("Metal3Data manager", func() {
 			}
 			if tc.expectedMetadata != nil {
 				tmpSecret := corev1.Secret{}
-				err = c.Get(context.TODO(),
+				err = faskeClient.Get(context.TODO(),
 					client.ObjectKey{
 						Name:      "abc-metadata",
 						Namespace: "myns",
@@ -241,7 +241,7 @@ var _ = Describe("Metal3Data manager", func() {
 			}
 			if tc.expectedNetworkData != nil {
 				tmpSecret := corev1.Secret{}
-				err = c.Get(context.TODO(),
+				err = faskeClient.Get(context.TODO(),
 					client.ObjectKey{
 						Name:      "abc-networkdata",
 						Namespace: "myns",
@@ -475,9 +475,16 @@ var _ = Describe("Metal3Data manager", func() {
 			bmh: &bmo.BareMetalHost{
 				ObjectMeta: testObjectMeta,
 			},
-			expectReady:         true,
-			expectedMetadata:    pointer.StringPtr(fmt.Sprintf("String-1: String-1\nprovideruid: %s\n", provideruid)),
-			expectedNetworkData: pointer.StringPtr("links:\n- ethernet_mac_address: XX:XX:XX:XX:XX:XX\n  id: eth0\n  mtu: 1500\n  type: phy\nnetworks: []\nservices: []\n"),
+			expectReady:      true,
+			expectedMetadata: pointer.StringPtr(fmt.Sprintf("String-1: String-1\nprovideruid: %s\n", provideruid)),
+			expectedNetworkData: pointer.StringPtr("" +
+				"links:\n" +
+				"- ethernet_mac_address: XX:XX:XX:XX:XX:XX\n" +
+				"  id: eth0\n" +
+				"  mtu: 1500\n" +
+				"  type: phy\n" +
+				"networks: []\n" +
+				"services: []\n"),
 		}),
 		Entry("No Machine OwnerRef on M3M", testCaseCreateSecrets{
 			m3d: &capm3.Metal3Data{
@@ -601,8 +608,8 @@ var _ = Describe("Metal3Data manager", func() {
 			if tc.m3dt != nil {
 				objects = append(objects, tc.m3dt)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
-			dataMgr, err := NewDataManager(c, tc.m3d,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			dataMgr, err := NewDataManager(fakeClient, tc.m3d,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -695,8 +702,8 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 				Spec: tc.m3dtSpec,
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
-			dataMgr, err := NewDataManager(c, m3d,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			dataMgr, err := NewDataManager(fakeClient, m3d,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -1030,8 +1037,8 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 				Spec: tc.m3dtSpec,
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
-			dataMgr, err := NewDataManager(c, m3d,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			dataMgr, err := NewDataManager(fakeClient, m3d,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -1180,8 +1187,8 @@ var _ = Describe("Metal3Data manager", func() {
 			if tc.ipClaim != nil {
 				objects = append(objects, tc.ipClaim)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
-			dataMgr, err := NewDataManager(c, tc.m3d,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			dataMgr, err := NewDataManager(fakeClient, tc.m3d,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -1377,8 +1384,8 @@ var _ = Describe("Metal3Data manager", func() {
 			if tc.ipClaim != nil {
 				objects = append(objects, tc.ipClaim)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
-			dataMgr, err := NewDataManager(c, tc.m3d,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			dataMgr, err := NewDataManager(fakeClient, tc.m3d,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -2991,17 +2998,17 @@ var _ = Describe("Metal3Data manager", func() {
 
 	DescribeTable("Test getM3Machine",
 		func(tc testCaseGetM3Machine) {
-			c := k8sClient
+			fakeClient := k8sClient
 			if tc.Machine != nil {
-				err := c.Create(context.TODO(), tc.Machine)
+				err := fakeClient.Create(context.TODO(), tc.Machine)
 				Expect(err).NotTo(HaveOccurred())
 			}
 			if tc.DataClaim != nil {
-				err := c.Create(context.TODO(), tc.DataClaim)
+				err := fakeClient.Create(context.TODO(), tc.DataClaim)
 				Expect(err).NotTo(HaveOccurred())
 			}
 
-			machineMgr, err := NewDataManager(c, tc.Data,
+			machineMgr, err := NewDataManager(fakeClient, tc.Data,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -3023,11 +3030,11 @@ var _ = Describe("Metal3Data manager", func() {
 				}
 			}
 			if tc.Machine != nil {
-				err = c.Delete(context.TODO(), tc.Machine)
+				err = fakeClient.Delete(context.TODO(), tc.Machine)
 				Expect(err).NotTo(HaveOccurred())
 			}
 			if tc.DataClaim != nil {
-				err = c.Delete(context.TODO(), tc.DataClaim)
+				err = fakeClient.Delete(context.TODO(), tc.DataClaim)
 				Expect(err).NotTo(HaveOccurred())
 			}
 		},

--- a/baremetal/metal3datatemplate_manager_test.go
+++ b/baremetal/metal3datatemplate_manager_test.go
@@ -154,8 +154,8 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			for _, address := range tc.indexes {
 				objects = append(objects, address)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
-			templateMgr, err := NewDataTemplateManager(c, tc.template,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			templateMgr, err := NewDataTemplateManager(fakeClient, tc.template,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -267,8 +267,8 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			for _, claim := range tc.dataClaims {
 				objects = append(objects, claim)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
-			templateMgr, err := NewDataTemplateManager(c, tc.template,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			templateMgr, err := NewDataTemplateManager(fakeClient, tc.template,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -291,7 +291,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			// get list of Metal3Data objects
 			dataObjects := capm3.Metal3DataClaimList{}
 			opts := &client.ListOptions{}
-			err = c.List(context.TODO(), &dataObjects, opts)
+			err = fakeClient.List(context.TODO(), &dataObjects, opts)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Iterate over the Metal3Data objects to find all indexes and objects
@@ -461,8 +461,8 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			if tc.dataObject != nil {
 				objects = append(objects, tc.dataObject)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
-			templateMgr, err := NewDataTemplateManager(c, tc.template2,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			templateMgr, err := NewDataTemplateManager(fakeClient, tc.template2,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -476,7 +476,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 
 			dataObjects := capm3.Metal3DataList{}
 			opts := &client.ListOptions{}
-			err = c.List(context.TODO(), &dataObjects, opts)
+			err = fakeClient.List(context.TODO(), &dataObjects, opts)
 			Expect(err).NotTo(HaveOccurred())
 			if tc.dataObject != nil {
 				Expect(len(dataObjects.Items)).To(Equal(2))
@@ -495,7 +495,8 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 					result := templateMgr.dataObjectBelongsToTemplate(*tc.dataObject)
 					Expect(result).To(BeTrue())
 					dataClaimIndex := tc.template1.Status.Indexes[tc.dataClaim.ObjectMeta.Name]
-					Expect(tc.dataObject.ObjectMeta.Name).To(Equal(tc.template1.ObjectMeta.Name + "-" + strconv.Itoa(dataClaimIndex)))
+					Expect(tc.dataObject.ObjectMeta.Name).To(Equal(
+						tc.template1.ObjectMeta.Name + "-" + strconv.Itoa(dataClaimIndex)))
 				} else {
 					result := templateMgr.dataObjectBelongsToTemplate(*tc.dataObject)
 					Expect(result).To(BeFalse())
@@ -636,8 +637,8 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			for _, address := range tc.datas {
 				objects = append(objects, address)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
-			templateMgr, err := NewDataTemplateManager(c, tc.template,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			templateMgr, err := NewDataTemplateManager(fakeClient, tc.template,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -658,7 +659,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			// get list of Metal3Data objects
 			dataObjects := capm3.Metal3DataList{}
 			opts := &client.ListOptions{}
-			err = c.List(context.TODO(), &dataObjects, opts)
+			err = fakeClient.List(context.TODO(), &dataObjects, opts)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(len(tc.expectedDatas)).To(Equal(len(dataObjects.Items)))
@@ -784,8 +785,8 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			for _, address := range tc.datas {
 				objects = append(objects, address)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
-			templateMgr, err := NewDataTemplateManager(c, tc.template,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			templateMgr, err := NewDataTemplateManager(fakeClient, tc.template,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -800,7 +801,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			// get list of Metal3Data objects
 			dataObjects := capm3.Metal3DataList{}
 			opts := &client.ListOptions{}
-			err = c.List(context.TODO(), &dataObjects, opts)
+			err = fakeClient.List(context.TODO(), &dataObjects, opts)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(dataObjects.Items)).To(Equal(0))
 


### PR DESCRIPTION
This commit tries to align the unit test syntax with CAPI's
syntax.
