### PR TITLE
✨ [Part2] Add more linters into golangci.yml

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,28 +8,100 @@ run:
 linters:
   disable-all: true
   enable:
+    - asciicheck
+    - bodyclose
     - deadcode
+    - depguard
+    - dogsled
     - errcheck
     - errorlint
+    - exportloopref
     - goconst
+    - gocritic
     - godot
     - gofmt
     - goimports
     - golint
     - gosimple
     - govet
+    - importas
     - ineffassign
     - misspell
     - nakedret
+    - nilerr
+    - noctx 
+    - nolintlint
     - prealloc
+    - predeclared
+    - revive
+    - rowserrcheck
     - staticcheck
     - structcheck
+    - stylecheck
+    - thelper
+    - typecheck
     - unconvert
     - unused
     - varcheck
     - whitespace
   # Run with --fast=false for more extensive checks
   fast: true
+
+linters-settings:
+  importas:
+      no-unaliased: true
+      alias:
+        # Kubernetes
+        - pkg: k8s.io/api/core/v1
+          alias: corev1
+        - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+          alias: apiextensionsv1
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: apierrors
+        - pkg: k8s.io/apimachinery/pkg/util/errors
+          alias: kerrors
+        # Controller Runtime
+        - pkg: sigs.k8s.io/controller-runtime
+          alias: ctrl
+        # KCP
+        - pkg: sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1
+          alias: controlplanev1
+        # CAPI
+        - pkg: sigs.k8s.io/cluster-api/api/v1alpha3
+          alias: clusterv1alpha3
+        - pkg: sigs.k8s.io/cluster-api/api/v1alpha4
+          alias: clusterv1alpha4
+        - pkg: sigs.k8s.io/cluster-api/api/v1beta1
+          alias: clusterv1
+  nolintlint:
+    allow-unused: false
+    allow-leading-space: false
+    require-specific: true
+  staticcheck:
+    go: "1.17"
+  stylecheck:
+    go: "1.17"
+  gocritic:
+    enabled-tags:
+      - experimental
+    disabled-checks:
+    - appendAssign
+    - dupImport # https://github.com/go-critic/go-critic/issues/845
+    - evalOrder
+    - ifElseChain
+    - octalLiteral
+    - regexpSimplify
+    - sloppyReassign
+    - truncateCmp
+    - typeDefFirst
+    - unnamedResult
+    - unnecessaryDefer
+    - whyNoLint
+    - wrapperFunc
+  unused:
+    go: "1.17"
 issues:
   exclude-rules:
     - path: api/v1alpha4/types\.go
@@ -41,19 +113,49 @@ issues:
     - path: _test\.go
       linters:
         - unused
+    # Disable linters for conversion
     - linters:
         - staticcheck
       text: "SA1019:"
+      path: .*(api|types)\/.*\/conversion.*\.go$
     # Dot imports for gomega or ginkgo are allowed
     # within test files.
     - path: _test\.go
       text: should not use dot imports
     - path: (test|e2e)/.*.go
       text: should not use dot imports
-    - path: _test\.go
-      text: cyclomatic complexity
-    - path: baremetal/.*.go
-      text: cyclomatic complexity
+    - linters:
+      - revive
+      text: "exported: exported method .*\\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported"
+    # Exclude some packages or code to require comments, for example test code, or fake clients.
+    - linters:
+      - revive
+      text: exported (method|function|type|const) (.+) should have comment or be unexported
+      source: (func|type).*Fake.*
+    - linters:
+      - revive
+      text: exported (method|function|type|const) (.+) should have comment or be unexported
+      path: fake_\.go
+    - linters:
+      - revive
+      text: exported (method|function|type|const) (.+) should have comment or be unexported
+      path: .*(api|types)\/.*\/conversion.*\.go$
+    - linters:
+      - revive
+      text: "var-naming: don't use underscores in Go names;"
+      path: .*(api|types)\/.*\/conversion.*\.go$
+    - linters:
+      - revive
+      text: "receiver-naming: receiver name"
+      path: .*(api|types)\/.*\/conversion.*\.go$
+    - linters:
+      - stylecheck
+      text: "ST1003: should not use underscores in Go names;"
+      path: .*(api|types)\/.*\/conversion.*\.go$
+    - linters:
+      - stylecheck
+      text: "ST1016: methods on the same type should have the same receiver name"
+      path: .*(api|types)\/.*\/conversion.*\.go$
   include:
   - EXC0002 # include "missing comments" issues from golint
   max-issues-per-linter: 0

--- a/api/v1alpha5/metal3machine_types.go
+++ b/api/v1alpha5/metal3machine_types.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	capi "sigs.k8s.io/cluster-api/api/v1alpha4"
+	clusterv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 )
 
@@ -133,7 +133,7 @@ type Metal3MachineStatus struct {
 	// Addresses is a list of addresses assigned to the machine.
 	// This field is copied from the infrastructure provider reference.
 	// +optional
-	Addresses capi.MachineAddresses `json:"addresses,omitempty"`
+	Addresses clusterv1alpha4.MachineAddresses `json:"addresses,omitempty"`
 
 	// Phase represents the current phase of machine actuation.
 	// E.g. Pending, Running, Terminating, Failed etc.

--- a/api/v1beta1/metal3machine_types.go
+++ b/api/v1beta1/metal3machine_types.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 )
 
