### PR TITLE
:book: Add creation of BMO namespace in root README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ provider:
 
     ```shell
     git clone https://github.com/metal3-io/baremetal-operator.git
+    kubectl create namespace baremetal-operator-system
     cd baremetal-operator
     kustomize build config/default | kubectl apply -f -
     ```


### PR DESCRIPTION
For the kustomize command to succeed the namespace baremetal-operator-system
must already exist in the kubernetes cluster.

**What this PR does / why we need it**:
Adds a command to create the target namespace (please see step 2 in https://github.com/metal3-io/baremetal-operator/blob/main/docs/dev-setup.md). Otherwise the kustomize command will fail.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
