### PR TITLE
🐛 Add live-iso option to Image's DiskFormat in v1a5 and v1b1

### DIFF
--- a/api/v1alpha5/common_types.go
+++ b/api/v1alpha5/common_types.go
@@ -65,6 +65,6 @@ type Image struct {
 	ChecksumType *string `json:"checksumType,omitempty"`
 
 	//DiskFormat contains the image disk format
-	// +kubebuilder:validation:Enum=raw;qcow2;vdi;vmdk
+	// +kubebuilder:validation:Enum=raw;qcow2;vdi;vmdk;live-iso
 	DiskFormat *string `json:"format,omitempty"`
 }

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -68,7 +68,7 @@ type Image struct {
 	ChecksumType *string `json:"checksumType,omitempty"`
 
 	//DiskFormat contains the image disk format
-	// +kubebuilder:validation:Enum=raw;qcow2;vdi;vmdk
+	// +kubebuilder:validation:Enum=raw;qcow2;vdi;vmdk;live-iso
 	// +optional
 	DiskFormat *string `json:"format,omitempty"`
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machines.yaml
@@ -510,6 +510,7 @@ spec:
                     - qcow2
                     - vdi
                     - vmdk
+                    - live-iso
                     type: string
                   url:
                     description: URL is a location of an image to deploy.
@@ -858,6 +859,7 @@ spec:
                     - qcow2
                     - vdi
                     - vmdk
+                    - live-iso
                     type: string
                   url:
                     description: URL is a location of an image to deploy.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machinetemplates.yaml
@@ -367,6 +367,7 @@ spec:
                             - qcow2
                             - vdi
                             - vmdk
+                            - live-iso
                             type: string
                           url:
                             description: URL is a location of an image to deploy.
@@ -575,6 +576,7 @@ spec:
                             - qcow2
                             - vdi
                             - vmdk
+                            - live-iso
                             type: string
                           url:
                             description: URL is a location of an image to deploy.


### PR DESCRIPTION
The image.format option of 'live-iso' was available in the v1alpha4 API but had gone missing in the v1alpha5 and v1beta1 APIs.

**What this PR does / why we need it**: The live-iso option for the disk format of images for Metal3Machines was supported in v1alpha4 and should be supported in v1alpha5 and v1beta1.

**Which issue(s) this PR fixes**:
Fixes #500

Also, this commit may need cherry-picking into release branches, I'm not sure exactly which branches would need this fix.