### PR TITLE
🐛 Fix IMAGE_OS case

### DIFF
--- a/hack/e2e/environment.sh
+++ b/hack/e2e/environment.sh
@@ -43,9 +43,9 @@ export FORCE_REPO_UPDATE="false"
 os_check
 
 if [[ "${OS}" == ubuntu ]]; then
-    export IMAGE_OS=${IMAGE_OS:-"Ubuntu"}
+    export IMAGE_OS=${IMAGE_OS:-"ubuntu"}
 else
-    export IMAGE_OS=${IMAGE_OS:-"Centos"}
+    export IMAGE_OS=${IMAGE_OS:-"centos"}
 fi
 M3_DEV_ENV_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck disable=SC1091


### PR DESCRIPTION
Since IMAGE_OS changed to lowercase in Dev_Env in this [PR](https://github.com/metal3-io/metal3-dev-env/pull/948), updates in capm3 hack file are need else it will break the test locally. 