### PR TITLE
:seedling: Standardize controller & baremetal unit test syntax

### DIFF
--- a/baremetal/manager_factory_test.go
+++ b/baremetal/manager_factory_test.go
@@ -24,21 +24,21 @@ import (
 	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("Manager factory testing", func() {
-	var managerClient client.Client
+	var fakeClient client.Client
 	var managerFactory ManagerFactory
 	clusterLog := logr.Discard()
 
 	BeforeEach(func() {
-		managerClient = fakeclient.NewClientBuilder().WithScheme(setupScheme()).Build()
-		managerFactory = NewManagerFactory(managerClient)
+		fakeClient = fake.NewClientBuilder().WithScheme(setupScheme()).Build()
+		managerFactory = NewManagerFactory(fakeClient)
 	})
 
 	It("returns a manager factory", func() {
-		Expect(managerFactory.client).To(Equal(managerClient))
+		Expect(managerFactory.client).To(Equal(fakeClient))
 	})
 
 	It("returns a cluster manager", func() {

--- a/baremetal/metal3cluster_manager_test.go
+++ b/baremetal/metal3cluster_manager_test.go
@@ -33,7 +33,7 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func bmcSpec() *capm3.Metal3ClusterSpec {
@@ -73,7 +73,7 @@ var _ = Describe("Metal3Cluster manager", func() {
 		var fakeClient client.Client
 
 		BeforeEach(func() {
-			fakeClient = fakeclient.NewClientBuilder().WithScheme(setupScheme()).Build()
+			fakeClient = fake.NewClientBuilder().WithScheme(setupScheme()).Build()
 		})
 
 		DescribeTable("Test NewClusterManager",
@@ -371,10 +371,10 @@ func newBMClusterSetup(tc testCaseBMClusterManager) (*ClusterManager, error) {
 	if tc.BMCluster != nil {
 		objects = append(objects, tc.BMCluster)
 	}
-	c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+	fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
 
 	return &ClusterManager{
-		client:        c,
+		client:        fakeClient,
 		Metal3Cluster: tc.BMCluster,
 		Cluster:       tc.Cluster,
 		Log:           logr.Discard(),
@@ -393,10 +393,10 @@ func descendantsSetup(tc descendantsTestCase) *ClusterManager {
 	for _, machine := range tc.Machines {
 		objects = append(objects, machine)
 	}
-	c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+	fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
 
 	return &ClusterManager{
-		client:        c,
+		client:        fakeClient,
 		Metal3Cluster: bmCluster,
 		Cluster:       cluster,
 		Log:           logr.Discard(),

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/utils/pointer"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var (
@@ -124,8 +124,8 @@ var _ = Describe("Metal3Data manager", func() {
 			if tc.m3m != nil {
 				objects = append(objects, tc.m3m)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
-			dataMgr, err := NewDataManager(c, tc.m3d,
+			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			dataMgr, err := NewDataManager(fakeClient, tc.m3d,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -205,8 +205,8 @@ var _ = Describe("Metal3Data manager", func() {
 			if tc.networkdataSecret != nil {
 				objects = append(objects, tc.networkdataSecret)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
-			dataMgr, err := NewDataManager(c, tc.m3d,
+			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			dataMgr, err := NewDataManager(fakeClient, tc.m3d,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -229,7 +229,7 @@ var _ = Describe("Metal3Data manager", func() {
 			}
 			if tc.expectedMetadata != nil {
 				tmpSecret := corev1.Secret{}
-				err = c.Get(context.TODO(),
+				err = fakeClient.Get(context.TODO(),
 					client.ObjectKey{
 						Name:      "abc-metadata",
 						Namespace: "myns",
@@ -241,7 +241,7 @@ var _ = Describe("Metal3Data manager", func() {
 			}
 			if tc.expectedNetworkData != nil {
 				tmpSecret := corev1.Secret{}
-				err = c.Get(context.TODO(),
+				err = fakeClient.Get(context.TODO(),
 					client.ObjectKey{
 						Name:      "abc-networkdata",
 						Namespace: "myns",
@@ -475,9 +475,16 @@ var _ = Describe("Metal3Data manager", func() {
 			bmh: &bmo.BareMetalHost{
 				ObjectMeta: testObjectMeta,
 			},
-			expectReady:         true,
-			expectedMetadata:    pointer.StringPtr(fmt.Sprintf("String-1: String-1\nprovideruid: %s\n", provideruid)),
-			expectedNetworkData: pointer.StringPtr("links:\n- ethernet_mac_address: XX:XX:XX:XX:XX:XX\n  id: eth0\n  mtu: 1500\n  type: phy\nnetworks: []\nservices: []\n"),
+			expectReady:      true,
+			expectedMetadata: pointer.StringPtr(fmt.Sprintf("String-1: String-1\nprovideruid: %s\n", provideruid)),
+			expectedNetworkData: pointer.StringPtr("" +
+				"links:\n" +
+				"- ethernet_mac_address: XX:XX:XX:XX:XX:XX\n" +
+				"  id: eth0\n" +
+				"  mtu: 1500\n" +
+				"  type: phy\n" +
+				"networks: []\n" +
+				"services: []\n"),
 		}),
 		Entry("No Machine OwnerRef on M3M", testCaseCreateSecrets{
 			m3d: &capm3.Metal3Data{
@@ -601,8 +608,8 @@ var _ = Describe("Metal3Data manager", func() {
 			if tc.m3dt != nil {
 				objects = append(objects, tc.m3dt)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
-			dataMgr, err := NewDataManager(c, tc.m3d,
+			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			dataMgr, err := NewDataManager(fakeClient, tc.m3d,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -695,8 +702,8 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 				Spec: tc.m3dtSpec,
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
-			dataMgr, err := NewDataManager(c, m3d,
+			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			dataMgr, err := NewDataManager(fakeClient, m3d,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -1030,8 +1037,8 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 				Spec: tc.m3dtSpec,
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
-			dataMgr, err := NewDataManager(c, m3d,
+			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			dataMgr, err := NewDataManager(fakeClient, m3d,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -1180,8 +1187,8 @@ var _ = Describe("Metal3Data manager", func() {
 			if tc.ipClaim != nil {
 				objects = append(objects, tc.ipClaim)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
-			dataMgr, err := NewDataManager(c, tc.m3d,
+			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			dataMgr, err := NewDataManager(fakeClient, tc.m3d,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -1377,8 +1384,8 @@ var _ = Describe("Metal3Data manager", func() {
 			if tc.ipClaim != nil {
 				objects = append(objects, tc.ipClaim)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
-			dataMgr, err := NewDataManager(c, tc.m3d,
+			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			dataMgr, err := NewDataManager(fakeClient, tc.m3d,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -2991,17 +2998,17 @@ var _ = Describe("Metal3Data manager", func() {
 
 	DescribeTable("Test getM3Machine",
 		func(tc testCaseGetM3Machine) {
-			c := k8sClient
+			fakeClient := k8sClient
 			if tc.Machine != nil {
-				err := c.Create(context.TODO(), tc.Machine)
+				err := fakeClient.Create(context.TODO(), tc.Machine)
 				Expect(err).NotTo(HaveOccurred())
 			}
 			if tc.DataClaim != nil {
-				err := c.Create(context.TODO(), tc.DataClaim)
+				err := fakeClient.Create(context.TODO(), tc.DataClaim)
 				Expect(err).NotTo(HaveOccurred())
 			}
 
-			machineMgr, err := NewDataManager(c, tc.Data,
+			machineMgr, err := NewDataManager(fakeClient, tc.Data,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -3023,11 +3030,11 @@ var _ = Describe("Metal3Data manager", func() {
 				}
 			}
 			if tc.Machine != nil {
-				err = c.Delete(context.TODO(), tc.Machine)
+				err = fakeClient.Delete(context.TODO(), tc.Machine)
 				Expect(err).NotTo(HaveOccurred())
 			}
 			if tc.DataClaim != nil {
-				err = c.Delete(context.TODO(), tc.DataClaim)
+				err = fakeClient.Delete(context.TODO(), tc.DataClaim)
 				Expect(err).NotTo(HaveOccurred())
 			}
 		},

--- a/baremetal/metal3datatemplate_manager_test.go
+++ b/baremetal/metal3datatemplate_manager_test.go
@@ -31,7 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var timeNow = metav1.Now()
@@ -154,8 +154,8 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			for _, address := range tc.indexes {
 				objects = append(objects, address)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
-			templateMgr, err := NewDataTemplateManager(c, tc.template,
+			fakeClient := fake.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			templateMgr, err := NewDataTemplateManager(fakeClient, tc.template,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -267,8 +267,8 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			for _, claim := range tc.dataClaims {
 				objects = append(objects, claim)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
-			templateMgr, err := NewDataTemplateManager(c, tc.template,
+			fakeClient := fake.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			templateMgr, err := NewDataTemplateManager(fakeClient, tc.template,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -291,7 +291,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			// get list of Metal3Data objects
 			dataObjects := capm3.Metal3DataClaimList{}
 			opts := &client.ListOptions{}
-			err = c.List(context.TODO(), &dataObjects, opts)
+			err = fakeClient.List(context.TODO(), &dataObjects, opts)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Iterate over the Metal3Data objects to find all indexes and objects
@@ -461,8 +461,8 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			if tc.dataObject != nil {
 				objects = append(objects, tc.dataObject)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
-			templateMgr, err := NewDataTemplateManager(c, tc.template2,
+			fakeClient := fake.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			templateMgr, err := NewDataTemplateManager(fakeClient, tc.template2,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -476,7 +476,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 
 			dataObjects := capm3.Metal3DataList{}
 			opts := &client.ListOptions{}
-			err = c.List(context.TODO(), &dataObjects, opts)
+			err = fakeClient.List(context.TODO(), &dataObjects, opts)
 			Expect(err).NotTo(HaveOccurred())
 			if tc.dataObject != nil {
 				Expect(len(dataObjects.Items)).To(Equal(2))
@@ -495,7 +495,8 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 					result := templateMgr.dataObjectBelongsToTemplate(*tc.dataObject)
 					Expect(result).To(BeTrue())
 					dataClaimIndex := tc.template1.Status.Indexes[tc.dataClaim.ObjectMeta.Name]
-					Expect(tc.dataObject.ObjectMeta.Name).To(Equal(tc.template1.ObjectMeta.Name + "-" + strconv.Itoa(dataClaimIndex)))
+					Expect(tc.dataObject.ObjectMeta.Name).To(Equal(
+						tc.template1.ObjectMeta.Name + "-" + strconv.Itoa(dataClaimIndex)))
 				} else {
 					result := templateMgr.dataObjectBelongsToTemplate(*tc.dataObject)
 					Expect(result).To(BeFalse())
@@ -636,8 +637,8 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			for _, address := range tc.datas {
 				objects = append(objects, address)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
-			templateMgr, err := NewDataTemplateManager(c, tc.template,
+			fakeClient := fake.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			templateMgr, err := NewDataTemplateManager(fakeClient, tc.template,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -658,7 +659,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			// get list of Metal3Data objects
 			dataObjects := capm3.Metal3DataList{}
 			opts := &client.ListOptions{}
-			err = c.List(context.TODO(), &dataObjects, opts)
+			err = fakeClient.List(context.TODO(), &dataObjects, opts)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(len(tc.expectedDatas)).To(Equal(len(dataObjects.Items)))
@@ -784,8 +785,8 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			for _, address := range tc.datas {
 				objects = append(objects, address)
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
-			templateMgr, err := NewDataTemplateManager(c, tc.template,
+			fakeClient := fake.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			templateMgr, err := NewDataTemplateManager(fakeClient, tc.template,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -800,7 +801,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			// get list of Metal3Data objects
 			dataObjects := capm3.Metal3DataList{}
 			opts := &client.ListOptions{}
-			err = c.List(context.TODO(), &dataObjects, opts)
+			err = fakeClient.List(context.TODO(), &dataObjects, opts)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(dataObjects.Items)).To(Equal(0))
 

--- a/baremetal/metal3machinetemplate_manager_test.go
+++ b/baremetal/metal3machinetemplate_manager_test.go
@@ -46,8 +46,8 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 				tc.M3MachineTemplate,
 				tc.M3MachineList,
 			}
-			c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithRuntimeObjects(objects...).Build()
-			templateMgr, err := NewMachineTemplateManager(c, tc.M3MachineTemplate,
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithRuntimeObjects(objects...).Build()
+			templateMgr, err := NewMachineTemplateManager(fakeClient, tc.M3MachineTemplate,
 				tc.M3MachineList, logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -62,7 +62,7 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 					Namespace: m3m.Namespace,
 				}
 				updatedM3M := capm3.Metal3Machine{}
-				err = c.Get(context.TODO(), key, &updatedM3M)
+				err = fakeClient.Get(context.TODO(), key, &updatedM3M)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(updatedM3M.Spec.AutomatedCleaningMode).To(Equal(tc.ExpectedValue))
 			}

--- a/baremetal/metal3remediation_manager_test.go
+++ b/baremetal/metal3remediation_manager_test.go
@@ -29,7 +29,7 @@ import (
 	_ "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 type testCaseRemediationManager struct {
@@ -44,14 +44,17 @@ var _ = Describe("Metal3Remediation manager", func() {
 	var fakeClient client.Client
 
 	BeforeEach(func() {
-		fakeClient = fakeclient.NewClientBuilder().WithScheme(setupScheme()).Build()
+		fakeClient = fake.NewClientBuilder().WithScheme(setupScheme()).Build()
 	})
 
 	Describe("Test New Remediation Manager", func() {
 
 		DescribeTable("Test NewRemediationManager",
 			func(tc testCaseRemediationManager) {
-				_, err := NewRemediationManager(fakeClient, tc.Metal3Remediation, tc.Metal3Machine, tc.Machine,
+				_, err := NewRemediationManager(fakeClient,
+					tc.Metal3Remediation,
+					tc.Metal3Machine,
+					tc.Machine,
 					logr.Discard(),
 				)
 				if tc.ExpectSuccess {
@@ -288,9 +291,9 @@ var _ = Describe("Metal3Remediation manager", func() {
 				},
 			}
 
-			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(&host).Build()
+			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(&host).Build()
 
-			remediationMgr, err := NewRemediationManager(c, nil, tc.M3Machine, nil,
+			remediationMgr, err := NewRemediationManager(fakeClient, nil, tc.M3Machine, nil,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())

--- a/controllers/metal3cluster_controller_integration_test.go
+++ b/controllers/metal3cluster_controller_integration_test.go
@@ -51,11 +51,11 @@ var _ = Describe("Reconcile metal3Cluster", func() {
 	DescribeTable("Reconcile tests metal3Cluster",
 		func(tc TestCaseReconcileBMC) {
 			testclstr := &capm3.Metal3Cluster{}
-			c := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(tc.Objects...).Build()
+			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(tc.Objects...).Build()
 
 			r := &Metal3ClusterReconciler{
-				Client:           c,
-				ManagerFactory:   baremetal.NewManagerFactory(c),
+				Client:           fakeClient,
+				ManagerFactory:   baremetal.NewManagerFactory(fakeClient),
 				Log:              logr.Discard(),
 				WatchFilterValue: "",
 			}
@@ -68,7 +68,7 @@ var _ = Describe("Reconcile metal3Cluster", func() {
 			}
 			ctx := context.Background()
 			res, err := r.Reconcile(ctx, req)
-			_ = c.Get(ctx, *getKey(metal3ClusterName), testclstr)
+			_ = fakeClient.Get(ctx, *getKey(metal3ClusterName), testclstr)
 
 			if tc.ErrorExpected {
 				Expect(err).To(HaveOccurred())

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -77,7 +77,8 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 	// Bootstrap data not ready, we'll requeue, not call anything else
 	m.EXPECT().IsBootstrapReady().Return(!tc.BootstrapNotReady)
 	if tc.BootstrapNotReady {
-		m.EXPECT().SetConditionMetal3MachineToFalse(capm3.AssociateBMHCondition, capm3.WaitingForBootstrapReadyReason, capi.ConditionSeverityInfo, "")
+		m.EXPECT().SetConditionMetal3MachineToFalse(capm3.AssociateBMHCondition,
+			capm3.WaitingForBootstrapReadyReason, capi.ConditionSeverityInfo, "")
 		m.EXPECT().AssociateM3Metadata(context.TODO()).MaxTimes(0)
 		m.EXPECT().HasAnnotation().MaxTimes(0)
 		m.EXPECT().GetProviderIDAndBMHID().MaxTimes(0)
@@ -141,7 +142,8 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 				Return(errors.New("Failed"))
 			m.EXPECT().SetProviderID(string(bmhuid)).MaxTimes(0)
 			m.EXPECT().SetError(gomock.Any(), gomock.Any())
-			m.EXPECT().SetConditionMetal3MachineToFalse(capm3.KubernetesNodeReadyCondition, capm3.SettingProviderIDOnNodeFailedReason, capi.ConditionSeverityError, gomock.Any())
+			m.EXPECT().SetConditionMetal3MachineToFalse(capm3.KubernetesNodeReadyCondition,
+				capm3.SettingProviderIDOnNodeFailedReason, capi.ConditionSeverityError, gomock.Any())
 			return m
 		}
 
@@ -205,11 +207,11 @@ var _ = Describe("Metal3Machine manager", func() {
 		BeforeEach(func() {
 			gomockCtrl = gomock.NewController(GinkgoT())
 
-			c := fake.NewClientBuilder().WithScheme(setupScheme()).Build()
+			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).Build()
 
 			bmReconcile = &Metal3MachineReconciler{
-				Client:           c,
-				ManagerFactory:   baremetal.NewManagerFactory(c),
+				Client:           fakeClient,
+				ManagerFactory:   baremetal.NewManagerFactory(fakeClient),
 				Log:              logr.Discard(),
 				CapiClientGetter: nil,
 				WatchFilterValue: "",
@@ -295,11 +297,11 @@ var _ = Describe("Metal3Machine manager", func() {
 		BeforeEach(func() {
 			gomockCtrl = gomock.NewController(GinkgoT())
 
-			c := fake.NewClientBuilder().WithScheme(setupScheme()).Build()
+			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).Build()
 
 			bmReconcile = &Metal3MachineReconciler{
-				Client:           c,
-				ManagerFactory:   baremetal.NewManagerFactory(c),
+				Client:           fakeClient,
+				ManagerFactory:   baremetal.NewManagerFactory(fakeClient),
 				Log:              logr.Discard(),
 				CapiClientGetter: nil,
 				WatchFilterValue: "",
@@ -361,10 +363,10 @@ var _ = Describe("Metal3Machine manager", func() {
 				tc.Machine1,
 				tc.Machine2,
 			}
-			c := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
 
 			r := Metal3MachineReconciler{
-				Client:           c,
+				Client:           fakeClient,
 				Log:              logr.Discard(),
 				WatchFilterValue: "",
 			}
@@ -580,9 +582,9 @@ var _ = Describe("Metal3Machine manager", func() {
 				tc.Machine1,
 				tc.M3Machine,
 			}
-			c := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
 			r := Metal3MachineReconciler{
-				Client: c,
+				Client: fakeClient,
 			}
 			obj := client.Object(tc.Cluster)
 			reqs := r.ClusterToMetal3Machines(obj)
@@ -590,7 +592,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			if tc.ExpectRequest {
 				Expect(len(reqs)).To(Equal(1), "Expected 1 request, found %d", len(reqs))
 				req := capm3.Metal3Machine{}
-				err := c.Get(context.TODO(), reqs[0].NamespacedName, &req)
+				err := fakeClient.Get(context.TODO(), reqs[0].NamespacedName, &req)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(req.Labels[capi.ClusterLabelName]).To(Equal(tc.Cluster.Name),
@@ -636,9 +638,9 @@ var _ = Describe("Metal3Machine manager", func() {
 					OwnerReferences: tc.ownerRefs,
 				},
 			}
-			c := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(ipClaim).Build()
+			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(ipClaim).Build()
 			r := Metal3MachineReconciler{
-				Client: c,
+				Client: fakeClient,
 			}
 			obj := client.Object(ipClaim)
 			reqs := r.Metal3DataToMetal3Machines(obj)

--- a/controllers/metal3remediation_controller_test.go
+++ b/controllers/metal3remediation_controller_test.go
@@ -136,11 +136,11 @@ var _ = Describe("Metal3Remediation controller", func() {
 
 			BeforeEach(func() {
 				ctrl = gomock.NewController(GinkgoT())
-				c := fake.NewClientBuilder().WithScheme(setupScheme()).Build()
+				fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).Build()
 
 				remReconcile = &Metal3RemediationReconciler{
-					Client:         c,
-					ManagerFactory: baremetal.NewManagerFactory(c),
+					Client:         fakeClient,
+					ManagerFactory: baremetal.NewManagerFactory(fakeClient),
 					Log:            logr.Discard(),
 				}
 			})


### PR DESCRIPTION
This commit removes:
    - unnecessary 'fakeclient' import alias
    - unnecessary variable declarations

This commit also replaces the previously used variable name 'c'
with the 'fakeClient' name as it is more descriptive and it is also
used in CAPI.

This commit also breaks up some long lines in order to make them more
readable.