### PR TITLE
✨ [Part1] Add golangci lint yaml

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,60 @@
+run:
+  deadline: 5m
+  skip-dirs:
+    - mock*
+  skip-files:
+  - "zz_generated.*\\.go$"
+  - ".*conversion.*\\.go$"
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - errcheck
+    - errorlint
+    - goconst
+    - godot
+    - gofmt
+    - goimports
+    - golint
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - prealloc
+    - staticcheck
+    - structcheck
+    - unconvert
+    - unused
+    - varcheck
+    - whitespace
+  # Run with --fast=false for more extensive checks
+  fast: true
+issues:
+  exclude-rules:
+    - path: api/v1alpha4/types\.go
+      linters:
+        - golint
+    - path: test/e2e
+      linters:
+        - golint
+    - path: _test\.go
+      linters:
+        - unused
+    - linters:
+        - staticcheck
+      text: "SA1019:"
+    # Dot imports for gomega or ginkgo are allowed
+    # within test files.
+    - path: _test\.go
+      text: should not use dot imports
+    - path: (test|e2e)/.*.go
+      text: should not use dot imports
+    - path: _test\.go
+      text: cyclomatic complexity
+    - path: baremetal/.*.go
+      text: cyclomatic complexity
+  include:
+  - EXC0002 # include "missing comments" issues from golint
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/baremetal/manager_factory.go
+++ b/baremetal/manager_factory.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ManagerFactoryInterface is a collection of new managers.
 type ManagerFactoryInterface interface {
 	NewClusterManager(cluster *capi.Cluster,
 		metal3Cluster *capm3.Metal3Cluster,
@@ -46,7 +47,7 @@ type ManagerFactoryInterface interface {
 	)
 }
 
-// ManagerFactory only contains a client
+// ManagerFactory only contains a client.
 type ManagerFactory struct {
 	client client.Client
 }
@@ -56,12 +57,12 @@ func NewManagerFactory(client client.Client) ManagerFactory {
 	return ManagerFactory{client: client}
 }
 
-// NewClusterManager creates a new ClusterManager
+// NewClusterManager creates a new ClusterManager.
 func (f ManagerFactory) NewClusterManager(cluster *capi.Cluster, capm3Cluster *capm3.Metal3Cluster, clusterLog logr.Logger) (ClusterManagerInterface, error) {
 	return NewClusterManager(f.client, cluster, capm3Cluster, clusterLog)
 }
 
-// NewMachineManager creates a new MachineManager
+// NewMachineManager creates a new MachineManager.
 func (f ManagerFactory) NewMachineManager(capiCluster *capi.Cluster,
 	capm3Cluster *capm3.Metal3Cluster,
 	capiMachine *capi.Machine, capm3Machine *capm3.Metal3Machine,
@@ -70,24 +71,24 @@ func (f ManagerFactory) NewMachineManager(capiCluster *capi.Cluster,
 		capm3Machine, machineLog)
 }
 
-// NewDataTemplateManager creates a new DataTemplateManager
+// NewDataTemplateManager creates a new DataTemplateManager.
 func (f ManagerFactory) NewDataTemplateManager(metadata *capm3.Metal3DataTemplate, metadataLog logr.Logger) (DataTemplateManagerInterface, error) {
 	return NewDataTemplateManager(f.client, metadata, metadataLog)
 }
 
-// NewDataManager creates a new DataManager
+// NewDataManager creates a new DataManager.
 func (f ManagerFactory) NewDataManager(metadata *capm3.Metal3Data, metadataLog logr.Logger) (DataManagerInterface, error) {
 	return NewDataManager(f.client, metadata, metadataLog)
 }
 
-// NewMachineTemplateManager creates a new Metal3MachineTemplateManager
+// NewMachineTemplateManager creates a new Metal3MachineTemplateManager.
 func (f ManagerFactory) NewMachineTemplateManager(capm3Template *capm3.Metal3MachineTemplate,
 	capm3MachineList *capm3.Metal3MachineList,
 	metadataLog logr.Logger) (TemplateManagerInterface, error) {
 	return NewMachineTemplateManager(f.client, capm3Template, capm3MachineList, metadataLog)
 }
 
-// NewRemediationManager creates a new RemediationManager
+// NewRemediationManager creates a new RemediationManager.
 func (f ManagerFactory) NewRemediationManager(remediation *capm3.Metal3Remediation,
 	metal3machine *capm3.Metal3Machine, machine *capi.Machine,
 	remediationLog logr.Logger) (RemediationManagerInterface, error) {

--- a/baremetal/metal3cluster_manager.go
+++ b/baremetal/metal3cluster_manager.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ClusterManagerInterface is an interface for a ClusterManager
+// ClusterManagerInterface is an interface for a ClusterManager.
 type ClusterManagerInterface interface {
 	Create(context.Context) error
 	Delete() error
@@ -45,7 +45,7 @@ type ClusterManagerInterface interface {
 	CountDescendants(context.Context) (int, error)
 }
 
-// ClusterManager is responsible for performing metal3 cluster reconciliation
+// ClusterManager is responsible for performing metal3 cluster reconciliation.
 type ClusterManager struct {
 	client client.Client
 
@@ -59,7 +59,6 @@ type ClusterManager struct {
 func NewClusterManager(client client.Client, cluster *capi.Cluster,
 	metal3Cluster *capm3.Metal3Cluster,
 	clusterLog logr.Logger) (ClusterManagerInterface, error) {
-
 	if metal3Cluster == nil {
 		return nil, errors.New("Metal3Cluster is required when creating a ClusterManager")
 	}
@@ -75,7 +74,7 @@ func NewClusterManager(client client.Client, cluster *capi.Cluster,
 	}, nil
 }
 
-// SetFinalizer sets finalizer
+// SetFinalizer sets finalizer.
 func (s *ClusterManager) SetFinalizer() {
 	// If the Metal3Cluster doesn't have finalizer, add it.
 	if !Contains(s.Metal3Cluster.ObjectMeta.Finalizers, capm3.ClusterFinalizer) {
@@ -85,7 +84,7 @@ func (s *ClusterManager) SetFinalizer() {
 	}
 }
 
-// UnsetFinalizer unsets finalizer
+// UnsetFinalizer unsets finalizer.
 func (s *ClusterManager) UnsetFinalizer() {
 	// Cluster is deleted so remove the finalizer.
 	s.Metal3Cluster.ObjectMeta.Finalizers = Filter(
@@ -95,24 +94,23 @@ func (s *ClusterManager) UnsetFinalizer() {
 
 // Create creates a cluster manager for the cluster.
 func (s *ClusterManager) Create(ctx context.Context) error {
-
 	config := s.Metal3Cluster.Spec
 	err := config.IsValid()
 	if err != nil {
-		// Should have been picked earlier. Do not requeue
+		// Should have been picked earlier. Do not requeue.
 		s.setError("Invalid Metal3Cluster provided", capierrors.InvalidConfigurationClusterError)
 		return err
 	}
 
-	// clear an error if one was previously set
+	// clear an error if one was previously set.
 	s.clearError()
 
 	return nil
 }
 
-// ControlPlaneEndpoint returns cluster controlplane endpoint
+// ControlPlaneEndpoint returns cluster controlplane endpoint.
 func (s *ClusterManager) ControlPlaneEndpoint() ([]capm3.APIEndpoint, error) {
-	//Get IP address from spec, which gets it from posted cr yaml
+	//Get IP address from spec, which gets it from posted cr yaml.
 	endPoint := s.Metal3Cluster.Spec.ControlPlaneEndpoint
 	var err error
 
@@ -129,14 +127,13 @@ func (s *ClusterManager) ControlPlaneEndpoint() ([]capm3.APIEndpoint, error) {
 	}, nil
 }
 
-// Delete function, no-op for now
+// Delete function, no-op for now.
 func (s *ClusterManager) Delete() error {
 	return nil
 }
 
 // UpdateClusterStatus updates a metal3Cluster object's status.
 func (s *ClusterManager) UpdateClusterStatus() error {
-
 	// Get APIEndpoints from  metal3Cluster Spec
 	_, err := s.ControlPlaneEndpoint()
 
@@ -147,7 +144,7 @@ func (s *ClusterManager) UpdateClusterStatus() error {
 		return err
 	}
 
-	// Mark the metal3Cluster ready
+	// Mark the metal3Cluster ready.
 	s.Metal3Cluster.Status.Ready = true
 	conditions.MarkTrue(s.Metal3Cluster, capm3.BaremetalInfrastructureReadyCondition)
 	now := metav1.Now()
@@ -173,7 +170,7 @@ func (s *ClusterManager) clearError() {
 }
 
 // CountDescendants will return the number of descendants objects of the
-// metal3Cluster
+// metal3Cluster.
 func (s *ClusterManager) CountDescendants(ctx context.Context) (int, error) {
 	// Verify that no metal3machine depend on the metal3cluster
 	descendants, err := s.listDescendants(ctx)
@@ -197,7 +194,6 @@ func (s *ClusterManager) CountDescendants(ctx context.Context) (int, error) {
 // listDescendants returns a list of all Machines, for the cluster owning the
 // metal3Cluster.
 func (s *ClusterManager) listDescendants(ctx context.Context) (capi.MachineList, error) {
-
 	machines := capi.MachineList{}
 	cluster, err := util.GetOwnerCluster(ctx, s.client,
 		s.Metal3Cluster.ObjectMeta,

--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -48,8 +48,6 @@ const (
 	capimachine   = "machine"
 )
 
-var reqAfter *RequeueAfterError
-
 // DataManagerInterface is an interface for a DataManager.
 type DataManagerInterface interface {
 	SetFinalizer()
@@ -108,7 +106,7 @@ func (m *DataManager) Reconcile(ctx context.Context) error {
 	m.clearError(ctx)
 
 	if err := m.createSecrets(ctx); err != nil {
-		if ok := errors.As(err, &reqAfter); ok {
+		if ok := errors.As(err, &hasRequeueAfterError); ok {
 			return err
 		}
 		m.setError(ctx, errors.Cause(err).Error())
@@ -653,7 +651,7 @@ func (m *DataManager) getAddressFromPool(ctx context.Context, poolName string,
 		m.Data.Namespace,
 	)
 	if err != nil {
-		if ok := errors.As(err, &reqAfter); !ok {
+		if ok := errors.As(err, &hasRequeueAfterError); !ok {
 			return addresses, false, err
 		}
 		// Create the claim
@@ -682,7 +680,7 @@ func (m *DataManager) getAddressFromPool(ctx context.Context, poolName string,
 
 		err = createObject(ctx, m.client, ipClaim)
 		if err != nil {
-			if ok := errors.As(err, &reqAfter); !ok {
+			if ok := errors.As(err, &hasRequeueAfterError); !ok {
 				return addresses, false, err
 			}
 		}
@@ -746,7 +744,7 @@ func (m *DataManager) releaseAddressFromPool(ctx context.Context, poolName strin
 		m.Data.Namespace,
 	)
 	if err != nil {
-		if ok := errors.As(err, &reqAfter); !ok {
+		if ok := errors.As(err, &hasRequeueAfterError); !ok {
 			return addresses, false, err
 		}
 		addresses[poolName] = true

--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -41,9 +41,16 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-const providerIDKey = "provideruid"
+const (
+	providerIDKey = "provideruid"
+	m3machine     = "metal3machine"
+	host          = "baremetalhost"
+	capimachine   = "machine"
+)
 
-// DataManagerInterface is an interface for a DataManager
+var reqAfter *RequeueAfterError
+
+// DataManagerInterface is an interface for a DataManager.
 type DataManagerInterface interface {
 	SetFinalizer()
 	UnsetFinalizer()
@@ -51,17 +58,16 @@ type DataManagerInterface interface {
 	ReleaseLeases(ctx context.Context) error
 }
 
-// DataManager is responsible for performing machine reconciliation
+// DataManager is responsible for performing machine reconciliation.
 type DataManager struct {
 	client client.Client
 	Data   *capm3.Metal3Data
 	Log    logr.Logger
 }
 
-// NewDataManager returns a new helper for managing a Metal3Data object
+// NewDataManager returns a new helper for managing a Metal3Data object.
 func NewDataManager(client client.Client,
 	data *capm3.Metal3Data, dataLog logr.Logger) (*DataManager, error) {
-
 	return &DataManager{
 		client: client,
 		Data:   data,
@@ -69,7 +75,7 @@ func NewDataManager(client client.Client,
 	}, nil
 }
 
-// SetFinalizer sets finalizer
+// SetFinalizer sets finalizer.
 func (m *DataManager) SetFinalizer() {
 	// If the Metal3Data doesn't have finalizer, add it.
 	if !Contains(m.Data.Finalizers, capm3.DataFinalizer) {
@@ -79,7 +85,7 @@ func (m *DataManager) SetFinalizer() {
 	}
 }
 
-// UnsetFinalizer unsets finalizer
+// UnsetFinalizer unsets finalizer.
 func (m *DataManager) UnsetFinalizer() {
 	// Remove the finalizer.
 	m.Data.Finalizers = Filter(m.Data.Finalizers,
@@ -87,19 +93,22 @@ func (m *DataManager) UnsetFinalizer() {
 	)
 }
 
+// clearError clears error message from Metal3Data status.
 func (m *DataManager) clearError(ctx context.Context) {
 	m.Data.Status.ErrorMessage = nil
 }
 
+// setError sets error message to Metal3Data status.
 func (m *DataManager) setError(ctx context.Context, msg string) {
 	m.Data.Status.ErrorMessage = &msg
 }
 
+// Reconcile handles Metal3Data events.
 func (m *DataManager) Reconcile(ctx context.Context) error {
 	m.clearError(ctx)
 
 	if err := m.createSecrets(ctx); err != nil {
-		if _, ok := errors.Cause(err).(HasRequeueAfterError); ok {
+		if ok := errors.As(err, &reqAfter); ok {
 			return err
 		}
 		m.setError(ctx, errors.Cause(err).Error())
@@ -154,7 +163,7 @@ func (m *DataManager) createSecrets(ctx context.Context) error {
 		// Try to fetch the secret. If it exists, we do not modify it, to be able
 		// to reprovision a node in the exact same state.
 		m.Log.Info("Checking if secret exists", "secret", m.Data.Spec.MetaData.Name)
-		_, metaDataErr = checkSecretExists(m.client, ctx, m.Data.Spec.MetaData.Name,
+		_, metaDataErr = checkSecretExists(ctx, m.client, m.Data.Spec.MetaData.Name,
 			m.Data.Namespace,
 		)
 
@@ -179,7 +188,7 @@ func (m *DataManager) createSecrets(ctx context.Context) error {
 		// Try to fetch the secret. If it exists, we do not modify it, to be able
 		// to reprovision a node in the exact same state.
 		m.Log.Info("Checking if secret exists", "secret", m.Data.Spec.NetworkData.Name)
-		_, networkDataErr = checkSecretExists(m.client, ctx, m.Data.Spec.NetworkData.Name,
+		_, networkDataErr = checkSecretExists(ctx, m.client, m.Data.Spec.NetworkData.Name,
 			m.Data.Namespace,
 		)
 		if networkDataErr != nil && !apierrors.IsNotFound(networkDataErr) {
@@ -244,7 +253,7 @@ func (m *DataManager) createSecrets(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		if err := createSecret(m.client, ctx, m.Data.Spec.MetaData.Name,
+		if err := createSecret(ctx, m.client, m.Data.Spec.MetaData.Name,
 			m.Data.Namespace, m3dt.Labels[capi.ClusterLabelName],
 			ownerRefs, map[string][]byte{"metaData": metadata},
 		); err != nil {
@@ -259,7 +268,7 @@ func (m *DataManager) createSecrets(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		if err := createSecret(m.client, ctx, m.Data.Spec.NetworkData.Name,
+		if err := createSecret(ctx, m.client, m.Data.Spec.NetworkData.Name,
 			m.Data.Namespace, m3dt.Labels[capi.ClusterLabelName],
 			ownerRefs, map[string][]byte{"networkData": networkData},
 		); err != nil {
@@ -295,7 +304,7 @@ func (m *DataManager) ReleaseLeases(ctx context.Context) error {
 	return m.releaseAddressesFromPool(ctx, *m3dt)
 }
 
-// addressFromPool contains the elements coming from an IPPool
+// addressFromPool contains the elements coming from an IPPool.
 type addressFromPool struct {
 	address    ipamv1.IPAddressStr
 	prefix     int
@@ -307,7 +316,7 @@ type addressFromPool struct {
 // set the Ownerreference if not set, and check if the Metal3IPAddress has been
 // allocated. If not, it will requeue once all IPPools were fetched. If all have
 // been allocated it will return a map containing the IPPool name and the address,
-// prefix and gateway from that IPPool
+// prefix and gateway from that IPPool.
 func (m *DataManager) getAddressesFromPool(ctx context.Context,
 	m3dt capm3.Metal3DataTemplate,
 ) (map[string]addressFromPool, error) {
@@ -465,7 +474,7 @@ func (m *DataManager) getAddressesFromPool(ctx context.Context,
 	return addresses, nil
 }
 
-// releaseAddressesFromPool removes the OwnerReference on the IPPool objects
+// releaseAddressesFromPool removes the OwnerReference on the IPPool objects.
 func (m *DataManager) releaseAddressesFromPool(ctx context.Context,
 	m3dt capm3.Metal3DataTemplate,
 ) error {
@@ -630,7 +639,6 @@ func (m *DataManager) releaseAddressesFromPool(ctx context.Context,
 func (m *DataManager) getAddressFromPool(ctx context.Context, poolName string,
 	addresses map[string]addressFromPool,
 ) (map[string]addressFromPool, bool, error) {
-
 	if addresses == nil {
 		addresses = make(map[string]addressFromPool)
 	}
@@ -645,7 +653,7 @@ func (m *DataManager) getAddressFromPool(ctx context.Context, poolName string,
 		m.Data.Namespace,
 	)
 	if err != nil {
-		if _, ok := err.(HasRequeueAfterError); !ok {
+		if ok := errors.As(err, &reqAfter); !ok {
 			return addresses, false, err
 		}
 		// Create the claim
@@ -672,9 +680,9 @@ func (m *DataManager) getAddressFromPool(ctx context.Context, poolName string,
 			},
 		}
 
-		err = createObject(m.client, ctx, ipClaim)
+		err = createObject(ctx, m.client, ipClaim)
 		if err != nil {
-			if _, ok := err.(HasRequeueAfterError); !ok {
+			if ok := errors.As(err, &reqAfter); !ok {
 				return addresses, false, err
 			}
 		}
@@ -722,11 +730,10 @@ func (m *DataManager) getAddressFromPool(ctx context.Context, poolName string,
 }
 
 // releaseAddressFromPool removes the owner reference on existing referenced
-// Metal3IPPool objects
+// Metal3IPPool objects.
 func (m *DataManager) releaseAddressFromPool(ctx context.Context, poolName string,
 	addresses map[string]bool,
 ) (map[string]bool, bool, error) {
-
 	if addresses == nil {
 		addresses = make(map[string]bool)
 	}
@@ -739,14 +746,14 @@ func (m *DataManager) releaseAddressFromPool(ctx context.Context, poolName strin
 		m.Data.Namespace,
 	)
 	if err != nil {
-		if _, ok := err.(HasRequeueAfterError); !ok {
+		if ok := errors.As(err, &reqAfter); !ok {
 			return addresses, false, err
 		}
 		addresses[poolName] = true
 		return addresses, false, nil
 	}
 
-	err = deleteObject(m.client, ctx, ipClaim)
+	err = deleteObject(ctx, m.client, ipClaim)
 	if err != nil {
 		return addresses, false, err
 	}
@@ -756,7 +763,7 @@ func (m *DataManager) releaseAddressFromPool(ctx context.Context, poolName strin
 }
 
 // renderNetworkData renders the networkData into an object that will be
-// marshalled into the secret
+// marshalled into the secret.
 func renderNetworkData(m3d *capm3.Metal3Data, m3dt *capm3.Metal3DataTemplate,
 	bmh *bmo.BareMetalHost, poolAddresses map[string]addressFromPool,
 ) ([]byte, error) {
@@ -787,7 +794,7 @@ func renderNetworkData(m3d *capm3.Metal3Data, m3dt *capm3.Metal3DataTemplate,
 	return yaml.Marshal(networkData)
 }
 
-// renderNetworkServices renders the services
+// renderNetworkServices renders the services.
 func renderNetworkServices(services capm3.NetworkDataService, poolAddresses map[string]addressFromPool) ([]interface{}, error) {
 	data := []interface{}{}
 
@@ -814,13 +821,13 @@ func renderNetworkServices(services capm3.NetworkDataService, poolAddresses map[
 	return data, nil
 }
 
-// renderNetworkLinks renders the different types of links
+// renderNetworkLinks renders the different types of links.
 func renderNetworkLinks(networkLinks capm3.NetworkDataLink, bmh *bmo.BareMetalHost) ([]interface{}, error) {
 	data := []interface{}{}
 
 	// Ethernet links
 	for _, link := range networkLinks.Ethernets {
-		mac_address, err := getLinkMacAddress(link.MACAddress, bmh)
+		macAddress, err := getLinkMacAddress(link.MACAddress, bmh)
 		if err != nil {
 			return nil, err
 		}
@@ -828,13 +835,13 @@ func renderNetworkLinks(networkLinks capm3.NetworkDataLink, bmh *bmo.BareMetalHo
 			"type":                 link.Type,
 			"id":                   link.Id,
 			"mtu":                  link.MTU,
-			"ethernet_mac_address": mac_address,
+			"ethernet_mac_address": macAddress,
 		})
 	}
 
 	// Bond links
 	for _, link := range networkLinks.Bonds {
-		mac_address, err := getLinkMacAddress(link.MACAddress, bmh)
+		macAddress, err := getLinkMacAddress(link.MACAddress, bmh)
 		if err != nil {
 			return nil, err
 		}
@@ -842,7 +849,7 @@ func renderNetworkLinks(networkLinks capm3.NetworkDataLink, bmh *bmo.BareMetalHo
 			"type":                 "bond",
 			"id":                   link.Id,
 			"mtu":                  link.MTU,
-			"ethernet_mac_address": mac_address,
+			"ethernet_mac_address": macAddress,
 			"bond_mode":            link.BondMode,
 			"bond_links":           link.BondLinks,
 		})
@@ -850,7 +857,7 @@ func renderNetworkLinks(networkLinks capm3.NetworkDataLink, bmh *bmo.BareMetalHo
 
 	// Vlan links
 	for _, link := range networkLinks.Vlans {
-		mac_address, err := getLinkMacAddress(link.MACAddress, bmh)
+		macAddress, err := getLinkMacAddress(link.MACAddress, bmh)
 		if err != nil {
 			return nil, err
 		}
@@ -858,7 +865,7 @@ func renderNetworkLinks(networkLinks capm3.NetworkDataLink, bmh *bmo.BareMetalHo
 			"type":             "vlan",
 			"id":               link.Id,
 			"mtu":              link.MTU,
-			"vlan_mac_address": mac_address,
+			"vlan_mac_address": macAddress,
 			"vlan_id":          link.VlanID,
 			"vlan_link":        link.VlanLink,
 		})
@@ -867,7 +874,7 @@ func renderNetworkLinks(networkLinks capm3.NetworkDataLink, bmh *bmo.BareMetalHo
 	return data, nil
 }
 
-// renderNetworkNetworks renders the different types of network
+// renderNetworkNetworks renders the different types of network.
 func renderNetworkNetworks(networks capm3.NetworkDataNetwork,
 	m3d *capm3.Metal3Data, poolAddresses map[string]addressFromPool,
 ) ([]interface{}, error) {
@@ -962,7 +969,7 @@ func renderNetworkNetworks(networks capm3.NetworkDataNetwork,
 	return data, nil
 }
 
-// getRoutesv4 returns the IPv4 routes
+// getRoutesv4 returns the IPv4 routes.
 func getRoutesv4(netRoutes []capm3.NetworkDataRoutev4,
 	poolAddresses map[string]addressFromPool,
 ) ([]interface{}, error) {
@@ -1008,7 +1015,7 @@ func getRoutesv4(netRoutes []capm3.NetworkDataRoutev4,
 	return routes, nil
 }
 
-// getRoutesv6 returns the IPv6 routes
+// getRoutesv6 returns the IPv6 routes.
 func getRoutesv6(netRoutes []capm3.NetworkDataRoutev6,
 	poolAddresses map[string]addressFromPool,
 ) ([]interface{}, error) {
@@ -1054,7 +1061,7 @@ func getRoutesv6(netRoutes []capm3.NetworkDataRoutev6,
 	return routes, nil
 }
 
-// translateMask transforms a mask given as integer into a dotted-notation string
+// translateMask transforms a mask given as integer into a dotted-notation string.
 func translateMask(maskInt int, ipv4 bool) interface{} {
 	if ipv4 {
 		// Get the mask by concatenating the IPv4 prefix of net package and the mask
@@ -1062,33 +1069,32 @@ func translateMask(maskInt int, ipv4 bool) interface{} {
 			[]byte(net.CIDRMask(maskInt, 32))...,
 		)).String()
 		return ipamv1.IPAddressv4Str(address)
-	} else {
-		// get the mask
-		address := net.IP(net.CIDRMask(maskInt, 128)).String()
-		return ipamv1.IPAddressv6Str(address)
 	}
+	// get the mask
+	address := net.IP(net.CIDRMask(maskInt, 128)).String()
+	return ipamv1.IPAddressv6Str(address)
 }
 
-// getLinkMacAddress returns the mac address
+// getLinkMacAddress returns the mac address.
 func getLinkMacAddress(mac *capm3.NetworkLinkEthernetMac, bmh *bmo.BareMetalHost) (
 	string, error,
 ) {
-	mac_address := ""
+	macAddress := ""
 	var err error
 
 	// if a string was given
 	if mac.String != nil {
-		mac_address = *mac.String
+		macAddress = *mac.String
 
 		// Otherwise fetch the mac from the interface name
 	} else if mac.FromHostInterface != nil {
-		mac_address, err = getBMHMacByName(*mac.FromHostInterface, bmh)
+		macAddress, err = getBMHMacByName(*mac.FromHostInterface, bmh)
 	}
 
-	return mac_address, err
+	return macAddress, err
 }
 
-// renderMetaData renders the MetaData items
+// renderMetaData renders the MetaData items.
 func renderMetaData(m3d *capm3.Metal3Data, m3dt *capm3.Metal3DataTemplate,
 	m3m *capm3.Metal3Machine, machine *capi.Machine, bmh *bmo.BareMetalHost,
 	poolAddresses map[string]addressFromPool,
@@ -1150,11 +1156,11 @@ func renderMetaData(m3d *capm3.Metal3Data, m3dt *capm3.Metal3DataTemplate,
 	// Object names
 	for _, entry := range m3dt.Spec.MetaData.ObjectNames {
 		switch strings.ToLower(entry.Object) {
-		case "metal3machine":
+		case m3machine:
 			metadata[entry.Key] = m3m.Name
-		case "machine":
+		case capimachine:
 			metadata[entry.Key] = machine.Name
-		case "baremetalhost":
+		case host:
 			metadata[entry.Key] = bmh.Name
 		default:
 			return nil, errors.New("Unknown object type")
@@ -1164,11 +1170,11 @@ func renderMetaData(m3d *capm3.Metal3Data, m3dt *capm3.Metal3DataTemplate,
 	// Labels
 	for _, entry := range m3dt.Spec.MetaData.FromLabels {
 		switch strings.ToLower(entry.Object) {
-		case "metal3machine":
+		case m3machine:
 			metadata[entry.Key] = m3m.Labels[entry.Label]
-		case "machine":
+		case capimachine:
 			metadata[entry.Key] = machine.Labels[entry.Label]
-		case "baremetalhost":
+		case host:
 			metadata[entry.Key] = bmh.Labels[entry.Label]
 		default:
 			return nil, errors.New("Unknown object type")
@@ -1178,11 +1184,11 @@ func renderMetaData(m3d *capm3.Metal3Data, m3dt *capm3.Metal3DataTemplate,
 	// Annotations
 	for _, entry := range m3dt.Spec.MetaData.FromAnnotations {
 		switch strings.ToLower(entry.Object) {
-		case "metal3machine":
+		case m3machine:
 			metadata[entry.Key] = m3m.Annotations[entry.Annotation]
-		case "machine":
+		case capimachine:
 			metadata[entry.Key] = machine.Annotations[entry.Annotation]
-		case "baremetalhost":
+		case host:
 			metadata[entry.Key] = bmh.Annotations[entry.Annotation]
 		default:
 			return nil, errors.New("Unknown object type")
@@ -1203,7 +1209,7 @@ func renderMetaData(m3d *capm3.Metal3Data, m3dt *capm3.Metal3DataTemplate,
 	return yaml.Marshal(metadata)
 }
 
-// getBMHMacByName returns the mac address of the interface matching the name
+// getBMHMacByName returns the mac address of the interface matching the name.
 func getBMHMacByName(name string, bmh *bmo.BareMetalHost) (string, error) {
 	if bmh == nil || bmh.Status.HardwareDetails == nil || bmh.Status.HardwareDetails.NIC == nil {
 		return "", errors.New("Nics list not populated")
@@ -1270,10 +1276,9 @@ func fetchM3IPClaim(ctx context.Context, cl client.Client, mLog logr.Logger,
 		if apierrors.IsNotFound(err) {
 			mLog.Info("Address claim not found, requeuing")
 			return nil, &RequeueAfterError{RequeueAfter: requeueAfter}
-		} else {
-			err := errors.Wrap(err, "Failed to get address claim")
-			return nil, err
 		}
+		err := errors.Wrap(err, "Failed to get address claim")
+		return nil, err
 	}
 	return metal3IPClaim, nil
 }

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -219,9 +219,8 @@ var _ = Describe("Metal3Data manager", func() {
 					Expect(err).NotTo(BeAssignableToTypeOf(&RequeueAfterError{}))
 				}
 				return
-			} else {
-				Expect(err).NotTo(HaveOccurred())
 			}
+			Expect(err).NotTo(HaveOccurred())
 			if tc.expectReady {
 				Expect(tc.m3d.Status.Ready).To(BeTrue())
 			} else {
@@ -1497,9 +1496,8 @@ var _ = Describe("Metal3Data manager", func() {
 			if tc.expectError {
 				Expect(err).To(HaveOccurred())
 				return
-			} else {
-				Expect(err).NotTo(HaveOccurred())
 			}
+			Expect(err).NotTo(HaveOccurred())
 			output := map[string][]interface{}{}
 			err = yaml.Unmarshal(result, output)
 			Expect(err).NotTo(HaveOccurred())
@@ -1708,9 +1706,8 @@ var _ = Describe("Metal3Data manager", func() {
 			if tc.expectError {
 				Expect(err).To(HaveOccurred())
 				return
-			} else {
-				Expect(err).NotTo(HaveOccurred())
 			}
+			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(tc.expectedOutput))
 		},
 		Entry("Ethernet, MAC from string", testCaseRenderNetworkLinks{
@@ -1866,9 +1863,8 @@ var _ = Describe("Metal3Data manager", func() {
 			if tc.expectError {
 				Expect(err).To(HaveOccurred())
 				return
-			} else {
-				Expect(err).NotTo(HaveOccurred())
 			}
+			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(tc.expectedOutput))
 		},
 		Entry("IPv4 network", testCaseRenderNetworkNetworks{
@@ -2343,9 +2339,8 @@ var _ = Describe("Metal3Data manager", func() {
 			if tc.expectError {
 				Expect(err).To(HaveOccurred())
 				return
-			} else {
-				Expect(err).NotTo(HaveOccurred())
 			}
+			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(tc.expectedMAC))
 		},
 		Entry("String", testCaseGetLinkMacAddress{
@@ -2429,9 +2424,8 @@ var _ = Describe("Metal3Data manager", func() {
 			if tc.expectError {
 				Expect(err).To(HaveOccurred())
 				return
-			} else {
-				Expect(err).NotTo(HaveOccurred())
 			}
+			Expect(err).NotTo(HaveOccurred())
 			var outputMap map[string]string
 			err = yaml.Unmarshal(resultBytes, &outputMap)
 			Expect(err).NotTo(HaveOccurred())

--- a/baremetal/metal3datatemplate_manager.go
+++ b/baremetal/metal3datatemplate_manager.go
@@ -35,8 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var notFoundErr *NotFoundError
-
 // DataTemplateManagerInterface is an interface for a DataTemplateManager.
 type DataTemplateManagerInterface interface {
 	SetFinalizer()
@@ -357,8 +355,7 @@ func (m *DataTemplateManager) createData(ctx context.Context,
 	// HasRequeueAfterError), then requeue to retrigger the reconciliation with
 	// the new state
 	if err := createObject(ctx, m.client, dataObject); err != nil {
-		var reqAfter *RequeueAfterError
-		if ok := errors.As(err, &reqAfter); !ok {
+		if ok := errors.As(err, &requeueAfterError); !ok {
 			dataClaim.Status.ErrorMessage = pointer.StringPtr("Failed to create associated Metal3Data object")
 		}
 		return indexes, err

--- a/baremetal/metal3datatemplate_manager.go
+++ b/baremetal/metal3datatemplate_manager.go
@@ -35,7 +35,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// DataTemplateManagerInterface is an interface for a DataTemplateManager
+var notFoundErr *NotFoundError
+
+// DataTemplateManagerInterface is an interface for a DataTemplateManager.
 type DataTemplateManagerInterface interface {
 	SetFinalizer()
 	UnsetFinalizer()
@@ -43,17 +45,16 @@ type DataTemplateManagerInterface interface {
 	UpdateDatas(context.Context) (int, error)
 }
 
-// DataTemplateManager is responsible for performing machine reconciliation
+// DataTemplateManager is responsible for performing machine reconciliation.
 type DataTemplateManager struct {
 	client       client.Client
 	DataTemplate *capm3.Metal3DataTemplate
 	Log          logr.Logger
 }
 
-// NewDataTemplateManager returns a new helper for managing a dataTemplate object
+// NewDataTemplateManager returns a new helper for managing a dataTemplate object.
 func NewDataTemplateManager(client client.Client,
 	dataTemplate *capm3.Metal3DataTemplate, dataTemplateLog logr.Logger) (*DataTemplateManager, error) {
-
 	return &DataTemplateManager{
 		client:       client,
 		DataTemplate: dataTemplate,
@@ -61,7 +62,7 @@ func NewDataTemplateManager(client client.Client,
 	}, nil
 }
 
-// SetFinalizer sets finalizer
+// SetFinalizer sets finalizer.
 func (m *DataTemplateManager) SetFinalizer() {
 	// If the Metal3Machine doesn't have finalizer, add it.
 	if !Contains(m.DataTemplate.Finalizers, capm3.DataTemplateFinalizer) {
@@ -71,7 +72,7 @@ func (m *DataTemplateManager) SetFinalizer() {
 	}
 }
 
-// UnsetFinalizer unsets finalizer
+// UnsetFinalizer unsets finalizer.
 func (m *DataTemplateManager) UnsetFinalizer() {
 	// Remove the finalizer.
 	m.DataTemplate.Finalizers = Filter(m.DataTemplate.Finalizers,
@@ -79,6 +80,7 @@ func (m *DataTemplateManager) UnsetFinalizer() {
 	)
 }
 
+// SetClusterOwnerRef sets ownerRef.
 func (m *DataTemplateManager) SetClusterOwnerRef(cluster *capi.Cluster) error {
 	// Verify that the owner reference is there, if not add it and update object,
 	// if error requeue.
@@ -88,7 +90,7 @@ func (m *DataTemplateManager) SetClusterOwnerRef(cluster *capi.Cluster) error {
 	_, err := findOwnerRefFromList(m.DataTemplate.OwnerReferences,
 		cluster.TypeMeta, cluster.ObjectMeta)
 	if err != nil {
-		if _, ok := err.(*NotFoundError); !ok {
+		if ok := errors.As(err, &notFoundErr); !ok {
 			return err
 		}
 		m.DataTemplate.OwnerReferences, err = setOwnerRefInList(
@@ -102,9 +104,8 @@ func (m *DataTemplateManager) SetClusterOwnerRef(cluster *capi.Cluster) error {
 	return nil
 }
 
-// RecreateStatus recreates the status if empty
+// RecreateStatus recreates the status if empty.
 func (m *DataTemplateManager) getIndexes(ctx context.Context) (map[int]string, error) {
-
 	m.Log.Info("Fetching Metal3Data objects")
 
 	//start from empty maps
@@ -126,7 +127,6 @@ func (m *DataTemplateManager) getIndexes(ctx context.Context) (map[int]string, e
 
 	// Iterate over the Metal3Data objects to find all indexes and objects
 	for _, dataObject := range dataObjects.Items {
-
 		// If DataTemplate does not point to this object, discard
 		if dataObject.Spec.Template.Name == "" {
 			continue
@@ -171,9 +171,8 @@ func (m *DataTemplateManager) updateStatusTimestamp() {
 }
 
 // UpdateDatas manages the claims and creates or deletes Metal3Data accordingly.
-// It returns the number of current allocations
+// It returns the number of current allocations.
 func (m *DataTemplateManager) UpdateDatas(ctx context.Context) (int, error) {
-
 	indexes, err := m.getIndexes(ctx)
 	if err != nil {
 		return 0, err
@@ -214,7 +213,6 @@ func (m *DataTemplateManager) UpdateDatas(ctx context.Context) (int, error) {
 func (m *DataTemplateManager) updateData(ctx context.Context,
 	dataClaim *capm3.Metal3DataClaim, indexes map[int]string,
 ) (map[int]string, error) {
-
 	helper, err := patch.NewHelper(dataClaim, m.client)
 	if err != nil {
 		return indexes, errors.Wrap(err, "failed to init patch helper")
@@ -246,7 +244,6 @@ func (m *DataTemplateManager) updateData(ctx context.Context,
 func (m *DataTemplateManager) createData(ctx context.Context,
 	dataClaim *capm3.Metal3DataClaim, indexes map[int]string,
 ) (map[int]string, error) {
-
 	var dataName string
 
 	if !Contains(dataClaim.Finalizers, capm3.DataClaimFinalizer) {
@@ -359,8 +356,9 @@ func (m *DataTemplateManager) createData(ctx context.Context,
 	// Create the Metal3Data object. If we get a conflict (that will set
 	// HasRequeueAfterError), then requeue to retrigger the reconciliation with
 	// the new state
-	if err := createObject(m.client, ctx, dataObject); err != nil {
-		if _, ok := err.(*RequeueAfterError); !ok {
+	if err := createObject(ctx, m.client, dataObject); err != nil {
+		var reqAfter *RequeueAfterError
+		if ok := errors.As(err, &reqAfter); !ok {
 			dataClaim.Status.ErrorMessage = pointer.StringPtr("Failed to create associated Metal3Data object")
 		}
 		return indexes, err
@@ -377,7 +375,7 @@ func (m *DataTemplateManager) createData(ctx context.Context,
 	return indexes, nil
 }
 
-// DeleteDatas deletes old secrets
+// DeleteDatas deletes old secrets.
 func (m *DataTemplateManager) deleteData(ctx context.Context,
 	dataClaim *capm3.Metal3DataClaim, indexes map[int]string,
 ) (map[int]string, error) {
@@ -412,7 +410,6 @@ func (m *DataTemplateManager) deleteData(ctx context.Context,
 				return indexes, err
 			}
 		}
-
 	}
 	dataClaim.Status.RenderedData = nil
 	dataClaim.Finalizers = Filter(dataClaim.Finalizers,

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	// comment for go-lint
+	// comment for go-lint.
 	"github.com/go-logr/logr"
 
 	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
@@ -58,20 +58,26 @@ const (
 	// reference what BareMetalHost it corresponds to.
 	HostAnnotation = "metal3.io/BareMetalHost"
 	// nodeReuseLabelName is the label set on BMH when node reuse feature is enabled.
-	nodeReuseLabelName  = "infrastructure.cluster.x-k8s.io/node-reuse"
-	requeueAfter        = time.Second * 30
-	bmRoleControlPlane  = "control-plane"
-	bmRoleNode          = "node"
+	nodeReuseLabelName = "infrastructure.cluster.x-k8s.io/node-reuse"
+	requeueAfter       = time.Second * 30
+	bmRoleControlPlane = "control-plane"
+	bmRoleNode         = "node"
+	// PausedAnnotationKey is an annotation to be used for pausing a BMH.
 	PausedAnnotationKey = "metal3.io/capm3"
-	ProviderIDPrefix    = "metal3://"
+	// ProviderIDPrefix is a prefix for ProviderID.
+	ProviderIDPrefix = "metal3://"
+	// ProviderLabelPrefix is a label prefix for ProviderID.
 	ProviderLabelPrefix = "metal3.io/uuid"
 )
 
 var (
+	// Capm3FastTrack is the variable fetched from the CAPM3_FAST_TRACK environment variable.
 	Capm3FastTrack = os.Getenv("CAPM3_FAST_TRACK")
+	// MachineManagerInterface is an interface for a MachineManager.
+	hasRequeueAfterError *RequeueAfterError
 )
 
-// MachineManagerInterface is an interface for a MachineManager
+// MachineManagerInterface is an interface for a MachineManager.
 type MachineManagerInterface interface {
 	SetFinalizer()
 	UnsetFinalizer()
@@ -94,7 +100,7 @@ type MachineManagerInterface interface {
 	SetConditionMetal3MachineToTrue(capi.ConditionType)
 }
 
-// MachineManager is responsible for performing machine reconciliation
+// MachineManager is responsible for performing machine reconciliation.
 type MachineManager struct {
 	client client.Client
 
@@ -109,12 +115,11 @@ type MachineManager struct {
 	Log                   logr.Logger
 }
 
-// NewMachineManager returns a new helper for managing a machine
+// NewMachineManager returns a new helper for managing a machine.
 func NewMachineManager(client client.Client,
 	cluster *capi.Cluster, metal3Cluster *capm3.Metal3Cluster,
 	machine *capi.Machine, metal3machine *capm3.Metal3Machine,
 	machineLog logr.Logger) (*MachineManager, error) {
-
 	return &MachineManager{
 		client: client,
 
@@ -126,11 +131,10 @@ func NewMachineManager(client client.Client,
 	}, nil
 }
 
-// NewMachineSetManager returns a new helper for managing a machineset
+// NewMachineSetManager returns a new helper for managing a machineset.
 func NewMachineSetManager(client client.Client,
 	machine *capi.Machine, machineSetList *capi.MachineSetList,
 	machineLog logr.Logger) (*MachineManager, error) {
-
 	return &MachineManager{
 		client:         client,
 		Machine:        machine,
@@ -139,7 +143,7 @@ func NewMachineSetManager(client client.Client,
 	}, nil
 }
 
-// SetFinalizer sets finalizer
+// SetFinalizer sets finalizer.
 func (m *MachineManager) SetFinalizer() {
 	// If the Metal3Machine doesn't have finalizer, add it.
 	if !Contains(m.Metal3Machine.Finalizers, capm3.MachineFinalizer) {
@@ -149,7 +153,7 @@ func (m *MachineManager) SetFinalizer() {
 	}
 }
 
-// UnsetFinalizer unsets finalizer
+// UnsetFinalizer unsets finalizer.
 func (m *MachineManager) UnsetFinalizer() {
 	// Cluster is deleted so remove the finalizer.
 	m.Metal3Machine.Finalizers = Filter(m.Metal3Machine.Finalizers,
@@ -157,7 +161,7 @@ func (m *MachineManager) UnsetFinalizer() {
 	)
 }
 
-// IsProvisioned checks if the metal3machine is provisioned
+// IsProvisioned checks if the metal3machine is provisioned.
 func (m *MachineManager) IsProvisioned() bool {
 	if m.Metal3Machine.Spec.ProviderID != nil && m.Metal3Machine.Status.Ready {
 		return true
@@ -165,7 +169,7 @@ func (m *MachineManager) IsProvisioned() bool {
 	return false
 }
 
-// IsBootstrapReady checks if the machine is given Bootstrap data
+// IsBootstrapReady checks if the machine is given Bootstrap data.
 func (m *MachineManager) IsBootstrapReady() bool {
 	return m.Machine.Status.BootstrapReady
 }
@@ -183,7 +187,7 @@ func (m *MachineManager) role() string {
 	return bmRoleNode
 }
 
-// RemovePauseAnnotation checks and/or Removes the pause annotations on associated bmh
+// RemovePauseAnnotation checks and/or Removes the pause annotations on associated bmh.
 func (m *MachineManager) RemovePauseAnnotation(ctx context.Context) error {
 	// look for associated BMH
 	host, helper, err := m.getHost(ctx)
@@ -203,7 +207,7 @@ func (m *MachineManager) RemovePauseAnnotation(ctx context.Context) error {
 	if annotations != nil {
 		if _, ok := annotations[bmh.PausedAnnotation]; ok {
 			if m.Cluster.Name == host.Labels[capi.ClusterLabelName] && annotations[bmh.PausedAnnotation] == PausedAnnotationKey {
-				// Removing BMH Paused Annotation Since Owner Cluster is not paused
+				// Removing BMH Paused Annotation Since Owner Cluster is not paused.
 				delete(host.Annotations, bmh.PausedAnnotation)
 			} else if m.Cluster.Name == host.Labels[capi.ClusterLabelName] && annotations[bmh.PausedAnnotation] != PausedAnnotationKey {
 				m.Log.Info("BMH is paused by user. Not removing Pause Annotation")
@@ -214,7 +218,7 @@ func (m *MachineManager) RemovePauseAnnotation(ctx context.Context) error {
 	return helper.Patch(ctx, host)
 }
 
-// SetPauseAnnotation sets the pause annotations on associated bmh
+// SetPauseAnnotation sets the pause annotations on associated bmh.
 func (m *MachineManager) SetPauseAnnotation(ctx context.Context) error {
 	// look for associated BMH
 	host, helper, err := m.getHost(ctx)
@@ -253,7 +257,7 @@ func (m *MachineManager) SetPauseAnnotation(ctx context.Context) error {
 	return helper.Patch(ctx, host)
 }
 
-// GetBaremetalHostID return the provider identifier for this machine
+// GetBaremetalHostID return the provider identifier for this machine.
 func (m *MachineManager) GetBaremetalHostID(ctx context.Context) (*string, error) {
 	// look for associated BMH
 	host, _, err := m.getHost(ctx)
@@ -275,7 +279,7 @@ func (m *MachineManager) GetBaremetalHostID(ctx context.Context) (*string, error
 	return nil, nil
 }
 
-// Associate associates a machine and is invoked by the Machine Controller
+// Associate associates a machine and is invoked by the Machine Controller.
 func (m *MachineManager) Associate(ctx context.Context) error {
 	m.Log.Info("Associating machine", "machine", m.Machine.Name)
 
@@ -309,7 +313,7 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 	if host == nil {
 		host, helper, err = m.chooseHost(ctx)
 		if err != nil {
-			if _, ok := err.(HasRequeueAfterError); !ok {
+			if ok := errors.As(err, &hasRequeueAfterError); !ok {
 				m.SetError("Failed to pick a BaremetalHost for the Metal3Machine",
 					capierrors.CreateMachineError,
 				)
@@ -329,7 +333,7 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 	// ReconcileNormal function
 	err = m.getUserDataSecretName(ctx, host)
 	if err != nil {
-		if _, ok := err.(HasRequeueAfterError); !ok {
+		if ok := errors.As(err, &hasRequeueAfterError); !ok {
 			m.SetError("Failed to set the UserData for the Metal3Machine",
 				capierrors.CreateMachineError,
 			)
@@ -339,7 +343,7 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 
 	err = m.setHostLabel(ctx, host)
 	if err != nil {
-		if _, ok := err.(HasRequeueAfterError); !ok {
+		if ok := errors.As(err, &hasRequeueAfterError); !ok {
 			m.SetError("Failed to set the Cluster label in the BareMetalHost",
 				capierrors.CreateMachineError,
 			)
@@ -349,7 +353,7 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 
 	err = m.setHostConsumerRef(ctx, host)
 	if err != nil {
-		if _, ok := err.(HasRequeueAfterError); !ok {
+		if ok := errors.As(err, &hasRequeueAfterError); !ok {
 			m.SetError("Failed to associate the BaremetalHost to the Metal3Machine",
 				capierrors.CreateMachineError,
 			)
@@ -361,7 +365,7 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 	// specs, nothing to wait for.
 	if m.Metal3Machine.Spec.DataTemplate == nil {
 		if err = m.setHostSpec(ctx, host); err != nil {
-			if _, ok := err.(HasRequeueAfterError); !ok {
+			if ok := errors.As(err, &hasRequeueAfterError); !ok {
 				m.SetError("Failed to associate the BaremetalHost to the Metal3Machine",
 					capierrors.CreateMachineError,
 				)
@@ -372,7 +376,7 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 
 	err = m.setBMCSecretLabel(ctx, host)
 	if err != nil {
-		if _, ok := err.(HasRequeueAfterError); !ok {
+		if ok := errors.As(err, &hasRequeueAfterError); !ok {
 			m.SetError("Failed to associate the BaremetalHost to the Metal3Machine",
 				capierrors.CreateMachineError,
 			)
@@ -382,7 +386,8 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 
 	err = helper.Patch(ctx, host)
 	if err != nil {
-		if aggr, ok := err.(kerrors.Aggregate); ok {
+		var aggr kerrors.Aggregate
+		if ok := errors.As(err, aggr); ok {
 			for _, kerr := range aggr.Errors() {
 				if apierrors.IsConflict(kerr) {
 					return &RequeueAfterError{}
@@ -394,7 +399,7 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 
 	err = m.ensureAnnotation(ctx, host)
 	if err != nil {
-		if _, ok := err.(HasRequeueAfterError); !ok {
+		if ok := errors.As(err, &hasRequeueAfterError); !ok {
 			m.SetError("Failed to annotate the Metal3Machine",
 				capierrors.CreateMachineError,
 			)
@@ -420,7 +425,7 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 		}
 
 		if err = m.setHostSpec(ctx, host); err != nil {
-			if _, ok := err.(HasRequeueAfterError); !ok {
+			if ok := errors.As(err, &hasRequeueAfterError); !ok {
 				m.SetError("Failed to set the BaremetalHost Specs",
 					capierrors.CreateMachineError,
 				)
@@ -431,7 +436,8 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 		// Update the BMH object.
 		err = helper.Patch(ctx, host)
 		if err != nil {
-			if aggr, ok := err.(kerrors.Aggregate); ok {
+			var aggr kerrors.Aggregate
+			if ok := errors.As(err, aggr); ok {
 				for _, kerr := range aggr.Errors() {
 					if apierrors.IsConflict(kerr) {
 						return &RequeueAfterError{}
@@ -451,7 +457,6 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 // CABPK v0.3.0+, but if it is in a different namespace than the BareMetalHost,
 // then we need to create the secret.
 func (m *MachineManager) getUserDataSecretName(ctx context.Context, host *bmh.BareMetalHost) error {
-
 	if m.Metal3Machine.Status.UserData != nil {
 		return nil
 	}
@@ -460,7 +465,7 @@ func (m *MachineManager) getUserDataSecretName(ctx context.Context, host *bmh.Ba
 		m.Metal3Machine.Status.UserData = m.Metal3Machine.Spec.UserData
 	}
 
-	// if datasecretname is set just pass the reference
+	// if datasecretname is set just pass the reference.
 	if m.Machine.Spec.Bootstrap.DataSecretName != nil {
 		m.Metal3Machine.Status.UserData = &corev1.SecretReference{
 			Name:      *m.Machine.Spec.Bootstrap.DataSecretName,
@@ -477,11 +482,11 @@ func (m *MachineManager) getUserDataSecretName(ctx context.Context, host *bmh.Ba
 	return nil
 }
 
-// Delete deletes a metal3 machine and is invoked by the Machine Controller
+// Delete deletes a metal3 machine and is invoked by the Machine Controller.
 func (m *MachineManager) Delete(ctx context.Context) error {
 	m.Log.Info("Deleting metal3 machine", "metal3machine", m.Metal3Machine.Name)
 
-	// clear an error if one was previously set
+	// clear an error if one was previously set.
 	m.clearError()
 
 	if Capm3FastTrack == "" {
@@ -508,18 +513,17 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 			return nil
 		}
 
-		//Remove clusterLabel from BMC secret
+		//Remove clusterLabel from BMC secret.
 		tmpBMCSecret, errBMC := m.getBMCSecret(ctx, host)
 		if errBMC != nil && apierrors.IsNotFound(errBMC) {
 			m.Log.Info("BMC credential not found for BareMetalhost", host.Name)
 		} else if errBMC == nil && tmpBMCSecret != nil {
-
 			m.Log.Info("Deleting cluster label from BMC credential", host.Spec.BMC.CredentialsName)
 			if tmpBMCSecret.Labels != nil && tmpBMCSecret.Labels[capi.ClusterLabelName] == m.Machine.Spec.ClusterName {
 				delete(tmpBMCSecret.Labels, capi.ClusterLabelName)
-				errBMC = updateObject(m.client, ctx, tmpBMCSecret)
+				errBMC = updateObject(ctx, m.client, tmpBMCSecret)
 				if errBMC != nil {
-					if _, ok := errBMC.(HasRequeueAfterError); !ok {
+					if ok := errors.As(errBMC, &hasRequeueAfterError); !ok {
 						m.Log.Info("Failed to delete the clusterLabel from BMC Secret")
 					}
 					return errBMC
@@ -570,7 +574,7 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 
 		if bmhUpdated {
 			// Update the BMH object, if the errors are NotFound, do not return the
-			// errors
+			// errors.
 			if err := patchIfFound(ctx, helper, host); err != nil {
 				return err
 			}
@@ -585,11 +589,11 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 			bmh.StateMatchProfile, bmh.StateInspecting,
 			bmh.StateReady, bmh.StateAvailable, bmh.StateNone,
 			bmh.StateUnmanaged:
-			// Host is not provisioned
+			// Host is not provisioned.
 			waiting = false
 		case bmh.StateExternallyProvisioned:
 			// We have no control over provisioning, so just wait until the
-			// host is powered off
+			// host is powered off.
 			waiting = host.Status.PoweredOn
 		}
 		if waiting {
@@ -665,11 +669,11 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 		if m.Machine.Spec.Bootstrap.DataSecretName == nil {
 			m.Log.Info("Deleting User data secret for machine")
 			if m.Metal3Machine.Status.UserData != nil {
-				err = deleteSecret(m.client, ctx, m.Metal3Machine.Status.UserData.Name,
+				err = deleteSecret(ctx, m.client, m.Metal3Machine.Status.UserData.Name,
 					m.Metal3Machine.Namespace,
 				)
 				if err != nil {
-					if _, ok := err.(HasRequeueAfterError); !ok {
+					if ok := errors.As(err, &hasRequeueAfterError); !ok {
 						m.SetError("Failed to delete userdata secret",
 							capierrors.DeleteMachineError,
 						)
@@ -681,7 +685,7 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 
 		host.Spec.ConsumerRef = nil
 
-		// Remove the ownerreference to this machine
+		// Remove the ownerreference to this machine.
 		host.OwnerReferences, err = m.DeleteOwnerRef(host.OwnerReferences)
 		if err != nil {
 			return err
@@ -697,7 +701,7 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 		}
 
 		// Update the BMH object, if the errors are NotFound, do not return the
-		// errors
+		// errors.
 		if err := patchIfFound(ctx, helper, host); err != nil {
 			return err
 		}
@@ -707,7 +711,7 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 	return nil
 }
 
-// Update updates a machine and is invoked by the Machine Controller
+// Update updates a machine and is invoked by the Machine Controller.
 func (m *MachineManager) Update(ctx context.Context) error {
 	m.Log.Info("Updating machine")
 
@@ -724,7 +728,7 @@ func (m *MachineManager) Update(ctx context.Context) error {
 	}
 
 	if err := m.WaitForM3Metadata(ctx); err != nil {
-		if _, ok := err.(HasRequeueAfterError); !ok {
+		if ok := errors.As(err, &hasRequeueAfterError); !ok {
 			m.SetError("Failed to get the DataTemplate",
 				capierrors.CreateMachineError,
 			)
@@ -732,10 +736,10 @@ func (m *MachineManager) Update(ctx context.Context) error {
 		return err
 	}
 
-	// ensure that the BMH specs are correctly set
+	// ensure that the BMH specs are correctly set.
 	err = m.setHostConsumerRef(ctx, host)
 	if err != nil {
-		if _, ok := err.(HasRequeueAfterError); !ok {
+		if ok := errors.As(err, &hasRequeueAfterError); !ok {
 			m.SetError("Failed to associate the BaremetalHost to the Metal3Machine",
 				capierrors.CreateMachineError,
 			)
@@ -743,10 +747,10 @@ func (m *MachineManager) Update(ctx context.Context) error {
 		return err
 	}
 
-	// ensure that the BMH specs are correctly set
+	// ensure that the BMH specs are correctly set.
 	err = m.setHostSpec(ctx, host)
 	if err != nil {
-		if _, ok := err.(HasRequeueAfterError); !ok {
+		if ok := errors.As(err, &hasRequeueAfterError); !ok {
 			m.SetError("Failed to associate the BaremetalHost to the Metal3Machine",
 				capierrors.CreateMachineError,
 			)
@@ -772,7 +776,7 @@ func (m *MachineManager) Update(ctx context.Context) error {
 	return nil
 }
 
-// exists tests for the existence of a baremetalHost
+// exists tests for the existence of a baremetalHost.
 func (m *MachineManager) exists(ctx context.Context) (bool, error) {
 	m.Log.Info("Checking if host exists.")
 	host, _, err := m.getHost(ctx)
@@ -835,10 +839,9 @@ func getHost(ctx context.Context, m3Machine *capm3.Metal3Machine, cl client.Clie
 // associated with the metal3 machine. It searches all hosts in case one already has an
 // association with this metal3 machine.
 func (m *MachineManager) chooseHost(ctx context.Context) (*bmh.BareMetalHost, *patch.Helper, error) {
-
-	// get list of BMH
+	// get list of BMH.
 	hosts := bmh.BareMetalHostList{}
-	// without this ListOption, all namespaces would be including in the listing
+	// without this ListOption, all namespaces would be including in the listing.
 	opts := &client.ListOptions{
 		Namespace: m.Metal3Machine.Namespace,
 	}
@@ -900,7 +903,7 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmh.BareMetalHost, *p
 			continue
 		}
 
-		// continue if BaremetalHost is paused or marked with UnhealthyAnnotation
+		// continue if BaremetalHost is paused or marked with UnhealthyAnnotation.
 		annotations := host.GetAnnotations()
 		if annotations != nil {
 			if _, ok := annotations[bmh.PausedAnnotation]; ok {
@@ -935,7 +938,7 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmh.BareMetalHost, *p
 		return nil, nil, nil
 	}
 
-	// choose a host
+	// choose a host.
 	rand.Seed(time.Now().Unix())
 	var chosenHost *bmh.BareMetalHost
 
@@ -973,7 +976,7 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmh.BareMetalHost, *p
 }
 
 // consumerRefMatches returns a boolean based on whether the consumer
-// reference and bare metal machine metadata match
+// reference and bare metal machine metadata match.
 func consumerRefMatches(consumer *corev1.ObjectReference, m3machine *capm3.Metal3Machine) bool {
 	if consumer.Name != m3machine.Name {
 		return false
@@ -990,9 +993,8 @@ func consumerRefMatches(consumer *corev1.ObjectReference, m3machine *capm3.Metal
 	return true
 }
 
-// nodeReuseLabelMatches returns true if nodeReuseLabelName matches KubeadmControlPlane or MachineDeployment name on the host
+// nodeReuseLabelMatches returns true if nodeReuseLabelName matches KubeadmControlPlane or MachineDeployment name on the host.
 func (m *MachineManager) nodeReuseLabelMatches(ctx context.Context, host *bmh.BareMetalHost) bool {
-
 	if host == nil {
 		return false
 	}
@@ -1012,25 +1014,23 @@ func (m *MachineManager) nodeReuseLabelMatches(ctx context.Context, host *bmh.Ba
 		}
 		m.Log.Info(fmt.Sprintf("nodeReuseLabelName on the host %v matches KubeadmControlPlane name %v", host.Name, kcp))
 		return true
-	} else {
-		md, err := m.getMachineDeploymentName(ctx)
-		if err != nil {
-			return false
-		}
-		if host.Labels[nodeReuseLabelName] == "" {
-			return false
-		}
-		if host.Labels[nodeReuseLabelName] != md {
-			return false
-		}
-		m.Log.Info(fmt.Sprintf("nodeReuseLabelName on the host %v matches MachineDeployment name %v", host.Name, md))
-		return true
 	}
+	md, err := m.getMachineDeploymentName(ctx)
+	if err != nil {
+		return false
+	}
+	if host.Labels[nodeReuseLabelName] == "" {
+		return false
+	}
+	if host.Labels[nodeReuseLabelName] != md {
+		return false
+	}
+	m.Log.Info(fmt.Sprintf("nodeReuseLabelName on the host %v matches MachineDeployment name %v", host.Name, md))
+	return true
 }
 
-// nodeReuseLabelExists returns true if host contains nodeReuseLabelName label
+// nodeReuseLabelExists returns true if host contains nodeReuseLabelName label.
 func (m *MachineManager) nodeReuseLabelExists(ctx context.Context, host *bmh.BareMetalHost) bool {
-
 	if host == nil {
 		return false
 	}
@@ -1042,9 +1042,8 @@ func (m *MachineManager) nodeReuseLabelExists(ctx context.Context, host *bmh.Bar
 	return ok
 }
 
-// getBMCSecret will return the BMCSecret associated with BMH
+// getBMCSecret will return the BMCSecret associated with BMH.
 func (m *MachineManager) getBMCSecret(ctx context.Context, host *bmh.BareMetalHost) (*corev1.Secret, error) {
-
 	if host.Spec.BMC.CredentialsName == "" {
 		return nil, nil
 	}
@@ -1058,9 +1057,8 @@ func (m *MachineManager) getBMCSecret(ctx context.Context, host *bmh.BareMetalHo
 	return &tmpBMCSecret, nil
 }
 
-// setBMCSecretLabel will set the set cluster.x-k8s.io/cluster-name to BMCSecret
+// setBMCSecretLabel will set the set cluster.x-k8s.io/cluster-name to BMCSecret.
 func (m *MachineManager) setBMCSecretLabel(ctx context.Context, host *bmh.BareMetalHost) error {
-
 	tmpBMCSecret, err := m.getBMCSecret(ctx, host)
 	if err != nil {
 		return err
@@ -1071,15 +1069,14 @@ func (m *MachineManager) setBMCSecretLabel(ctx context.Context, host *bmh.BareMe
 			tmpBMCSecret.Labels = make(map[string]string)
 		}
 		tmpBMCSecret.Labels[capi.ClusterLabelName] = m.Machine.Spec.ClusterName
-		return updateObject(m.client, ctx, tmpBMCSecret)
+		return updateObject(ctx, m.client, tmpBMCSecret)
 	}
 
 	return nil
 }
 
-// setHostLabel will set the set cluster.x-k8s.io/cluster-name to bmh
+// setHostLabel will set the set cluster.x-k8s.io/cluster-name to bmh.
 func (m *MachineManager) setHostLabel(ctx context.Context, host *bmh.BareMetalHost) error {
-
 	if host.Labels == nil {
 		host.Labels = make(map[string]string)
 	}
@@ -1092,14 +1089,13 @@ func (m *MachineManager) setHostLabel(ctx context.Context, host *bmh.BareMetalHo
 // details. It will then update the host via the kube API. If UserData does not
 // include a Namespace, it will default to the Metal3Machine's namespace.
 func (m *MachineManager) setHostSpec(ctx context.Context, host *bmh.BareMetalHost) error {
-
 	// We only want to update the image setting if the host does not
 	// already have an image.
 	//
 	// A host with an existing image is already provisioned and
 	// upgrades are not supported at this time. To re-provision a
 	// host, we must fully deprovision it and then provision it again.
-	// Not provisioning while we do not have the UserData
+	// Not provisioning while we do not have the UserData.
 	if host.Spec.Image == nil && m.Metal3Machine.Status.UserData != nil {
 		checksumType := ""
 		if m.Metal3Machine.Spec.Image.ChecksumType != nil {
@@ -1132,7 +1128,7 @@ func (m *MachineManager) setHostSpec(ctx context.Context, host *bmh.BareMetalHos
 	}
 	// Set automatedCleaningMode from metal3Machine.spec.automatedCleaningMode.
 	if m.Metal3Machine.Spec.AutomatedCleaningMode != nil {
-		if bmh.AutomatedCleaningMode(host.Spec.AutomatedCleaningMode) != bmh.AutomatedCleaningMode(*m.Metal3Machine.Spec.AutomatedCleaningMode) {
+		if host.Spec.AutomatedCleaningMode != bmh.AutomatedCleaningMode(*m.Metal3Machine.Spec.AutomatedCleaningMode) {
 			host.Spec.AutomatedCleaningMode = bmh.AutomatedCleaningMode(*m.Metal3Machine.Spec.AutomatedCleaningMode)
 		}
 	}
@@ -1143,9 +1139,8 @@ func (m *MachineManager) setHostSpec(ctx context.Context, host *bmh.BareMetalHos
 }
 
 // setHostConsumerRef will ensure the host's Spec is set to link to this
-// Metal3Machine
+// Metal3Machine.
 func (m *MachineManager) setHostConsumerRef(ctx context.Context, host *bmh.BareMetalHost) error {
-
 	host.Spec.ConsumerRef = &corev1.ObjectReference{
 		Kind:       "Metal3Machine",
 		Name:       m.Metal3Machine.Name,
@@ -1153,14 +1148,14 @@ func (m *MachineManager) setHostConsumerRef(ctx context.Context, host *bmh.BareM
 		APIVersion: m.Metal3Machine.APIVersion,
 	}
 
-	// Set OwnerReferences
+	// Set OwnerReferences.
 	hostOwnerReferences, err := m.SetOwnerRef(host.OwnerReferences, true)
 	if err != nil {
 		return err
 	}
 	host.OwnerReferences = hostOwnerReferences
 
-	// Delete nodeReuseLabelName from host
+	// Delete nodeReuseLabelName from host.
 	m.Log.Info("Deleting nodeReuseLabelName from host, if any")
 
 	labels := host.GetLabels()
@@ -1199,7 +1194,7 @@ func (m *MachineManager) ensureAnnotation(ctx context.Context, host *bmh.BareMet
 	return nil
 }
 
-// HasAnnotation makes sure the machine has an annotation that references a host
+// HasAnnotation makes sure the machine has an annotation that references a host.
 func (m *MachineManager) HasAnnotation() bool {
 	annotations := m.Metal3Machine.ObjectMeta.GetAnnotations()
 	if annotations == nil {
@@ -1228,10 +1223,12 @@ func (m *MachineManager) SetError(message string, reason capierrors.MachineStatu
 	m.Metal3Machine.Status.FailureReason = &reason
 }
 
+// SetConditionMetal3MachineToFalse sets Metal3Machine condition status to False.
 func (m *MachineManager) SetConditionMetal3MachineToFalse(t capi.ConditionType, reason string, severity capi.ConditionSeverity, messageFormat string, messageArgs ...interface{}) {
 	conditions.MarkFalse(m.Metal3Machine, t, reason, severity, messageFormat, messageArgs...)
 }
 
+// SetConditionMetal3MachineToTrue sets Metal3Machine condition status to True.
 func (m *MachineManager) SetConditionMetal3MachineToTrue(t capi.ConditionType) {
 	conditions.MarkTrue(m.Metal3Machine, t)
 }
@@ -1297,7 +1294,7 @@ func (m *MachineManager) nodeAddresses(host *bmh.BareMetalHost) []capi.MachineAd
 	return addrs
 }
 
-// GetProviderIDAndBMHID returns providerID and bmhID
+// GetProviderIDAndBMHID returns providerID and bmhID.
 func (m *MachineManager) GetProviderIDAndBMHID() (string, *string) {
 	providerID := m.Metal3Machine.Spec.ProviderID
 	if providerID == nil {
@@ -1306,10 +1303,10 @@ func (m *MachineManager) GetProviderIDAndBMHID() (string, *string) {
 	return *providerID, pointer.StringPtr(parseProviderID(*providerID))
 }
 
-// ClientGetter prototype
+// ClientGetter prototype.
 type ClientGetter func(ctx context.Context, c client.Client, cluster *capi.Cluster) (clientcorev1.CoreV1Interface, error)
 
-// SetNodeProviderID sets the metal3 provider ID on the kubernetes node
+// SetNodeProviderID sets the metal3 provider ID on the kubernetes node.
 func (m *MachineManager) SetNodeProviderID(ctx context.Context, bmhID, providerID string, clientFactory ClientGetter) error {
 	if !m.Metal3Cluster.Spec.NoCloudProvider {
 		return nil
@@ -1327,7 +1324,7 @@ func (m *MachineManager) SetNodeProviderID(ctx context.Context, bmhID, providerI
 	}
 	if nodesCount == 0 {
 		// The node could either be still running cloud-init or have been
-		// deleted manually. TODO: handle a manual deletion case
+		// deleted manually. TODO: handle a manual deletion case.
 		m.Log.Info("Target node is not found, requeuing")
 		return &RequeueAfterError{RequeueAfter: requeueAfter}
 	}
@@ -1346,29 +1343,28 @@ func (m *MachineManager) SetNodeProviderID(ctx context.Context, bmhID, providerI
 	return nil
 }
 
-// SetProviderID sets the metal3 provider ID on the metal3machine
+// SetProviderID sets the metal3 provider ID on the Metal3Machine.
 func (m *MachineManager) SetProviderID(providerID string) {
 	m.Metal3Machine.Spec.ProviderID = &providerID
 	m.Metal3Machine.Status.Ready = true
 	m.SetConditionMetal3MachineToTrue(capm3.KubernetesNodeReadyCondition)
-
 }
 
-// SetOwnerRef adds an ownerreference to this Metal3 machine
+// SetOwnerRef adds an ownerreference to this Metal3Machine.
 func (m *MachineManager) SetOwnerRef(refList []metav1.OwnerReference, controller bool) ([]metav1.OwnerReference, error) {
 	return setOwnerRefInList(refList, controller, m.Metal3Machine.TypeMeta,
 		m.Metal3Machine.ObjectMeta,
 	)
 }
 
-// DeleteOwnerRef removes the ownerreference to this Metal3 machine
+// DeleteOwnerRef removes the ownerreference to this Metal3Machine.
 func (m *MachineManager) DeleteOwnerRef(refList []metav1.OwnerReference) ([]metav1.OwnerReference, error) {
 	return deleteOwnerRefFromList(refList, m.Metal3Machine.TypeMeta,
 		m.Metal3Machine.ObjectMeta,
 	)
 }
 
-// DeleteOwnerRefFromList removes the ownerreference to this Metal3 machine
+// DeleteOwnerRefFromList removes the ownerreference to this Metal3Machine.
 func deleteOwnerRefFromList(refList []metav1.OwnerReference,
 	objType metav1.TypeMeta, objMeta metav1.ObjectMeta,
 ) ([]metav1.OwnerReference, error) {
@@ -1377,7 +1373,7 @@ func deleteOwnerRefFromList(refList []metav1.OwnerReference,
 	}
 	index, err := findOwnerRefFromList(refList, objType, objMeta)
 	if err != nil {
-		if _, ok := err.(*NotFoundError); !ok {
+		if ok := errors.As(err, &notFoundErr); !ok {
 			return nil, err
 		}
 		return refList, nil
@@ -1394,21 +1390,21 @@ func deleteOwnerRefFromList(refList []metav1.OwnerReference,
 	return refList, nil
 }
 
-// FindOwnerRef checks if an ownerreference to this Metal3 machine exists
-// and returns the index
+// FindOwnerRef checks if an ownerreference to this Metal3Machine exists
+// and returns the index.
 func (m *MachineManager) FindOwnerRef(refList []metav1.OwnerReference) (int, error) {
 	return findOwnerRefFromList(refList, m.Metal3Machine.TypeMeta,
 		m.Metal3Machine.ObjectMeta,
 	)
 }
 
-// SetOwnerRef adds an ownerreference to this Metal3 machine
+// SetOwnerRef adds an ownerreference to this Metal3Machine.
 func setOwnerRefInList(refList []metav1.OwnerReference, controller bool,
 	objType metav1.TypeMeta, objMeta metav1.ObjectMeta,
 ) ([]metav1.OwnerReference, error) {
 	index, err := findOwnerRefFromList(refList, objType, objMeta)
 	if err != nil {
-		if _, ok := err.(*NotFoundError); !ok {
+		if ok := errors.As(err, &notFoundErr); !ok {
 			return nil, err
 		}
 		refList = append(refList, metav1.OwnerReference{
@@ -1419,7 +1415,7 @@ func setOwnerRefInList(refList []metav1.OwnerReference, controller bool,
 			Controller: pointer.BoolPtr(controller),
 		})
 	} else {
-		//The UID and the APIVersion might change due to move or version upgrade
+		//The UID and the APIVersion might change due to move or version upgrade.
 		refList[index].APIVersion = objType.APIVersion
 		refList[index].UID = objMeta.UID
 		refList[index].Controller = pointer.BoolPtr(controller)
@@ -1427,11 +1423,10 @@ func setOwnerRefInList(refList []metav1.OwnerReference, controller bool,
 	return refList, nil
 }
 
-// findOwnerRefFromList finds OwnerRef to this Metal3 machine
+// findOwnerRefFromList finds OwnerRef to this Metal3Machine.
 func findOwnerRefFromList(refList []metav1.OwnerReference, objType metav1.TypeMeta,
 	objMeta metav1.ObjectMeta,
 ) (int, error) {
-
 	for i, curOwnerRef := range refList {
 		aGV, err := schema.ParseGroupVersion(curOwnerRef.APIVersion)
 		if err != nil {
@@ -1442,8 +1437,8 @@ func findOwnerRefFromList(refList []metav1.OwnerReference, objType metav1.TypeMe
 		if err != nil {
 			return 0, err
 		}
-		// not matching on UID since when pivoting it might change
-		// Not matching on API version as this might change
+		// not matching on UID since when pivoting it might change.
+		// Not matching on API version as this might change.
 		if curOwnerRef.Name == objMeta.Name &&
 			curOwnerRef.Kind == objType.Kind &&
 			aGV.Group == bGV.Group {
@@ -1453,10 +1448,10 @@ func findOwnerRefFromList(refList []metav1.OwnerReference, objType metav1.TypeMe
 	return 0, &NotFoundError{}
 }
 
-// RetrieveMetadata fetches the Metal3DataTemplate object and sets the
-// owner references
+// AssociateM3Metadata fetches the Metal3DataTemplate object and sets the
+// owner references.
 func (m *MachineManager) AssociateM3Metadata(ctx context.Context) error {
-	// If the secrets were provided by the user, use them
+	// If the secrets were provided by the user, use them.
 	if m.Metal3Machine.Spec.MetaData != nil {
 		m.Metal3Machine.Status.MetaData = m.Metal3Machine.Spec.MetaData
 	}
@@ -1465,7 +1460,7 @@ func (m *MachineManager) AssociateM3Metadata(ctx context.Context) error {
 	}
 
 	// If we have RenderedData set already, it means that the owner reference was
-	// already set
+	// already set.
 	if m.Metal3Machine.Status.RenderedData != nil {
 		return nil
 	}
@@ -1480,7 +1475,7 @@ func (m *MachineManager) AssociateM3Metadata(ctx context.Context) error {
 		m.Metal3Machine.Name, m.Metal3Machine.Namespace,
 	)
 	if err != nil {
-		if _, ok := err.(HasRequeueAfterError); !ok {
+		if ok := errors.As(err, &hasRequeueAfterError); !ok {
 			return err
 		}
 	} else {
@@ -1507,7 +1502,7 @@ func (m *MachineManager) AssociateM3Metadata(ctx context.Context) error {
 		},
 	}
 
-	err = createObject(m.client, ctx, dataClaim)
+	err = createObject(ctx, m.client, dataClaim)
 	if err != nil {
 		return err
 	}
@@ -1515,9 +1510,8 @@ func (m *MachineManager) AssociateM3Metadata(ctx context.Context) error {
 }
 
 // WaitForM3Metadata fetches the Metal3DataTemplate object and sets the
-// owner references
+// owner references.
 func (m *MachineManager) WaitForM3Metadata(ctx context.Context) error {
-
 	// If we do not have RenderedData set yet, try to find it in
 	// Metal3DataTemplate. If it is not there yet, it means that the reconciliation
 	// of Metal3DataTemplate did not yet complete, requeue.
@@ -1546,7 +1540,7 @@ func (m *MachineManager) WaitForM3Metadata(ctx context.Context) error {
 		}
 	}
 
-	// Fetch the Metal3Data
+	// Fetch the Metal3Data.
 	metal3Data, err := fetchM3Data(ctx, m.client, m.Log,
 		m.Metal3Machine.Status.RenderedData.Name, m.Metal3Machine.Namespace,
 	)
@@ -1563,7 +1557,7 @@ func (m *MachineManager) WaitForM3Metadata(ctx context.Context) error {
 		return &RequeueAfterError{RequeueAfter: requeueAfter}
 	}
 
-	// Get the secrets if given in Metal3Data and not already set
+	// Get the secrets if given in Metal3Data and not already set.
 	if m.Metal3Machine.Status.MetaData == nil &&
 		metal3Data.Spec.MetaData != nil {
 		if metal3Data.Spec.MetaData.Name != "" {
@@ -1587,9 +1581,8 @@ func (m *MachineManager) WaitForM3Metadata(ctx context.Context) error {
 	return nil
 }
 
-// remove machine from OwnerReferences of meta3DataTemplate, on failure requeue
+// DissociateM3Metadata removes machine from OwnerReferences of meta3DataTemplate, on failure requeue.
 func (m *MachineManager) DissociateM3Metadata(ctx context.Context) error {
-
 	if m.Metal3Machine.Status.MetaData != nil && m.Metal3Machine.Spec.MetaData == nil {
 		m.Metal3Machine.Status.MetaData = nil
 	}
@@ -1600,12 +1593,12 @@ func (m *MachineManager) DissociateM3Metadata(ctx context.Context) error {
 
 	m.Metal3Machine.Status.RenderedData = nil
 
-	// Get the Metal3DataTemplate object
+	// Get the Metal3DataClaim object.
 	metal3DataClaim, err := fetchM3DataClaim(ctx, m.client, m.Log,
 		m.Metal3Machine.Name, m.Metal3Machine.Namespace,
 	)
 	if err != nil {
-		if _, ok := err.(HasRequeueAfterError); !ok {
+		if ok := errors.As(err, &hasRequeueAfterError); !ok {
 			return err
 		}
 		return nil
@@ -1614,7 +1607,7 @@ func (m *MachineManager) DissociateM3Metadata(ctx context.Context) error {
 		return nil
 	}
 
-	return deleteObject(m.client, ctx, metal3DataClaim)
+	return deleteObject(ctx, m.client, metal3DataClaim)
 }
 
 // getKubeadmControlPlaneName retrieves the KubeadmControlPlane object corresponding to the CAPI machine.
@@ -1640,7 +1633,7 @@ func (m *MachineManager) getKubeadmControlPlaneName(ctx context.Context) (string
 		// adding prefix to KubeadmControlPlane name in order to be able to differentiate
 		// KubeadmControlPlane and MachineDeployment in case they have the same names set in the cluster.
 		m.Log.Info(fmt.Sprintf("Fetched KubeadmControlPlane name %v", "kcp-"+mOwnerRef.Name))
-		return string("kcp-" + mOwnerRef.Name), nil
+		return "kcp-" + mOwnerRef.Name, nil
 	}
 	return "", errors.New("KubeadmControlPlane name is not found")
 }
@@ -1649,7 +1642,7 @@ func (m *MachineManager) getKubeadmControlPlaneName(ctx context.Context) (string
 func (m *MachineManager) getMachineDeploymentName(ctx context.Context) (string, error) {
 	m.Log.Info("Fetching MachineDeployment name")
 
-	// Fetch MachineSet
+	// Fetch MachineSet.
 	m.Log.Info("Fetching MachineSet first to find corresponding MachineDeployment later")
 
 	machineSet, err := m.getMachineSet(ctx)
@@ -1673,7 +1666,7 @@ func (m *MachineManager) getMachineDeploymentName(ctx context.Context) (string, 
 		// adding prefix to MachineDeployment name in order to be able to differentiate
 		// MachineDeployment and KubeadmControlPlane in case they have the same names set in the cluster.
 		m.Log.Info(fmt.Sprintf("Fetched MachineDeployment name %v", "md-"+msOwnerRef.Name))
-		return string("md-" + msOwnerRef.Name), nil
+		return "md-" + msOwnerRef.Name, nil
 	}
 	return "", errors.New("MachineDeployment name is not found")
 }
@@ -1681,7 +1674,7 @@ func (m *MachineManager) getMachineDeploymentName(ctx context.Context) (string, 
 // getMachineSet retrieves the MachineSet object corresponding to the CAPI machine.
 func (m *MachineManager) getMachineSet(ctx context.Context) (*capi.MachineSet, error) {
 	m.Log.Info("Fetching MachineSet name")
-	// Get list of MachineSets
+	// Get list of MachineSets.
 	machineSets := &capi.MachineSetList{}
 	if m.Machine == nil {
 		return nil, errors.New("Could not find corresponding machine object")
@@ -1696,7 +1689,7 @@ func (m *MachineManager) getMachineSet(ctx context.Context) (*capi.MachineSet, e
 		return nil, err
 	}
 
-	// Iterate over MachineSets list and find MachineSet which references specific machine
+	// Iterate over MachineSets list and find MachineSet which references specific machine.
 	for index := range machineSets.Items {
 		machineset := &machineSets.Items[index]
 		for _, mOwnerRef := range m.Machine.ObjectMeta.OwnerReferences {
@@ -1718,7 +1711,7 @@ func (m *MachineManager) getMachineSet(ctx context.Context) (*capi.MachineSet, e
 	return nil, errors.New("MachineSet is not found")
 }
 
-// getNodesWithLabel gets kubernetes nodes with a given label
+// getNodesWithLabel gets kubernetes nodes with a given label.
 func (m *MachineManager) getNodesWithLabel(ctx context.Context, nodeLabel string, clientFactory ClientGetter) (*corev1.NodeList, int, error) {
 	corev1Remote, err := clientFactory(ctx, m.client, m.Cluster)
 	if err != nil {

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -72,9 +72,10 @@ const (
 
 var (
 	// Capm3FastTrack is the variable fetched from the CAPM3_FAST_TRACK environment variable.
-	Capm3FastTrack = os.Getenv("CAPM3_FAST_TRACK")
-	// MachineManagerInterface is an interface for a MachineManager.
-	hasRequeueAfterError *RequeueAfterError
+	Capm3FastTrack       = os.Getenv("CAPM3_FAST_TRACK")
+	hasRequeueAfterError HasRequeueAfterError
+	notFoundErr          *NotFoundError
+	requeueAfterError    *RequeueAfterError
 )
 
 // MachineManagerInterface is an interface for a MachineManager.

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -1459,10 +1459,9 @@ var _ = Describe("Metal3Machine manager", func() {
 			if tc.ExpectedResult == nil {
 				Expect(err).NotTo(HaveOccurred())
 			} else {
-				var requeueAfterErr *RequeueAfterError
-				ok := errors.As(err, &requeueAfterErr)
+				ok := errors.As(err, &requeueAfterError)
 				Expect(ok).To(BeTrue())
-				Expect(requeueAfterErr.Error()).To(Equal(tc.ExpectedResult.Error()))
+				Expect(requeueAfterError.Error()).To(Equal(tc.ExpectedResult.Error()))
 			}
 
 			if tc.Host != nil {

--- a/baremetal/metal3machinetemplate_manager.go
+++ b/baremetal/metal3machinetemplate_manager.go
@@ -29,12 +29,12 @@ const (
 	clonedFromGroupKind = capi.TemplateClonedFromGroupKindAnnotation
 )
 
-// TemplateManagerInterface is an interface for a TemplateManager
+// TemplateManagerInterface is an interface for a TemplateManager.
 type TemplateManagerInterface interface {
 	UpdateAutomatedCleaningMode(context.Context) error
 }
 
-// MachineTemplateManager is responsible for performing metal3MachineTemplate reconciliation
+// MachineTemplateManager is responsible for performing metal3MachineTemplate reconciliation.
 type MachineTemplateManager struct {
 	client client.Client
 
@@ -43,13 +43,12 @@ type MachineTemplateManager struct {
 	Log                   logr.Logger
 }
 
-// NewMachineTemplateManager returns a new helper for managing a metal3MachineTemplate
+// NewMachineTemplateManager returns a new helper for managing a metal3MachineTemplate.
 func NewMachineTemplateManager(client client.Client,
 	metal3MachineTemplate *capm3.Metal3MachineTemplate,
 
 	metal3MachineList *capm3.Metal3MachineList,
 	metal3MachineTemplateLog logr.Logger) (*MachineTemplateManager, error) {
-
 	return &MachineTemplateManager{
 		client: client,
 
@@ -91,7 +90,6 @@ func (m *MachineTemplateManager) UpdateAutomatedCleaningMode(ctx context.Context
 			// don't synchronize AutomatedCleaningMode between metal3MachineTemplate
 			// and metal3Machine if unset in metal3MachineTemplate.
 			if m.Metal3MachineTemplate.Spec.Template.Spec.AutomatedCleaningMode != nil {
-
 				m3m.Spec.AutomatedCleaningMode = m.Metal3MachineTemplate.Spec.Template.Spec.AutomatedCleaningMode
 
 				if err := m.client.Update(ctx, m3m); err != nil {

--- a/baremetal/metal3remediation_manager.go
+++ b/baremetal/metal3remediation_manager.go
@@ -41,7 +41,7 @@ const (
 	rebootAnnotation = "reboot.metal3.io"
 )
 
-// RemediationManagerInterface is an interface for a RemediationManager
+// RemediationManagerInterface is an interface for a RemediationManager.
 type RemediationManagerInterface interface {
 	SetFinalizer()
 	UnsetFinalizer()
@@ -63,7 +63,7 @@ type RemediationManagerInterface interface {
 	GetCapiMachine(ctx context.Context) (*capi.Machine, error)
 }
 
-// RemediationManager is responsible for performing remediation reconciliation
+// RemediationManager is responsible for performing remediation reconciliation.
 type RemediationManager struct {
 	Client            client.Client
 	Metal3Remediation *capm3.Metal3Remediation
@@ -72,11 +72,10 @@ type RemediationManager struct {
 	Log               logr.Logger
 }
 
-// NewRemediationManager returns a new helper for managing a Metal3Remediation object
+// NewRemediationManager returns a new helper for managing a Metal3Remediation object.
 func NewRemediationManager(client client.Client,
 	metal3remediation *capm3.Metal3Remediation, metal3Machine *capm3.Metal3Machine, machine *capi.Machine,
 	remediationLog logr.Logger) (*RemediationManager, error) {
-
 	return &RemediationManager{
 		Client:            client,
 		Metal3Remediation: metal3remediation,
@@ -86,7 +85,7 @@ func NewRemediationManager(client client.Client,
 	}, nil
 }
 
-// SetFinalizer sets finalizer
+// SetFinalizer sets finalizer.
 func (r *RemediationManager) SetFinalizer() {
 	// If the Metal3Remediation doesn't have finalizer, add it.
 	if !Contains(r.Metal3Remediation.Finalizers, capm3.RemediationFinalizer) {
@@ -96,7 +95,7 @@ func (r *RemediationManager) SetFinalizer() {
 	}
 }
 
-// UnsetFinalizer unsets finalizer
+// UnsetFinalizer unsets finalizer.
 func (r *RemediationManager) UnsetFinalizer() {
 	// Cluster is deleted so remove the finalizer.
 	r.Metal3Remediation.Finalizers = Filter(r.Metal3Remediation.Finalizers,
@@ -104,8 +103,8 @@ func (r *RemediationManager) UnsetFinalizer() {
 	)
 }
 
-// timeToRemediate checks if it is time to execute a next remediation step
-// and returns seconds to next remediation time
+// TimeToRemediate checks if it is time to execute a next remediation step
+// and returns seconds to next remediation time.
 func (r *RemediationManager) TimeToRemediate(timeout time.Duration) (bool, time.Duration) {
 	now := time.Now()
 
@@ -123,7 +122,7 @@ func (r *RemediationManager) TimeToRemediate(timeout time.Duration) (bool, time.
 	return false, nextRemediation
 }
 
-// SetRebootAnnotation sets reboot annotation on unhealthy host
+// SetRebootAnnotation sets reboot annotation on unhealthy host.
 func (r *RemediationManager) SetRebootAnnotation(ctx context.Context) error {
 	host, helper, err := r.GetUnhealthyHost(ctx)
 	if err != nil {
@@ -146,7 +145,7 @@ func (r *RemediationManager) SetRebootAnnotation(ctx context.Context) error {
 	return helper.Patch(ctx, host)
 }
 
-// SetUnhealthyAnnotation sets capm3.UnhealthyAnnotation on unhealthy host
+// SetUnhealthyAnnotation sets capm3.UnhealthyAnnotation on unhealthy host.
 func (r *RemediationManager) SetUnhealthyAnnotation(ctx context.Context) error {
 	host, helper, err := r.GetUnhealthyHost(ctx)
 	if err != nil {
@@ -161,7 +160,7 @@ func (r *RemediationManager) SetUnhealthyAnnotation(ctx context.Context) error {
 	return helper.Patch(ctx, host)
 }
 
-// getUnhealthyHost gets the associated host for unhealthy machine. Returns nil if not found. Assumes the
+// GetUnhealthyHost gets the associated host for unhealthy machine. Returns nil if not found. Assumes the
 // host is in the same namespace as the unhealthy machine.
 func (r *RemediationManager) GetUnhealthyHost(ctx context.Context) (*bmh.BareMetalHost, *patch.Helper, error) {
 	host, err := getUnhealthyHost(ctx, r.Metal3Machine, r.Client, r.Log)
@@ -206,58 +205,60 @@ func getUnhealthyHost(ctx context.Context, m3Machine *capm3.Metal3Machine, cl cl
 	return &host, nil
 }
 
-// onlineStatus returns hosts Online field value
+// OnlineStatus returns hosts Online field value.
 func (r *RemediationManager) OnlineStatus(host *bmh.BareMetalHost) bool {
 	return host.Spec.Online
 }
 
-// getRemediationType return type of remediation strategy
+// GetRemediationType return type of remediation strategy.
 func (r *RemediationManager) GetRemediationType() capm3.RemediationType {
 	return r.Metal3Remediation.Spec.Strategy.Type
 }
 
-// retryLimitIsSet returns true if retryLimit is set, false if not
+// RetryLimitIsSet returns true if retryLimit is set, false if not.
 func (r *RemediationManager) RetryLimitIsSet() bool {
 	return r.Metal3Remediation.Spec.Strategy.RetryLimit > 0
 }
 
-// HasReachRetryLimit returns true if retryLimit is reached
+// HasReachRetryLimit returns true if retryLimit is reached.
 func (r *RemediationManager) HasReachRetryLimit() bool {
 	return r.Metal3Remediation.Spec.Strategy.RetryLimit == r.Metal3Remediation.Status.RetryCount
 }
 
-// SetRemediationPhase setting the state of the remediation
+// SetRemediationPhase setting the state of the remediation.
 func (r *RemediationManager) SetRemediationPhase(phase string) {
 	r.Log.Info("Switching remediation phase", "remediationPhase", phase)
 	r.Metal3Remediation.Status.Phase = phase
 }
 
-// GetRemediationPhase returns current status of the remediation
+// GetRemediationPhase returns current status of the remediation.
 func (r *RemediationManager) GetRemediationPhase() string {
 	return r.Metal3Remediation.Status.Phase
 }
 
-// GetLastRemediatedTime returns last remediation time
+// GetLastRemediatedTime returns last remediation time.
 func (r *RemediationManager) GetLastRemediatedTime() *metav1.Time {
 	return r.Metal3Remediation.Status.LastRemediated
 }
 
-// SetLastRemediationTime setting last remediation timestamp on Status
+// SetLastRemediationTime setting last remediation timestamp on Status.
 func (r *RemediationManager) SetLastRemediationTime(remediationTime *metav1.Time) {
 	r.Log.Info("Last remediation time", "remediationTime", remediationTime)
 	r.Metal3Remediation.Status.LastRemediated = remediationTime
 }
 
-// GetTimeout returns timeout duration from remediation request Spec
+// GetTimeout returns timeout duration from remediation request Spec.
 func (r *RemediationManager) GetTimeout() *metav1.Duration {
 	return r.Metal3Remediation.Spec.Strategy.Timeout
 }
 
-// IncreaseRetryCount increases the retry count on Status
+// IncreaseRetryCount increases the retry count on Status.
 func (r *RemediationManager) IncreaseRetryCount() {
 	r.Metal3Remediation.Status.RetryCount++
 }
 
+// SetOwnerRemediatedConditionNew sets MachineOwnerRemediatedCondition on CAPI machine object
+// that have failed a healthcheck.
 func (r *RemediationManager) SetOwnerRemediatedConditionNew(ctx context.Context) error {
 	capiMachine, err := r.GetCapiMachine(ctx)
 	if err != nil {
@@ -279,6 +280,7 @@ func (r *RemediationManager) SetOwnerRemediatedConditionNew(ctx context.Context)
 	return nil
 }
 
+// GetCapiMachine returns CAPI machine object owning the current resource.
 func (r *RemediationManager) GetCapiMachine(ctx context.Context) (*capi.Machine, error) {
 	capiMachine, err := util.GetOwnerMachine(ctx, r.Client, r.Metal3Remediation.ObjectMeta)
 	if err != nil {

--- a/baremetal/requeue_error.go
+++ b/baremetal/requeue_error.go
@@ -37,7 +37,7 @@ type RequeueAfterError struct {
 	RequeueAfter time.Duration
 }
 
-// Error implements the error interface
+// Error implements the error interface.
 func (e *RequeueAfterError) Error() string {
 	return fmt.Sprintf("requeue in: %s", e.RequeueAfter)
 }

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -115,9 +115,10 @@ var bmcOwnerRef = &metav1.OwnerReference{
 	Name:       clusterName,
 }
 
-//-----------------------------------
-//------ Helper functions -----------
-//-----------------------------------
+/*-----------------------------------
+---------Helper functions------------
+------------------------------------*/
+
 func setupScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
 	if err := capi.AddToScheme(s); err != nil {

--- a/baremetal/utils.go
+++ b/baremetal/utils.go
@@ -75,7 +75,6 @@ func patchIfFound(ctx context.Context, helper *patch.Helper, host client.Object)
 		notFound := true
 		var aggr kerrors.Aggregate
 		if ok := errors.As(err, &aggr); ok {
-			// if aggr, ok := err.(kerrors.Aggregate); ok {
 			for _, kerr := range aggr.Errors() {
 				if !apierrors.IsNotFound(kerr) {
 					notFound = false

--- a/baremetal/utils.go
+++ b/baremetal/utils.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"strings"
 
-	// comment for go-lint
+	// comment for go-lint.
 	"github.com/go-logr/logr"
 
 	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	// metal3SecretType defines the type of secret created by metal3
+	// metal3SecretType defines the type of secret created by metal3.
 	metal3SecretType corev1.SecretType = "infrastructure.cluster.x-k8s.io/secret"
 )
 
@@ -60,11 +60,11 @@ func Contains(list []string, strToSearch string) bool {
 	return false
 }
 
-// NotFoundError represents that an object was not found
+// NotFoundError represents that an object was not found.
 type NotFoundError struct {
 }
 
-// Error implements the error interface
+// Error implements the error interface.
 func (e *NotFoundError) Error() string {
 	return "Object not found"
 }
@@ -73,7 +73,9 @@ func patchIfFound(ctx context.Context, helper *patch.Helper, host client.Object)
 	err := helper.Patch(ctx, host)
 	if err != nil {
 		notFound := true
-		if aggr, ok := err.(kerrors.Aggregate); ok {
+		var aggr kerrors.Aggregate
+		if ok := errors.As(err, &aggr); ok {
+			// if aggr, ok := err.(kerrors.Aggregate); ok {
 			for _, kerr := range aggr.Errors() {
 				if !apierrors.IsNotFound(kerr) {
 					notFound = false
@@ -92,7 +94,7 @@ func patchIfFound(ctx context.Context, helper *patch.Helper, host client.Object)
 	return err
 }
 
-func updateObject(cl client.Client, ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+func updateObject(ctx context.Context, cl client.Client, obj client.Object, opts ...client.UpdateOption) error {
 	err := cl.Update(ctx, obj.DeepCopyObject().(client.Object), opts...)
 	if apierrors.IsConflict(err) {
 		return &RequeueAfterError{}
@@ -100,7 +102,7 @@ func updateObject(cl client.Client, ctx context.Context, obj client.Object, opts
 	return err
 }
 
-func createObject(cl client.Client, ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+func createObject(ctx context.Context, cl client.Client, obj client.Object, opts ...client.CreateOption) error {
 	err := cl.Create(ctx, obj.DeepCopyObject().(client.Object), opts...)
 	if apierrors.IsAlreadyExists(err) {
 		return &RequeueAfterError{}
@@ -108,7 +110,7 @@ func createObject(cl client.Client, ctx context.Context, obj client.Object, opts
 	return err
 }
 
-func deleteObject(cl client.Client, ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+func deleteObject(ctx context.Context, cl client.Client, obj client.Object, opts ...client.DeleteOption) error {
 	err := cl.Delete(ctx, obj.DeepCopyObject().(client.Object), opts...)
 	if apierrors.IsNotFound(err) {
 		return nil
@@ -116,7 +118,7 @@ func deleteObject(cl client.Client, ctx context.Context, obj client.Object, opts
 	return err
 }
 
-func createSecret(cl client.Client, ctx context.Context, name string,
+func createSecret(ctx context.Context, cl client.Client, name string,
 	namespace string, clusterName string,
 	ownerRefs []metav1.OwnerReference, content map[string][]byte,
 ) error {
@@ -137,21 +139,21 @@ func createSecret(cl client.Client, ctx context.Context, name string,
 		Type: metal3SecretType,
 	}
 
-	secret, err := checkSecretExists(cl, ctx, name, namespace)
+	secret, err := checkSecretExists(ctx, cl, name, namespace)
 	if err == nil {
-		// Update the secret with user data
+		// Update the secret with user data.
 		secret.ObjectMeta.Labels = bootstrapSecret.ObjectMeta.Labels
 		secret.ObjectMeta.OwnerReferences = bootstrapSecret.ObjectMeta.OwnerReferences
 		bootstrapSecret.ObjectMeta = secret.ObjectMeta
-		return updateObject(cl, ctx, bootstrapSecret)
+		return updateObject(ctx, cl, bootstrapSecret)
 	} else if apierrors.IsNotFound(err) {
-		// Create the secret with user data
-		return createObject(cl, ctx, bootstrapSecret)
+		// Create the secret with user data.
+		return createObject(ctx, cl, bootstrapSecret)
 	}
 	return err
 }
 
-func checkSecretExists(cl client.Client, ctx context.Context, name string,
+func checkSecretExists(ctx context.Context, cl client.Client, name string,
 	namespace string,
 ) (corev1.Secret, error) {
 	tmpBootstrapSecret := corev1.Secret{}
@@ -163,21 +165,21 @@ func checkSecretExists(cl client.Client, ctx context.Context, name string,
 	return tmpBootstrapSecret, err
 }
 
-func deleteSecret(cl client.Client, ctx context.Context, name string,
+func deleteSecret(ctx context.Context, cl client.Client, name string,
 	namespace string,
 ) error {
-	tmpBootstrapSecret, err := checkSecretExists(cl, ctx, name, namespace)
+	tmpBootstrapSecret, err := checkSecretExists(ctx, cl, name, namespace)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	} else if err == nil {
 		//unset the finalizers (remove all since we do not expect anything else
-		// to control that object)
+		// to control that object).
 		tmpBootstrapSecret.Finalizers = []string{}
-		err = updateObject(cl, ctx, &tmpBootstrapSecret)
+		err = updateObject(ctx, cl, &tmpBootstrapSecret)
 		if err != nil {
 			return err
 		}
-		// Delete the secret with metadata
+		// Delete the secret with metadata.
 		err = cl.Delete(ctx, &tmpBootstrapSecret)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return err
@@ -186,13 +188,12 @@ func deleteSecret(cl client.Client, ctx context.Context, name string,
 	return nil
 }
 
-// fetchMetadata fetches the Metal3DataTemplate object
+// fetchMetadata fetches the Metal3DataTemplate object.
 func fetchM3DataTemplate(ctx context.Context,
 	templateRef *corev1.ObjectReference, cl client.Client, mLog logr.Logger,
 	clusterName string,
 ) (*capm3.Metal3DataTemplate, error) {
-
-	// If the user did not specify a DataTemplate, just keep going
+	// If the user did not specify a DataTemplate, just keep going.
 	if templateRef == nil {
 		return nil, nil
 	}
@@ -210,13 +211,12 @@ func fetchM3DataTemplate(ctx context.Context,
 		if apierrors.IsNotFound(err) {
 			mLog.Info("Metadata not found, requeuing")
 			return nil, &RequeueAfterError{RequeueAfter: requeueAfter}
-		} else {
-			err := errors.Wrap(err, "Failed to get metadata")
-			return nil, err
 		}
+		err := errors.Wrap(err, "Failed to get metadata")
+		return nil, err
 	}
 
-	// Verify that this Metal3Data belongs to the correct cluster
+	// Verify that this Metal3Data belongs to the correct cluster.
 	if clusterName != metal3DataTemplate.Spec.ClusterName {
 		return nil, errors.New("Metal3DataTemplate associated with another cluster")
 	}
@@ -227,28 +227,27 @@ func fetchM3DataTemplate(ctx context.Context,
 func fetchM3DataClaim(ctx context.Context, cl client.Client, mLog logr.Logger,
 	name, namespace string,
 ) (*capm3.Metal3DataClaim, error) {
-	// Fetch the Metal3Data
-	m3Data := &capm3.Metal3DataClaim{}
-	metal3DataName := types.NamespacedName{
+	// Fetch the Metal3DataClaim.
+	m3DataClaim := &capm3.Metal3DataClaim{}
+	metal3DataClaimName := types.NamespacedName{
 		Namespace: namespace,
 		Name:      name,
 	}
-	if err := cl.Get(ctx, metal3DataName, m3Data); err != nil {
+	if err := cl.Get(ctx, metal3DataClaimName, m3DataClaim); err != nil {
 		if apierrors.IsNotFound(err) {
 			mLog.Info("Data Claim not found")
 			return nil, &RequeueAfterError{RequeueAfter: requeueAfter}
-		} else {
-			err := errors.Wrap(err, "Failed to get metadata")
-			return nil, err
 		}
+		err := errors.Wrap(err, "Failed to get metadata claim")
+		return nil, err
 	}
-	return m3Data, nil
+	return m3DataClaim, nil
 }
 
 func fetchM3Data(ctx context.Context, cl client.Client, mLog logr.Logger,
 	name, namespace string,
 ) (*capm3.Metal3Data, error) {
-	// Fetch the Metal3Data
+	// Fetch the Metal3Data.
 	m3Data := &capm3.Metal3Data{}
 	metal3DataName := types.NamespacedName{
 		Namespace: namespace,
@@ -258,10 +257,9 @@ func fetchM3Data(ctx context.Context, cl client.Client, mLog logr.Logger,
 		if apierrors.IsNotFound(err) {
 			mLog.Info("Rendered data not found, requeuing")
 			return nil, &RequeueAfterError{RequeueAfter: requeueAfter}
-		} else {
-			err := errors.Wrap(err, "Failed to get metadata")
-			return nil, err
 		}
+		err := errors.Wrap(err, "Failed to get metadata")
+		return nil, err
 	}
 	return m3Data, nil
 }
@@ -270,8 +268,7 @@ func getM3Machine(ctx context.Context, cl client.Client, mLog logr.Logger,
 	name, namespace string, dataTemplate *capm3.Metal3DataTemplate,
 	requeueifNotFound bool,
 ) (*capm3.Metal3Machine, error) {
-
-	// Get the Metal3Machine
+	// Get the Metal3Machine.
 	tmpM3Machine := &capm3.Metal3Machine{}
 	key := client.ObjectKey{
 		Name:      name,
@@ -284,16 +281,15 @@ func getM3Machine(ctx context.Context, cl client.Client, mLog logr.Logger,
 				return nil, &RequeueAfterError{RequeueAfter: requeueAfter}
 			}
 			return nil, nil
-		} else {
-			return nil, err
 		}
+		return nil, err
 	}
 
 	if dataTemplate == nil {
 		return tmpM3Machine, nil
 	}
 
-	// Verify that the Metal3Machine fulfills the conditions
+	// Verify that the Metal3Machine fulfills the conditions.
 	if tmpM3Machine.Spec.DataTemplate == nil {
 		return nil, nil
 	}

--- a/baremetal/utils_test.go
+++ b/baremetal/utils_test.go
@@ -28,11 +28,9 @@ import (
 	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	//"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	//fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -253,7 +251,7 @@ var _ = Describe("Metal3 manager utils", func() {
 				tc.TestObject.ObjectMeta = m3m.ObjectMeta
 			}
 			obj := tc.TestObject.DeepCopy()
-			err := updateObject(k8sClient, context.TODO(), obj)
+			err := updateObject(context.TODO(), k8sClient, obj)
 			if tc.ExpectedError {
 				Expect(err).To(HaveOccurred())
 				Expect(err).NotTo(BeAssignableToTypeOf(&RequeueAfterError{}))
@@ -272,7 +270,7 @@ var _ = Describe("Metal3 manager utils", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(savedObject.Spec).To(Equal(tc.TestObject.Spec))
 				Expect(savedObject.ResourceVersion).NotTo(Equal(tc.TestObject.ResourceVersion))
-				err := updateObject(k8sClient, context.TODO(), obj)
+				err := updateObject(context.TODO(), k8sClient, obj)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(BeAssignableToTypeOf(&RequeueAfterError{}))
 			}
@@ -300,7 +298,7 @@ var _ = Describe("Metal3 manager utils", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 			obj := tc.TestObject.DeepCopy()
-			err := createObject(k8sClient, context.TODO(), obj)
+			err := createObject(context.TODO(), k8sClient, obj)
 			if tc.ExpectedError {
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(BeAssignableToTypeOf(&RequeueAfterError{}))
@@ -347,7 +345,7 @@ var _ = Describe("Metal3 manager utils", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 			}
-			_, err := checkSecretExists(k8sClient, context.TODO(), "abc", "myns")
+			_, err := checkSecretExists(context.TODO(), k8sClient, "abc", "myns")
 			if secretExists {
 				Expect(err).NotTo(HaveOccurred())
 				err = k8sClient.Delete(context.TODO(), &corev1.Secret{
@@ -398,7 +396,7 @@ var _ = Describe("Metal3 manager utils", func() {
 			content := map[string][]byte{
 				"abc": []byte("def"),
 			}
-			err := createSecret(k8sClient, context.TODO(), "abc", "myns", "ghi",
+			err := createSecret(context.TODO(), k8sClient, "abc", "myns", "ghi",
 				ownerRef, content,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -442,7 +440,7 @@ var _ = Describe("Metal3 manager utils", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 
-			err := deleteSecret(k8sClient, context.TODO(), "abc", "myns")
+			err := deleteSecret(context.TODO(), k8sClient, "abc", "myns")
 			Expect(err).NotTo(HaveOccurred())
 			savedSecret := corev1.Secret{}
 			err = k8sClient.Get(context.TODO(),

--- a/controllers/metal3cluster_controller.go
+++ b/controllers/metal3cluster_controller.go
@@ -51,7 +51,7 @@ const (
 	requeueAfter          = time.Second * 30
 )
 
-// Metal3ClusterReconciler reconciles a Metal3Cluster object
+// Metal3ClusterReconciler reconciles a Metal3Cluster object.
 type Metal3ClusterReconciler struct {
 	Client           client.Client
 	ManagerFactory   baremetal.ManagerFactoryInterface
@@ -64,9 +64,8 @@ type Metal3ClusterReconciler struct {
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
 
 // Reconcile reads that state of the cluster for a Metal3Cluster object and makes changes based on the state read
-// and what is in the Metal3Cluster.Spec
+// and what is in the Metal3Cluster.Spec.
 func (r *Metal3ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
-
 	clusterLog := log.Log.WithName(clusterControllerName).WithValues("metal3-cluster", req.NamespacedName)
 
 	// Fetch the Metal3Cluster instance
@@ -134,7 +133,6 @@ func (r *Metal3ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 }
 
 func patchMetal3Cluster(ctx context.Context, patchHelper *patch.Helper, metal3Cluster *capm3.Metal3Cluster, options ...patch.Option) error {
-
 	// Always update the readyCondition by summarizing the state of other conditions.
 	conditions.SetSummary(metal3Cluster,
 		conditions.WithConditions(
@@ -172,7 +170,6 @@ func reconcileNormal(ctx context.Context, clusterMgr baremetal.ClusterManagerInt
 
 func reconcileDelete(ctx context.Context,
 	clusterMgr baremetal.ClusterManagerInterface) (ctrl.Result, error) {
-
 	// Verify that no metal3machine depend on the metal3cluster
 	descendants, err := clusterMgr.CountDescendants(ctx)
 	if err != nil {
@@ -194,7 +191,7 @@ func reconcileDelete(ctx context.Context,
 	return ctrl.Result{}, nil
 }
 
-// SetupWithManager will add watches for this controller
+// SetupWithManager will add watches for this controller.
 func (r *Metal3ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	clusterToInfraFn := util.ClusterToInfrastructureMapFunc(capm3.GroupVersion.WithKind("Metal3Cluster"))
 	return ctrl.NewControllerManagedBy(mgr).

--- a/controllers/metal3data_controller.go
+++ b/controllers/metal3data_controller.go
@@ -43,7 +43,7 @@ const (
 	dataControllerName = "Metal3Data-controller"
 )
 
-// Metal3DataReconciler reconciles a Metal3Data object
+// Metal3DataReconciler reconciles a Metal3Data object.
 type Metal3DataReconciler struct {
 	Client           client.Client
 	ManagerFactory   baremetal.ManagerFactoryInterface
@@ -56,7 +56,7 @@ type Metal3DataReconciler struct {
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
-// Reconcile handles Metal3Machine events
+// Reconcile handles Metal3Machine events.
 func (r *Metal3DataReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
 	metadataLog := r.Log.WithName(dataControllerName).WithValues("metal3-data", req.NamespacedName)
 
@@ -122,7 +122,6 @@ func (r *Metal3DataReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 func (r *Metal3DataReconciler) reconcileNormal(ctx context.Context,
 	metadataMgr baremetal.DataManagerInterface,
 ) (ctrl.Result, error) {
-
 	// If the Metal3Data doesn't have finalizer, add it.
 	metadataMgr.SetFinalizer()
 
@@ -136,7 +135,6 @@ func (r *Metal3DataReconciler) reconcileNormal(ctx context.Context,
 func (r *Metal3DataReconciler) reconcileDelete(ctx context.Context,
 	metadataMgr baremetal.DataManagerInterface,
 ) (ctrl.Result, error) {
-
 	err := metadataMgr.ReleaseLeases(ctx)
 	if err != nil {
 		return checkRequeueError(err, "Failed to release IP address leases")
@@ -147,7 +145,7 @@ func (r *Metal3DataReconciler) reconcileDelete(ctx context.Context,
 	return ctrl.Result{}, nil
 }
 
-// SetupWithManager will add watches for this controller
+// SetupWithManager will add watches for this controller.
 func (r *Metal3DataReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&capm3.Metal3Data{}).

--- a/controllers/metal3datatemplate_controller.go
+++ b/controllers/metal3datatemplate_controller.go
@@ -39,7 +39,7 @@ const (
 	dataTemplateControllerName = "Metal3DataTemplate-controller"
 )
 
-// Metal3DataTemplateReconciler reconciles a Metal3DataTemplate object
+// Metal3DataTemplateReconciler reconciles a Metal3DataTemplate object.
 type Metal3DataTemplateReconciler struct {
 	Client           client.Client
 	ManagerFactory   baremetal.ManagerFactoryInterface
@@ -62,7 +62,7 @@ type Metal3DataTemplateReconciler struct {
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
-// Reconcile handles Metal3Machine events
+// Reconcile handles Metal3Machine events.
 func (r *Metal3DataTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
 	metadataLog := r.Log.WithName(dataTemplateControllerName).WithValues("metal3-datatemplate", req.NamespacedName)
 
@@ -145,7 +145,6 @@ func (r *Metal3DataTemplateReconciler) reconcileNormal(ctx context.Context,
 func (r *Metal3DataTemplateReconciler) reconcileDelete(ctx context.Context,
 	metadataMgr baremetal.DataTemplateManagerInterface,
 ) (ctrl.Result, error) {
-
 	allocationsNb, err := metadataMgr.UpdateDatas(ctx)
 	if err != nil {
 		return checkRequeueError(err, "Failed to recreate the status")
@@ -160,7 +159,7 @@ func (r *Metal3DataTemplateReconciler) reconcileDelete(ctx context.Context,
 	return ctrl.Result{}, nil
 }
 
-// SetupWithManager will add watches for this controller
+// SetupWithManager will add watches for this controller.
 func (r *Metal3DataTemplateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&capm3.Metal3DataTemplate{}).
@@ -174,7 +173,7 @@ func (r *Metal3DataTemplateReconciler) SetupWithManager(ctx context.Context, mgr
 
 // Metal3DataClaimToMetal3DataTemplate will return a reconcile request for a
 // Metal3DataTemplate if the event is for a
-// Metal3DataClaim and that Metal3DataClaim references a Metal3DataTemplate
+// Metal3DataClaim and that Metal3DataClaim references a Metal3DataTemplate.
 func (r *Metal3DataTemplateReconciler) Metal3DataClaimToMetal3DataTemplate(obj client.Object) []ctrl.Request {
 	if m3dc, ok := obj.(*capm3.Metal3DataClaim); ok {
 		if m3dc.Spec.Template.Name != "" {
@@ -199,8 +198,9 @@ func checkRequeueError(err error, errMessage string) (ctrl.Result, error) {
 	if err == nil {
 		return ctrl.Result{}, nil
 	}
-	if requeueErr, ok := errors.Cause(err).(baremetal.HasRequeueAfterError); ok {
-		return ctrl.Result{Requeue: true, RequeueAfter: requeueErr.GetRequeueAfter()}, nil
+	var hasReq baremetal.HasRequeueAfterError
+	if ok := errors.As(err, &hasReq); ok {
+		return ctrl.Result{Requeue: true, RequeueAfter: hasReq.GetRequeueAfter()}, nil
 	}
 	return ctrl.Result{}, errors.Wrap(err, errMessage)
 }

--- a/controllers/metal3datatemplate_controller.go
+++ b/controllers/metal3datatemplate_controller.go
@@ -198,9 +198,8 @@ func checkRequeueError(err error, errMessage string) (ctrl.Result, error) {
 	if err == nil {
 		return ctrl.Result{}, nil
 	}
-	var hasReq baremetal.HasRequeueAfterError
-	if ok := errors.As(err, &hasReq); ok {
-		return ctrl.Result{Requeue: true, RequeueAfter: hasReq.GetRequeueAfter()}, nil
+	if ok := errors.As(err, &hasRequeueAfterError); ok {
+		return ctrl.Result{Requeue: true, RequeueAfter: hasRequeueAfterError.GetRequeueAfter()}, nil
 	}
 	return ctrl.Result{}, errors.Wrap(err, errMessage)
 }

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -46,6 +46,8 @@ const (
 	machineControllerName = "Metal3Machine-controller"
 )
 
+var hasRequeueAfterError baremetal.HasRequeueAfterError
+
 // Metal3MachineReconciler reconciles a Metal3Machine object.
 type Metal3MachineReconciler struct {
 	Client           client.Client
@@ -525,9 +527,8 @@ func checkMachineError(machineMgr baremetal.MachineManagerInterface, err error,
 	if err == nil {
 		return ctrl.Result{}, nil
 	}
-	var hasReq baremetal.HasRequeueAfterError
-	if ok := errors.As(err, &hasReq); ok {
-		return ctrl.Result{Requeue: true, RequeueAfter: hasReq.GetRequeueAfter()}, nil
+	if ok := errors.As(err, &hasRequeueAfterError); ok {
+		return ctrl.Result{Requeue: true, RequeueAfter: hasRequeueAfterError.GetRequeueAfter()}, nil
 	}
 	machineMgr.SetError(errMessage, errType)
 	return ctrl.Result{}, errors.Wrap(err, errMessage)

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -57,7 +57,6 @@ type reconcileNormalTestCase struct {
 func setReconcileNormalExpectations(ctrl *gomock.Controller,
 	tc reconcileNormalTestCase,
 ) *baremetal_mocks.MockMachineManagerInterface {
-
 	m := baremetal_mocks.NewMockMachineManagerInterface(ctrl)
 
 	m.EXPECT().SetFinalizer()
@@ -100,9 +99,8 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 			m.EXPECT().GetBaremetalHostID(context.TODO()).MaxTimes(0)
 			m.EXPECT().SetError(gomock.Any(), gomock.Any())
 			return m
-		} else {
-			m.EXPECT().Associate(context.TODO()).Return(nil)
 		}
+		m.EXPECT().Associate(context.TODO()).Return(nil)
 	}
 
 	m.EXPECT().SetConditionMetal3MachineToTrue(capm3.AssociateBMHCondition)
@@ -176,7 +174,6 @@ type reconcileDeleteTestCase struct {
 func setReconcileDeleteExpectations(ctrl *gomock.Controller,
 	tc reconcileDeleteTestCase,
 ) *baremetal_mocks.MockMachineManagerInterface {
-
 	m := baremetal_mocks.NewMockMachineManagerInterface(ctrl)
 
 	if tc.DeleteFails {

--- a/controllers/metal3machinetemplate_controller.go
+++ b/controllers/metal3machinetemplate_controller.go
@@ -42,7 +42,7 @@ const (
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=metal3machines,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=metal3machines/status,verbs=get
 
-// Metal3MachineTemplateReconciler reconciles a Metal3MachineTemplate object
+// Metal3MachineTemplateReconciler reconciles a Metal3MachineTemplate object.
 type Metal3MachineTemplateReconciler struct {
 	Client           client.Client
 	ManagerFactory   baremetal.ManagerFactoryInterface
@@ -50,7 +50,7 @@ type Metal3MachineTemplateReconciler struct {
 	WatchFilterValue string
 }
 
-// Reconcile handles Metal3MachineTemplate events
+// Reconcile handles Metal3MachineTemplate events.
 func (r *Metal3MachineTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
 	m3templateLog := r.Log.WithName(templateControllerName).WithValues("metal3-machine-template", req.NamespacedName)
 
@@ -104,7 +104,6 @@ func (r *Metal3MachineTemplateReconciler) Reconcile(ctx context.Context, req ctr
 func (r *Metal3MachineTemplateReconciler) reconcileNormal(ctx context.Context,
 	templateMgr baremetal.TemplateManagerInterface,
 ) (ctrl.Result, error) {
-
 	// Find the Metal3Machines with clonedFromName annotation referencing
 	// to the same Metal3MachineTemplate
 	if err := templateMgr.UpdateAutomatedCleaningMode(ctx); err != nil {
@@ -115,7 +114,7 @@ func (r *Metal3MachineTemplateReconciler) reconcileNormal(ctx context.Context,
 	return ctrl.Result{}, nil
 }
 
-// SetupWithManager will add watches for this controller
+// SetupWithManager will add watches for Metal3MachineTemplate controller.
 func (r *Metal3MachineTemplateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&capm3.Metal3MachineTemplate{}).
@@ -127,7 +126,9 @@ func (r *Metal3MachineTemplateReconciler) SetupWithManager(ctx context.Context, 
 		Complete(r)
 }
 
-func (m *Metal3MachineTemplateReconciler) Metal3MachinesToMetal3MachineTemplate(o client.Object) []ctrl.Request {
+// Metal3MachinesToMetal3MachineTemplate is a handler.ToRequestsFunc to be used to enqeue
+// requests for reconciliation of Metal3MachineTemplates.
+func (r *Metal3MachineTemplateReconciler) Metal3MachinesToMetal3MachineTemplate(o client.Object) []ctrl.Request {
 	result := []ctrl.Request{}
 	if m3m, ok := o.(*capm3.Metal3Machine); ok {
 		if m3m.Annotations[clonedFromGroupKind] == "" && m3m.Annotations[clonedFromGroupKind] != "Metal3MachineTemplate.infrastructure.cluster.x-k8s.io" {
@@ -140,7 +141,7 @@ func (m *Metal3MachineTemplateReconciler) Metal3MachinesToMetal3MachineTemplate(
 			},
 		})
 	} else {
-		m.Log.Error(errors.Errorf("expected a Metal3Machine but got a %T", o),
+		r.Log.Error(errors.Errorf("expected a Metal3Machine but got a %T", o),
 			"failed to get Metal3Machine for Metal3MachineTemplate",
 		)
 	}

--- a/controllers/metal3remediation_controller.go
+++ b/controllers/metal3remediation_controller.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Metal3RemediationReconciler reconciles a Metal3Remediation object
+// Metal3RemediationReconciler reconciles a Metal3Remediation object.
 type Metal3RemediationReconciler struct {
 	client.Client
 	ManagerFactory baremetal.ManagerFactoryInterface
@@ -44,6 +44,7 @@ type Metal3RemediationReconciler struct {
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=metal3remediations/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=get;list;watch;create;update;patch;delete
 
+// Reconcile handles Metal3Remediation events.
 func (r *Metal3RemediationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
 	remediationLog := r.Log.WithValues("metal3remediation", req.NamespacedName)
 
@@ -117,7 +118,6 @@ func (r *Metal3RemediationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 func (r *Metal3RemediationReconciler) reconcileNormal(ctx context.Context,
 	remediationMgr baremetal.RemediationManagerInterface,
 ) (ctrl.Result, error) {
-
 	// If host is gone, exit early
 	host, _, err := remediationMgr.GetUnhealthyHost(ctx)
 	if err != nil {
@@ -179,7 +179,6 @@ func (r *Metal3RemediationReconciler) reconcileNormal(ctx context.Context,
 					// Not yet time to remediate, requeue
 					return ctrl.Result{RequeueAfter: nextRemediation}, nil
 				}
-
 			} else {
 				remediationMgr.SetRemediationPhase(capm3.PhaseWaiting)
 			}
@@ -212,7 +211,6 @@ func (r *Metal3RemediationReconciler) reconcileNormal(ctx context.Context,
 				return ctrl.Result{RequeueAfter: nextCheck}, nil
 			}
 		default:
-
 		}
 	}
 	return ctrl.Result{}, nil
@@ -224,6 +222,7 @@ func (r *Metal3RemediationReconciler) reconcileDelete(ctx context.Context,
 	return ctrl.Result{}, nil
 }
 
+// SetupWithManager will add watches for Metal3Remediation controller.
 func (r *Metal3RemediationReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&capm3.Metal3Remediation{}).

--- a/controllers/metal3remediation_controller_test.go
+++ b/controllers/metal3remediation_controller_test.go
@@ -49,7 +49,6 @@ type reconcileNormalRemediationTestCase struct {
 
 func setReconcileNormalRemediationExpectations(ctrl *gomock.Controller,
 	tc reconcileNormalRemediationTestCase) *baremetal_mocks.MockRemediationManagerInterface {
-
 	m := baremetal_mocks.NewMockRemediationManagerInterface(ctrl)
 
 	// If the test case expects us to apply the reboot annotation at some point
@@ -80,18 +79,16 @@ func setReconcileNormalRemediationExpectations(ctrl *gomock.Controller,
 	if tc.GetUnhealthyHostFails {
 		m.EXPECT().GetUnhealthyHost(context.TODO()).Return(nil, nil, fmt.Errorf("can't find foo_bmh"))
 		return m
-	} else {
-		m.EXPECT().GetUnhealthyHost(context.TODO()).Return(bmh, nil, nil)
 	}
+	m.EXPECT().GetUnhealthyHost(context.TODO()).Return(bmh, nil, nil)
 
 	// If user has set bmh.Spec.Online to false, do not try to remediate the host and set remediation phase to failed
 	if tc.HostStatusOffline {
 		m.EXPECT().OnlineStatus(bmh).Return(false)
 		m.EXPECT().SetRemediationPhase(capm3.PhaseFailed)
 		return m
-	} else {
-		m.EXPECT().OnlineStatus(bmh).Return(true)
 	}
+	m.EXPECT().OnlineStatus(bmh).Return(true)
 
 	m.EXPECT().GetRemediationType().Return(capm3.RebootRemediationStrategy)
 	m.EXPECT().GetRemediationPhase().Return(tc.RemediationPhase).MinTimes(1)
@@ -109,9 +106,8 @@ func setReconcileNormalRemediationExpectations(ctrl *gomock.Controller,
 			// When there's no retrying to do, we don't do remediation and instead go to waiting phase
 			m.EXPECT().SetRemediationPhase(capm3.PhaseWaiting)
 			return m
-		} else {
-			m.EXPECT().RetryLimitIsSet().Return(true)
 		}
+		m.EXPECT().RetryLimitIsSet().Return(true)
 		m.EXPECT().HasReachRetryLimit().Return(false)
 	}
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -323,7 +323,6 @@ func newMetal3Machine(name string, meta *metav1.ObjectMeta,
 	spec *capm3.Metal3MachineSpec, status *capm3.Metal3MachineStatus,
 	pausedAnnotation bool,
 ) *capm3.Metal3Machine {
-
 	if meta == nil {
 		meta = &metav1.ObjectMeta{
 			Name:            name,
@@ -372,7 +371,6 @@ func newMetal3Machine(name string, meta *metav1.ObjectMeta,
 func newBareMetalHost(spec *bmh.BareMetalHostSpec,
 	status *bmh.BareMetalHostStatus, Labels map[string]string, paused bool,
 ) *bmh.BareMetalHost {
-
 	if spec == nil {
 		spec = &bmh.BareMetalHostSpec{}
 	}
@@ -406,5 +404,4 @@ func newBareMetalHost(spec *bmh.BareMetalHostSpec,
 	}
 
 	return bmh
-
 }

--- a/main.go
+++ b/main.go
@@ -246,7 +246,6 @@ func setupChecks(mgr ctrl.Manager) {
 }
 
 func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
-
 	if err := (&controllers.Metal3MachineReconciler{
 		Client:           mgr.GetClient(),
 		ManagerFactory:   baremetal.NewManagerFactory(mgr.GetClient()),
@@ -318,7 +317,6 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 }
 
 func setupWebhooks(mgr ctrl.Manager) {
-
 	if err := (&infrav1beta1.Metal3Cluster{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Metal3Cluster")
 		os.Exit(1)

--- a/test/e2e/cert_rotation_test.go
+++ b/test/e2e/cert_rotation_test.go
@@ -85,7 +85,6 @@ func certRotation() {
 		return errors.New("Ironic pod is not in running state")
 	}, e2eConfig.GetIntervals(specName, "wait-pod-restart")...).Should(BeNil())
 	By("CERTIFICATE ROTATION TESTS PASSED!")
-
 }
 
 func getDeployment(targetCluster framework.ClusterProxy, deploymentName string, namespace string) (*appv1.Deployment, error) {

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -67,8 +67,8 @@ func dumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterPr
 	}
 }
 
+// downloadFile will download a url and store it in local filepath.
 func downloadFile(filepath string, url string) error {
-
 	// Get the data
 	resp, err := http.Get(url)
 	if err != nil {
@@ -88,6 +88,7 @@ func downloadFile(filepath string, url string) error {
 	return err
 }
 
+// filterBmhsByProvisioningState returns a filtered list of BaremetalHost objects in certain provisioning state.
 func filterBmhsByProvisioningState(bmhs []bmo.BareMetalHost, state bmo.ProvisioningState) (result []bmo.BareMetalHost) {
 	for _, bmh := range bmhs {
 		if bmh.Status.Provisioning.State == state {
@@ -97,6 +98,7 @@ func filterBmhsByProvisioningState(bmhs []bmo.BareMetalHost, state bmo.Provision
 	return
 }
 
+// filterMachinesByPhase returns a filtered list of CAPI machine objects in certain desired phase.
 func filterMachinesByPhase(machines []capi.Machine, phase string) (result []capi.Machine) {
 	for _, machine := range machines {
 		if machine.Status.Phase == phase {
@@ -106,6 +108,7 @@ func filterMachinesByPhase(machines []capi.Machine, phase string) (result []capi
 	return
 }
 
+// annotateBmh annotates BaremetalHost with a given key and value.
 func annotateBmh(ctx context.Context, client client.Client, host bmo.BareMetalHost, key string, value *string) {
 	helper, err := patch.NewHelper(&host, client)
 	Expect(err).NotTo(HaveOccurred())
@@ -122,7 +125,7 @@ func annotateBmh(ctx context.Context, client client.Client, host bmo.BareMetalHo
 	Expect(helper.Patch(ctx, &host)).To(Succeed())
 }
 
-// deleteNodeReuseLabelFromHost deletes nodeReuseLabelName from the host if exists
+// deleteNodeReuseLabelFromHost deletes nodeReuseLabelName from the host if it exists.
 func deleteNodeReuseLabelFromHost(ctx context.Context, client client.Client, host bmo.BareMetalHost, nodeReuseLabelName string) {
 	helper, err := patch.NewHelper(&host, client)
 	Expect(err).NotTo(HaveOccurred())
@@ -135,6 +138,7 @@ func deleteNodeReuseLabelFromHost(ctx context.Context, client client.Client, hos
 	Expect(helper.Patch(ctx, &host)).To(Succeed())
 }
 
+// scaleMachineDeployment scales up/down MachineDeployment object to desired replicas.
 func scaleMachineDeployment(ctx context.Context, clusterClient client.Client, clusterName, namespace string, newReplicas int) {
 	machineDeployments := framework.GetMachineDeploymentsByCluster(ctx, framework.GetMachineDeploymentsByClusterInput{
 		Lister:      clusterClient,
@@ -148,7 +152,8 @@ func scaleMachineDeployment(ctx context.Context, clusterClient client.Client, cl
 	Expect(err).To(BeNil(), "Failed to patch workers MachineDeployment")
 }
 
-func scaleControlPlane(ctx context.Context, c client.Client, name client.ObjectKey, newReplicaCount int) {
+// scaleKubeadmControlPlane scales up/down KubeadmControlPlane object to desired replicas.
+func scaleKubeadmControlPlane(ctx context.Context, c client.Client, name client.ObjectKey, newReplicaCount int) {
 	ctrlplane := kcp.KubeadmControlPlane{}
 	Expect(c.Get(ctx, name, &ctrlplane)).To(Succeed())
 	helper, err := patch.NewHelper(&ctrlplane, c)

--- a/test/e2e/pivoting_test.go
+++ b/test/e2e/pivoting_test.go
@@ -27,6 +27,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const bmoPath = "BMOPATH"
+
 func pivoting() {
 	Logf("Starting pivoting tests")
 	By("Remove Ironic containers from the source cluster")
@@ -162,7 +164,6 @@ func pivoting() {
 }
 
 func configureIronicConfigmap(isIronicDeployed bool) {
-	bmoPath := "BMOPATH"
 	ironicDataDir := "IRONIC_DATA_DIR"
 	ironicConfigmap := fmt.Sprintf("%s/ironic-deployment/keepalived/ironic_bmo_configmap.env", os.Getenv(bmoPath))
 	newIronicConfigmap := fmt.Sprintf("%s/ironic_bmo_configmap.env", os.Getenv(ironicDataDir))
@@ -182,7 +183,6 @@ func configureIronicConfigmap(isIronicDeployed bool) {
 }
 
 func restoreBMOConfigmap() {
-	bmoPath := "BMOPATH"
 	bmoConfigmap := fmt.Sprintf("%s/config/default/ironic.env", os.Getenv(bmoPath))
 	backupBmoConfigmap := fmt.Sprintf("%s/config/default/ironic.env.orig", os.Getenv(bmoPath))
 	cmd := exec.Command("mv", backupBmoConfigmap, bmoConfigmap)
@@ -194,7 +194,6 @@ func installIronicBMO(targetCluster framework.ClusterProxy, isIronic, isBMO stri
 	ironicTLSSetup := "IRONIC_TLS_SETUP"
 	ironicBasicAuth := "IRONIC_BASIC_AUTH"
 	ironicHost := os.Getenv("CLUSTER_PROVISIONING_IP")
-	bmoPath := "BMOPATH"
 	path := fmt.Sprintf("%s/tools/", os.Getenv(bmoPath))
 	args := []string{
 		isBMO,
@@ -305,7 +304,6 @@ func rePivoting() {
 		fmt.Printf("%s\n", stdoutStderr)
 		Expect(err).To(BeNil(), "Cannot run local ironic")
 	} else {
-
 		By("Configure Ironic Configmap")
 		configureIronicConfigmap(true)
 
@@ -390,5 +388,4 @@ func rePivoting() {
 	}, e2eConfig.GetIntervals(specName, "wait-machine-running")...).Should(Succeed())
 
 	By("RE-PIVOTING TEST PASSED!")
-
 }

--- a/test/e2e/yaml.go
+++ b/test/e2e/yaml.go
@@ -46,13 +46,12 @@ func yamlFindByValue(node *yaml.Node, values ...string) (*yaml.Node, error) {
 }
 
 func splitYAML(resources []byte) ([]*yaml.Node, error) {
-
 	dec := yaml.NewDecoder(bytes.NewReader(resources))
 	listDocument := []*yaml.Node{}
 	for {
 		var value yaml.Node
 		err := dec.Decode(&value)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds golangci.yml to the repo which enables linters to help improve the codebase overall.
The `golangci.YAML` has been mostly copied from the Cluster-api repo with changes adapted for this repo. 
All issues in the codebase that came up after adding the linter file have been fixed

