### PR TITLE
✨ Add BMO upgrade e2e test

### DIFF
--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -83,6 +83,7 @@ variables:
   CONTAINER_REGISTRY: "${CONTAINER_REGISTRY:-quay.io}"
   IRONIC_IMAGE_TAG: "${IRONIC_IMAGE_TAG:-main}"
   MARIADB_IMAGE_TAG: "${MARIADB_IMAGE_TAG:-main}"
+  UPGRADED_BMO_IMAGE_TAG: "${UPGRADED_BMO_IMAGE_TAG:-main}"
   CAPIRELEASE: "${CAPIRELEASE}"
   CAPM3RELEASE: "${CAPM3RELEASE}"
   CONFIG_FILE_PATH: "${HOME}/.cluster-api/overrides/clusterctl.yaml"
@@ -111,4 +112,3 @@ intervals:
   default/wait-machine-running: ["50m", "20s"]
   default/wait-bmh-provisioned: ["50m", "20s"]
   default/wait-pod-restart: ["6m", "10s"]
-

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -75,6 +75,7 @@ var _ = Describe("Workload cluster creation", func() {
 			targetCluster = bootstrapClusterProxy.GetWorkloadCluster(ctx, namespace, clusterName)
 			remediation()
 			pivoting()
+			upgradeBMO()
 			upgradeIronic()
 			certRotation()
 			nodeReuse()

--- a/test/e2e/upgrade_baremetal_operator_test.go
+++ b/test/e2e/upgrade_baremetal_operator_test.go
@@ -1,0 +1,52 @@
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func upgradeBMO() {
+	Logf("Starting BMO containers upgrade tests")
+	var (
+		namePrefix = e2eConfig.GetVariable("NAMEPREFIX")
+		clientSet  = targetCluster.GetClientSet()
+		// BMO and Ironic share namespace
+		bmoNamespace      = e2eConfig.GetVariable("IRONIC_NAMESPACE")
+		bmoDeployName     = namePrefix + "-controller-manager"
+		containerRegistry = e2eConfig.GetVariable("CONTAINER_REGISTRY")
+		bmoImageTag       = e2eConfig.GetVariable("UPGRADED_BMO_IMAGE_TAG")
+		bmoImage          = containerRegistry + "/metal3-io/baremetal-operator:" + bmoImageTag
+	)
+
+	Logf("namePrefix %v", namePrefix)
+	Logf("bmoNamespace %v", bmoNamespace)
+	Logf("bmoDeployName %v", bmoDeployName)
+	Logf("containerRegistry %v", containerRegistry)
+	Logf("bmoImageTag %v", bmoImageTag)
+
+	By("Upgrading BMO deployment")
+	deploy, err := clientSet.AppsV1().Deployments(bmoNamespace).Get(ctx, bmoDeployName, metav1.GetOptions{})
+	Expect(err).To(BeNil())
+	for i, container := range deploy.Spec.Template.Spec.Containers {
+		switch container.Name {
+		case "manager":
+			Logf("Old image: %v", deploy.Spec.Template.Spec.Containers[i].Image)
+			Logf("New image: %v", bmoImage)
+			deploy.Spec.Template.Spec.Containers[i].Image = bmoImage
+		}
+	}
+
+	_, err = clientSet.AppsV1().Deployments(bmoNamespace).Update(ctx, deploy, metav1.UpdateOptions{})
+	Expect(err).To(BeNil())
+
+	By("Waiting for BMO update to rollout")
+	Eventually(func() bool {
+		return deploymentRolledOut(ctx, clientSet, bmoDeployName, bmoNamespace, deploy.Status.ObservedGeneration+1)
+	},
+		e2eConfig.GetIntervals(specName, "wait-deployment")...,
+	).Should(Equal(true))
+
+	By("BMO UPGRADE TESTS PASSED!")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a simple BMO upgrade e2e test.

This test is very similar to the ironic upgrade test. So far they do not
really upgrade from an older version to the latest. Instead they upgrade
from no tag (latest) to main. So we at least see that it is possible to
rollout an upgrade.

The idea is to later make the tests start from an older release and upgrade to the latest.
