### PR TITLE
Add providerid field metadata

### DIFF
--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -1196,7 +1196,8 @@ func renderMetaData(m3d *capm3.Metal3Data, m3dt *capm3.Metal3DataTemplate,
 	for _, entry := range m3dt.Spec.MetaData.Strings {
 		metadata[entry.Key] = entry.Value
 	}
-
+	providerid := fmt.Sprintf("%s/%s/%s", m3dt.GetNamespace(), bmh.GetUID(), m3m.GetUID())
+	metadata["providerid"] = providerid
 	return yaml.Marshal(metadata)
 }
 

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -18,6 +18,7 @@ package baremetal
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 
@@ -473,7 +474,7 @@ var _ = Describe("Metal3Data manager", func() {
 				ObjectMeta: testObjectMeta,
 			},
 			expectReady:         true,
-			expectedMetadata:    pointer.StringPtr("String-1: String-1\n"),
+			expectedMetadata:    pointer.StringPtr(fmt.Sprintf("String-1: String-1\nproviderid: %s\n", providerid)),
 			expectedNetworkData: pointer.StringPtr("links:\n- ethernet_mac_address: XX:XX:XX:XX:XX:XX\n  id: eth0\n  mtu: 1500\n  type: phy\nnetworks: []\nservices: []\n"),
 		}),
 		Entry("No Machine OwnerRef on M3M", testCaseCreateSecrets{
@@ -2442,7 +2443,8 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			m3dt: &capm3.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "datatemplate-abc",
+					Name:      "datatemplate-abc",
+					Namespace: namespaceName,
 				},
 				Spec: capm3.Metal3DataTemplateSpec{
 					MetaData: &capm3.MetaData{
@@ -2590,7 +2592,8 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			m3m: &capm3.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "metal3machine-abc",
+					Name:      "metal3machine-abc",
+					Namespace: namespaceName,
 					Labels: map[string]string{
 						"M3M":   "Metal3MachineLabel",
 						"Empty": "",
@@ -2615,7 +2618,8 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			bmh: &bmo.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "bmh-abc",
+					Name:      "bmh-abc",
+					Namespace: namespaceName,
 					Labels: map[string]string{
 						"BMH": "BMHLabel",
 					},
@@ -2655,6 +2659,7 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			expectedMetaData: map[string]string{
 				"String-1":     "String-1",
+				"providerid":   fmt.Sprintf("%s/%s/%s", namespaceName, bmhuid, m3muid),
 				"ObjectName-1": "machine-abc",
 				"ObjectName-2": "metal3machine-abc",
 				"ObjectName-3": "bmh-abc",

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -18,6 +18,7 @@ package baremetal
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -53,6 +54,8 @@ const (
 	m3muid            = "11111111-9845-4321-1234-c74be387f57c"
 	bmhuid            = "22222222-9845-4c48-9e49-c74be387f57c"
 )
+
+var providerid = fmt.Sprintf("%s/%s/%s", namespaceName, bmhuid, m3muid)
 
 func TestManagers(t *testing.T) {
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
Add providerid field metadata.

The metadata has landed on the disk on the provisioned contorlplane node, as shown below.
This PR does not affect the current workflow as it just adds a new field  to the metadata.
Subsequent PRs will make use of this PR.

```
[metal3@test1-qjhht ~]$ head /var/run/cloud-init/instance-data.json  -n 17
{
 "base64_encoded_keys": [],
 "ds": {
  "_doc": "EXPERIMENTAL: The structure and format of content scoped under the 'ds' key may change in subsequent releases of cloud-init.",
  "ec2_metadata": {},
  "meta_data": {
   "instance-id": "4517acf8-d6fe-4afb-8bbb-a6de84a8d515",
   "local-hostname": "test1-qjhht",
   "local_hostname": "test1-qjhht",
   "metal3-name": "node-2",
   "metal3-namespace": "metal3",
   "name": "test1-qjhht",
   "providerid": "metal3/4517acf8-d6fe-4afb-8bbb-a6de84a8d515/997c6fe2-048c-464f-bf68-2ddfcbacb6f6",
   "provisioningCIDR": "24",
   "provisioningIP": "172.22.0.100",
   "uuid": "4517acf8-d6fe-4afb-8bbb-a6de84a8d515"
  },
```