### PR TITLE
🌱 Allow GA releases to trigger on v* tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-    - "v0.*.*"
+    - "v*"
 
 name: release
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow GA releases to trigger on v* tags. Currently it doesn't allow to trigger the
GA action on tags starting with any number except `v0.` 