### PR TITLE
🌱 Parameterize api folder path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ export GO111MODULE=on
 # Full directory of where the Makefile resides
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 TOOLS_DIR := hack/tools
+APIS_DIR := api
 TOOLS_BIN_DIR := $(TOOLS_DIR)/bin
 BIN_DIR := bin
 
@@ -97,7 +98,7 @@ unit: ## Run unit test
 		$(GO_TEST_FLAGS) \
 		$(GINKGO_TEST_FLAGS) \
 		-coverprofile ./cover.out; \
-	cd api; \
+	cd $(APIS_DIR); \
 	go test ./... \
 		$(GO_TEST_FLAGS) \
 		-coverprofile ./cover.out
@@ -212,12 +213,12 @@ lint-full: $(GOLANGCI_LINT) ## Run slower linters to detect possible issues
 # Run go fmt against code
 fmt:
 	go fmt ./controllers/... ./baremetal/... .
-	cd api; go fmt  ./...
+	cd $(APIS_DIR); go fmt  ./...
 
 # Run go vet against code
 vet:
 	go vet ./controllers/... ./baremetal/... .
-	cd api; go vet  ./...
+	cd $(APIS_DIR); go vet  ./...
 
 # Run manifest validation
 .PHONY: manifest-lint
@@ -234,8 +235,8 @@ modules: ## Runs go mod to ensure proper vendoring.
 	go mod verify
 	cd $(TOOLS_DIR); go mod tidy
 	cd $(TOOLS_DIR); go mod verify
-	cd api; go mod tidy
-	cd api; go mod verify
+	cd $(APIS_DIR); go mod tidy
+	cd $(APIS_DIR); go mod verify
 
 .PHONY: generate
 generate: ## Generate code
@@ -245,7 +246,7 @@ generate: ## Generate code
 .PHONY: generate-go
 generate-go: $(CONTROLLER_GEN) $(MOCKGEN) $(CONVERSION_GEN) $(KUBEBUILDER) $(KUSTOMIZE) ## Runs Go related generate targets
 	go generate ./...
-	cd api; go generate ./...
+	cd $(APIS_DIR); go generate ./...
 
 	cd ./api; ../$(CONTROLLER_GEN) \
 		paths=./... \
@@ -312,7 +313,7 @@ generate-go: $(CONTROLLER_GEN) $(MOCKGEN) $(CONVERSION_GEN) $(KUBEBUILDER) $(KUS
 
 .PHONY: generate-manifests
 generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
-	cd api; ../$(CONTROLLER_GEN) \
+	cd $(APIS_DIR); ../$(CONTROLLER_GEN) \
 		paths=./... \
 		crd:crdVersions=v1 \
 		output:crd:dir=../$(CRD_ROOT) \


### PR DESCRIPTION
**What this PR does / why we need it**:
Parameterizes api folder path in the Makefile targets. 

We can use just run: `make modules` instead of running `go mod tidy` in every folder where go.mod file is updated.