@@ -142,7 +142,7 @@ type Metal3MachineStatus struct {
 	// Addresses is a list of addresses assigned to the machine.
 	// This field is copied from the infrastructure provider reference.
 	// +optional
-	Addresses capi.MachineAddresses `json:"addresses,omitempty"`
+	Addresses clusterv1.MachineAddresses `json:"addresses,omitempty"`
 
 	// Phase represents the current phase of machine actuation.
 	// E.g. Pending, Running, Terminating, Failed etc.
@@ -178,7 +178,7 @@ type Metal3MachineStatus struct {
 	NetworkData *corev1.SecretReference `json:"networkData,omitempty"`
 	// Conditions defines current service state of the Metal3Machine.
 	// +optional
-	Conditions capi.Conditions `json:"conditions,omitempty"`
+	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -215,12 +215,12 @@ type Metal3MachineList struct {
 }
 
 // GetConditions returns the list of conditions for an Metal3Machine API object.
-func (c *Metal3Machine) GetConditions() capi.Conditions {
+func (c *Metal3Machine) GetConditions() clusterv1.Conditions {
 	return c.Status.Conditions
 }
 
 // SetConditions will set the given conditions on an Metal3Machine object.
-func (c *Metal3Machine) SetConditions(conditions capi.Conditions) {
+func (c *Metal3Machine) SetConditions(conditions clusterv1.Conditions) {
 	c.Status.Conditions = conditions
 }
 

--- a/baremetal/manager_factory.go
+++ b/baremetal/manager_factory.go
@@ -19,17 +19,17 @@ package baremetal
 import (
 	"github.com/go-logr/logr"
 	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ManagerFactoryInterface is a collection of new managers.
 type ManagerFactoryInterface interface {
-	NewClusterManager(cluster *capi.Cluster,
+	NewClusterManager(cluster *clusterv1.Cluster,
 		metal3Cluster *capm3.Metal3Cluster,
 		clusterLog logr.Logger,
 	) (ClusterManagerInterface, error)
-	NewMachineManager(*capi.Cluster, *capm3.Metal3Cluster, *capi.Machine,
+	NewMachineManager(*clusterv1.Cluster, *capm3.Metal3Cluster, *clusterv1.Machine,
 		*capm3.Metal3Machine, logr.Logger,
 	) (MachineManagerInterface, error)
 	NewDataTemplateManager(*capm3.Metal3DataTemplate, logr.Logger) (
@@ -42,7 +42,7 @@ type ManagerFactoryInterface interface {
 		capm3MachineList *capm3.Metal3MachineList,
 		metadataLog logr.Logger,
 	) (TemplateManagerInterface, error)
-	NewRemediationManager(*capm3.Metal3Remediation, *capm3.Metal3Machine, *capi.Machine, logr.Logger) (
+	NewRemediationManager(*capm3.Metal3Remediation, *capm3.Metal3Machine, *clusterv1.Machine, logr.Logger) (
 		RemediationManagerInterface, error,
 	)
 }
@@ -58,14 +58,14 @@ func NewManagerFactory(client client.Client) ManagerFactory {
 }
 
 // NewClusterManager creates a new ClusterManager.
-func (f ManagerFactory) NewClusterManager(cluster *capi.Cluster, capm3Cluster *capm3.Metal3Cluster, clusterLog logr.Logger) (ClusterManagerInterface, error) {
+func (f ManagerFactory) NewClusterManager(cluster *clusterv1.Cluster, capm3Cluster *capm3.Metal3Cluster, clusterLog logr.Logger) (ClusterManagerInterface, error) {
 	return NewClusterManager(f.client, cluster, capm3Cluster, clusterLog)
 }
 
 // NewMachineManager creates a new MachineManager.
-func (f ManagerFactory) NewMachineManager(capiCluster *capi.Cluster,
+func (f ManagerFactory) NewMachineManager(capiCluster *clusterv1.Cluster,
 	capm3Cluster *capm3.Metal3Cluster,
-	capiMachine *capi.Machine, capm3Machine *capm3.Metal3Machine,
+	capiMachine *clusterv1.Machine, capm3Machine *capm3.Metal3Machine,
 	machineLog logr.Logger) (MachineManagerInterface, error) {
 	return NewMachineManager(f.client, capiCluster, capm3Cluster, capiMachine,
 		capm3Machine, machineLog)
@@ -90,7 +90,7 @@ func (f ManagerFactory) NewMachineTemplateManager(capm3Template *capm3.Metal3Mac
 
 // NewRemediationManager creates a new RemediationManager.
 func (f ManagerFactory) NewRemediationManager(remediation *capm3.Metal3Remediation,
-	metal3machine *capm3.Metal3Machine, machine *capi.Machine,
+	metal3machine *capm3.Metal3Machine, machine *clusterv1.Machine,
 	remediationLog logr.Logger) (RemediationManagerInterface, error) {
 	return NewRemediationManager(f.client, remediation, metal3machine, machine, remediationLog)
 }

--- a/baremetal/manager_factory_test.go
+++ b/baremetal/manager_factory_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -42,7 +42,7 @@ var _ = Describe("Manager factory testing", func() {
 	})
 
 	It("returns a cluster manager", func() {
-		_, err := managerFactory.NewClusterManager(&capi.Cluster{},
+		_, err := managerFactory.NewClusterManager(&clusterv1.Cluster{},
 			&capm3.Metal3Cluster{}, clusterLog,
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -56,15 +56,15 @@ var _ = Describe("Manager factory testing", func() {
 	})
 
 	It("fails to return a cluster manager with nil m3cluster", func() {
-		_, err := managerFactory.NewClusterManager(&capi.Cluster{}, nil,
+		_, err := managerFactory.NewClusterManager(&clusterv1.Cluster{}, nil,
 			clusterLog,
 		)
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("returns a metal3 machine manager", func() {
-		_, err := managerFactory.NewMachineManager(&capi.Cluster{},
-			&capm3.Metal3Cluster{}, &capi.Machine{}, &capm3.Metal3Machine{},
+		_, err := managerFactory.NewMachineManager(&clusterv1.Cluster{},
+			&capm3.Metal3Cluster{}, &clusterv1.Machine{}, &capm3.Metal3Machine{},
 			clusterLog,
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -86,7 +86,7 @@ var _ = Describe("Manager factory testing", func() {
 	})
 
 	It("returns a Remediation manager", func() {
-		_, err := managerFactory.NewRemediationManager(&capm3.Metal3Remediation{}, &capm3.Metal3Machine{}, &capi.Machine{}, clusterLog)
+		_, err := managerFactory.NewRemediationManager(&capm3.Metal3Remediation{}, &capm3.Metal3Machine{}, &clusterv1.Machine{}, clusterLog)
 		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/baremetal/metal3cluster_manager.go
+++ b/baremetal/metal3cluster_manager.go
@@ -28,7 +28,7 @@ import (
 
 	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -49,14 +49,14 @@ type ClusterManagerInterface interface {
 type ClusterManager struct {
 	client client.Client
 
-	Cluster       *capi.Cluster
+	Cluster       *clusterv1.Cluster
 	Metal3Cluster *capm3.Metal3Cluster
 	Log           logr.Logger
 	// name string
 }
 
 // NewClusterManager returns a new helper for managing a cluster with a given name.
-func NewClusterManager(client client.Client, cluster *capi.Cluster,
+func NewClusterManager(client client.Client, cluster *clusterv1.Cluster,
 	metal3Cluster *capm3.Metal3Cluster,
 	clusterLog logr.Logger) (ClusterManagerInterface, error) {
 	if metal3Cluster == nil {
@@ -110,7 +110,7 @@ func (s *ClusterManager) Create(ctx context.Context) error {
 
 // ControlPlaneEndpoint returns cluster controlplane endpoint.
 func (s *ClusterManager) ControlPlaneEndpoint() ([]capm3.APIEndpoint, error) {
-	//Get IP address from spec, which gets it from posted cr yaml.
+	// Get IP address from spec, which gets it from posted cr yaml.
 	endPoint := s.Metal3Cluster.Spec.ControlPlaneEndpoint
 	var err error
 
@@ -140,7 +140,7 @@ func (s *ClusterManager) UpdateClusterStatus() error {
 	if err != nil {
 		s.Metal3Cluster.Status.Ready = false
 		s.setError("Invalid ControlPlaneEndpoint values", capierrors.InvalidConfigurationClusterError)
-		conditions.MarkFalse(s.Metal3Cluster, capm3.BaremetalInfrastructureReadyCondition, capm3.ControlPlaneEndpointFailedReason, capi.ConditionSeverityError, err.Error())
+		conditions.MarkFalse(s.Metal3Cluster, capm3.BaremetalInfrastructureReadyCondition, capm3.ControlPlaneEndpointFailedReason, clusterv1.ConditionSeverityError, err.Error())
 		return err
 	}
 
@@ -193,8 +193,8 @@ func (s *ClusterManager) CountDescendants(ctx context.Context) (int, error) {
 
 // listDescendants returns a list of all Machines, for the cluster owning the
 // metal3Cluster.
-func (s *ClusterManager) listDescendants(ctx context.Context) (capi.MachineList, error) {
-	machines := capi.MachineList{}
+func (s *ClusterManager) listDescendants(ctx context.Context) (clusterv1.MachineList, error) {
+	machines := clusterv1.MachineList{}
 	cluster, err := util.GetOwnerCluster(ctx, s.client,
 		s.Metal3Cluster.ObjectMeta,
 	)
@@ -205,7 +205,7 @@ func (s *ClusterManager) listDescendants(ctx context.Context) (capi.MachineList,
 	listOptions := []client.ListOption{
 		client.InNamespace(cluster.Namespace),
 		client.MatchingLabels(map[string]string{
-			capi.ClusterLabelName: cluster.Name,
+			clusterv1.ClusterLabelName: cluster.Name,
 		}),
 	}
 

--- a/baremetal/metal3cluster_manager_test.go
+++ b/baremetal/metal3cluster_manager_test.go
@@ -25,12 +25,11 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
-	_ "github.com/go-logr/logr"
 	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/pointer"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -56,12 +55,12 @@ func bmcSpecAPIEmpty() *capm3.Metal3ClusterSpec {
 
 type testCaseBMClusterManager struct {
 	BMCluster     *capm3.Metal3Cluster
-	Cluster       *capi.Cluster
+	Cluster       *clusterv1.Cluster
 	ExpectSuccess bool
 }
 
 type descendantsTestCase struct {
-	Machines            []*capi.Machine
+	Machines            []*clusterv1.Machine
 	ExpectError         bool
 	ExpectedDescendants int
 }
@@ -88,12 +87,12 @@ var _ = Describe("Metal3Cluster manager", func() {
 				}
 			},
 			Entry("Cluster and BMCluster Defined", testCaseBMClusterManager{
-				Cluster:       &capi.Cluster{},
+				Cluster:       &clusterv1.Cluster{},
 				BMCluster:     &capm3.Metal3Cluster{},
 				ExpectSuccess: true,
 			}),
 			Entry("BMCluster undefined", testCaseBMClusterManager{
-				Cluster:       &capi.Cluster{},
+				Cluster:       &clusterv1.Cluster{},
 				BMCluster:     nil,
 				ExpectSuccess: false,
 			}),
@@ -192,7 +191,7 @@ var _ = Describe("Metal3Cluster manager", func() {
 			}
 		},
 		Entry("deleting BMCluster", testCaseBMClusterManager{
-			Cluster:       &capi.Cluster{},
+			Cluster:       &clusterv1.Cluster{},
 			BMCluster:     &capm3.Metal3Cluster{},
 			ExpectSuccess: true,
 		}),
@@ -225,7 +224,7 @@ var _ = Describe("Metal3Cluster manager", func() {
 			ExpectSuccess: false,
 		}),
 		Entry("Cluster empty, BMCluster exists", testCaseBMClusterManager{
-			Cluster: &capi.Cluster{},
+			Cluster: &clusterv1.Cluster{},
 			BMCluster: newMetal3Cluster(metal3ClusterName, bmcOwnerRef,
 				bmcSpec(), nil,
 			),
@@ -233,7 +232,7 @@ var _ = Describe("Metal3Cluster manager", func() {
 		}),
 		Entry("Cluster empty, BMCluster exists without owner",
 			testCaseBMClusterManager{
-				Cluster: &capi.Cluster{},
+				Cluster: &clusterv1.Cluster{},
 				BMCluster: newMetal3Cluster(metal3ClusterName, nil,
 					bmcSpec(), nil,
 				),
@@ -260,13 +259,6 @@ var _ = Describe("Metal3Cluster manager", func() {
 			err = clusterMgr.UpdateClusterStatus()
 			Expect(err).NotTo(HaveOccurred())
 
-			//apiEndPoints := tc.BMCluster.Status.APIEndpoints
-			//if tc.ExpectSuccess {
-			//	Expect(apiEndPoints[0].Host).To(Equal("192.168.111.249"))
-			//	Expect(apiEndPoints[0].Port).To(Equal(6443))
-			//} else {
-			//	Expect(apiEndPoints[0].Host).To(Equal(""))
-			//}
 		},
 		Entry("Cluster and BMCluster exist", testCaseBMClusterManager{
 			Cluster: newCluster(clusterName),
@@ -281,7 +273,7 @@ var _ = Describe("Metal3Cluster manager", func() {
 			ExpectSuccess: false,
 		}),
 		Entry("Cluster empty, BMCluster exists", testCaseBMClusterManager{
-			Cluster: &capi.Cluster{},
+			Cluster: &clusterv1.Cluster{},
 			BMCluster: newMetal3Cluster(metal3ClusterName, bmcOwnerRef,
 				bmcSpec(), nil,
 			),
@@ -289,7 +281,7 @@ var _ = Describe("Metal3Cluster manager", func() {
 		}),
 		Entry("Cluster empty, BMCluster exists without owner",
 			testCaseBMClusterManager{
-				Cluster: &capi.Cluster{},
+				Cluster: &clusterv1.Cluster{},
 				BMCluster: newMetal3Cluster(metal3ClusterName, nil, bmcSpec(),
 					nil,
 				),
@@ -309,17 +301,17 @@ var _ = Describe("Metal3Cluster manager", func() {
 
 	var descendantsTestCases = []TableEntry{
 		Entry("No Cluster Descendants", descendantsTestCase{
-			Machines:            []*capi.Machine{},
+			Machines:            []*clusterv1.Machine{},
 			ExpectError:         false,
 			ExpectedDescendants: 0,
 		}),
 		Entry("One Cluster Descendant", descendantsTestCase{
-			Machines: []*capi.Machine{
+			Machines: []*clusterv1.Machine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: namespaceName,
 						Labels: map[string]string{
-							capi.ClusterLabelName: clusterName,
+							clusterv1.ClusterLabelName: clusterName,
 						},
 					},
 				},

--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
@@ -127,7 +127,7 @@ func (m *DataManager) createSecrets(ctx context.Context) error {
 	}
 	// Fetch the Metal3DataTemplate object to get the templates
 	m3dt, err := fetchM3DataTemplate(ctx, &m.Data.Spec.Template, m.client,
-		m.Log, m.Data.Labels[capi.ClusterLabelName],
+		m.Log, m.Data.Labels[clusterv1.ClusterLabelName],
 	)
 	if err != nil {
 		return err
@@ -251,7 +251,7 @@ func (m *DataManager) createSecrets(ctx context.Context) error {
 			return err
 		}
 		if err := createSecret(ctx, m.client, m.Data.Spec.MetaData.Name,
-			m.Data.Namespace, m3dt.Labels[capi.ClusterLabelName],
+			m.Data.Namespace, m3dt.Labels[clusterv1.ClusterLabelName],
 			ownerRefs, map[string][]byte{"metaData": metadata},
 		); err != nil {
 			return err
@@ -266,7 +266,7 @@ func (m *DataManager) createSecrets(ctx context.Context) error {
 			return err
 		}
 		if err := createSecret(ctx, m.client, m.Data.Spec.NetworkData.Name,
-			m.Data.Namespace, m3dt.Labels[capi.ClusterLabelName],
+			m.Data.Namespace, m3dt.Labels[clusterv1.ClusterLabelName],
 			ownerRefs, map[string][]byte{"networkData": networkData},
 		); err != nil {
 			return err
@@ -288,7 +288,7 @@ func (m *DataManager) ReleaseLeases(ctx context.Context) error {
 	}
 	// Fetch the Metal3DataTemplate object to get the templates
 	m3dt, err := fetchM3DataTemplate(ctx, &m.Data.Spec.Template, m.client,
-		m.Log, m.Data.Labels[capi.ClusterLabelName],
+		m.Log, m.Data.Labels[clusterv1.ClusterLabelName],
 	)
 	if err != nil {
 		return err
@@ -1093,7 +1093,7 @@ func getLinkMacAddress(mac *capm3.NetworkLinkEthernetMac, bmh *bmo.BareMetalHost
 
 // renderMetaData renders the MetaData items.
 func renderMetaData(m3d *capm3.Metal3Data, m3dt *capm3.Metal3DataTemplate,
-	m3m *capm3.Metal3Machine, machine *capi.Machine, bmh *bmo.BareMetalHost,
+	m3m *capm3.Metal3Machine, machine *clusterv1.Machine, bmh *bmo.BareMetalHost,
 	poolAddresses map[string]addressFromPool,
 ) ([]byte, error) {
 	if m3dt.Spec.MetaData == nil {
@@ -1210,7 +1210,7 @@ func getBMHMacByName(name string, bmh *bmo.BareMetalHost) (string, error) {
 			return nics.MAC, nil
 		}
 	}
-	return "", errors.New(fmt.Sprintf("Nic name not found %v", name))
+	return "", fmt.Errorf("nic name not found %v", name)
 }
 
 func (m *DataManager) getM3Machine(ctx context.Context, m3dt *capm3.Metal3DataTemplate) (*capm3.Metal3Machine, error) {

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -34,7 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -168,7 +168,7 @@ var _ = Describe("Metal3Data manager", func() {
 		m3dt                *capm3.Metal3DataTemplate
 		m3m                 *capm3.Metal3Machine
 		dataClaim           *capm3.Metal3DataClaim
-		machine             *capi.Machine
+		machine             *clusterv1.Machine
 		bmh                 *bmo.BareMetalHost
 		metadataSecret      *corev1.Secret
 		networkdataSecret   *corev1.Secret
@@ -451,7 +451,7 @@ var _ = Describe("Metal3Data manager", func() {
 						{
 							Name:       "abc",
 							Kind:       "Machine",
-							APIVersion: capi.GroupVersion.String(),
+							APIVersion: clusterv1.GroupVersion.String(),
 						},
 					},
 					Annotations: map[string]string{
@@ -466,7 +466,7 @@ var _ = Describe("Metal3Data manager", func() {
 				ObjectMeta: testObjectMetaWithOR,
 				Spec:       capm3.Metal3DataClaimSpec{},
 			},
-			machine: &capi.Machine{
+			machine: &clusterv1.Machine{
 				ObjectMeta: testObjectMeta,
 			},
 			bmh: &bmo.BareMetalHost{
@@ -566,7 +566,7 @@ var _ = Describe("Metal3Data manager", func() {
 						{
 							Name:       "abc",
 							Kind:       "Machine",
-							APIVersion: capi.GroupVersion.String(),
+							APIVersion: clusterv1.GroupVersion.String(),
 						},
 					},
 				},
@@ -574,7 +574,7 @@ var _ = Describe("Metal3Data manager", func() {
 					DataTemplate: testObjectReference,
 				},
 			},
-			machine: &capi.Machine{
+			machine: &clusterv1.Machine{
 				ObjectMeta: testObjectMeta,
 			},
 			dataClaim: &capm3.Metal3DataClaim{
@@ -2400,7 +2400,7 @@ var _ = Describe("Metal3Data manager", func() {
 		m3d              *capm3.Metal3Data
 		m3dt             *capm3.Metal3DataTemplate
 		m3m              *capm3.Metal3Machine
-		machine          *capi.Machine
+		machine          *clusterv1.Machine
 		bmh              *bmo.BareMetalHost
 		poolAddresses    map[string]addressFromPool
 		expectedMetaData map[string]string
@@ -2602,7 +2602,7 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 				},
 			},
-			machine: &capi.Machine{
+			machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "machine-abc",
 					Labels: map[string]string{

--- a/baremetal/metal3datatemplate_manager.go
+++ b/baremetal/metal3datatemplate_manager.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -39,7 +39,7 @@ import (
 type DataTemplateManagerInterface interface {
 	SetFinalizer()
 	UnsetFinalizer()
-	SetClusterOwnerRef(*capi.Cluster) error
+	SetClusterOwnerRef(*clusterv1.Cluster) error
 	UpdateDatas(context.Context) (int, error)
 }
 
@@ -79,7 +79,7 @@ func (m *DataTemplateManager) UnsetFinalizer() {
 }
 
 // SetClusterOwnerRef sets ownerRef.
-func (m *DataTemplateManager) SetClusterOwnerRef(cluster *capi.Cluster) error {
+func (m *DataTemplateManager) SetClusterOwnerRef(cluster *clusterv1.Cluster) error {
 	// Verify that the owner reference is there, if not add it and update object,
 	// if error requeue.
 	if cluster == nil {
@@ -106,7 +106,7 @@ func (m *DataTemplateManager) SetClusterOwnerRef(cluster *capi.Cluster) error {
 func (m *DataTemplateManager) getIndexes(ctx context.Context) (map[int]string, error) {
 	m.Log.Info("Fetching Metal3Data objects")
 
-	//start from empty maps
+	// start from empty maps
 	m.DataTemplate.Status.Indexes = make(map[string]int)
 
 	indexes := make(map[int]string)

--- a/baremetal/metal3datatemplate_manager_test.go
+++ b/baremetal/metal3datatemplate_manager_test.go
@@ -29,7 +29,7 @@ import (
 	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -65,7 +65,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 	)
 
 	type testCaseSetClusterOwnerRef struct {
-		cluster     *capi.Cluster
+		cluster     *clusterv1.Cluster
 		template    *capm3.Metal3DataTemplate
 		expectError bool
 	}
@@ -95,7 +95,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 					Name: "abc",
 				},
 			},
-			cluster: &capi.Cluster{
+			cluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "abc-cluster",
 				},
@@ -112,7 +112,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 					},
 				},
 			},
-			cluster: &capi.Cluster{
+			cluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "abc-cluster",
 				},
@@ -132,7 +132,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 					},
 				},
 			},
-			cluster: &capi.Cluster{
+			cluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "abc-cluster",
 				},

--- a/baremetal/metal3machinetemplate_manager.go
+++ b/baremetal/metal3machinetemplate_manager.go
@@ -20,13 +20,13 @@ import (
 	"github.com/go-logr/logr"
 	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/pkg/errors"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	clonedFromName      = capi.TemplateClonedFromNameAnnotation
-	clonedFromGroupKind = capi.TemplateClonedFromGroupKindAnnotation
+	clonedFromName      = clusterv1.TemplateClonedFromNameAnnotation
+	clonedFromGroupKind = clusterv1.TemplateClonedFromGroupKindAnnotation
 )
 
 // TemplateManagerInterface is an interface for a TemplateManager.

--- a/baremetal/metal3remediation_manager.go
+++ b/baremetal/metal3remediation_manager.go
@@ -30,7 +30,7 @@ import (
 	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -60,7 +60,7 @@ type RemediationManagerInterface interface {
 	GetTimeout() *metav1.Duration
 	IncreaseRetryCount()
 	SetOwnerRemediatedConditionNew(ctx context.Context) error
-	GetCapiMachine(ctx context.Context) (*capi.Machine, error)
+	GetCapiMachine(ctx context.Context) (*clusterv1.Machine, error)
 }
 
 // RemediationManager is responsible for performing remediation reconciliation.
@@ -68,13 +68,13 @@ type RemediationManager struct {
 	Client            client.Client
 	Metal3Remediation *capm3.Metal3Remediation
 	Metal3Machine     *capm3.Metal3Machine
-	Machine           *capi.Machine
+	Machine           *clusterv1.Machine
 	Log               logr.Logger
 }
 
 // NewRemediationManager returns a new helper for managing a Metal3Remediation object.
 func NewRemediationManager(client client.Client,
-	metal3remediation *capm3.Metal3Remediation, metal3Machine *capm3.Metal3Machine, machine *capi.Machine,
+	metal3remediation *capm3.Metal3Remediation, metal3Machine *capm3.Metal3Machine, machine *clusterv1.Machine,
 	remediationLog logr.Logger) (*RemediationManager, error) {
 	return &RemediationManager{
 		Client:            client,
@@ -271,7 +271,7 @@ func (r *RemediationManager) SetOwnerRemediatedConditionNew(ctx context.Context)
 		r.Log.Info("Unable to create patch helper for Machine")
 		return err
 	}
-	conditions.MarkFalse(capiMachine, capi.MachineOwnerRemediatedCondition, capi.WaitingForRemediationReason, capi.ConditionSeverityWarning, "")
+	conditions.MarkFalse(capiMachine, clusterv1.MachineOwnerRemediatedCondition, clusterv1.WaitingForRemediationReason, clusterv1.ConditionSeverityWarning, "")
 	err = machineHelper.Patch(ctx, capiMachine)
 	if err != nil {
 		r.Log.Info("Unable to patch Machine %d", capiMachine)
@@ -281,7 +281,7 @@ func (r *RemediationManager) SetOwnerRemediatedConditionNew(ctx context.Context)
 }
 
 // GetCapiMachine returns CAPI machine object owning the current resource.
-func (r *RemediationManager) GetCapiMachine(ctx context.Context) (*capi.Machine, error) {
+func (r *RemediationManager) GetCapiMachine(ctx context.Context) (*clusterv1.Machine, error) {
 	capiMachine, err := util.GetOwnerMachine(ctx, r.Client, r.Metal3Remediation.ObjectMeta)
 	if err != nil {
 		r.Log.Error(err, "metal3Remediation's owner Machine could not be retrieved")

--- a/baremetal/metal3remediation_manager_test.go
+++ b/baremetal/metal3remediation_manager_test.go
@@ -22,12 +22,11 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
-	_ "github.com/go-logr/logr"
 	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -35,7 +34,7 @@ import (
 type testCaseRemediationManager struct {
 	Metal3Remediation *capm3.Metal3Remediation
 	Metal3Machine     *capm3.Metal3Machine
-	Machine           *capi.Machine
+	Machine           *clusterv1.Machine
 	ExpectSuccess     bool
 }
 
@@ -66,7 +65,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 			Entry("All fields defined", testCaseRemediationManager{
 				Metal3Remediation: &capm3.Metal3Remediation{},
 				Metal3Machine:     &capm3.Metal3Machine{},
-				Machine:           &capi.Machine{},
+				Machine:           &clusterv1.Machine{},
 				ExpectSuccess:     true,
 			}),
 			Entry("None of the fields defined", testCaseRemediationManager{
@@ -299,7 +298,6 @@ var _ = Describe("Metal3Remediation manager", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			result, helper, err := remediationMgr.GetUnhealthyHost(context.TODO())
-			//Expect(err).NotTo(HaveOccurred())
 			if tc.ExpectPresent {
 				Expect(result).NotTo(BeNil())
 				Expect(helper).NotTo(BeNil())

--- a/baremetal/remote/remote.go
+++ b/baremetal/remote/remote.go
@@ -20,13 +20,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	kcfg "sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewClusterClient creates a new ClusterClient.
-func NewClusterClient(ctx context.Context, c client.Client, cluster *capi.Cluster) (corev1.CoreV1Interface, error) {
+func NewClusterClient(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) (corev1.CoreV1Interface, error) {
 	kubeconfig, err := kcfg.FromSecret(ctx, c, types.NamespacedName{
 		Name:      cluster.Name,
 		Namespace: cluster.Namespace,

--- a/baremetal/remote/remote_test.go
+++ b/baremetal/remote/remote_test.go
@@ -21,7 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/secret"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -30,27 +30,27 @@ var _ = Describe("Metal3 baremetal remote", func() {
 	Describe("NewClusterClient", func() {
 
 		var (
-			clusterWithValidKubeConfig   *capi.Cluster
-			clusterWithInvalidKubeConfig *capi.Cluster
-			clusterWithNoKubeConfig      *capi.Cluster
+			clusterWithValidKubeConfig   *clusterv1.Cluster
+			clusterWithInvalidKubeConfig *clusterv1.Cluster
+			clusterWithNoKubeConfig      *clusterv1.Cluster
 			validKubeConfig              string
 			validSecret                  *corev1.Secret
 			invalidSecret                *corev1.Secret
 		)
 		BeforeEach(func() {
-			clusterWithValidKubeConfig = &capi.Cluster{
+			clusterWithValidKubeConfig = &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test1",
 					Namespace: "test",
 				},
 			}
-			clusterWithInvalidKubeConfig = &capi.Cluster{
+			clusterWithInvalidKubeConfig = &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test2-invalid",
 					Namespace: "test",
 				},
 			}
-			clusterWithNoKubeConfig = &capi.Cluster{
+			clusterWithNoKubeConfig = &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test3",
 					Namespace: "test",

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -29,14 +29,13 @@ import (
 	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -107,7 +106,7 @@ var _ = AfterSuite(func() {
 })
 
 var bmcOwnerRef = &metav1.OwnerReference{
-	APIVersion: capi.GroupVersion.String(),
+	APIVersion: clusterv1.GroupVersion.String(),
 	Kind:       "Cluster",
 	Name:       clusterName,
 }
@@ -118,7 +117,7 @@ var bmcOwnerRef = &metav1.OwnerReference{
 
 func setupScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
-	if err := capi.AddToScheme(s); err != nil {
+	if err := clusterv1.AddToScheme(s); err != nil {
 		panic(err)
 	}
 	if err := capm3.AddToScheme(s); err != nil {
@@ -136,8 +135,8 @@ func setupScheme() *runtime.Scheme {
 	return s
 }
 
-func newCluster(clusterName string) *capi.Cluster {
-	return &capi.Cluster{
+func newCluster(clusterName string) *clusterv1.Cluster {
+	return &clusterv1.Cluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "Cluster",
 		},
@@ -145,15 +144,15 @@ func newCluster(clusterName string) *capi.Cluster {
 			Name:      clusterName,
 			Namespace: namespaceName,
 		},
-		Spec: capi.ClusterSpec{
-			InfrastructureRef: &v1.ObjectReference{
+		Spec: clusterv1.ClusterSpec{
+			InfrastructureRef: &corev1.ObjectReference{
 				Name:       metal3ClusterName,
 				Namespace:  namespaceName,
 				Kind:       "InfrastructureConfig",
 				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
 			},
 		},
-		Status: capi.ClusterStatus{
+		Status: clusterv1.ClusterStatus{
 			InfrastructureReady: true,
 		},
 	}

--- a/baremetal/utils.go
+++ b/baremetal/utils.go
@@ -30,7 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -130,7 +130,7 @@ func createSecret(ctx context.Context, cl client.Client, name string,
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				capi.ClusterLabelName: clusterName,
+				clusterv1.ClusterLabelName: clusterName,
 			},
 			OwnerReferences: ownerRefs,
 		},
@@ -171,7 +171,7 @@ func deleteSecret(ctx context.Context, cl client.Client, name string,
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	} else if err == nil {
-		//unset the finalizers (remove all since we do not expect anything else
+		// unset the finalizers (remove all since we do not expect anything else
 		// to control that object).
 		tmpBootstrapSecret.Finalizers = []string{}
 		err = updateObject(ctx, cl, &tmpBootstrapSecret)

--- a/baremetal/utils_test.go
+++ b/baremetal/utils_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/patch"
 )
 
@@ -410,7 +410,7 @@ var _ = Describe("Metal3 manager utils", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(savedSecret.ObjectMeta.Labels).To(Equal(map[string]string{
-				capi.ClusterLabelName: "ghi",
+				clusterv1.ClusterLabelName: "ghi",
 			}))
 			Expect(savedSecret.ObjectMeta.OwnerReferences).To(Equal(ownerRef))
 			Expect(savedSecret.Data).To(Equal(content))

--- a/controllers/metal3cluster_controller_integration_test.go
+++ b/controllers/metal3cluster_controller_integration_test.go
@@ -168,9 +168,9 @@ var _ = Describe("Reconcile metal3Cluster", func() {
 			},
 		),
 
-		//Given: Cluster, Metal3Cluster.
-		//Cluster.Spec.Paused=true
-		//Expected: Requeue Expected
+		// Given: Cluster, Metal3Cluster.
+		// Cluster.Spec.Paused=true
+		// Expected: Requeue Expected
 		Entry("Should requeue when owner Cluster is paused",
 			TestCaseReconcileBMC{
 				Objects: []client.Object{
@@ -183,7 +183,7 @@ var _ = Describe("Reconcile metal3Cluster", func() {
 		),
 
 		//Given: Cluster, Metal3Cluster.
-		//Metal3Cluster has cluster.x-k8s.io/paused annotation
+		// Metal3Cluster has cluster.x-k8s.io/paused annotation
 		//Expected: Requeue Expected
 		Entry("Should requeue when Metal3Cluster has paused annotation",
 			TestCaseReconcileBMC{

--- a/controllers/metal3data_controller.go
+++ b/controllers/metal3data_controller.go
@@ -28,7 +28,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -89,7 +89,7 @@ func (r *Metal3DataReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, nil
 		}
 		if cluster == nil {
-			metadataLog.Info(fmt.Sprintf("This metadata is not yet associated with a cluster using the label %s: <name of cluster>", capi.ClusterLabelName))
+			metadataLog.Info(fmt.Sprintf("This metadata is not yet associated with a cluster using the label %s: <name of cluster>", clusterv1.ClusterLabelName))
 			return ctrl.Result{}, nil
 		}
 	}

--- a/controllers/metal3data_controller_test.go
+++ b/controllers/metal3data_controller_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -49,7 +49,7 @@ var (
 		Name:      "abc",
 		Namespace: "myns",
 		Labels: map[string]string{
-			capi.ClusterLabelName: "abc",
+			clusterv1.ClusterLabelName: "abc",
 		},
 	}
 )
@@ -63,7 +63,7 @@ var _ = Describe("Metal3Data manager", func() {
 			expectRequeue        bool
 			expectManager        bool
 			m3d                  *capm3.Metal3Data
-			cluster              *capi.Cluster
+			cluster              *clusterv1.Cluster
 			managerError         bool
 			reconcileNormal      bool
 			reconcileNormalError bool
@@ -159,7 +159,7 @@ var _ = Describe("Metal3Data manager", func() {
 						Name:      "abc",
 						Namespace: "myns",
 						Labels: map[string]string{
-							capi.ClusterLabelName: "abc",
+							clusterv1.ClusterLabelName: "abc",
 						},
 						DeletionTimestamp: &timestampNow,
 					},
@@ -172,7 +172,7 @@ var _ = Describe("Metal3Data manager", func() {
 						Name:      "abc",
 						Namespace: "myns",
 						Labels: map[string]string{
-							capi.ClusterLabelName: "abc",
+							clusterv1.ClusterLabelName: "abc",
 						},
 						DeletionTimestamp: &timestampNow,
 					},
@@ -187,7 +187,7 @@ var _ = Describe("Metal3Data manager", func() {
 						Name:      "abc",
 						Namespace: "myns",
 						Labels: map[string]string{
-							capi.ClusterLabelName: "abc",
+							clusterv1.ClusterLabelName: "abc",
 						},
 						DeletionTimestamp: &timestampNow,
 					},
@@ -200,9 +200,9 @@ var _ = Describe("Metal3Data manager", func() {
 				m3d: &capm3.Metal3Data{
 					ObjectMeta: testObjectMetaWithLabel,
 				},
-				cluster: &capi.Cluster{
+				cluster: &clusterv1.Cluster{
 					ObjectMeta: testObjectMeta,
-					Spec: capi.ClusterSpec{
+					Spec: clusterv1.ClusterSpec{
 						Paused: true,
 					},
 				},
@@ -212,7 +212,7 @@ var _ = Describe("Metal3Data manager", func() {
 				m3d: &capm3.Metal3Data{
 					ObjectMeta: testObjectMetaWithLabel,
 				},
-				cluster: &capi.Cluster{
+				cluster: &clusterv1.Cluster{
 					ObjectMeta: testObjectMeta,
 				},
 				managerError: true,
@@ -221,7 +221,7 @@ var _ = Describe("Metal3Data manager", func() {
 				m3d: &capm3.Metal3Data{
 					ObjectMeta: testObjectMetaWithLabel,
 				},
-				cluster: &capi.Cluster{
+				cluster: &clusterv1.Cluster{
 					ObjectMeta: testObjectMeta,
 				},
 				reconcileNormal:      true,
@@ -232,7 +232,7 @@ var _ = Describe("Metal3Data manager", func() {
 				m3d: &capm3.Metal3Data{
 					ObjectMeta: testObjectMetaWithLabel,
 				},
-				cluster: &capi.Cluster{
+				cluster: &clusterv1.Cluster{
 					ObjectMeta: testObjectMeta,
 				},
 				reconcileNormal: true,

--- a/controllers/metal3datatemplate_controller.go
+++ b/controllers/metal3datatemplate_controller.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/predicates"
@@ -87,7 +87,7 @@ func (r *Metal3DataTemplateReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}()
 
-	cluster := &capi.Cluster{}
+	cluster := &clusterv1.Cluster{}
 	key := client.ObjectKey{
 		Name:      capm3DataTemplate.Spec.ClusterName,
 		Namespace: capm3DataTemplate.Namespace,

--- a/controllers/metal3datatemplate_controller_test.go
+++ b/controllers/metal3datatemplate_controller_test.go
@@ -33,7 +33,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -47,7 +47,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		expectRequeue        bool
 		expectManager        bool
 		m3dt                 *capm3.Metal3DataTemplate
-		cluster              *capi.Cluster
+		cluster              *clusterv1.Cluster
 		managerError         bool
 		reconcileNormal      bool
 		reconcileNormalError bool
@@ -165,9 +165,9 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				ObjectMeta: testObjectMeta,
 				Spec:       capm3.Metal3DataTemplateSpec{ClusterName: "abc"},
 			},
-			cluster: &capi.Cluster{
+			cluster: &clusterv1.Cluster{
 				ObjectMeta: testObjectMeta,
-				Spec: capi.ClusterSpec{
+				Spec: clusterv1.ClusterSpec{
 					Paused: true,
 				},
 			},
@@ -179,7 +179,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				ObjectMeta: testObjectMeta,
 				Spec:       capm3.Metal3DataTemplateSpec{ClusterName: "abc"},
 			},
-			cluster: &capi.Cluster{
+			cluster: &clusterv1.Cluster{
 				ObjectMeta: testObjectMeta,
 			},
 			managerError: true,
@@ -189,7 +189,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				ObjectMeta: testObjectMeta,
 				Spec:       capm3.Metal3DataTemplateSpec{ClusterName: "abc"},
 			},
-			cluster: &capi.Cluster{
+			cluster: &clusterv1.Cluster{
 				ObjectMeta: testObjectMeta,
 			},
 			reconcileNormal:      true,
@@ -201,7 +201,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				ObjectMeta: testObjectMeta,
 				Spec:       capm3.Metal3DataTemplateSpec{ClusterName: "abc"},
 			},
-			cluster: &capi.Cluster{
+			cluster: &clusterv1.Cluster{
 				ObjectMeta: testObjectMeta,
 			},
 			reconcileNormal: true,

--- a/controllers/metal3labelsync_controller_test.go
+++ b/controllers/metal3labelsync_controller_test.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clientfake "k8s.io/client-go/kubernetes/fake"
 	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -296,9 +296,9 @@ var _ = Describe("Metal3LabelSync controller", func() {
 		}),
 	)
 	type TestCaseMetal3ClusterToBMHs struct {
-		Cluster        *capi.Cluster
+		Cluster        *clusterv1.Cluster
 		M3Cluster      *capm3.Metal3Cluster
-		Machine        *capi.Machine
+		Machine        *clusterv1.Machine
 		M3Machine      *capm3.Metal3Machine
 		ExpectRequests []ctrl.Request
 	}
@@ -365,7 +365,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 			"metal3.io/incorrect-metal3-label-sync-prefixes": "incorrect",
 		}
 		nodeName := "testNode"
-		cluserCapiSpec := capi.ClusterSpec{
+		cluserCapiSpec := clusterv1.ClusterSpec{
 			Paused: true,
 			InfrastructureRef: &corev1.ObjectReference{
 				Name:       metal3ClusterName,
@@ -376,9 +376,9 @@ var _ = Describe("Metal3LabelSync controller", func() {
 		}
 		type testCaseReconcile struct {
 			host            *bmh.BareMetalHost
-			machine         *capi.Machine
+			machine         *clusterv1.Machine
 			metal3Machine   *capm3.Metal3Machine
-			cluster         *capi.Cluster
+			cluster         *clusterv1.Cluster
 			metal3Cluster   *capm3.Metal3Cluster
 			expectError     bool
 			expectRequeue   bool
@@ -414,7 +414,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 					Client:         fakeClient,
 					ManagerFactory: baremetal.NewManagerFactory(fakeClient),
 					Log:            logr.Discard(),
-					CapiClientGetter: func(ctx context.Context, client client.Client, cluster *capi.Cluster) (
+					CapiClientGetter: func(ctx context.Context, client client.Client, cluster *clusterv1.Cluster) (
 						clientcorev1.CoreV1Interface, error,
 					) {
 						return corev1Client, nil
@@ -525,8 +525,8 @@ var _ = Describe("Metal3LabelSync controller", func() {
 		type TestCaseReconcileBMHLabels struct {
 			PrefixSet   map[string]struct{}
 			Host        *bmh.BareMetalHost
-			Machine     *capi.Machine
-			Cluster     *capi.Cluster
+			Machine     *clusterv1.Machine
+			Cluster     *clusterv1.Cluster
 			ExpectError bool
 		}
 
@@ -545,7 +545,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 					Client:         fakeClient,
 					ManagerFactory: baremetal.NewManagerFactory(fakeClient),
 					Log:            logr.Discard(),
-					CapiClientGetter: func(ctx context.Context, client client.Client, cluster *capi.Cluster) (
+					CapiClientGetter: func(ctx context.Context, client client.Client, cluster *clusterv1.Cluster) (
 						clientcorev1.CoreV1Interface, error,
 					) {
 						return corev1Client, nil
@@ -579,7 +579,7 @@ func m3mObjectMeta() *metav1.ObjectMeta {
 		Namespace:       namespaceName,
 		OwnerReferences: m3mOwnerRefs(),
 		Labels: map[string]string{
-			capi.ClusterLabelName: clusterName,
+			clusterv1.ClusterLabelName: clusterName,
 		},
 		Annotations: map[string]string{
 			baremetal.HostAnnotation: "myns/myhost",

--- a/controllers/metal3machinetemplate_controller.go
+++ b/controllers/metal3machinetemplate_controller.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/predicates"
@@ -34,8 +34,8 @@ import (
 
 const (
 	templateControllerName = "Metal3MachineTemplate-controller"
-	clonedFromGroupKind    = capi.TemplateClonedFromGroupKindAnnotation
-	clonedFromName         = capi.TemplateClonedFromNameAnnotation
+	clonedFromGroupKind    = clusterv1.TemplateClonedFromGroupKindAnnotation
+	clonedFromName         = clusterv1.TemplateClonedFromNameAnnotation
 )
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=metal3machinetemplates,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/metal3machinetemplate_controller_test.go
+++ b/controllers/metal3machinetemplate_controller_test.go
@@ -32,7 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utils "k8s.io/utils/pointer"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -241,7 +241,7 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 						metal3machineTemplateName,
 						namespaceName,
 						map[string]string{
-							capi.PausedAnnotation: "true",
+							clusterv1.PausedAnnotation: "true",
 						}),
 				},
 				m3mTemplateIsPaused: true,

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -66,7 +66,7 @@ func init() {
 
 	// Register required object kinds with global scheme.
 	_ = apiextensionsv1.AddToScheme(scheme.Scheme)
-	_ = capi.AddToScheme(scheme.Scheme)
+	_ = clusterv1.AddToScheme(scheme.Scheme)
 	_ = capm3.AddToScheme(scheme.Scheme)
 	_ = ipamv1.AddToScheme(scheme.Scheme)
 	_ = corev1.AddToScheme(scheme.Scheme)
@@ -75,7 +75,7 @@ func init() {
 
 func setupScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
-	if err := capi.AddToScheme(s); err != nil {
+	if err := clusterv1.AddToScheme(s); err != nil {
 		panic(err)
 	}
 	if err := capm3.AddToScheme(s); err != nil {
@@ -139,8 +139,8 @@ var _ = AfterSuite(func() {
 
 var deletionTimestamp = metav1.Now()
 
-func clusterPauseSpec() *capi.ClusterSpec {
-	return &capi.ClusterSpec{
+func clusterPauseSpec() *clusterv1.ClusterSpec {
+	return &clusterv1.ClusterSpec{
 		Paused: true,
 		InfrastructureRef: &corev1.ObjectReference{
 			Name:       metal3ClusterName,
@@ -157,7 +157,7 @@ func m3mObjectMetaWithOwnerRef() *metav1.ObjectMeta {
 		Namespace:       namespaceName,
 		OwnerReferences: m3mOwnerRefs(),
 		Labels: map[string]string{
-			capi.ClusterLabelName: clusterName,
+			clusterv1.ClusterLabelName: clusterName,
 		},
 	}
 }
@@ -174,7 +174,7 @@ func bmcSpec() *capm3.Metal3ClusterSpec {
 
 func bmcOwnerRef() *metav1.OwnerReference {
 	return &metav1.OwnerReference{
-		APIVersion: capi.GroupVersion.String(),
+		APIVersion: clusterv1.GroupVersion.String(),
 		Kind:       "Cluster",
 		Name:       clusterName,
 	}
@@ -196,9 +196,9 @@ func getKey(objectName string) *client.ObjectKey {
 	}
 }
 
-func newCluster(clusterName string, spec *capi.ClusterSpec, status *capi.ClusterStatus) *capi.Cluster {
+func newCluster(clusterName string, spec *clusterv1.ClusterSpec, status *clusterv1.ClusterStatus) *clusterv1.Cluster {
 	if spec == nil {
-		spec = &capi.ClusterSpec{
+		spec = &clusterv1.ClusterSpec{
 			InfrastructureRef: &corev1.ObjectReference{
 				Name:       metal3ClusterName,
 				Namespace:  namespaceName,
@@ -208,14 +208,14 @@ func newCluster(clusterName string, spec *capi.ClusterSpec, status *capi.Cluster
 		}
 	}
 	if status == nil {
-		status = &capi.ClusterStatus{
+		status = &clusterv1.ClusterStatus{
 			InfrastructureReady: true,
 		}
 	}
-	return &capi.Cluster{
+	return &clusterv1.Cluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Cluster",
-			APIVersion: capi.GroupVersion.String(),
+			APIVersion: clusterv1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterName,
@@ -248,13 +248,13 @@ func newMetal3Cluster(baremetalName string, ownerRef *metav1.OwnerReference, spe
 			Namespace: namespaceName,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: capi.GroupVersion.String(),
+					APIVersion: clusterv1.GroupVersion.String(),
 					Kind:       "Cluster",
 					Name:       clusterName,
 				},
 			},
 			Annotations: map[string]string{
-				capi.PausedAnnotation: "true",
+				clusterv1.PausedAnnotation: "true",
 			},
 		}
 	}
@@ -273,17 +273,17 @@ func newMetal3Cluster(baremetalName string, ownerRef *metav1.OwnerReference, spe
 	}
 }
 
-func newMachine(clusterName, machineName string, metal3machineName string, nodeRefName string) *capi.Machine {
-	machine := &capi.Machine{
+func newMachine(clusterName, machineName string, metal3machineName string, nodeRefName string) *clusterv1.Machine {
+	machine := &clusterv1.Machine{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Machine",
-			APIVersion: capi.GroupVersion.String(),
+			APIVersion: clusterv1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      machineName,
 			Namespace: namespaceName,
 			Labels: map[string]string{
-				capi.ClusterLabelName: clusterName,
+				clusterv1.ClusterLabelName: clusterName,
 			},
 		},
 	}
@@ -338,13 +338,13 @@ func newMetal3Machine(name string, meta *metav1.ObjectMeta,
 			Namespace: namespaceName,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: capi.GroupVersion.String(),
+					APIVersion: clusterv1.GroupVersion.String(),
 					Kind:       "Machine",
 					Name:       machineName,
 				},
 			},
 			Annotations: map[string]string{
-				capi.PausedAnnotation: "true",
+				clusterv1.PausedAnnotation: "true",
 			},
 		}
 	}
@@ -369,7 +369,7 @@ func newMetal3Machine(name string, meta *metav1.ObjectMeta,
 }
 
 func newBareMetalHost(spec *bmh.BareMetalHostSpec,
-	status *bmh.BareMetalHostStatus, Labels map[string]string, paused bool,
+	status *bmh.BareMetalHostStatus, labels map[string]string, paused bool,
 ) *bmh.BareMetalHost {
 	if spec == nil {
 		spec = &bmh.BareMetalHostSpec{}
@@ -394,8 +394,8 @@ func newBareMetalHost(spec *bmh.BareMetalHostSpec,
 		Spec:   *spec,
 		Status: *status,
 	}
-	if Labels != nil {
-		bmh.ObjectMeta.Labels = Labels
+	if labels != nil {
+		bmh.ObjectMeta.Labels = labels
 	}
 	if paused {
 		bmh.ObjectMeta.Annotations = map[string]string{

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	// +kubebuilder:scaffold:imports
 )
@@ -68,7 +68,7 @@ func init() {
 	_ = ipamv1.AddToScheme(myscheme)
 	_ = infrav1beta1.AddToScheme(myscheme)
 	_ = infrav1alpha5.AddToScheme(myscheme)
-	_ = capi.AddToScheme(myscheme)
+	_ = clusterv1.AddToScheme(myscheme)
 	_ = bmoapis.AddToScheme(myscheme)
 	// +kubebuilder:scaffold:scheme
 }
@@ -174,7 +174,7 @@ func initFlags(fs *pflag.FlagSet) {
 		&watchFilterValue,
 		"watch-filter",
 		"",
-		fmt.Sprintf("Label value that the controller watches to reconcile cluster-api objects. Label key is always %s. If unspecified, the controller watches for all cluster-api objects.", capi.WatchLabel),
+		fmt.Sprintf("Label value that the controller watches to reconcile cluster-api objects. Label key is always %s. If unspecified, the controller watches for all cluster-api objects.", clusterv1.WatchLabel),
 	)
 
 	flag.DurationVar(

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -15,8 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
-	kcp "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,7 +36,7 @@ func LogFromFile(logFile string) {
 	Logf(string(data))
 }
 
-func dumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterProxy framework.ClusterProxy, artifactFolder string, namespace string, cluster *capi.Cluster, intervalsGetter func(spec, key string) []interface{}, clusterName, clusterctlLogFolder string, skipCleanup bool) {
+func dumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterProxy framework.ClusterProxy, artifactFolder string, namespace string, cluster *clusterv1.Cluster, intervalsGetter func(spec, key string) []interface{}, clusterName, clusterctlLogFolder string, skipCleanup bool) {
 	Expect(os.RemoveAll(clusterctlLogFolder)).Should(Succeed())
 	client := clusterProxy.GetClient()
 
@@ -70,7 +70,7 @@ func dumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterPr
 // downloadFile will download a url and store it in local filepath.
 func downloadFile(filepath string, url string) error {
 	// Get the data
-	resp, err := http.Get(url)
+	resp, err := http.Get(url) //nolint:noctx // NB: as we're just implementing an external interface we won't be able to get a context here.
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func filterBmhsByProvisioningState(bmhs []bmo.BareMetalHost, state bmo.Provision
 }
 
 // filterMachinesByPhase returns a filtered list of CAPI machine objects in certain desired phase.
-func filterMachinesByPhase(machines []capi.Machine, phase string) (result []capi.Machine) {
+func filterMachinesByPhase(machines []clusterv1.Machine, phase string) (result []clusterv1.Machine) {
 	for _, machine := range machines {
 		if machine.Status.Phase == phase {
 			result = append(result, machine)
@@ -154,7 +154,7 @@ func scaleMachineDeployment(ctx context.Context, clusterClient client.Client, cl
 
 // scaleKubeadmControlPlane scales up/down KubeadmControlPlane object to desired replicas.
 func scaleKubeadmControlPlane(ctx context.Context, c client.Client, name client.ObjectKey, newReplicaCount int) {
-	ctrlplane := kcp.KubeadmControlPlane{}
+	ctrlplane := controlplanev1.KubeadmControlPlane{}
 	Expect(c.Get(ctx, name, &ctrlplane)).To(Succeed())
 	helper, err := patch.NewHelper(&ctrlplane, c)
 	Expect(err).To(BeNil(), "Failed to create new patch helper")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
@@ -20,7 +20,7 @@ var (
 	ctx                      = context.TODO()
 	specName                 = "metal3"
 	namespace                = "metal3"
-	cluster                  *capi.Cluster
+	cluster                  *clusterv1.Cluster
 	clusterName              = "test1"
 	clusterctlLogFolder      string
 	controlplaneListOptions  metav1.ListOptions

--- a/test/e2e/inspection_test.go
+++ b/test/e2e/inspection_test.go
@@ -17,8 +17,8 @@ func inspection() {
 	Logf("Starting inspection tests")
 
 	var (
-		numberOfWorkers       int = int(*e2eConfig.GetInt32PtrVariable("WORKER_MACHINE_COUNT"))
-		numberOfAvailableBMHs int = 2 * numberOfWorkers
+		numberOfWorkers       = int(*e2eConfig.GetInt32PtrVariable("WORKER_MACHINE_COUNT"))
+		numberOfAvailableBMHs = 2 * numberOfWorkers
 	)
 
 	bootstrapClient := bootstrapClusterProxy.GetClient()

--- a/test/e2e/pivoting_test.go
+++ b/test/e2e/pivoting_test.go
@@ -17,7 +17,7 @@ import (
 	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	dockerTypes "github.com/docker/docker/api/types"
 	docker "github.com/docker/docker/client"
@@ -148,7 +148,7 @@ func pivoting() {
 
 	By("Check if machines become running.")
 	Eventually(func() error {
-		machines := &capi.MachineList{}
+		machines := &clusterv1.MachineList{}
 		if err := targetCluster.GetClient().List(ctx, machines, client.InNamespace(namespace)); err != nil {
 			return err
 		}
@@ -375,7 +375,7 @@ func rePivoting() {
 
 	By("Check if machines become running.")
 	Eventually(func() error {
-		machines := &capi.MachineList{}
+		machines := &clusterv1.MachineList{}
 		if err := bootstrapClusterProxy.GetClient().List(ctx, machines, client.InNamespace(namespace)); err != nil {
 			return err
 		}

--- a/test/e2e/upgrade_baremetal_operator_test.go
+++ b/test/e2e/upgrade_baremetal_operator_test.go
@@ -30,8 +30,7 @@ func upgradeBMO() {
 	deploy, err := clientSet.AppsV1().Deployments(bmoNamespace).Get(ctx, bmoDeployName, metav1.GetOptions{})
 	Expect(err).To(BeNil())
 	for i, container := range deploy.Spec.Template.Spec.Containers {
-		switch container.Name {
-		case "manager":
+		if container.Name == "manager" {
 			Logf("Old image: %v", deploy.Spec.Template.Spec.Containers[i].Image)
 			Logf("New image: %v", bmoImage)
 			deploy.Spec.Template.Spec.Containers[i].Image = bmoImage

--- a/test/e2e/yaml.go
+++ b/test/e2e/yaml.go
@@ -10,7 +10,7 @@ import (
 
 func yamlContainKeyValue(yamlNodes []*yaml.Node, value string, keys ...string) ([]*yaml.Node, error) {
 	if yamlNodes == nil {
-		return nil, errors.New("Input list of yaml node is null")
+		return nil, errors.New("input list of yaml node is null")
 	}
 	foundNode := []*yaml.Node{}
 	for _, obj := range yamlNodes {
@@ -23,14 +23,14 @@ func yamlContainKeyValue(yamlNodes []*yaml.Node, value string, keys ...string) (
 		}
 	}
 	if len(foundNode) == 0 {
-		return nil, errors.New("Could not find the appropriate yaml node")
+		return nil, errors.New("could not find the appropriate yaml node")
 	}
 	return foundNode, nil
 }
 
 func yamlFindByValue(node *yaml.Node, values ...string) (*yaml.Node, error) {
 	if node == nil {
-		return nil, errors.New("Input yaml node is null")
+		return nil, errors.New("input yaml node is null")
 	}
 	value := values[0]
 	for i, child := range node.Content {
@@ -42,7 +42,7 @@ func yamlFindByValue(node *yaml.Node, values ...string) (*yaml.Node, error) {
 			return targetNode, nil
 		}
 	}
-	return nil, errors.New("Could not find the appropriate yaml node")
+	return nil, errors.New("could not find the appropriate yaml node")
 }
 
 func splitYAML(resources []byte) ([]*yaml.Node, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add more linters to .golangci.yaml and this is the continuation of  efforts in #514 

Usage of `importas` linter and it is alias has been copied and aligned with upstream projects, i,e [CAPI](https://github.com/kubernetes-sigs/cluster-api/blob/main/.golangci.yml#L60-L97)/[CAPZ](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/.golangci.yml#L57-L73), where frequently imported packages have pre-defined aliases and that exact alias needs to be used only for that package when imported in the code base, such as:

```
        - pkg: k8s.io/api/core/v1
          alias: corev1
        - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
          alias: apiextensionsv1
        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
          alias: metav1
        - pkg: k8s.io/apimachinery/pkg/api/errors
          alias: apierrors
        - pkg: k8s.io/apimachinery/pkg/util/errors
          alias: kerrors
        # Controller Runtime
        - pkg: sigs.k8s.io/controller-runtime
          alias: ctrl
        # KCP
        - pkg: sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1
          alias: controlplanev1
        # CAPI
        - pkg: sigs.k8s.io/cluster-api/api/v1alpha3
          alias: clusterv1alpha3
        - pkg: sigs.k8s.io/cluster-api/api/v1alpha4
          alias: clusterv1alpha4
        - pkg: sigs.k8s.io/cluster-api/api/v1beta1
          alias: clusterv1`
```

Full list of linters added by this patch:

- asciicheck
- bodyclose
- depguard
- dogsled
- exportloopref
- gocritic
- importas
- nilerr
- noctx
- nolintlint
- predeclared
- revive
- rowserrcheck
- stylecheck
- thelper
- typecheck

