### PR TITLE
✨ Add LogFolder parameter in e2e for collecting kind logs

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -187,6 +187,7 @@ func setupBootstrapCluster(config *clusterctl.E2EConfig, scheme *runtime.Scheme,
 			Name:               config.ManagementClusterName,
 			RequiresDockerSock: config.HasDockerProvider(),
 			Images:             config.Images,
+			LogFolder:          filepath.Join(artifactFolder, "kind", bootstrapClusterProxy.GetName()),
 		})
 		Expect(clusterProvider).ToNot(BeNil(), "Failed to create a bootstrap cluster")
 


### PR DESCRIPTION
This PR adds LogFolder Parameter in e2e for collecting kind logs. Please see https://github.com/kubernetes-sigs/cluster-api/pull/5910/ for reference.