### PR TITLE
🐛Cherrypick live-iso option to Image's DiskFormat for v1a5 in release-0.5

### DIFF
--- a/api/v1alpha5/common_types.go
+++ b/api/v1alpha5/common_types.go
@@ -65,6 +65,6 @@ type Image struct {
 	ChecksumType *string `json:"checksumType,omitempty"`
 
 	//DiskFormat contains the image disk format
-	// +kubebuilder:validation:Enum=raw;qcow2;vdi;vmdk
+	// +kubebuilder:validation:Enum=raw;qcow2;vdi;vmdk;live-iso
 	DiskFormat *string `json:"format,omitempty"`
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machines.yaml
@@ -511,6 +511,7 @@ spec:
                     - qcow2
                     - vdi
                     - vmdk
+                    - live-iso
                     type: string
                   url:
                     description: URL is a location of an image to deploy.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machinetemplates.yaml
@@ -368,6 +368,7 @@ spec:
                             - qcow2
                             - vdi
                             - vmdk
+                            - live-iso
                             type: string
                           url:
                             description: URL is a location of an image to deploy.


### PR DESCRIPTION

This PR will add the live-iso option for v1a5 in release-0.5 branch and changes are done according to main branch https://github.com/metal3-io/cluster-api-provider-metal3/pull/527