### PR TITLE
Replace ironic containers by the all-in-one

### DIFF
--- a/test/e2e/pivoting_test.go
+++ b/test/e2e/pivoting_test.go
@@ -239,11 +239,9 @@ func installIronicBMO(targetCluster framework.ClusterProxy, isIronic, isBMO stri
 
 func removeIronicContainers() {
 	ironicContainerList := []string{
-		"ironic-api",
-		"ironic-conductor",
+		"ironic",
 		"ironic-inspector",
 		"dnsmasq",
-		"mariadb",
 		"ironic-endpoint-keepalived",
 		"ironic-log-watch",
 	}


### PR DESCRIPTION
After merging [https://github.com/metal3-io/baremetal-operator/pull/1065](https://github.com/metal3-io/baremetal-operator/pull/1065) some tests are broken in pivoting because they cannot find `ironic-api `, ` ironic-conductor`& `mariadb`.

This PR replaces these containers by the all-in-one `ironic` container.

