### PR TITLE
🌱 Add unit tests for metal3MachineTemplate reconciliation

### DIFF
--- a/api/v1beta1/metal3machine_types.go
+++ b/api/v1beta1/metal3machine_types.go
@@ -27,7 +27,10 @@ import (
 const (
 	// MachineFinalizer allows ReconcileMetal3Machine to clean up resources associated with Metal3Machine before
 	// removing it from the apiserver.
-	MachineFinalizer = "metal3machine.infrastructure.cluster.x-k8s.io"
+	MachineFinalizer     = "metal3machine.infrastructure.cluster.x-k8s.io"
+	CleaningModeDisabled = "disabled"
+	CleaningModeMetadata = "metadata"
+	ClonedFromGroupKind  = "Metal3MachineTemplate.infrastructure.cluster.x-k8s.io"
 )
 
 // Metal3MachineSpec defines the desired state of Metal3Machine

--- a/baremetal/metal3machinetemplate_manager_test.go
+++ b/baremetal/metal3machinetemplate_manager_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 				Spec: capm3.Metal3MachineTemplateSpec{
 					Template: capm3.Metal3MachineTemplateResource{
 						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr("disabled"),
+							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeDisabled),
 						},
 					},
 				},
@@ -100,11 +100,11 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 							Namespace: "foo",
 							Annotations: map[string]string{
 								"cluster.x-k8s.io/cloned-from-name":      "abc",
-								"cluster.x-k8s.io/cloned-from-groupkind": "Metal3MachineTemplate.infrastructure.cluster.x-k8s.io",
+								"cluster.x-k8s.io/cloned-from-groupkind": capm3.ClonedFromGroupKind,
 							},
 						},
 						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr("metadata"),
+							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeMetadata),
 						},
 					},
 					{
@@ -114,11 +114,11 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 							Namespace: "foo",
 							Annotations: map[string]string{
 								"cluster.x-k8s.io/cloned-from-name":      "abc",
-								"cluster.x-k8s.io/cloned-from-groupkind": "Metal3MachineTemplate.infrastructure.cluster.x-k8s.io",
+								"cluster.x-k8s.io/cloned-from-groupkind": capm3.ClonedFromGroupKind,
 							},
 						},
 						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr("metadata"),
+							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeMetadata),
 						},
 					},
 					{
@@ -128,11 +128,11 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 							Namespace: "foo",
 							Annotations: map[string]string{
 								"cluster.x-k8s.io/cloned-from-name":      "abc",
-								"cluster.x-k8s.io/cloned-from-groupkind": "Metal3MachineTemplate.infrastructure.cluster.x-k8s.io",
+								"cluster.x-k8s.io/cloned-from-groupkind": capm3.ClonedFromGroupKind,
 							},
 						},
 						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr("metadata"),
+							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeMetadata),
 						},
 					},
 				},
@@ -152,7 +152,7 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 				Spec: capm3.Metal3MachineTemplateSpec{
 					Template: capm3.Metal3MachineTemplateResource{
 						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr("metadata"),
+							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeMetadata),
 						},
 					},
 				},
@@ -171,11 +171,11 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 							Namespace: "foo",
 							Annotations: map[string]string{
 								"cluster.x-k8s.io/cloned-from-name":      "abc",
-								"cluster.x-k8s.io/cloned-from-groupkind": "Metal3MachineTemplate.infrastructure.cluster.x-k8s.io",
+								"cluster.x-k8s.io/cloned-from-groupkind": capm3.ClonedFromGroupKind,
 							},
 						},
 						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr("disabled"),
+							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeDisabled),
 						},
 					},
 					{
@@ -185,11 +185,11 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 							Namespace: "foo",
 							Annotations: map[string]string{
 								"cluster.x-k8s.io/cloned-from-name":      "abc",
-								"cluster.x-k8s.io/cloned-from-groupkind": "Metal3MachineTemplate.infrastructure.cluster.x-k8s.io",
+								"cluster.x-k8s.io/cloned-from-groupkind": capm3.ClonedFromGroupKind,
 							},
 						},
 						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr("disabled"),
+							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeDisabled),
 						},
 					},
 					{
@@ -199,11 +199,11 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 							Namespace: "foo",
 							Annotations: map[string]string{
 								"cluster.x-k8s.io/cloned-from-name":      "abc",
-								"cluster.x-k8s.io/cloned-from-groupkind": "Metal3MachineTemplate.infrastructure.cluster.x-k8s.io",
+								"cluster.x-k8s.io/cloned-from-groupkind": capm3.ClonedFromGroupKind,
 							},
 						},
 						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr("disabled"),
+							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeDisabled),
 						},
 					},
 				},
@@ -242,11 +242,11 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 							Namespace: "foo",
 							Annotations: map[string]string{
 								"cluster.x-k8s.io/cloned-from-name":      "xyz",
-								"cluster.x-k8s.io/cloned-from-groupkind": "Metal3MachineTemplate.infrastructure.cluster.x-k8s.io",
+								"cluster.x-k8s.io/cloned-from-groupkind": capm3.ClonedFromGroupKind,
 							},
 						},
 						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr("metadata"),
+							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeMetadata),
 						},
 					},
 				},

--- a/controllers/metal3machinetemplate_controller.go
+++ b/controllers/metal3machinetemplate_controller.go
@@ -131,7 +131,7 @@ func (r *Metal3MachineTemplateReconciler) SetupWithManager(ctx context.Context, 
 func (r *Metal3MachineTemplateReconciler) Metal3MachinesToMetal3MachineTemplate(o client.Object) []ctrl.Request {
 	result := []ctrl.Request{}
 	if m3m, ok := o.(*capm3.Metal3Machine); ok {
-		if m3m.Annotations[clonedFromGroupKind] == "" && m3m.Annotations[clonedFromGroupKind] != "Metal3MachineTemplate.infrastructure.cluster.x-k8s.io" {
+		if m3m.Annotations[clonedFromGroupKind] == "" && m3m.Annotations[clonedFromGroupKind] != capm3.ClonedFromGroupKind {
 			return nil
 		}
 		result = append(result, ctrl.Request{


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds unit tests to the `Metal3MachinesToMetal3MachineTemplate` reconciliation request func.