### PR TITLE
:seedling: Allow kubectl caching after cluster creation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -185,6 +185,7 @@ spec:
     - systemctl start monitor.keepalived.service
   postKubeadmCommands:
     - mkdir -p /home/metal3/.kube
+    - chown metal3:metal3 /home/metal3/.kube
     - cp /etc/kubernetes/admin.conf /home/metal3/.kube/config
     - systemctl enable --now keepalived
     - chown metal3:metal3 /home/metal3/.kube/config

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -115,6 +115,7 @@ CTLPLANE_KUBEADM_EXTRA_CONFIG="
       - usermod -aG docker ubuntu
     postKubeadmCommands:
       - mkdir -p /home/ubuntu/.kube
+      - chown ubuntu:ubuntu /home/ubuntu/.kube
       - cp /etc/kubernetes/admin.conf /home/ubuntu/.kube/config
       - systemctl enable --now keepalived
       - chown ubuntu:ubuntu /home/ubuntu/.kube/config

--- a/examples/clusterctl-templates/example_variables.rc
+++ b/examples/clusterctl-templates/example_variables.rc
@@ -28,6 +28,7 @@ export CTLPLANE_KUBEADM_EXTRA_CONFIG="
       - usermod -aG docker ubuntu
     postKubeadmCommands:
       - mkdir -p /home/ubuntu/.kube
+      - chown ubuntu:ubuntu /home/ubuntu/.kube
       - cp /etc/kubernetes/admin.conf /home/ubuntu/.kube/config
       - systemctl enable --now keepalived
       - chown ubuntu:ubuntu /home/ubuntu/.kube/config

--- a/test/e2e/data/infrastructure-metal3/bases/centos-kubeadm-config/centos-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/bases/centos-kubeadm-config/centos-kubeadm-config.yaml
@@ -143,6 +143,7 @@ spec:
         name: '{{ ds.meta_data.name }}'
     postKubeadmCommands:
     - mkdir -p /home/${IMAGE_USERNAME}/.kube
+    - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube
     - cp /etc/kubernetes/admin.conf /home/${IMAGE_USERNAME}/.kube/config
     - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube/config
     preKubeadmCommands:

--- a/test/e2e/data/infrastructure-metal3/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
@@ -107,6 +107,7 @@ spec:
         name: '{{ ds.meta_data.name }}'
     postKubeadmCommands:
     - mkdir -p /home/${IMAGE_USERNAME}/.kube
+    - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube
     - cp /etc/kubernetes/admin.conf /home/${IMAGE_USERNAME}/.kube/config
     - systemctl enable --now keepalived
     - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube/config


### PR DESCRIPTION
The .kube directory must belong to the (non-root) user issuing kubectl.
Otherwise kubectl will not be able to cache requests and will issue warnings
due to client-side throttling taking place when requests normally hitting the
cache are directed at the server instead.

fix related to issue: https://github.com/metal3-io/metal3-dev-env/issues/957

**What this PR does / why we need it**:

Fixes example setup templates which lead to kubectl not being able to cache requests correctly. It then issues warnings about client-side-throttling. See https://github.com/metal3-io/metal3-dev-env/issues/957 for more details.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

