### PR TITLE
🌱 Unify provider and baremetal operator imports in the codebase

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -81,6 +81,9 @@ linters-settings:
           alias: clusterv1alpha4
         - pkg: sigs.k8s.io/cluster-api/api/v1beta1
           alias: clusterv1
+        # CAPM3
+        - pkg: github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1
+          alias: infrav1
   nolintlint:
     allow-unused: false
     allow-leading-space: false

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -82,6 +82,8 @@ linters-settings:
         - pkg: sigs.k8s.io/cluster-api/api/v1beta1
           alias: clusterv1
         # CAPM3
+        - pkg: github.com/metal3-io/cluster-api-provider-metal3/api/v1alpha5
+          alias: infrav1alpha5
         - pkg: github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1
           alias: infrav1
         # BMO

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -84,6 +84,9 @@ linters-settings:
         # CAPM3
         - pkg: github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1
           alias: infrav1
+        # BMO
+        - pkg: github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1
+          alias: bmov1alpha1
   nolintlint:
     allow-unused: false
     allow-leading-space: false

--- a/baremetal/manager_factory.go
+++ b/baremetal/manager_factory.go
@@ -18,7 +18,7 @@ package baremetal
 
 import (
 	"github.com/go-logr/logr"
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -26,23 +26,23 @@ import (
 // ManagerFactoryInterface is a collection of new managers.
 type ManagerFactoryInterface interface {
 	NewClusterManager(cluster *clusterv1.Cluster,
-		metal3Cluster *capm3.Metal3Cluster,
+		metal3Cluster *infrav1.Metal3Cluster,
 		clusterLog logr.Logger,
 	) (ClusterManagerInterface, error)
-	NewMachineManager(*clusterv1.Cluster, *capm3.Metal3Cluster, *clusterv1.Machine,
-		*capm3.Metal3Machine, logr.Logger,
+	NewMachineManager(*clusterv1.Cluster, *infrav1.Metal3Cluster, *clusterv1.Machine,
+		*infrav1.Metal3Machine, logr.Logger,
 	) (MachineManagerInterface, error)
-	NewDataTemplateManager(*capm3.Metal3DataTemplate, logr.Logger) (
+	NewDataTemplateManager(*infrav1.Metal3DataTemplate, logr.Logger) (
 		DataTemplateManagerInterface, error,
 	)
-	NewDataManager(*capm3.Metal3Data, logr.Logger) (
+	NewDataManager(*infrav1.Metal3Data, logr.Logger) (
 		DataManagerInterface, error,
 	)
-	NewMachineTemplateManager(capm3Template *capm3.Metal3MachineTemplate,
-		capm3MachineList *capm3.Metal3MachineList,
+	NewMachineTemplateManager(capm3Template *infrav1.Metal3MachineTemplate,
+		capm3MachineList *infrav1.Metal3MachineList,
 		metadataLog logr.Logger,
 	) (TemplateManagerInterface, error)
-	NewRemediationManager(*capm3.Metal3Remediation, *capm3.Metal3Machine, *clusterv1.Machine, logr.Logger) (
+	NewRemediationManager(*infrav1.Metal3Remediation, *infrav1.Metal3Machine, *clusterv1.Machine, logr.Logger) (
 		RemediationManagerInterface, error,
 	)
 }
@@ -58,39 +58,39 @@ func NewManagerFactory(client client.Client) ManagerFactory {
 }
 
 // NewClusterManager creates a new ClusterManager.
-func (f ManagerFactory) NewClusterManager(cluster *clusterv1.Cluster, capm3Cluster *capm3.Metal3Cluster, clusterLog logr.Logger) (ClusterManagerInterface, error) {
+func (f ManagerFactory) NewClusterManager(cluster *clusterv1.Cluster, capm3Cluster *infrav1.Metal3Cluster, clusterLog logr.Logger) (ClusterManagerInterface, error) {
 	return NewClusterManager(f.client, cluster, capm3Cluster, clusterLog)
 }
 
 // NewMachineManager creates a new MachineManager.
 func (f ManagerFactory) NewMachineManager(capiCluster *clusterv1.Cluster,
-	capm3Cluster *capm3.Metal3Cluster,
-	capiMachine *clusterv1.Machine, capm3Machine *capm3.Metal3Machine,
+	capm3Cluster *infrav1.Metal3Cluster,
+	capiMachine *clusterv1.Machine, capm3Machine *infrav1.Metal3Machine,
 	machineLog logr.Logger) (MachineManagerInterface, error) {
 	return NewMachineManager(f.client, capiCluster, capm3Cluster, capiMachine,
 		capm3Machine, machineLog)
 }
 
 // NewDataTemplateManager creates a new DataTemplateManager.
-func (f ManagerFactory) NewDataTemplateManager(metadata *capm3.Metal3DataTemplate, metadataLog logr.Logger) (DataTemplateManagerInterface, error) {
+func (f ManagerFactory) NewDataTemplateManager(metadata *infrav1.Metal3DataTemplate, metadataLog logr.Logger) (DataTemplateManagerInterface, error) {
 	return NewDataTemplateManager(f.client, metadata, metadataLog)
 }
 
 // NewDataManager creates a new DataManager.
-func (f ManagerFactory) NewDataManager(metadata *capm3.Metal3Data, metadataLog logr.Logger) (DataManagerInterface, error) {
+func (f ManagerFactory) NewDataManager(metadata *infrav1.Metal3Data, metadataLog logr.Logger) (DataManagerInterface, error) {
 	return NewDataManager(f.client, metadata, metadataLog)
 }
 
 // NewMachineTemplateManager creates a new Metal3MachineTemplateManager.
-func (f ManagerFactory) NewMachineTemplateManager(capm3Template *capm3.Metal3MachineTemplate,
-	capm3MachineList *capm3.Metal3MachineList,
+func (f ManagerFactory) NewMachineTemplateManager(capm3Template *infrav1.Metal3MachineTemplate,
+	capm3MachineList *infrav1.Metal3MachineList,
 	metadataLog logr.Logger) (TemplateManagerInterface, error) {
 	return NewMachineTemplateManager(f.client, capm3Template, capm3MachineList, metadataLog)
 }
 
 // NewRemediationManager creates a new RemediationManager.
-func (f ManagerFactory) NewRemediationManager(remediation *capm3.Metal3Remediation,
-	metal3machine *capm3.Metal3Machine, machine *clusterv1.Machine,
+func (f ManagerFactory) NewRemediationManager(remediation *infrav1.Metal3Remediation,
+	metal3machine *infrav1.Metal3Machine, machine *clusterv1.Machine,
 	remediationLog logr.Logger) (RemediationManagerInterface, error) {
 	return NewRemediationManager(f.client, remediation, metal3machine, machine, remediationLog)
 }

--- a/baremetal/manager_factory_test.go
+++ b/baremetal/manager_factory_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -43,13 +43,13 @@ var _ = Describe("Manager factory testing", func() {
 
 	It("returns a cluster manager", func() {
 		_, err := managerFactory.NewClusterManager(&clusterv1.Cluster{},
-			&capm3.Metal3Cluster{}, clusterLog,
+			&infrav1.Metal3Cluster{}, clusterLog,
 		)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("fails to return a cluster manager with nil cluster", func() {
-		_, err := managerFactory.NewClusterManager(nil, &capm3.Metal3Cluster{},
+		_, err := managerFactory.NewClusterManager(nil, &infrav1.Metal3Cluster{},
 			clusterLog,
 		)
 		Expect(err).To(HaveOccurred())
@@ -64,29 +64,29 @@ var _ = Describe("Manager factory testing", func() {
 
 	It("returns a metal3 machine manager", func() {
 		_, err := managerFactory.NewMachineManager(&clusterv1.Cluster{},
-			&capm3.Metal3Cluster{}, &clusterv1.Machine{}, &capm3.Metal3Machine{},
+			&infrav1.Metal3Cluster{}, &clusterv1.Machine{}, &infrav1.Metal3Machine{},
 			clusterLog,
 		)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("returns a DataTemplate manager", func() {
-		_, err := managerFactory.NewDataTemplateManager(&capm3.Metal3DataTemplate{}, clusterLog)
+		_, err := managerFactory.NewDataTemplateManager(&infrav1.Metal3DataTemplate{}, clusterLog)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("returns a Data manager", func() {
-		_, err := managerFactory.NewDataManager(&capm3.Metal3Data{}, clusterLog)
+		_, err := managerFactory.NewDataManager(&infrav1.Metal3Data{}, clusterLog)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("returns a MachineTemplate manager", func() {
-		_, err := managerFactory.NewMachineTemplateManager(&capm3.Metal3MachineTemplate{}, &capm3.Metal3MachineList{}, clusterLog)
+		_, err := managerFactory.NewMachineTemplateManager(&infrav1.Metal3MachineTemplate{}, &infrav1.Metal3MachineList{}, clusterLog)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("returns a Remediation manager", func() {
-		_, err := managerFactory.NewRemediationManager(&capm3.Metal3Remediation{}, &capm3.Metal3Machine{}, &clusterv1.Machine{}, clusterLog)
+		_, err := managerFactory.NewRemediationManager(&infrav1.Metal3Remediation{}, &infrav1.Metal3Machine{}, &clusterv1.Machine{}, clusterLog)
 		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/baremetal/metal3cluster_manager_test.go
+++ b/baremetal/metal3cluster_manager_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/pointer"
@@ -35,18 +35,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func bmcSpec() *capm3.Metal3ClusterSpec {
-	return &capm3.Metal3ClusterSpec{
-		ControlPlaneEndpoint: capm3.APIEndpoint{
+func bmcSpec() *infrav1.Metal3ClusterSpec {
+	return &infrav1.Metal3ClusterSpec{
+		ControlPlaneEndpoint: infrav1.APIEndpoint{
 			Host: "192.168.111.249",
 			Port: 6443,
 		},
 	}
 }
 
-func bmcSpecAPIEmpty() *capm3.Metal3ClusterSpec {
-	return &capm3.Metal3ClusterSpec{
-		ControlPlaneEndpoint: capm3.APIEndpoint{
+func bmcSpecAPIEmpty() *infrav1.Metal3ClusterSpec {
+	return &infrav1.Metal3ClusterSpec{
+		ControlPlaneEndpoint: infrav1.APIEndpoint{
 			Host: "",
 			Port: 0,
 		},
@@ -54,7 +54,7 @@ func bmcSpecAPIEmpty() *capm3.Metal3ClusterSpec {
 }
 
 type testCaseBMClusterManager struct {
-	BMCluster     *capm3.Metal3Cluster
+	BMCluster     *infrav1.Metal3Cluster
 	Cluster       *clusterv1.Cluster
 	ExpectSuccess bool
 }
@@ -88,7 +88,7 @@ var _ = Describe("Metal3Cluster manager", func() {
 			},
 			Entry("Cluster and BMCluster Defined", testCaseBMClusterManager{
 				Cluster:       &clusterv1.Cluster{},
-				BMCluster:     &capm3.Metal3Cluster{},
+				BMCluster:     &infrav1.Metal3Cluster{},
 				ExpectSuccess: true,
 			}),
 			Entry("BMCluster undefined", testCaseBMClusterManager{
@@ -98,7 +98,7 @@ var _ = Describe("Metal3Cluster manager", func() {
 			}),
 			Entry("Cluster undefined", testCaseBMClusterManager{
 				Cluster:       nil,
-				BMCluster:     &capm3.Metal3Cluster{},
+				BMCluster:     &infrav1.Metal3Cluster{},
 				ExpectSuccess: false,
 			}),
 		)
@@ -112,13 +112,13 @@ var _ = Describe("Metal3Cluster manager", func() {
 			clusterMgr.SetFinalizer()
 
 			Expect(tc.BMCluster.ObjectMeta.Finalizers).To(ContainElement(
-				capm3.ClusterFinalizer,
+				infrav1.ClusterFinalizer,
 			))
 
 			clusterMgr.UnsetFinalizer()
 
 			Expect(tc.BMCluster.ObjectMeta.Finalizers).NotTo(ContainElement(
-				capm3.ClusterFinalizer,
+				infrav1.ClusterFinalizer,
 			))
 		},
 		Entry("No finalizers", testCaseBMClusterManager{
@@ -129,7 +129,7 @@ var _ = Describe("Metal3Cluster manager", func() {
 		}),
 		Entry("Finalizers", testCaseBMClusterManager{
 			Cluster: nil,
-			BMCluster: &capm3.Metal3Cluster{
+			BMCluster: &infrav1.Metal3Cluster{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "Metal3Cluster",
 				},
@@ -137,10 +137,10 @@ var _ = Describe("Metal3Cluster manager", func() {
 					Name:            metal3ClusterName,
 					Namespace:       namespaceName,
 					OwnerReferences: []metav1.OwnerReference{*bmcOwnerRef},
-					Finalizers:      []string{capm3.ClusterFinalizer},
+					Finalizers:      []string{infrav1.ClusterFinalizer},
 				},
-				Spec:   capm3.Metal3ClusterSpec{},
-				Status: capm3.Metal3ClusterStatus{},
+				Spec:   infrav1.Metal3ClusterSpec{},
+				Status: infrav1.Metal3ClusterStatus{},
 			},
 		}),
 	)
@@ -171,7 +171,7 @@ var _ = Describe("Metal3Cluster manager", func() {
 		Entry("Pre-existing error message overridden", testCaseBMClusterManager{
 			Cluster: newCluster(clusterName),
 			BMCluster: newMetal3Cluster(metal3ClusterName,
-				bmcOwnerRef, nil, &capm3.Metal3ClusterStatus{
+				bmcOwnerRef, nil, &infrav1.Metal3ClusterStatus{
 					FailureMessage: pointer.StringPtr("cba"),
 				},
 			),
@@ -192,7 +192,7 @@ var _ = Describe("Metal3Cluster manager", func() {
 		},
 		Entry("deleting BMCluster", testCaseBMClusterManager{
 			Cluster:       &clusterv1.Cluster{},
-			BMCluster:     &capm3.Metal3Cluster{},
+			BMCluster:     &infrav1.Metal3Cluster{},
 			ExpectSuccess: true,
 		}),
 	)
@@ -220,7 +220,7 @@ var _ = Describe("Metal3Cluster manager", func() {
 		}),
 		Entry("Cluster exists, BMCluster empty", testCaseBMClusterManager{
 			Cluster:       newCluster(clusterName),
-			BMCluster:     &capm3.Metal3Cluster{},
+			BMCluster:     &infrav1.Metal3Cluster{},
 			ExpectSuccess: false,
 		}),
 		Entry("Cluster empty, BMCluster exists", testCaseBMClusterManager{
@@ -269,7 +269,7 @@ var _ = Describe("Metal3Cluster manager", func() {
 		}),
 		Entry("Cluster exists, BMCluster empty", testCaseBMClusterManager{
 			Cluster:       newCluster(clusterName),
-			BMCluster:     &capm3.Metal3Cluster{},
+			BMCluster:     &infrav1.Metal3Cluster{},
 			ExpectSuccess: false,
 		}),
 		Entry("Cluster empty, BMCluster exists", testCaseBMClusterManager{

--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/go-logr/logr"
 
-	bmo "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	"github.com/pkg/errors"
@@ -791,7 +791,7 @@ func (m *DataManager) releaseAddressFromPool(ctx context.Context, poolName strin
 // renderNetworkData renders the networkData into an object that will be
 // marshalled into the secret.
 func renderNetworkData(m3d *infrav1.Metal3Data, m3dt *infrav1.Metal3DataTemplate,
-	bmh *bmo.BareMetalHost, poolAddresses map[string]addressFromPool,
+	bmh *bmov1alpha1.BareMetalHost, poolAddresses map[string]addressFromPool,
 ) ([]byte, error) {
 	if m3dt.Spec.NetworkData == nil {
 		return nil, nil
@@ -848,7 +848,7 @@ func renderNetworkServices(services infrav1.NetworkDataService, poolAddresses ma
 }
 
 // renderNetworkLinks renders the different types of links.
-func renderNetworkLinks(networkLinks infrav1.NetworkDataLink, bmh *bmo.BareMetalHost) ([]interface{}, error) {
+func renderNetworkLinks(networkLinks infrav1.NetworkDataLink, bmh *bmov1alpha1.BareMetalHost) ([]interface{}, error) {
 	data := []interface{}{}
 
 	// Ethernet links
@@ -1102,7 +1102,7 @@ func translateMask(maskInt int, ipv4 bool) interface{} {
 }
 
 // getLinkMacAddress returns the mac address.
-func getLinkMacAddress(mac *infrav1.NetworkLinkEthernetMac, bmh *bmo.BareMetalHost) (
+func getLinkMacAddress(mac *infrav1.NetworkLinkEthernetMac, bmh *bmov1alpha1.BareMetalHost) (
 	string, error,
 ) {
 	macAddress := ""
@@ -1122,7 +1122,7 @@ func getLinkMacAddress(mac *infrav1.NetworkLinkEthernetMac, bmh *bmo.BareMetalHo
 
 // renderMetaData renders the MetaData items.
 func renderMetaData(m3d *infrav1.Metal3Data, m3dt *infrav1.Metal3DataTemplate,
-	m3m *infrav1.Metal3Machine, machine *clusterv1.Machine, bmh *bmo.BareMetalHost,
+	m3m *infrav1.Metal3Machine, machine *clusterv1.Machine, bmh *bmov1alpha1.BareMetalHost,
 	poolAddresses map[string]addressFromPool,
 ) ([]byte, error) {
 	if m3dt.Spec.MetaData == nil {
@@ -1231,7 +1231,7 @@ func renderMetaData(m3d *infrav1.Metal3Data, m3dt *infrav1.Metal3DataTemplate,
 }
 
 // getBMHMacByName returns the mac address of the interface matching the name.
-func getBMHMacByName(name string, bmh *bmo.BareMetalHost) (string, error) {
+func getBMHMacByName(name string, bmh *bmov1alpha1.BareMetalHost) (string, error) {
 	if bmh == nil || bmh.Status.HardwareDetails == nil || bmh.Status.HardwareDetails.NIC == nil {
 		return "", errors.New("Nics list not populated")
 	}

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
 
-	bmo "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -170,7 +170,7 @@ var _ = Describe("Metal3Data manager", func() {
 		m3m                 *infrav1.Metal3Machine
 		dataClaim           *infrav1.Metal3DataClaim
 		machine             *clusterv1.Machine
-		bmh                 *bmo.BareMetalHost
+		bmh                 *bmov1alpha1.BareMetalHost
 		metadataSecret      *corev1.Secret
 		networkdataSecret   *corev1.Secret
 		expectError         bool
@@ -470,7 +470,7 @@ var _ = Describe("Metal3Data manager", func() {
 			machine: &clusterv1.Machine{
 				ObjectMeta: testObjectMeta,
 			},
-			bmh: &bmo.BareMetalHost{
+			bmh: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: testObjectMeta,
 			},
 			expectReady:         true,
@@ -1476,7 +1476,7 @@ var _ = Describe("Metal3Data manager", func() {
 	type testCaseRenderNetworkData struct {
 		m3d            *infrav1.Metal3Data
 		m3dt           *infrav1.Metal3DataTemplate
-		bmh            *bmo.BareMetalHost
+		bmh            *bmov1alpha1.BareMetalHost
 		poolAddresses  map[string]addressFromPool
 		expectError    bool
 		expectedOutput map[string][]interface{}
@@ -1687,7 +1687,7 @@ var _ = Describe("Metal3Data manager", func() {
 
 	type testCaseRenderNetworkLinks struct {
 		links          infrav1.NetworkDataLink
-		bmh            *bmo.BareMetalHost
+		bmh            *bmov1alpha1.BareMetalHost
 		expectError    bool
 		expectedOutput []interface{}
 	}
@@ -1737,11 +1737,11 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 				},
 			},
-			bmh: &bmo.BareMetalHost{
+			bmh: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "bmh-abc",
 				},
-				Status: bmo.BareMetalHostStatus{},
+				Status: bmov1alpha1.BareMetalHostStatus{},
 			},
 			expectError: true,
 		}),
@@ -1784,11 +1784,11 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 				},
 			},
-			bmh: &bmo.BareMetalHost{
+			bmh: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "bmh-abc",
 				},
-				Status: bmo.BareMetalHostStatus{},
+				Status: bmov1alpha1.BareMetalHostStatus{},
 			},
 			expectError: true,
 		}),
@@ -1831,11 +1831,11 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 				},
 			},
-			bmh: &bmo.BareMetalHost{
+			bmh: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "bmh-abc",
 				},
-				Status: bmo.BareMetalHostStatus{},
+				Status: bmov1alpha1.BareMetalHostStatus{},
 			},
 			expectError: true,
 		}),
@@ -2320,7 +2320,7 @@ var _ = Describe("Metal3Data manager", func() {
 
 	type testCaseGetLinkMacAddress struct {
 		mac         *infrav1.NetworkLinkEthernetMac
-		bmh         *bmo.BareMetalHost
+		bmh         *bmov1alpha1.BareMetalHost
 		expectError bool
 		expectedMAC string
 	}
@@ -2345,13 +2345,13 @@ var _ = Describe("Metal3Data manager", func() {
 			mac: &infrav1.NetworkLinkEthernetMac{
 				FromHostInterface: pointer.StringPtr("eth1"),
 			},
-			bmh: &bmo.BareMetalHost{
+			bmh: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "bmh-abc",
 				},
-				Status: bmo.BareMetalHostStatus{
-					HardwareDetails: &bmo.HardwareDetails{
-						NIC: []bmo.NIC{
+				Status: bmov1alpha1.BareMetalHostStatus{
+					HardwareDetails: &bmov1alpha1.HardwareDetails{
+						NIC: []bmov1alpha1.NIC{
 							{
 								Name: "eth0",
 								MAC:  "XX:XX:XX:XX:XX:XX",
@@ -2372,13 +2372,13 @@ var _ = Describe("Metal3Data manager", func() {
 			mac: &infrav1.NetworkLinkEthernetMac{
 				FromHostInterface: pointer.StringPtr("eth2"),
 			},
-			bmh: &bmo.BareMetalHost{
+			bmh: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "bmh-abc",
 				},
-				Status: bmo.BareMetalHostStatus{
-					HardwareDetails: &bmo.HardwareDetails{
-						NIC: []bmo.NIC{
+				Status: bmov1alpha1.BareMetalHostStatus{
+					HardwareDetails: &bmov1alpha1.HardwareDetails{
+						NIC: []bmov1alpha1.NIC{
 							{
 								Name: "eth0",
 								MAC:  "XX:XX:XX:XX:XX:XX",
@@ -2402,7 +2402,7 @@ var _ = Describe("Metal3Data manager", func() {
 		m3dt             *infrav1.Metal3DataTemplate
 		m3m              *infrav1.Metal3Machine
 		machine          *clusterv1.Machine
-		bmh              *bmo.BareMetalHost
+		bmh              *bmov1alpha1.BareMetalHost
 		poolAddresses    map[string]addressFromPool
 		expectedMetaData map[string]string
 		expectError      bool
@@ -2616,7 +2616,7 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 				},
 			},
-			bmh: &bmo.BareMetalHost{
+			bmh: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bmh-abc",
 					Namespace: namespaceName,
@@ -2628,9 +2628,9 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 					UID: bmhuid,
 				},
-				Status: bmo.BareMetalHostStatus{
-					HardwareDetails: &bmo.HardwareDetails{
-						NIC: []bmo.NIC{
+				Status: bmov1alpha1.BareMetalHostStatus{
+					HardwareDetails: &bmov1alpha1.HardwareDetails{
+						NIC: []bmov1alpha1.NIC{
 							{
 								Name: "eth0",
 								MAC:  "XX:XX:XX:XX:XX:XX",
@@ -2704,13 +2704,13 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 				},
 			},
-			bmh: &bmo.BareMetalHost{
+			bmh: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "bmh-abc",
 				},
-				Status: bmo.BareMetalHostStatus{
-					HardwareDetails: &bmo.HardwareDetails{
-						NIC: []bmo.NIC{
+				Status: bmov1alpha1.BareMetalHostStatus{
+					HardwareDetails: &bmov1alpha1.HardwareDetails{
+						NIC: []bmov1alpha1.NIC{
 							{
 								Name: "eth0",
 								MAC:  "XX:XX:XX:XX:XX:XX",
@@ -2867,7 +2867,7 @@ var _ = Describe("Metal3Data manager", func() {
 	)
 
 	type testCaseGetBMHMacByName struct {
-		bmh         *bmo.BareMetalHost
+		bmh         *bmov1alpha1.BareMetalHost
 		name        string
 		expectError bool
 		expectedMAC string
@@ -2884,26 +2884,26 @@ var _ = Describe("Metal3Data manager", func() {
 			}
 		},
 		Entry("No hardware details", testCaseGetBMHMacByName{
-			bmh: &bmo.BareMetalHost{
-				Status: bmo.BareMetalHostStatus{},
+			bmh: &bmov1alpha1.BareMetalHost{
+				Status: bmov1alpha1.BareMetalHostStatus{},
 			},
 			name:        "eth1",
 			expectError: true,
 		}),
 		Entry("No Nics detail", testCaseGetBMHMacByName{
-			bmh: &bmo.BareMetalHost{
-				Status: bmo.BareMetalHostStatus{
-					HardwareDetails: &bmo.HardwareDetails{},
+			bmh: &bmov1alpha1.BareMetalHost{
+				Status: bmov1alpha1.BareMetalHostStatus{
+					HardwareDetails: &bmov1alpha1.HardwareDetails{},
 				},
 			},
 			name:        "eth1",
 			expectError: true,
 		}),
 		Entry("Empty nic list", testCaseGetBMHMacByName{
-			bmh: &bmo.BareMetalHost{
-				Status: bmo.BareMetalHostStatus{
-					HardwareDetails: &bmo.HardwareDetails{
-						NIC: []bmo.NIC{},
+			bmh: &bmov1alpha1.BareMetalHost{
+				Status: bmov1alpha1.BareMetalHostStatus{
+					HardwareDetails: &bmov1alpha1.HardwareDetails{
+						NIC: []bmov1alpha1.NIC{},
 					},
 				},
 			},
@@ -2911,10 +2911,10 @@ var _ = Describe("Metal3Data manager", func() {
 			expectError: true,
 		}),
 		Entry("Nic not found", testCaseGetBMHMacByName{
-			bmh: &bmo.BareMetalHost{
-				Status: bmo.BareMetalHostStatus{
-					HardwareDetails: &bmo.HardwareDetails{
-						NIC: []bmo.NIC{
+			bmh: &bmov1alpha1.BareMetalHost{
+				Status: bmov1alpha1.BareMetalHostStatus{
+					HardwareDetails: &bmov1alpha1.HardwareDetails{
+						NIC: []bmov1alpha1.NIC{
 							{
 								Name: "eth0",
 								MAC:  "XX:XX:XX:XX:XX:XX",
@@ -2927,10 +2927,10 @@ var _ = Describe("Metal3Data manager", func() {
 			expectError: true,
 		}),
 		Entry("Nic found", testCaseGetBMHMacByName{
-			bmh: &bmo.BareMetalHost{
-				Status: bmo.BareMetalHostStatus{
-					HardwareDetails: &bmo.HardwareDetails{
-						NIC: []bmo.NIC{
+			bmh: &bmov1alpha1.BareMetalHost{
+				Status: bmov1alpha1.BareMetalHostStatus{
+					HardwareDetails: &bmov1alpha1.HardwareDetails{
+						NIC: []bmov1alpha1.NIC{
 							{
 								Name: "eth0",
 								MAC:  "XX:XX:XX:XX:XX:XX",
@@ -2949,10 +2949,10 @@ var _ = Describe("Metal3Data manager", func() {
 			expectedMAC: "XX:XX:XX:XX:XX:YY",
 		}),
 		Entry("Nic found, Empty Mac", testCaseGetBMHMacByName{
-			bmh: &bmo.BareMetalHost{
-				Status: bmo.BareMetalHostStatus{
-					HardwareDetails: &bmo.HardwareDetails{
-						NIC: []bmo.NIC{
+			bmh: &bmov1alpha1.BareMetalHost{
+				Status: bmov1alpha1.BareMetalHostStatus{
+					HardwareDetails: &bmov1alpha1.HardwareDetails{
+						NIC: []bmov1alpha1.NIC{
 							{
 								Name: "eth0",
 								MAC:  "XX:XX:XX:XX:XX:XX",

--- a/baremetal/metal3datatemplate_manager_test.go
+++ b/baremetal/metal3datatemplate_manager_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -38,7 +38,7 @@ var timeNow = metav1.Now()
 
 var _ = Describe("Metal3DataTemplate manager", func() {
 	DescribeTable("Test Finalizers",
-		func(template *capm3.Metal3DataTemplate) {
+		func(template *infrav1.Metal3DataTemplate) {
 			templateMgr, err := NewDataTemplateManager(nil, template,
 				logr.Discard(),
 			)
@@ -47,17 +47,17 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			templateMgr.SetFinalizer()
 
 			Expect(template.ObjectMeta.Finalizers).To(ContainElement(
-				capm3.DataTemplateFinalizer,
+				infrav1.DataTemplateFinalizer,
 			))
 
 			templateMgr.UnsetFinalizer()
 
 			Expect(template.ObjectMeta.Finalizers).NotTo(ContainElement(
-				capm3.DataTemplateFinalizer,
+				infrav1.DataTemplateFinalizer,
 			))
 		},
-		Entry("No finalizers", &capm3.Metal3DataTemplate{}),
-		Entry("Additional Finalizers", &capm3.Metal3DataTemplate{
+		Entry("No finalizers", &infrav1.Metal3DataTemplate{}),
+		Entry("Additional Finalizers", &infrav1.Metal3DataTemplate{
 			ObjectMeta: metav1.ObjectMeta{
 				Finalizers: []string{"foo"},
 			},
@@ -66,7 +66,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 
 	type testCaseSetClusterOwnerRef struct {
 		cluster     *clusterv1.Cluster
-		template    *capm3.Metal3DataTemplate
+		template    *infrav1.Metal3DataTemplate
 		expectError bool
 	}
 
@@ -90,7 +90,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			expectError: true,
 		}),
 		Entry("no previous ownerref", testCaseSetClusterOwnerRef{
-			template: &capm3.Metal3DataTemplate{
+			template: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "abc",
 				},
@@ -102,7 +102,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			},
 		}),
 		Entry("previous ownerref", testCaseSetClusterOwnerRef{
-			template: &capm3.Metal3DataTemplate{
+			template: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "abc",
 					OwnerReferences: []metav1.OwnerReference{
@@ -119,7 +119,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			},
 		}),
 		Entry("ownerref present", testCaseSetClusterOwnerRef{
-			template: &capm3.Metal3DataTemplate{
+			template: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "abc",
 					OwnerReferences: []metav1.OwnerReference{
@@ -141,8 +141,8 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 	)
 
 	type testGetIndexes struct {
-		template        *capm3.Metal3DataTemplate
-		indexes         []*capm3.Metal3Data
+		template        *infrav1.Metal3DataTemplate
+		indexes         []*infrav1.Metal3Data
 		expectError     bool
 		expectedMap     map[int]string
 		expectedIndexes map[string]int
@@ -171,22 +171,22 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			Expect(tc.template.Status.LastUpdated.IsZero()).To(BeFalse())
 		},
 		Entry("No indexes", testGetIndexes{
-			template:        &capm3.Metal3DataTemplate{},
+			template:        &infrav1.Metal3DataTemplate{},
 			expectedMap:     map[int]string{},
 			expectedIndexes: map[string]int{},
 		}),
 		Entry("indexes", testGetIndexes{
-			template: &capm3.Metal3DataTemplate{
+			template: &infrav1.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta,
-				Spec:       capm3.Metal3DataTemplateSpec{},
+				Spec:       infrav1.Metal3DataTemplateSpec{},
 			},
-			indexes: []*capm3.Metal3Data{
+			indexes: []*infrav1.Metal3Data{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc-0",
 						Namespace: namespaceName,
 					},
-					Spec: capm3.Metal3DataSpec{
+					Spec: infrav1.Metal3DataSpec{
 						Index:    0,
 						Template: *testObjectReference,
 						Claim:    *testObjectReference,
@@ -197,7 +197,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 						Name:      "bbc-1",
 						Namespace: namespaceName,
 					},
-					Spec: capm3.Metal3DataSpec{
+					Spec: infrav1.Metal3DataSpec{
 						Index: 1,
 						Template: corev1.ObjectReference{
 							Name:      "bbc",
@@ -214,7 +214,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 						Name:      "abc-2",
 						Namespace: namespaceName,
 					},
-					Spec: capm3.Metal3DataSpec{
+					Spec: infrav1.Metal3DataSpec{
 						Index:    2,
 						Template: corev1.ObjectReference{},
 						Claim:    *testObjectReference,
@@ -225,7 +225,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 						Name:      "abc-3",
 						Namespace: namespaceName,
 					},
-					Spec: capm3.Metal3DataSpec{
+					Spec: infrav1.Metal3DataSpec{
 						Index: 3,
 						Template: corev1.ObjectReference{
 							Namespace: namespaceName,
@@ -249,9 +249,9 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 	}
 
 	type testCaseUpdateDatas struct {
-		template          *capm3.Metal3DataTemplate
-		dataClaims        []*capm3.Metal3DataClaim
-		datas             []*capm3.Metal3Data
+		template          *infrav1.Metal3DataTemplate
+		dataClaims        []*infrav1.Metal3DataClaim
+		datas             []*infrav1.Metal3Data
 		expectRequeue     bool
 		expectError       bool
 		expectedNbIndexes int
@@ -289,7 +289,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			Expect(tc.template.Status.Indexes).To(Equal(tc.expectedIndexes))
 
 			// get list of Metal3Data objects
-			dataObjects := capm3.Metal3DataClaimList{}
+			dataObjects := infrav1.Metal3DataClaimList{}
 			opts := &client.ListOptions{}
 			err = fakeClient.List(context.TODO(), &dataObjects, opts)
 			Expect(err).NotTo(HaveOccurred())
@@ -303,23 +303,23 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 
 		},
 		Entry("No Claims", testCaseUpdateDatas{
-			template: &capm3.Metal3DataTemplate{
+			template: &infrav1.Metal3DataTemplate{
 				ObjectMeta: templateMeta,
 			},
 			expectedIndexes: map[string]int{},
 		}),
 		Entry("Claim and IP exist", testCaseUpdateDatas{
-			template: &capm3.Metal3DataTemplate{
+			template: &infrav1.Metal3DataTemplate{
 				ObjectMeta: templateMeta,
-				Spec:       capm3.Metal3DataTemplateSpec{},
+				Spec:       infrav1.Metal3DataTemplateSpec{},
 			},
-			dataClaims: []*capm3.Metal3DataClaim{
+			dataClaims: []*infrav1.Metal3DataClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc",
 						Namespace: namespaceName,
 					},
-					Spec: capm3.Metal3DataClaimSpec{
+					Spec: infrav1.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
 							Name:      "abc",
 							Namespace: namespaceName,
@@ -331,13 +331,13 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 						Name:      "abcd",
 						Namespace: namespaceName,
 					},
-					Spec: capm3.Metal3DataClaimSpec{
+					Spec: infrav1.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
 							Name:      "abcd",
 							Namespace: namespaceName,
 						},
 					},
-					Status: capm3.Metal3DataClaimStatus{
+					Status: infrav1.Metal3DataClaimStatus{
 						RenderedData: &corev1.ObjectReference{
 							Name:      "abc-2",
 							Namespace: namespaceName,
@@ -349,13 +349,13 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 						Name:      "abce",
 						Namespace: namespaceName,
 					},
-					Spec: capm3.Metal3DataClaimSpec{
+					Spec: infrav1.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
 							Name:      "abc",
 							Namespace: namespaceName,
 						},
 					},
-					Status: capm3.Metal3DataClaimStatus{
+					Status: infrav1.Metal3DataClaimStatus{
 						RenderedData: &corev1.ObjectReference{
 							Name:      "abc-2",
 							Namespace: namespaceName,
@@ -368,13 +368,13 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 						Namespace:         namespaceName,
 						DeletionTimestamp: &timeNow,
 					},
-					Spec: capm3.Metal3DataClaimSpec{
+					Spec: infrav1.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
 							Name:      "abc",
 							Namespace: namespaceName,
 						},
 					},
-					Status: capm3.Metal3DataClaimStatus{
+					Status: infrav1.Metal3DataClaimStatus{
 						RenderedData: &corev1.ObjectReference{
 							Name:      "abc-3",
 							Namespace: namespaceName,
@@ -382,13 +382,13 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 					},
 				},
 			},
-			datas: []*capm3.Metal3Data{
+			datas: []*infrav1.Metal3Data{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc-0",
 						Namespace: namespaceName,
 					},
-					Spec: capm3.Metal3DataSpec{
+					Spec: infrav1.Metal3DataSpec{
 						Template: corev1.ObjectReference{
 							Name:      "abc",
 							Namespace: namespaceName,
@@ -405,7 +405,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 						Name:      "abc-1",
 						Namespace: namespaceName,
 					},
-					Spec: capm3.Metal3DataSpec{
+					Spec: infrav1.Metal3DataSpec{
 						Template: corev1.ObjectReference{
 							Name:      "abc",
 							Namespace: namespaceName,
@@ -422,7 +422,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 						Name:      "abc-3",
 						Namespace: namespaceName,
 					},
-					Spec: capm3.Metal3DataSpec{
+					Spec: infrav1.Metal3DataSpec{
 						Template: corev1.ObjectReference{
 							Name:      "abc",
 							Namespace: namespaceName,
@@ -444,10 +444,10 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 	)
 
 	type testCaseTemplateReference struct {
-		template1                  *capm3.Metal3DataTemplate
-		template2                  *capm3.Metal3DataTemplate
-		dataObject                 *capm3.Metal3Data
-		dataClaim                  *capm3.Metal3DataClaim
+		template1                  *infrav1.Metal3DataTemplate
+		template2                  *infrav1.Metal3DataTemplate
+		dataObject                 *infrav1.Metal3Data
+		dataClaim                  *infrav1.Metal3DataClaim
 		indexes                    map[int]string
 		expectError                bool
 		expectTemplateReference    bool
@@ -474,7 +474,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 
-			dataObjects := capm3.Metal3DataList{}
+			dataObjects := infrav1.Metal3DataList{}
 			opts := &client.ListOptions{}
 			err = fakeClient.List(context.TODO(), &dataObjects, opts)
 			Expect(err).NotTo(HaveOccurred())
@@ -506,106 +506,106 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			}
 		},
 		Entry("TemplateReferenceExist", testCaseTemplateReference{
-			template1: &capm3.Metal3DataTemplate{
+			template1: &infrav1.Metal3DataTemplate{
 				ObjectMeta: templateMeta,
-				Spec:       capm3.Metal3DataTemplateSpec{},
+				Spec:       infrav1.Metal3DataTemplateSpec{},
 			},
 			indexes: map[int]string{},
-			template2: &capm3.Metal3DataTemplate{
+			template2: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc1",
 					Namespace: namespaceName,
 				},
-				Spec: capm3.Metal3DataTemplateSpec{
+				Spec: infrav1.Metal3DataTemplateSpec{
 					TemplateReference: "abc",
 				},
-				Status: capm3.Metal3DataTemplateStatus{
+				Status: infrav1.Metal3DataTemplateStatus{
 					Indexes: map[string]int{},
 				},
 			},
-			dataClaim: &capm3.Metal3DataClaim{
+			dataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR,
 			},
 			expectTemplateReference: true,
 		}),
 		Entry("TemplateReferenceDoNotExist", testCaseTemplateReference{
-			template1: &capm3.Metal3DataTemplate{
+			template1: &infrav1.Metal3DataTemplate{
 				ObjectMeta: templateMeta,
-				Spec:       capm3.Metal3DataTemplateSpec{},
+				Spec:       infrav1.Metal3DataTemplateSpec{},
 			},
 			indexes: map[int]string{},
-			template2: &capm3.Metal3DataTemplate{
+			template2: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc1",
 					Namespace: namespaceName,
 				},
-				Spec: capm3.Metal3DataTemplateSpec{},
-				Status: capm3.Metal3DataTemplateStatus{
+				Spec: infrav1.Metal3DataTemplateSpec{},
+				Status: infrav1.Metal3DataTemplateStatus{
 					Indexes: map[string]int{},
 				},
 			},
-			dataClaim: &capm3.Metal3DataClaim{
+			dataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR,
 			},
 			expectTemplateReference: false,
 		}),
 		Entry("TemplateReferenceRefersToOldTemplate", testCaseTemplateReference{
-			template1: &capm3.Metal3DataTemplate{
+			template1: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "template1",
 					Namespace: namespaceName,
 				},
-				Spec: capm3.Metal3DataTemplateSpec{},
+				Spec: infrav1.Metal3DataTemplateSpec{},
 			},
 			indexes: map[int]string{},
-			template2: &capm3.Metal3DataTemplate{
+			template2: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "template2",
 					Namespace: namespaceName,
 				},
-				Spec: capm3.Metal3DataTemplateSpec{
+				Spec: infrav1.Metal3DataTemplateSpec{
 					TemplateReference: "template1",
 				},
-				Status: capm3.Metal3DataTemplateStatus{
+				Status: infrav1.Metal3DataTemplateStatus{
 					Indexes: map[string]int{},
 				},
 			},
-			dataClaim: &capm3.Metal3DataClaim{
+			dataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR,
 			},
 			expectTemplateReference:    true,
 			expectDataObjectAssociated: true,
 		}),
 		Entry("TemplateReferenceRefersToZombieTemplate", testCaseTemplateReference{
-			template1: &capm3.Metal3DataTemplate{
+			template1: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "template1",
 					Namespace: namespaceName,
 				},
-				Spec: capm3.Metal3DataTemplateSpec{},
+				Spec: infrav1.Metal3DataTemplateSpec{},
 			},
 			indexes: map[int]string{},
-			template2: &capm3.Metal3DataTemplate{
+			template2: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "template2",
 					Namespace: namespaceName,
 				},
-				Spec: capm3.Metal3DataTemplateSpec{
+				Spec: infrav1.Metal3DataTemplateSpec{
 					TemplateReference: "template1",
 				},
-				Status: capm3.Metal3DataTemplateStatus{
+				Status: infrav1.Metal3DataTemplateStatus{
 					Indexes: map[string]int{},
 				},
 			},
-			dataClaim: &capm3.Metal3DataClaim{
+			dataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR,
 			},
-			dataObject: &capm3.Metal3Data{
+			dataObject: &infrav1.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
 					Namespace: namespaceName,
 				},
-				Spec: capm3.Metal3DataSpec{
+				Spec: infrav1.Metal3DataSpec{
 					Index: 0,
 					Template: corev1.ObjectReference{
 						Name: "template12",
@@ -620,9 +620,9 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 	)
 
 	type testCaseCreateAddresses struct {
-		template        *capm3.Metal3DataTemplate
-		dataClaim       *capm3.Metal3DataClaim
-		datas           []*capm3.Metal3Data
+		template        *infrav1.Metal3DataTemplate
+		dataClaim       *infrav1.Metal3DataClaim
+		datas           []*infrav1.Metal3Data
 		indexes         map[int]string
 		expectRequeue   bool
 		expectError     bool
@@ -657,7 +657,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 			// get list of Metal3Data objects
-			dataObjects := capm3.Metal3DataList{}
+			dataObjects := infrav1.Metal3DataList{}
 			opts := &client.ListOptions{}
 			err = fakeClient.List(context.TODO(), &dataObjects, opts)
 			Expect(err).NotTo(HaveOccurred())
@@ -674,15 +674,15 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			Expect(tc.template.Status.Indexes).To(Equal(tc.expectedIndexes))
 		},
 		Entry("Already exists", testCaseCreateAddresses{
-			template: &capm3.Metal3DataTemplate{
+			template: &infrav1.Metal3DataTemplate{
 				ObjectMeta: templateMeta,
-				Status: capm3.Metal3DataTemplateStatus{
+				Status: infrav1.Metal3DataTemplateStatus{
 					Indexes: map[string]int{
 						"abc": 0,
 					},
 				},
 			},
-			dataClaim: &capm3.Metal3DataClaim{
+			dataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR,
 			},
 			expectedIndexes: map[string]int{
@@ -690,15 +690,15 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			},
 		}),
 		Entry("Not allocated yet, first", testCaseCreateAddresses{
-			template: &capm3.Metal3DataTemplate{
+			template: &infrav1.Metal3DataTemplate{
 				ObjectMeta: templateMeta,
-				Spec:       capm3.Metal3DataTemplateSpec{},
-				Status: capm3.Metal3DataTemplateStatus{
+				Spec:       infrav1.Metal3DataTemplateSpec{},
+				Status: infrav1.Metal3DataTemplateStatus{
 					Indexes: map[string]int{},
 				},
 			},
 			indexes: map[int]string{},
-			dataClaim: &capm3.Metal3DataClaim{
+			dataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR,
 			},
 			expectedIndexes: map[string]int{
@@ -710,17 +710,17 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			expectedDatas: []string{"abc-0"},
 		}),
 		Entry("Not allocated yet, second", testCaseCreateAddresses{
-			template: &capm3.Metal3DataTemplate{
+			template: &infrav1.Metal3DataTemplate{
 				ObjectMeta: templateMeta,
-				Spec:       capm3.Metal3DataTemplateSpec{},
-				Status: capm3.Metal3DataTemplateStatus{
+				Spec:       infrav1.Metal3DataTemplateSpec{},
+				Status: infrav1.Metal3DataTemplateStatus{
 					Indexes: map[string]int{
 						"bcd": 0,
 					},
 				},
 			},
 			indexes: map[int]string{0: "bcd"},
-			dataClaim: &capm3.Metal3DataClaim{
+			dataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR,
 			},
 			expectedIndexes: map[string]int{
@@ -734,24 +734,24 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			expectedDatas: []string{"abc-1"},
 		}),
 		Entry("Not allocated yet, conflict", testCaseCreateAddresses{
-			template: &capm3.Metal3DataTemplate{
+			template: &infrav1.Metal3DataTemplate{
 				ObjectMeta: templateMeta,
-				Spec:       capm3.Metal3DataTemplateSpec{},
-				Status: capm3.Metal3DataTemplateStatus{
+				Spec:       infrav1.Metal3DataTemplateSpec{},
+				Status: infrav1.Metal3DataTemplateStatus{
 					Indexes: map[string]int{},
 				},
 			},
 			indexes: map[int]string{},
-			dataClaim: &capm3.Metal3DataClaim{
+			dataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR,
 			},
-			datas: []*capm3.Metal3Data{
+			datas: []*infrav1.Metal3Data{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc-0",
 						Namespace: namespaceName,
 					},
-					Spec: capm3.Metal3DataSpec{
+					Spec: infrav1.Metal3DataSpec{
 						Index: 0,
 						Template: corev1.ObjectReference{
 							Name: "abc",
@@ -770,9 +770,9 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 	)
 
 	type testCaseDeleteDatas struct {
-		template        *capm3.Metal3DataTemplate
-		dataClaim       *capm3.Metal3DataClaim
-		datas           []*capm3.Metal3Data
+		template        *infrav1.Metal3DataTemplate
+		dataClaim       *infrav1.Metal3DataClaim
+		datas           []*infrav1.Metal3Data
 		indexes         map[int]string
 		expectedMap     map[int]string
 		expectedIndexes map[string]int
@@ -799,7 +799,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			}
 
 			// get list of Metal3Data objects
-			dataObjects := capm3.Metal3DataList{}
+			dataObjects := infrav1.Metal3DataList{}
 			opts := &client.ListOptions{}
 			err = fakeClient.List(context.TODO(), &dataObjects, opts)
 			Expect(err).NotTo(HaveOccurred())
@@ -811,16 +811,16 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			Expect(len(tc.dataClaim.Finalizers)).To(Equal(0))
 		},
 		Entry("Empty Template", testCaseDeleteDatas{
-			template: &capm3.Metal3DataTemplate{},
-			dataClaim: &capm3.Metal3DataClaim{
+			template: &infrav1.Metal3DataTemplate{},
+			dataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "TestRef",
 				},
 			},
 		}),
 		Entry("No Deletion needed", testCaseDeleteDatas{
-			template: &capm3.Metal3DataTemplate{},
-			dataClaim: &capm3.Metal3DataClaim{
+			template: &infrav1.Metal3DataTemplate{},
+			dataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "TestRef",
 				},
@@ -831,14 +831,14 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			},
 		}),
 		Entry("Deletion needed, not found", testCaseDeleteDatas{
-			template: &capm3.Metal3DataTemplate{
-				Status: capm3.Metal3DataTemplateStatus{
+			template: &infrav1.Metal3DataTemplate{
+				Status: infrav1.Metal3DataTemplateStatus{
 					Indexes: map[string]int{
 						"TestRef": 0,
 					},
 				},
 			},
-			dataClaim: &capm3.Metal3DataClaim{
+			dataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "TestRef",
 				},
@@ -850,22 +850,22 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			expectedMap:     map[int]string{},
 		}),
 		Entry("Deletion needed", testCaseDeleteDatas{
-			template: &capm3.Metal3DataTemplate{
+			template: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "abc",
 				},
-				Spec: capm3.Metal3DataTemplateSpec{},
-				Status: capm3.Metal3DataTemplateStatus{
+				Spec: infrav1.Metal3DataTemplateSpec{},
+				Status: infrav1.Metal3DataTemplateStatus{
 					Indexes: map[string]int{
 						"TestRef": 0,
 					},
 				},
 			},
-			dataClaim: &capm3.Metal3DataClaim{
+			dataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "TestRef",
 					Finalizers: []string{
-						capm3.DataClaimFinalizer,
+						infrav1.DataClaimFinalizer,
 					},
 				},
 			},
@@ -874,7 +874,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			},
 			expectedMap:     map[int]string{},
 			expectedIndexes: map[string]int{},
-			datas: []*capm3.Metal3Data{
+			datas: []*infrav1.Metal3Data{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "abc-0",

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -29,7 +29,7 @@ import (
 	// comment for go-lint.
 	"github.com/go-logr/logr"
 
-	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -207,11 +207,11 @@ func (m *MachineManager) RemovePauseAnnotation(ctx context.Context) error {
 	annotations := host.GetAnnotations()
 
 	if annotations != nil {
-		if _, ok := annotations[bmh.PausedAnnotation]; ok {
-			if m.Cluster.Name == host.Labels[clusterv1.ClusterLabelName] && annotations[bmh.PausedAnnotation] == PausedAnnotationKey {
+		if _, ok := annotations[bmov1alpha1.PausedAnnotation]; ok {
+			if m.Cluster.Name == host.Labels[clusterv1.ClusterLabelName] && annotations[bmov1alpha1.PausedAnnotation] == PausedAnnotationKey {
 				// Removing BMH Paused Annotation Since Owner Cluster is not paused.
-				delete(host.Annotations, bmh.PausedAnnotation)
-			} else if m.Cluster.Name == host.Labels[clusterv1.ClusterLabelName] && annotations[bmh.PausedAnnotation] != PausedAnnotationKey {
+				delete(host.Annotations, bmov1alpha1.PausedAnnotation)
+			} else if m.Cluster.Name == host.Labels[clusterv1.ClusterLabelName] && annotations[bmov1alpha1.PausedAnnotation] != PausedAnnotationKey {
 				m.Log.Info("BMH is paused by user. Not removing Pause Annotation")
 				return nil
 			}
@@ -237,7 +237,7 @@ func (m *MachineManager) SetPauseAnnotation(ctx context.Context) error {
 	annotations := host.GetAnnotations()
 
 	if annotations != nil {
-		if _, ok := annotations[bmh.PausedAnnotation]; ok {
+		if _, ok := annotations[bmov1alpha1.PausedAnnotation]; ok {
 			m.Log.Info("BaremetalHost is already paused")
 			return nil
 		}
@@ -245,7 +245,7 @@ func (m *MachineManager) SetPauseAnnotation(ctx context.Context) error {
 		host.Annotations = make(map[string]string)
 	}
 	m.Log.Info("Adding PausedAnnotation in BareMetalHost")
-	host.Annotations[bmh.PausedAnnotation] = PausedAnnotationKey
+	host.Annotations[bmov1alpha1.PausedAnnotation] = PausedAnnotationKey
 
 	// Setting annotation with BMH status
 	newAnnotation, err := json.Marshal(&host.Status)
@@ -255,7 +255,7 @@ func (m *MachineManager) SetPauseAnnotation(ctx context.Context) error {
 		)
 		return errors.Wrap(err, "failed to marshall status annotation")
 	}
-	host.Annotations[bmh.StatusAnnotation] = string(newAnnotation)
+	host.Annotations[bmov1alpha1.StatusAnnotation] = string(newAnnotation)
 	return helper.Patch(ctx, host)
 }
 
@@ -273,7 +273,7 @@ func (m *MachineManager) GetBaremetalHostID(ctx context.Context) (*string, error
 		m.Log.Info("BaremetalHost not associated, requeuing")
 		return nil, &RequeueAfterError{RequeueAfter: requeueAfter}
 	}
-	if host.Status.Provisioning.State == bmh.StateProvisioned {
+	if host.Status.Provisioning.State == bmov1alpha1.StateProvisioned {
 		return pointer.StringPtr(string(host.ObjectMeta.UID)), nil
 	}
 	m.Log.Info("Provisioning BaremetalHost, requeuing")
@@ -458,7 +458,7 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 // for the BareMetalHost. The UserDataSecretName might already be in a secret with
 // CABPK v0.3.0+, but if it is in a different namespace than the BareMetalHost,
 // then we need to create the secret.
-func (m *MachineManager) getUserDataSecretName(ctx context.Context, host *bmh.BareMetalHost) error {
+func (m *MachineManager) getUserDataSecretName(ctx context.Context, host *bmov1alpha1.BareMetalHost) error {
 	if m.Metal3Machine.Status.UserData != nil {
 		return nil
 	}
@@ -587,13 +587,13 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 
 		waiting := true
 		switch host.Status.Provisioning.State {
-		case bmh.StateRegistering,
-			bmh.StateMatchProfile, bmh.StateInspecting,
-			bmh.StateReady, bmh.StateAvailable, bmh.StateNone,
-			bmh.StateUnmanaged:
+		case bmov1alpha1.StateRegistering,
+			bmov1alpha1.StateMatchProfile, bmov1alpha1.StateInspecting,
+			bmov1alpha1.StateReady, bmov1alpha1.StateAvailable, bmov1alpha1.StateNone,
+			bmov1alpha1.StateUnmanaged:
 			// Host is not provisioned.
 			waiting = false
-		case bmh.StateExternallyProvisioned:
+		case bmov1alpha1.StateExternallyProvisioned:
 			// We have no control over provisioning, so just wait until the
 			// host is powered off.
 			waiting = host.Status.PoweredOn
@@ -698,8 +698,8 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 		}
 
 		m.Log.Info("Removing Paused Annotation (if any)")
-		if host.Annotations != nil && host.Annotations[bmh.PausedAnnotation] == PausedAnnotationKey {
-			delete(host.Annotations, bmh.PausedAnnotation)
+		if host.Annotations != nil && host.Annotations[bmov1alpha1.PausedAnnotation] == PausedAnnotationKey {
+			delete(host.Annotations, bmov1alpha1.PausedAnnotation)
 		}
 
 		// Update the BMH object, if the errors are NotFound, do not return the
@@ -796,7 +796,7 @@ func (m *MachineManager) exists(ctx context.Context) (bool, error) {
 // getHost gets the associated host by looking for an annotation on the machine
 // that contains a reference to the host. Returns nil if not found. Assumes the
 // host is in the same namespace as the machine.
-func (m *MachineManager) getHost(ctx context.Context) (*bmh.BareMetalHost, *patch.Helper, error) {
+func (m *MachineManager) getHost(ctx context.Context) (*bmov1alpha1.BareMetalHost, *patch.Helper, error) {
 	host, err := getHost(ctx, m.Metal3Machine, m.client, m.Log)
 	if err != nil || host == nil {
 		return host, nil, err
@@ -807,7 +807,7 @@ func (m *MachineManager) getHost(ctx context.Context) (*bmh.BareMetalHost, *patc
 
 func getHost(ctx context.Context, m3Machine *infrav1.Metal3Machine, cl client.Client,
 	mLog logr.Logger,
-) (*bmh.BareMetalHost, error) {
+) (*bmov1alpha1.BareMetalHost, error) {
 	annotations := m3Machine.ObjectMeta.GetAnnotations()
 	if annotations == nil {
 		return nil, nil
@@ -822,7 +822,7 @@ func getHost(ctx context.Context, m3Machine *infrav1.Metal3Machine, cl client.Cl
 		return nil, err
 	}
 
-	host := bmh.BareMetalHost{}
+	host := bmov1alpha1.BareMetalHost{}
 	key := client.ObjectKey{
 		Name:      hostName,
 		Namespace: hostNamespace,
@@ -840,9 +840,9 @@ func getHost(ctx context.Context, m3Machine *infrav1.Metal3Machine, cl client.Cl
 // chooseHost iterates through known hosts and returns one that can be
 // associated with the metal3 machine. It searches all hosts in case one already has an
 // association with this metal3 machine.
-func (m *MachineManager) chooseHost(ctx context.Context) (*bmh.BareMetalHost, *patch.Helper, error) {
+func (m *MachineManager) chooseHost(ctx context.Context) (*bmov1alpha1.BareMetalHost, *patch.Helper, error) {
 	// get list of BMH.
-	hosts := bmh.BareMetalHostList{}
+	hosts := bmov1alpha1.BareMetalHostList{}
 	// without this ListOption, all namespaces would be including in the listing.
 	opts := &client.ListOptions{
 		Namespace: m.Metal3Machine.Namespace,
@@ -884,8 +884,8 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmh.BareMetalHost, *p
 	}
 	labelSelector = labelSelector.Add(reqs...)
 
-	availableHosts := []*bmh.BareMetalHost{}
-	availableHostsWithNodeReuse := []*bmh.BareMetalHost{}
+	availableHosts := []*bmov1alpha1.BareMetalHost{}
+	availableHostsWithNodeReuse := []*bmov1alpha1.BareMetalHost{}
 
 	for i, host := range hosts.Items {
 		host := host
@@ -909,7 +909,7 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmh.BareMetalHost, *p
 		// continue if BaremetalHost is paused or marked with UnhealthyAnnotation.
 		annotations := host.GetAnnotations()
 		if annotations != nil {
-			if _, ok := annotations[bmh.PausedAnnotation]; ok {
+			if _, ok := annotations[bmov1alpha1.PausedAnnotation]; ok {
 				continue
 			}
 			if _, ok := annotations[infrav1.UnhealthyAnnotation]; ok {
@@ -923,7 +923,7 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmh.BareMetalHost, *p
 				availableHostsWithNodeReuse = append(availableHostsWithNodeReuse, &hosts.Items[i])
 			} else if !m.nodeReuseLabelExists(ctx, &host) {
 				switch host.Status.Provisioning.State {
-				case bmh.StateReady, bmh.StateAvailable:
+				case bmov1alpha1.StateReady, bmov1alpha1.StateAvailable:
 				default:
 					continue
 				}
@@ -942,16 +942,16 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmh.BareMetalHost, *p
 	}
 
 	// choose a host.
-	var chosenHost *bmh.BareMetalHost
+	var chosenHost *bmov1alpha1.BareMetalHost
 
 	// If there are hosts with nodeReuseLabelName:
 	if len(availableHostsWithNodeReuse) != 0 {
 		for _, host := range availableHostsWithNodeReuse {
 			// Build list of hosts in Ready state with nodeReuseLabelName
-			hostsInAvailableStateWithNodeReuse := []*bmh.BareMetalHost{}
+			hostsInAvailableStateWithNodeReuse := []*bmov1alpha1.BareMetalHost{}
 			// Build list of hosts in any other state than Ready state with nodeReuseLabelName
-			hostsInNotAvailableStateWithNodeReuse := []*bmh.BareMetalHost{}
-			if host.Status.Provisioning.State == bmh.StateReady || host.Status.Provisioning.State == bmh.StateAvailable {
+			hostsInNotAvailableStateWithNodeReuse := []*bmov1alpha1.BareMetalHost{}
+			if host.Status.Provisioning.State == bmov1alpha1.StateReady || host.Status.Provisioning.State == bmov1alpha1.StateAvailable {
 				hostsInAvailableStateWithNodeReuse = append(hostsInAvailableStateWithNodeReuse, host)
 			} else {
 				hostsInNotAvailableStateWithNodeReuse = append(hostsInNotAvailableStateWithNodeReuse, host)
@@ -1000,7 +1000,7 @@ func consumerRefMatches(consumer *corev1.ObjectReference, m3machine *infrav1.Met
 }
 
 // nodeReuseLabelMatches returns true if nodeReuseLabelName matches KubeadmControlPlane or MachineDeployment name on the host.
-func (m *MachineManager) nodeReuseLabelMatches(ctx context.Context, host *bmh.BareMetalHost) bool {
+func (m *MachineManager) nodeReuseLabelMatches(ctx context.Context, host *bmov1alpha1.BareMetalHost) bool {
 	if host == nil {
 		return false
 	}
@@ -1036,7 +1036,7 @@ func (m *MachineManager) nodeReuseLabelMatches(ctx context.Context, host *bmh.Ba
 }
 
 // nodeReuseLabelExists returns true if host contains nodeReuseLabelName label.
-func (m *MachineManager) nodeReuseLabelExists(ctx context.Context, host *bmh.BareMetalHost) bool {
+func (m *MachineManager) nodeReuseLabelExists(ctx context.Context, host *bmov1alpha1.BareMetalHost) bool {
 	if host == nil {
 		return false
 	}
@@ -1049,7 +1049,7 @@ func (m *MachineManager) nodeReuseLabelExists(ctx context.Context, host *bmh.Bar
 }
 
 // getBMCSecret will return the BMCSecret associated with BMH.
-func (m *MachineManager) getBMCSecret(ctx context.Context, host *bmh.BareMetalHost) (*corev1.Secret, error) {
+func (m *MachineManager) getBMCSecret(ctx context.Context, host *bmov1alpha1.BareMetalHost) (*corev1.Secret, error) {
 	if host.Spec.BMC.CredentialsName == "" {
 		return nil, nil
 	}
@@ -1064,7 +1064,7 @@ func (m *MachineManager) getBMCSecret(ctx context.Context, host *bmh.BareMetalHo
 }
 
 // setBMCSecretLabel will set the set cluster.x-k8s.io/cluster-name to BMCSecret.
-func (m *MachineManager) setBMCSecretLabel(ctx context.Context, host *bmh.BareMetalHost) error {
+func (m *MachineManager) setBMCSecretLabel(ctx context.Context, host *bmov1alpha1.BareMetalHost) error {
 	tmpBMCSecret, err := m.getBMCSecret(ctx, host)
 	if err != nil {
 		return err
@@ -1082,7 +1082,7 @@ func (m *MachineManager) setBMCSecretLabel(ctx context.Context, host *bmh.BareMe
 }
 
 // setHostLabel will set the set cluster.x-k8s.io/cluster-name to bmh.
-func (m *MachineManager) setHostLabel(ctx context.Context, host *bmh.BareMetalHost) error {
+func (m *MachineManager) setHostLabel(ctx context.Context, host *bmov1alpha1.BareMetalHost) error {
 	if host.Labels == nil {
 		host.Labels = make(map[string]string)
 	}
@@ -1094,7 +1094,7 @@ func (m *MachineManager) setHostLabel(ctx context.Context, host *bmh.BareMetalHo
 // setHostSpec will ensure the host's Spec is set according to the machine's
 // details. It will then update the host via the kube API. If UserData does not
 // include a Namespace, it will default to the Metal3Machine's namespace.
-func (m *MachineManager) setHostSpec(ctx context.Context, host *bmh.BareMetalHost) error {
+func (m *MachineManager) setHostSpec(ctx context.Context, host *bmov1alpha1.BareMetalHost) error {
 	// We only want to update the image setting if the host does not
 	// already have an image.
 	//
@@ -1107,10 +1107,10 @@ func (m *MachineManager) setHostSpec(ctx context.Context, host *bmh.BareMetalHos
 		if m.Metal3Machine.Spec.Image.ChecksumType != nil {
 			checksumType = *m.Metal3Machine.Spec.Image.ChecksumType
 		}
-		host.Spec.Image = &bmh.Image{
+		host.Spec.Image = &bmov1alpha1.Image{
 			URL:          m.Metal3Machine.Spec.Image.URL,
 			Checksum:     m.Metal3Machine.Spec.Image.Checksum,
-			ChecksumType: bmh.ChecksumType(checksumType),
+			ChecksumType: bmov1alpha1.ChecksumType(checksumType),
 			DiskFormat:   m.Metal3Machine.Spec.Image.DiskFormat,
 		}
 		host.Spec.UserData = m.Metal3Machine.Status.UserData
@@ -1134,8 +1134,8 @@ func (m *MachineManager) setHostSpec(ctx context.Context, host *bmh.BareMetalHos
 	}
 	// Set automatedCleaningMode from metal3Machine.spec.automatedCleaningMode.
 	if m.Metal3Machine.Spec.AutomatedCleaningMode != nil {
-		if host.Spec.AutomatedCleaningMode != bmh.AutomatedCleaningMode(*m.Metal3Machine.Spec.AutomatedCleaningMode) {
-			host.Spec.AutomatedCleaningMode = bmh.AutomatedCleaningMode(*m.Metal3Machine.Spec.AutomatedCleaningMode)
+		if host.Spec.AutomatedCleaningMode != bmov1alpha1.AutomatedCleaningMode(*m.Metal3Machine.Spec.AutomatedCleaningMode) {
+			host.Spec.AutomatedCleaningMode = bmov1alpha1.AutomatedCleaningMode(*m.Metal3Machine.Spec.AutomatedCleaningMode)
 		}
 	}
 
@@ -1146,7 +1146,7 @@ func (m *MachineManager) setHostSpec(ctx context.Context, host *bmh.BareMetalHos
 
 // setHostConsumerRef will ensure the host's Spec is set to link to this
 // Metal3Machine.
-func (m *MachineManager) setHostConsumerRef(ctx context.Context, host *bmh.BareMetalHost) error {
+func (m *MachineManager) setHostConsumerRef(ctx context.Context, host *bmov1alpha1.BareMetalHost) error {
 	host.Spec.ConsumerRef = &corev1.ObjectReference{
 		Kind:       "Metal3Machine",
 		Name:       m.Metal3Machine.Name,
@@ -1177,7 +1177,7 @@ func (m *MachineManager) setHostConsumerRef(ctx context.Context, host *bmh.BareM
 
 // ensureAnnotation makes sure the machine has an annotation that references the
 // host and uses the API to update the machine if necessary.
-func (m *MachineManager) ensureAnnotation(ctx context.Context, host *bmh.BareMetalHost) error {
+func (m *MachineManager) ensureAnnotation(ctx context.Context, host *bmov1alpha1.BareMetalHost) error {
 	annotations := m.Metal3Machine.ObjectMeta.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)
@@ -1250,7 +1250,7 @@ func (m *MachineManager) clearError() {
 }
 
 // updateMachineStatus updates a Metal3Machine object's status.
-func (m *MachineManager) updateMachineStatus(ctx context.Context, host *bmh.BareMetalHost) error {
+func (m *MachineManager) updateMachineStatus(ctx context.Context, host *bmov1alpha1.BareMetalHost) error {
 	addrs := m.nodeAddresses(host)
 
 	metal3MachineOld := m.Metal3Machine.DeepCopy()
@@ -1270,7 +1270,7 @@ func (m *MachineManager) updateMachineStatus(ctx context.Context, host *bmh.Bare
 
 // NodeAddresses returns a slice of corev1.NodeAddress objects for a
 // given Metal3 machine.
-func (m *MachineManager) nodeAddresses(host *bmh.BareMetalHost) []clusterv1.MachineAddress {
+func (m *MachineManager) nodeAddresses(host *bmov1alpha1.BareMetalHost) []clusterv1.MachineAddress {
 	addrs := []clusterv1.MachineAddress{}
 
 	// If the host is nil or we have no hw details, return an empty address array.

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -29,7 +29,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
-	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -123,52 +123,52 @@ func consumerRefSome() *corev1.ObjectReference {
 	}
 }
 
-func expectedImg() *bmh.Image {
-	return &bmh.Image{
+func expectedImg() *bmov1alpha1.Image {
+	return &bmov1alpha1.Image{
 		URL:        testImageURL,
 		Checksum:   testImageChecksumURL,
 		DiskFormat: testImageDiskFormat,
 	}
 }
 
-func expectedImgTest() *bmh.Image {
-	return &bmh.Image{
+func expectedImgTest() *bmov1alpha1.Image {
+	return &bmov1alpha1.Image{
 		URL:      testImageURL + "test",
 		Checksum: testImageChecksumURL + "test",
 	}
 }
 
-func bmhSpec() *bmh.BareMetalHostSpec {
-	return &bmh.BareMetalHostSpec{
+func bmhSpec() *bmov1alpha1.BareMetalHostSpec {
+	return &bmov1alpha1.BareMetalHostSpec{
 		ConsumerRef: consumerRef(),
-		Image: &bmh.Image{
+		Image: &bmov1alpha1.Image{
 			URL: "myimage",
 		},
 		Online: true,
 	}
 }
 
-func bmhSpecBMC() *bmh.BareMetalHostSpec {
-	return &bmh.BareMetalHostSpec{
+func bmhSpecBMC() *bmov1alpha1.BareMetalHostSpec {
+	return &bmov1alpha1.BareMetalHostSpec{
 		ConsumerRef: consumerRef(),
-		BMC: bmh.BMCDetails{
+		BMC: bmov1alpha1.BMCDetails{
 			Address:         "myAddress",
 			CredentialsName: "mycredentials",
 		},
 	}
 }
 
-func bmhSpecTestImg() *bmh.BareMetalHostSpec {
-	return &bmh.BareMetalHostSpec{
+func bmhSpecTestImg() *bmov1alpha1.BareMetalHostSpec {
+	return &bmov1alpha1.BareMetalHostSpec{
 		ConsumerRef: consumerRef(),
 		Image:       expectedImgTest(),
 	}
 }
 
-func bmhSpecSomeImg() *bmh.BareMetalHostSpec {
-	return &bmh.BareMetalHostSpec{
+func bmhSpecSomeImg() *bmov1alpha1.BareMetalHostSpec {
+	return &bmov1alpha1.BareMetalHostSpec{
 		ConsumerRef: consumerRefSome(),
-		Image: &bmh.Image{
+		Image: &bmov1alpha1.Image{
 			URL: "someoneelsesimage",
 		},
 		MetaData:    &corev1.SecretReference{},
@@ -178,8 +178,8 @@ func bmhSpecSomeImg() *bmh.BareMetalHostSpec {
 	}
 }
 
-func bmhSpecNoImg() *bmh.BareMetalHostSpec {
-	return &bmh.BareMetalHostSpec{
+func bmhSpecNoImg() *bmov1alpha1.BareMetalHostSpec {
+	return &bmov1alpha1.BareMetalHostSpec{
 		ConsumerRef: consumerRef(),
 	}
 }
@@ -207,7 +207,7 @@ func bmhObjectMetaWithValidCAPM3PausedAnnotations() *metav1.ObjectMeta {
 			clusterv1.ClusterLabelName: clusterName,
 		},
 		Annotations: map[string]string{
-			bmh.PausedAnnotation: PausedAnnotationKey,
+			bmov1alpha1.PausedAnnotation: PausedAnnotationKey,
 		},
 	}
 }
@@ -218,7 +218,7 @@ func bmhObjectMetaWithValidEmptyPausedAnnotations() *metav1.ObjectMeta {
 		Namespace:       namespaceName,
 		OwnerReferences: []metav1.OwnerReference{},
 		Annotations: map[string]string{
-			bmh.PausedAnnotation: "",
+			bmov1alpha1.PausedAnnotation: "",
 		},
 	}
 }
@@ -297,19 +297,19 @@ func machineOwnedByMachineSet() *clusterv1.Machine {
 	}
 }
 
-func bmhPowerStatus() *bmh.BareMetalHostStatus {
-	return &bmh.BareMetalHostStatus{
-		Provisioning: bmh.ProvisionStatus{
-			State: bmh.StateNone,
+func bmhPowerStatus() *bmov1alpha1.BareMetalHostStatus {
+	return &bmov1alpha1.BareMetalHostStatus{
+		Provisioning: bmov1alpha1.ProvisionStatus{
+			State: bmov1alpha1.StateNone,
 		},
 		PoweredOn: true,
 	}
 }
 
-func bmhStatus() *bmh.BareMetalHostStatus {
-	return &bmh.BareMetalHostStatus{
-		Provisioning: bmh.ProvisionStatus{
-			State: bmh.StateNone,
+func bmhStatus() *bmov1alpha1.BareMetalHostStatus {
+	return &bmov1alpha1.BareMetalHostStatus{
+		Provisioning: bmov1alpha1.ProvisionStatus{
+			State: bmov1alpha1.StateNone,
 		},
 	}
 }
@@ -474,12 +474,12 @@ var _ = Describe("Metal3Machine manager", func() {
 	Describe("Test ChooseHost", func() {
 
 		// Creating the hosts
-		host1 := bmh.BareMetalHost{
+		host1 := bmov1alpha1.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "host1",
 				Namespace: namespaceName,
 			},
-			Spec: bmh.BareMetalHostSpec{
+			Spec: bmov1alpha1.BareMetalHostSpec{
 				ConsumerRef: &corev1.ObjectReference{
 					Name:       "someothermachine",
 					Namespace:  namespaceName,
@@ -488,14 +488,14 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			},
 		}
-		host2 := *newBareMetalHost("myhost", nil, bmh.StateNone, nil, false, "metadata", false)
+		host2 := *newBareMetalHost("myhost", nil, bmov1alpha1.StateNone, nil, false, "metadata", false)
 
-		host3 := bmh.BareMetalHost{
+		host3 := bmov1alpha1.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "host3",
 				Namespace: namespaceName,
 			},
-			Spec: bmh.BareMetalHostSpec{
+			Spec: bmov1alpha1.BareMetalHostSpec{
 				ConsumerRef: &corev1.ObjectReference{
 					Name:       "machine1",
 					Namespace:  namespaceName,
@@ -504,43 +504,43 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			},
 		}
-		host4 := bmh.BareMetalHost{
+		host4 := bmov1alpha1.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "host4",
 				Namespace: "someotherns",
 			},
 		}
-		discoveredHost := bmh.BareMetalHost{
+		discoveredHost := bmov1alpha1.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "discoveredHost",
 				Namespace: namespaceName,
 			},
-			Status: bmh.BareMetalHostStatus{
+			Status: bmov1alpha1.BareMetalHostStatus{
 				ErrorMessage: "this host is discovered but not usable",
 			},
 		}
-		hostWithLabel := bmh.BareMetalHost{
+		hostWithLabel := bmov1alpha1.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "hostWithLabel",
 				Namespace: namespaceName,
 				Labels:    map[string]string{"key1": "value1"},
 			},
 		}
-		hostWithUnhealthyAnnotation := bmh.BareMetalHost{
+		hostWithUnhealthyAnnotation := bmov1alpha1.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "hostWithUnhealthyAnnotation",
 				Namespace:   namespaceName,
 				Annotations: map[string]string{infrav1.UnhealthyAnnotation: "unhealthy"},
 			},
 		}
-		hostWithNodeReuseLabelSetToKCP := bmh.BareMetalHost{
+		hostWithNodeReuseLabelSetToKCP := bmov1alpha1.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "hostWithNodeReuseLabelSetToKCP",
 				Namespace: namespaceName,
 				Labels:    map[string]string{nodeReuseLabelName: "kcp-pool1"},
 			},
 		}
-		hostWithNodeReuseLabelSetToMD := bmh.BareMetalHost{
+		hostWithNodeReuseLabelSetToMD := bmov1alpha1.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "hostWithNodeReuseLabelSetToMD",
 				Namespace: namespaceName,
@@ -702,7 +702,7 @@ var _ = Describe("Metal3Machine manager", func() {
 
 	type testCaseSetPauseAnnotation struct {
 		M3Machine           *infrav1.Metal3Machine
-		Host                *bmh.BareMetalHost
+		Host                *bmov1alpha1.BareMetalHost
 		ExpectPausePresent  bool
 		ExpectStatusPresent bool
 		ExpectError         bool
@@ -724,7 +724,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 
-			savedHost := bmh.BareMetalHost{}
+			savedHost := bmov1alpha1.BareMetalHost{}
 			err = fakeClient.Get(context.TODO(),
 				client.ObjectKey{
 					Name:      tc.Host.Name,
@@ -733,13 +733,13 @@ var _ = Describe("Metal3Machine manager", func() {
 				&savedHost,
 			)
 			Expect(err).NotTo(HaveOccurred())
-			_, pausePresent := savedHost.Annotations[bmh.PausedAnnotation]
+			_, pausePresent := savedHost.Annotations[bmov1alpha1.PausedAnnotation]
 			if tc.ExpectPausePresent {
 				Expect(pausePresent).To(BeTrue())
 			} else {
 				Expect(pausePresent).To(BeFalse())
 			}
-			status, statusPresent := savedHost.Annotations[bmh.StatusAnnotation]
+			status, statusPresent := savedHost.Annotations[bmov1alpha1.StatusAnnotation]
 			if tc.ExpectStatusPresent {
 				Expect(statusPresent).To(BeTrue())
 				annotation, err := json.Marshal(&tc.Host.Status)
@@ -750,9 +750,9 @@ var _ = Describe("Metal3Machine manager", func() {
 			}
 		},
 		Entry("Set BMH Pause Annotation, with valid CAPM3 Paused annotations, already paused", testCaseSetPauseAnnotation{
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: *bmhObjectMetaWithValidCAPM3PausedAnnotations(),
-				Spec: bmh.BareMetalHostSpec{
+				Spec: bmov1alpha1.BareMetalHostSpec{
 					ConsumerRef: &corev1.ObjectReference{
 						Name:       "mym3machine",
 						Namespace:  namespaceName,
@@ -767,9 +767,9 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectError:        false,
 		}),
 		Entry("Set BMH Pause Annotation, with valid Paused annotations, Empty Key, already paused", testCaseSetPauseAnnotation{
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: *bmhObjectMetaWithValidEmptyPausedAnnotations(),
-				Spec: bmh.BareMetalHostSpec{
+				Spec: bmov1alpha1.BareMetalHostSpec{
 					ConsumerRef: &corev1.ObjectReference{
 						Name:       "mym3machine",
 						Namespace:  namespaceName,
@@ -784,9 +784,9 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectError:        false,
 		}),
 		Entry("Set BMH Pause Annotation, with no Paused annotations", testCaseSetPauseAnnotation{
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: *bmhObjectMetaEmptyAnnotations(),
-				Spec: bmh.BareMetalHostSpec{
+				Spec: bmov1alpha1.BareMetalHostSpec{
 					ConsumerRef: &corev1.ObjectReference{
 						Name:       "mym3machine",
 						Namespace:  namespaceName,
@@ -794,7 +794,7 @@ var _ = Describe("Metal3Machine manager", func() {
 						APIVersion: infrav1.GroupVersion.String(),
 					},
 				},
-				Status: bmh.BareMetalHostStatus{
+				Status: bmov1alpha1.BareMetalHostStatus{
 					OperationalStatus: "OK",
 				},
 			},
@@ -809,7 +809,7 @@ var _ = Describe("Metal3Machine manager", func() {
 	type testCaseRemovePauseAnnotation struct {
 		Cluster       *clusterv1.Cluster
 		M3Machine     *infrav1.Metal3Machine
-		Host          *bmh.BareMetalHost
+		Host          *bmov1alpha1.BareMetalHost
 		ExpectPresent bool
 		ExpectError   bool
 	}
@@ -836,7 +836,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 
-			savedHost := bmh.BareMetalHost{}
+			savedHost := bmov1alpha1.BareMetalHost{}
 			err = fakeClient.Get(context.TODO(),
 				client.ObjectKey{
 					Name:      tc.Host.Name,
@@ -846,16 +846,16 @@ var _ = Describe("Metal3Machine manager", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 			if tc.ExpectPresent {
-				Expect(savedHost.Annotations[bmh.PausedAnnotation]).NotTo(BeNil())
+				Expect(savedHost.Annotations[bmov1alpha1.PausedAnnotation]).NotTo(BeNil())
 			} else {
 				Expect(savedHost.Annotations).To(BeNil())
 			}
 		},
 		Entry("Remove BMH Pause Annotation, with valid CAPM3 Paused annotations", testCaseRemovePauseAnnotation{
 			Cluster: newCluster(clusterName),
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: *bmhObjectMetaWithValidCAPM3PausedAnnotations(),
-				Spec: bmh.BareMetalHostSpec{
+				Spec: bmov1alpha1.BareMetalHostSpec{
 					ConsumerRef: &corev1.ObjectReference{
 						Name:       "mym3machine",
 						Namespace:  namespaceName,
@@ -871,9 +871,9 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Do not Remove Annotation, with valid Paused annotations, Empty Key", testCaseRemovePauseAnnotation{
 			Cluster: newCluster(clusterName),
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: *bmhObjectMetaWithValidEmptyPausedAnnotations(),
-				Spec: bmh.BareMetalHostSpec{
+				Spec: bmov1alpha1.BareMetalHostSpec{
 					ConsumerRef: &corev1.ObjectReference{
 						Name:       "mym3machine",
 						Namespace:  namespaceName,
@@ -889,9 +889,9 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("No Annotation, Should Not Error", testCaseRemovePauseAnnotation{
 			Cluster: newCluster(clusterName),
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: *bmhObjectMetaNoAnnotations(),
-				Spec: bmh.BareMetalHostSpec{
+				Spec: bmov1alpha1.BareMetalHostSpec{
 					ConsumerRef: &corev1.ObjectReference{
 						Name:       "mym3machine",
 						Namespace:  namespaceName,
@@ -910,8 +910,8 @@ var _ = Describe("Metal3Machine manager", func() {
 	type testCaseSetHostSpec struct {
 		UserDataNamespace           string
 		ExpectedUserDataNamespace   string
-		Host                        *bmh.BareMetalHost
-		ExpectedImage               *bmh.Image
+		Host                        *bmov1alpha1.BareMetalHost
+		ExpectedImage               *bmov1alpha1.Image
 		ExpectUserData              bool
 		expectNodeReuseLabelDeleted bool
 	}
@@ -968,7 +968,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("User data has explicit alternate namespace", testCaseSetHostSpec{
 			UserDataNamespace:         "otherns",
 			ExpectedUserDataNamespace: "otherns",
-			Host: newBareMetalHost("host2", nil, bmh.StateNone,
+			Host: newBareMetalHost("host2", nil, bmov1alpha1.StateNone,
 				nil, false, "metadata", false,
 			),
 			ExpectedImage:  expectedImg(),
@@ -977,7 +977,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("User data has no namespace", testCaseSetHostSpec{
 			UserDataNamespace:         "",
 			ExpectedUserDataNamespace: namespaceName,
-			Host: newBareMetalHost("host2", nil, bmh.StateNone,
+			Host: newBareMetalHost("host2", nil, bmov1alpha1.StateNone,
 				nil, false, "metadata", false,
 			),
 			ExpectedImage:  expectedImg(),
@@ -986,7 +986,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Externally provisioned, same machine", testCaseSetHostSpec{
 			UserDataNamespace:         "",
 			ExpectedUserDataNamespace: namespaceName,
-			Host: newBareMetalHost("host2", nil, bmh.StateNone,
+			Host: newBareMetalHost("host2", nil, bmov1alpha1.StateNone,
 				nil, false, "metadata", false,
 			),
 			ExpectedImage:  expectedImg(),
@@ -997,7 +997,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				UserDataNamespace:         "",
 				ExpectedUserDataNamespace: namespaceName,
 				Host: newBareMetalHost("host2", bmhSpecTestImg(),
-					bmh.StateNone, nil, false, "metadata", false,
+					bmov1alpha1.StateNone, nil, false, "metadata", false,
 				),
 				ExpectedImage:  expectedImgTest(),
 				ExpectUserData: false,
@@ -1038,7 +1038,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("User data has explicit alternate namespace", testCaseSetHostSpec{
 			UserDataNamespace:         "otherns",
 			ExpectedUserDataNamespace: "otherns",
-			Host: newBareMetalHost("host2", nil, bmh.StateNone,
+			Host: newBareMetalHost("host2", nil, bmov1alpha1.StateNone,
 				nil, false, "metadata", false,
 			),
 			ExpectedImage:  expectedImg(),
@@ -1047,7 +1047,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("User data has no namespace", testCaseSetHostSpec{
 			UserDataNamespace:         "",
 			ExpectedUserDataNamespace: namespaceName,
-			Host: newBareMetalHost("host2", nil, bmh.StateNone,
+			Host: newBareMetalHost("host2", nil, bmov1alpha1.StateNone,
 				nil, false, "metadata", false,
 			),
 			ExpectedImage:  expectedImg(),
@@ -1056,7 +1056,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Externally provisioned, same machine", testCaseSetHostSpec{
 			UserDataNamespace:         "",
 			ExpectedUserDataNamespace: namespaceName,
-			Host: newBareMetalHost("host2", nil, bmh.StateNone,
+			Host: newBareMetalHost("host2", nil, bmov1alpha1.StateNone,
 				nil, false, "metadata", false,
 			),
 			ExpectedImage:  expectedImg(),
@@ -1067,7 +1067,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				UserDataNamespace:         "",
 				ExpectedUserDataNamespace: namespaceName,
 				Host: newBareMetalHost("host2", bmhSpecTestImg(),
-					bmh.StateNone, nil, false, "metadata", false,
+					bmov1alpha1.StateNone, nil, false, "metadata", false,
 				),
 				ExpectedImage:  expectedImgTest(),
 				ExpectUserData: false,
@@ -1076,7 +1076,7 @@ var _ = Describe("Metal3Machine manager", func() {
 	)
 
 	Describe("Test Exists function", func() {
-		host := bmh.BareMetalHost{
+		host := bmov1alpha1.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "somehost",
 				Namespace: namespaceName,
@@ -1128,7 +1128,7 @@ var _ = Describe("Metal3Machine manager", func() {
 	})
 
 	Describe("Test GetHost", func() {
-		host := bmh.BareMetalHost{
+		host := bmov1alpha1.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "myhost",
 				Namespace: namespaceName,
@@ -1186,7 +1186,7 @@ var _ = Describe("Metal3Machine manager", func() {
 	type testCaseGetSetProviderID struct {
 		Machine       *clusterv1.Machine
 		M3Machine     *infrav1.Metal3Machine
-		Host          *bmh.BareMetalHost
+		Host          *bmov1alpha1.BareMetalHost
 		ExpectPresent bool
 		ExpectError   bool
 	}
@@ -1221,7 +1221,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine("mym3machine", nil, m3mSpec(), nil,
 				m3mObjectMetaEmptyAnnotations(),
 			),
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: namespaceName,
@@ -1235,15 +1235,15 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine("mym3machine", nil, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: namespaceName,
 					UID:       Bmhuid,
 				},
-				Status: bmh.BareMetalHostStatus{
-					Provisioning: bmh.ProvisionStatus{
-						State: bmh.StateProvisioned,
+				Status: bmov1alpha1.BareMetalHostStatus{
+					Provisioning: bmov1alpha1.ProvisionStatus{
+						State: bmov1alpha1.StateProvisioned,
 					},
 				},
 			},
@@ -1255,15 +1255,15 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine("mym3machine", nil, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: namespaceName,
 					UID:       Bmhuid,
 				},
-				Status: bmh.BareMetalHostStatus{
-					Provisioning: bmh.ProvisionStatus{
-						State: bmh.StateProvisioning,
+				Status: bmov1alpha1.BareMetalHostStatus{
+					Provisioning: bmov1alpha1.ProvisionStatus{
+						State: bmov1alpha1.StateProvisioning,
 					},
 				},
 			},
@@ -1279,7 +1279,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectCtrlNode bool
 		}
 
-		host := bmh.BareMetalHost{
+		host := bmov1alpha1.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "myhost",
 				Namespace: namespaceName,
@@ -1339,7 +1339,7 @@ var _ = Describe("Metal3Machine manager", func() {
 
 	type testCaseEnsureAnnotation struct {
 		Machine          clusterv1.Machine
-		Host             *bmh.BareMetalHost
+		Host             *bmov1alpha1.BareMetalHost
 		M3Machine        *infrav1.Metal3Machine
 		ExpectAnnotation bool
 	}
@@ -1376,7 +1376,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, nil,
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			Host: newBareMetalHost("myhost", nil, bmh.StateNone, nil,
+			Host: newBareMetalHost("myhost", nil, bmov1alpha1.StateNone, nil,
 				false, "metadata", false,
 			),
 			ExpectAnnotation: true,
@@ -1386,7 +1386,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, nil,
 				m3mObjectMetaWithInvalidAnnotations(),
 			),
-			Host: newBareMetalHost("myhost", nil, bmh.StateNone,
+			Host: newBareMetalHost("myhost", nil, bmov1alpha1.StateNone,
 				nil, false, "metadata", false,
 			),
 			ExpectAnnotation: true,
@@ -1396,7 +1396,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, nil,
 				m3mObjectMetaEmptyAnnotations(),
 			),
-			Host: newBareMetalHost("myhost", nil, bmh.StateNone,
+			Host: newBareMetalHost("myhost", nil, bmov1alpha1.StateNone,
 				nil, false, "metadata", false,
 			),
 			ExpectAnnotation: true,
@@ -1406,7 +1406,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine("", nil, nil, nil,
 				m3mObjectMetaNoAnnotations(),
 			),
-			Host: newBareMetalHost("myhost", nil, bmh.StateNone,
+			Host: newBareMetalHost("myhost", nil, bmov1alpha1.StateNone,
 				nil, false, "metadata", false,
 			),
 			ExpectAnnotation: true,
@@ -1414,7 +1414,7 @@ var _ = Describe("Metal3Machine manager", func() {
 	)
 
 	type testCaseDelete struct {
-		Host                            *bmh.BareMetalHost
+		Host                            *bmov1alpha1.BareMetalHost
 		Secret                          *corev1.Secret
 		Machine                         *clusterv1.Machine
 		M3Machine                       *infrav1.Metal3Machine
@@ -1469,7 +1469,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					Name:      tc.Host.Name,
 					Namespace: tc.Host.Namespace,
 				}
-				host := bmh.BareMetalHost{}
+				host := bmov1alpha1.BareMetalHost{}
 
 				err := fakeClient.Get(context.TODO(), key, &host)
 				Expect(err).NotTo(HaveOccurred())
@@ -1510,7 +1510,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			}
 			if tc.ExpectedPausedAnnotationDeleted {
 				// get the saved host
-				savedHost := bmh.BareMetalHost{}
+				savedHost := bmov1alpha1.BareMetalHost{}
 				err = fakeClient.Get(context.TODO(),
 					client.ObjectKey{
 						Name:      tc.Host.Name,
@@ -1519,12 +1519,12 @@ var _ = Describe("Metal3Machine manager", func() {
 					&savedHost,
 				)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(savedHost.Annotations[bmh.PausedAnnotation]).NotTo(Equal(PausedAnnotationKey))
+				Expect(savedHost.Annotations[bmov1alpha1.PausedAnnotation]).NotTo(Equal(PausedAnnotationKey))
 			}
 
 			if tc.ExpectClusterLabelDeleted {
 				// get the saved host
-				savedHost := bmh.BareMetalHost{}
+				savedHost := bmov1alpha1.BareMetalHost{}
 				err = fakeClient.Get(context.TODO(),
 					client.ObjectKey{
 						Name:      tc.Host.Name,
@@ -1563,7 +1563,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			}
 
 			if tc.Host != nil {
-				savedbmh := bmh.BareMetalHost{}
+				savedbmh := bmov1alpha1.BareMetalHost{}
 				err = fakeClient.Get(context.TODO(),
 					client.ObjectKey{
 						Name:      tc.Host.Name,
@@ -1580,7 +1580,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		},
 		Entry("Deprovisioning needed", testCaseDelete{
 			Host: newBareMetalHost("myhost", bmhSpec(),
-				bmh.StateProvisioned, bmhStatus(), false, "metadata", true,
+				bmov1alpha1.StateProvisioned, bmhStatus(), false, "metadata", true,
 			),
 			Machine: newMachine("mymachine", "", nil),
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
@@ -1592,7 +1592,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectedBMHOnlineStatus: false,
 		}),
 		Entry("No Host status, deprovisioning needed", testCaseDelete{
-			Host: newBareMetalHost("myhost", bmhSpec(), bmh.StateNone,
+			Host: newBareMetalHost("myhost", bmhSpec(), bmov1alpha1.StateNone,
 				nil, false, "metadata", true,
 			),
 			Machine: newMachine("mymachine", "", nil),
@@ -1605,7 +1605,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectedBMHOnlineStatus: false,
 		}),
 		Entry("No Host status, no deprovisioning needed", testCaseDelete{
-			Host: newBareMetalHost("myhost", bmhSpecNoImg(), bmh.StateNone, nil,
+			Host: newBareMetalHost("myhost", bmhSpecNoImg(), bmov1alpha1.StateNone, nil,
 				false, "metadata", true,
 			),
 			Machine: newMachine("mymachine", "", nil),
@@ -1617,7 +1617,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Deprovisioning in progress", testCaseDelete{
 			Host: newBareMetalHost("myhost", bmhSpecNoImg(),
-				bmh.StateDeprovisioning, bmhStatus(), false, "metadata", true,
+				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "metadata", true,
 			),
 			Machine: newMachine("mymachine", "", nil),
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
@@ -1629,7 +1629,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Externally provisioned host should be powered down", testCaseDelete{
 			Host: newBareMetalHost("myhost", bmhSpecNoImg(),
-				bmh.StateExternallyProvisioned, bmhPowerStatus(), true, "metadata", true,
+				bmov1alpha1.StateExternallyProvisioned, bmhPowerStatus(), true, "metadata", true,
 			),
 			Machine: newMachine("mymachine", "", nil),
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
@@ -1642,7 +1642,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Consumer ref should be removed from externally provisioned host",
 			testCaseDelete{
 				Host: newBareMetalHost("myhost", bmhSpecNoImg(),
-					bmh.StateExternallyProvisioned, bmhPowerStatus(), false, "metadata", true,
+					bmov1alpha1.StateExternallyProvisioned, bmhPowerStatus(), false, "metadata", true,
 				),
 				Machine: newMachine("mymachine", "", nil),
 				M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
@@ -1655,7 +1655,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Consumer ref should be removed from unmanaged host",
 			testCaseDelete{
 				Host: newBareMetalHost("myhost", bmhSpecNoImg(),
-					bmh.StateUnmanaged, bmhPowerStatus(), false, "metadata", true,
+					bmov1alpha1.StateUnmanaged, bmhPowerStatus(), false, "metadata", true,
 				),
 				Machine: newMachine("mymachine", "", nil),
 				M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
@@ -1666,7 +1666,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 		),
 		Entry("Consumer ref should be removed, BMH state is available", testCaseDelete{
-			Host: newBareMetalHost("myhost", bmhSpecNoImg(), bmh.StateAvailable,
+			Host: newBareMetalHost("myhost", bmhSpecNoImg(), bmov1alpha1.StateAvailable,
 				bmhStatus(), false, "metadata", true,
 			),
 			Machine: newMachine("mymachine", "", nil),
@@ -1677,7 +1677,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectSecretDeleted: true,
 		}),
 		Entry("Consumer ref should be removed", testCaseDelete{
-			Host: newBareMetalHost("myhost", bmhSpecNoImg(), bmh.StateReady,
+			Host: newBareMetalHost("myhost", bmhSpecNoImg(), bmov1alpha1.StateReady,
 				bmhStatus(), false, "metadata", true,
 			),
 			Machine: newMachine("mymachine", "", nil),
@@ -1688,7 +1688,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectSecretDeleted: true,
 		}),
 		Entry("Consumer ref should be removed, secret not deleted", testCaseDelete{
-			Host: newBareMetalHost("myhost", bmhSpecNoImg(), bmh.StateReady,
+			Host: newBareMetalHost("myhost", bmhSpecNoImg(), bmov1alpha1.StateReady,
 				bmhStatus(), false, "metadata", true,
 			),
 			Machine: &clusterv1.Machine{
@@ -1709,7 +1709,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Consumer ref does not match, so it should not be removed",
 			testCaseDelete{
 				Host: newBareMetalHost("myhost", bmhSpecSomeImg(),
-					bmh.StateProvisioned, bmhStatus(), false, "metadata", true,
+					bmov1alpha1.StateProvisioned, bmhStatus(), false, "metadata", true,
 				),
 				Machine: newMachine("", "", nil),
 				M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
@@ -1721,7 +1721,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 		),
 		Entry("No consumer ref, so this is a no-op", testCaseDelete{
-			Host:    newBareMetalHost("myhost", nil, bmh.StateNone, nil, false, "metadata", true),
+			Host:    newBareMetalHost("myhost", nil, bmov1alpha1.StateNone, nil, false, "metadata", true),
 			Machine: newMachine("", "", nil),
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
@@ -1739,7 +1739,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectSecretDeleted: false,
 		}),
 		Entry("dataSecretName set, deleting secret", testCaseDelete{
-			Host: newBareMetalHost("myhost", bmhSpecNoImg(), bmh.StateNone, nil,
+			Host: newBareMetalHost("myhost", bmhSpecNoImg(), bmov1alpha1.StateNone, nil,
 				false, "metadata", true,
 			),
 			Machine: &clusterv1.Machine{
@@ -1761,7 +1761,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Clusterlabel should be removed", testCaseDelete{
 			Machine:                   newMachine("mymachine", "mym3machine", nil),
 			M3Machine:                 newMetal3Machine("mym3machine", nil, m3mSpecAll(), m3mSecretStatus(), m3mObjectMetaWithValidAnnotations()),
-			Host:                      newBareMetalHost("myhost", bmhSpecBMC(), bmh.StateNone, nil, false, "metadata", true),
+			Host:                      newBareMetalHost("myhost", bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", true),
 			BMCSecret:                 newBMCSecret("mycredentials", true),
 			ExpectSecretDeleted:       true,
 			ExpectClusterLabelDeleted: true,
@@ -1769,12 +1769,12 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("PausedAnnotation/CAPM3 should be removed", testCaseDelete{
 			Machine:   newMachine("mymachine", "mym3machine", nil),
 			M3Machine: newMetal3Machine("mym3machine", nil, m3mSpecAll(), m3mSecretStatus(), m3mObjectMetaWithValidAnnotations()),
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: *bmhObjectMetaWithValidCAPM3PausedAnnotations(),
 				Spec:       *bmhSpecBMC(),
-				Status: bmh.BareMetalHostStatus{
-					Provisioning: bmh.ProvisionStatus{
-						State: bmh.StateNone,
+				Status: bmov1alpha1.BareMetalHostStatus{
+					Provisioning: bmov1alpha1.ProvisionStatus{
+						State: bmov1alpha1.StateNone,
 					},
 					PoweredOn: false,
 				},
@@ -1786,14 +1786,14 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("No clusterLabel in BMH or BMC Secret so this is a no-op ", testCaseDelete{
 			Machine:                   newMachine("mymachine", "mym3machine", nil),
 			M3Machine:                 newMetal3Machine("mym3machine", nil, m3mSpecAll(), m3mSecretStatus(), m3mObjectMetaWithValidAnnotations()),
-			Host:                      newBareMetalHost("myhost", bmhSpecBMC(), bmh.StateNone, nil, false, "metadata", false),
+			Host:                      newBareMetalHost("myhost", bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", false),
 			BMCSecret:                 newBMCSecret("mycredentials", false),
 			ExpectSecretDeleted:       true,
 			ExpectClusterLabelDeleted: false,
 		}),
 		Entry("BMH MetaData, NetworkData and UserData should not be cleaned on deprovisioning", testCaseDelete{
 			Host: newBareMetalHost("myhost", bmhSpecSomeImg(),
-				bmh.StateProvisioned, bmhStatus(), false, "metadata", true,
+				bmov1alpha1.StateProvisioned, bmhStatus(), false, "metadata", true,
 			),
 			Machine: newMachine("mymachine", "mym3machine", nil),
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatusNil(),
@@ -1806,7 +1806,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Capm3FastTrack is set to false, AutomatedCleaning mode is set to metadata, set bmh online field to false", testCaseDelete{
 			Host: newBareMetalHost("myhost", bmhSpec(),
-				bmh.StateDeprovisioning, bmhStatus(), false, "metadata", true),
+				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "metadata", true),
 			Machine: newMachine("mymachine", "", nil),
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
@@ -1819,7 +1819,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Capm3FastTrack is set to true, AutomatedCleaning mode is set to metadata, set bmh online field to true", testCaseDelete{
 			Host: newBareMetalHost("myhost", bmhSpec(),
-				bmh.StateDeprovisioning, bmhStatus(), false, "metadata", true),
+				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "metadata", true),
 			Machine: newMachine("mymachine", "", nil),
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
@@ -1832,7 +1832,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Capm3FastTrack is set to false, AutomatedCleaning mode is set to disabled, set bmh online field to false", testCaseDelete{
 			Host: newBareMetalHost("myhost", bmhSpec(),
-				bmh.StateDeprovisioning, bmhStatus(), false, "disabled", true),
+				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "disabled", true),
 			Machine: newMachine("mymachine", "", nil),
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
@@ -1845,7 +1845,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Capm3FastTrack is set to true, AutomatedCleaning mode is set to disabled, set bmh online field to false", testCaseDelete{
 			Host: newBareMetalHost("myhost", bmhSpec(),
-				bmh.StateDeprovisioning, bmhStatus(), false, "disabled", true),
+				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "disabled", true),
 			Machine: newMachine("mymachine", "", nil),
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
@@ -1858,7 +1858,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Capm3FastTrack is empty, AutomatedCleaning mode is set to disabled, set bmh online field to false", testCaseDelete{
 			Host: newBareMetalHost("myhost", bmhSpec(),
-				bmh.StateDeprovisioning, bmhStatus(), false, "disabled", true),
+				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "disabled", true),
 			Machine: newMachine("mymachine", "", nil),
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
@@ -1871,7 +1871,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Capm3FastTrack is empty, AutomatedCleaning mode is set to metadata, set bmh online field to false", testCaseDelete{
 			Host: newBareMetalHost("myhost", bmhSpec(),
-				bmh.StateDeprovisioning, bmhStatus(), false, "metadata", true),
+				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "metadata", true),
 			Machine: newMachine("mymachine", "", nil),
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
@@ -1885,16 +1885,16 @@ var _ = Describe("Metal3Machine manager", func() {
 	)
 
 	Describe("Test UpdateMachineStatus", func() {
-		nic1 := bmh.NIC{
+		nic1 := bmov1alpha1.NIC{
 			IP: "192.168.1.1",
 		}
 
-		nic2 := bmh.NIC{
+		nic2 := bmov1alpha1.NIC{
 			IP: "172.0.20.2",
 		}
 
 		type testCaseUpdateMachineStatus struct {
-			Host            *bmh.BareMetalHost
+			Host            *bmov1alpha1.BareMetalHost
 			Machine         *clusterv1.Machine
 			ExpectedMachine clusterv1.Machine
 			M3Machine       infrav1.Metal3Machine
@@ -1927,10 +1927,10 @@ var _ = Describe("Metal3Machine manager", func() {
 				}
 			},
 			Entry("Machine status updated", testCaseUpdateMachineStatus{
-				Host: &bmh.BareMetalHost{
-					Status: bmh.BareMetalHostStatus{
-						HardwareDetails: &bmh.HardwareDetails{
-							NIC: []bmh.NIC{nic1, nic2},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1, nic2},
 						},
 					},
 				},
@@ -1991,10 +1991,10 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			}),
 			Entry("Machine status unchanged", testCaseUpdateMachineStatus{
-				Host: &bmh.BareMetalHost{
-					Status: bmh.BareMetalHostStatus{
-						HardwareDetails: &bmh.HardwareDetails{
-							NIC: []bmh.NIC{nic1, nic2},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1, nic2},
 						},
 					},
 				},
@@ -2056,7 +2056,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			}),
 			Entry("Machine status unchanged, status set empty",
 				testCaseUpdateMachineStatus{
-					Host: &bmh.BareMetalHost{},
+					Host: &bmov1alpha1.BareMetalHost{},
 					Machine: &clusterv1.Machine{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "mymachine",
@@ -2087,11 +2087,11 @@ var _ = Describe("Metal3Machine manager", func() {
 	})
 
 	Describe("Test NodeAddresses", func() {
-		nic1 := bmh.NIC{
+		nic1 := bmov1alpha1.NIC{
 			IP: "192.168.1.1",
 		}
 
-		nic2 := bmh.NIC{
+		nic2 := bmov1alpha1.NIC{
 			IP: "172.0.20.2",
 		}
 
@@ -2113,7 +2113,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		type testCaseNodeAddress struct {
 			Machine               clusterv1.Machine
 			M3Machine             infrav1.Metal3Machine
-			Host                  *bmh.BareMetalHost
+			Host                  *bmov1alpha1.BareMetalHost
 			ExpectedNodeAddresses []clusterv1.MachineAddress
 		}
 
@@ -2136,29 +2136,29 @@ var _ = Describe("Metal3Machine manager", func() {
 				}
 			},
 			Entry("One NIC", testCaseNodeAddress{
-				Host: &bmh.BareMetalHost{
-					Status: bmh.BareMetalHostStatus{
-						HardwareDetails: &bmh.HardwareDetails{
-							NIC: []bmh.NIC{nic1},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
 						},
 					},
 				},
 				ExpectedNodeAddresses: []clusterv1.MachineAddress{addr1},
 			}),
 			Entry("Two NICs", testCaseNodeAddress{
-				Host: &bmh.BareMetalHost{
-					Status: bmh.BareMetalHostStatus{
-						HardwareDetails: &bmh.HardwareDetails{
-							NIC: []bmh.NIC{nic1, nic2},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1, nic2},
 						},
 					},
 				},
 				ExpectedNodeAddresses: []clusterv1.MachineAddress{addr1, addr2},
 			}),
 			Entry("Hostname is set", testCaseNodeAddress{
-				Host: &bmh.BareMetalHost{
-					Status: bmh.BareMetalHostStatus{
-						HardwareDetails: &bmh.HardwareDetails{
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
 							Hostname: "mygreathost",
 						},
 					},
@@ -2166,9 +2166,9 @@ var _ = Describe("Metal3Machine manager", func() {
 				ExpectedNodeAddresses: []clusterv1.MachineAddress{addr3},
 			}),
 			Entry("Empty Hostname", testCaseNodeAddress{
-				Host: &bmh.BareMetalHost{
-					Status: bmh.BareMetalHostStatus{
-						HardwareDetails: &bmh.HardwareDetails{
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
 							Hostname: "",
 						},
 					},
@@ -2222,7 +2222,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		if err != nil {
 			log.Printf("AddToScheme failed: %v", err)
 		}
-		err = bmh.AddToScheme(s)
+		err = bmov1alpha1.AddToScheme(s)
 		if err != nil {
 			log.Printf("AddToScheme failed: %v", err)
 		}
@@ -2442,7 +2442,7 @@ var _ = Describe("Metal3Machine manager", func() {
 	type testCaseGetUserDataSecretName struct {
 		Machine     *clusterv1.Machine
 		M3Machine   *infrav1.Metal3Machine
-		BMHost      *bmh.BareMetalHost
+		BMHost      *bmov1alpha1.BareMetalHost
 		Secret      *corev1.Secret
 		ExpectError bool
 	}
@@ -2537,7 +2537,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			},
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, nil, nil),
-			BMHost:    newBareMetalHost("myhost", nil, bmh.StateNone, nil, false, "metadata", false),
+			BMHost:    newBareMetalHost("myhost", nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
 		}),
 		Entry("Secret set in Machine, different namespace", testCaseGetUserDataSecretName{
 			Secret: &corev1.Secret{
@@ -2565,7 +2565,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			},
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, nil, nil),
-			BMHost:    newBareMetalHost("myhost", nil, bmh.StateNone, nil, false, "metadata", false),
+			BMHost:    newBareMetalHost("myhost", nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
 		}),
 		Entry("Secret in other namespace set in Machine", testCaseGetUserDataSecretName{
 			Secret: &corev1.Secret{
@@ -2597,7 +2597,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			},
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, nil, nil),
-			BMHost:    newBareMetalHost("myhost", nil, bmh.StateNone, nil, false, "metadata", false),
+			BMHost:    newBareMetalHost("myhost", nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
 		}),
 		Entry("UserDataSecretName set in Machine, secret exists", testCaseGetUserDataSecretName{
 			Secret: newSecret(),
@@ -2612,7 +2612,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			},
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, nil, nil),
-			BMHost:    newBareMetalHost("myhost", nil, bmh.StateNone, nil, false, "metadata", false),
+			BMHost:    newBareMetalHost("myhost", nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
 		}),
 		Entry("UserDataSecretName set in Machine, no secret", testCaseGetUserDataSecretName{
 			Machine: &clusterv1.Machine{
@@ -2626,13 +2626,13 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			},
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, nil, nil),
-			BMHost:    newBareMetalHost("myhost", nil, bmh.StateNone, nil, false, "metadata", false),
+			BMHost:    newBareMetalHost("myhost", nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
 		}),
 	)
 
 	type testCaseAssociate struct {
 		Machine            *clusterv1.Machine
-		Host               *bmh.BareMetalHost
+		Host               *bmov1alpha1.BareMetalHost
 		M3Machine          *infrav1.Metal3Machine
 		BMCSecret          *corev1.Secret
 		DataTemplate       *infrav1.Metal3DataTemplate
@@ -2680,7 +2680,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				return
 			}
 			// get the saved host
-			savedHost := bmh.BareMetalHost{}
+			savedHost := bmov1alpha1.BareMetalHost{}
 			err = fakeClient.Get(context.TODO(),
 				client.ObjectKey{
 					Name:      tc.Host.Name,
@@ -2716,7 +2716,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				M3Machine: newMetal3Machine("mym3machine", nil, nil, nil,
 					m3mObjectMetaWithValidAnnotations(),
 				),
-				Host: newBareMetalHost("myhost", nil, bmh.StateNone, nil,
+				Host: newBareMetalHost("myhost", nil, bmov1alpha1.StateNone, nil,
 					false, "metadata", false,
 				),
 				ExpectRequeue: false,
@@ -2728,7 +2728,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				M3Machine: newMetal3Machine("mym3machine", nil, m3mSpecAll(), nil,
 					m3mObjectMetaWithValidAnnotations(),
 				),
-				Host: newBareMetalHost("myhost", bmhSpecBMC(), bmh.StateNone, nil,
+				Host: newBareMetalHost("myhost", bmhSpecBMC(), bmov1alpha1.StateNone, nil,
 					false, "metadata", false,
 				),
 				BMCSecret:      newBMCSecret("mycredentials", false),
@@ -2742,7 +2742,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				M3Machine: newMetal3Machine("mym3machine", nil, m3mSpecAll(), nil,
 					m3mObjectMetaWithValidAnnotations(),
 				),
-				Host:           newBareMetalHost("", nil, bmh.StateNone, nil, false, "metadata", false),
+				Host:           newBareMetalHost("", nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
 				ExpectRequeue:  true,
 				ExpectOwnerRef: false,
 			},
@@ -2761,7 +2761,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			testCaseAssociate{
 				Machine:            newMachine("mymachine", "mym3machine", nil),
 				M3Machine:          newMetal3Machine("mym3machine", nil, m3mSpecAll(), nil, nil),
-				Host:               newBareMetalHost("myhost", bmhSpecBMC(), bmh.StateNone, nil, false, "metadata", false),
+				Host:               newBareMetalHost("myhost", bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", false),
 				BMCSecret:          newBMCSecret("mycredentials", false),
 				ExpectClusterLabel: true,
 				ExpectRequeue:      false,
@@ -2788,7 +2788,7 @@ var _ = Describe("Metal3Machine manager", func() {
 						},
 					}, nil, nil,
 				),
-				Host:               newBareMetalHost("myhost", bmhSpecBMC(), bmh.StateNone, nil, false, "metadata", false),
+				Host:               newBareMetalHost("myhost", bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", false),
 				BMCSecret:          newBMCSecret("mycredentials", false),
 				ExpectClusterLabel: true,
 				ExpectRequeue:      true,
@@ -2817,7 +2817,7 @@ var _ = Describe("Metal3Machine manager", func() {
 						RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: namespaceName},
 					}, nil,
 				),
-				Host:      newBareMetalHost("myhost", bmhSpecBMC(), bmh.StateNone, nil, false, "metadata", false),
+				Host:      newBareMetalHost("myhost", bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", false),
 				BMCSecret: newBMCSecret("mycredentials", false),
 				Data: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
@@ -2845,7 +2845,7 @@ var _ = Describe("Metal3Machine manager", func() {
 
 	type testCaseUpdate struct {
 		Machine     *clusterv1.Machine
-		Host        *bmh.BareMetalHost
+		Host        *bmov1alpha1.BareMetalHost
 		M3Machine   *infrav1.Metal3Machine
 		ExpectError bool
 	}
@@ -2877,7 +2877,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine("mym3machine", nil, nil, nil,
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			Host: newBareMetalHost("myhost", nil, bmh.StateNone, nil, false, "metadata", false),
+			Host: newBareMetalHost("myhost", nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
 		}),
 		Entry("Update machine, DataTemplate missing", testCaseUpdate{
 			Machine: newMachine("mymachine", "", nil),
@@ -2888,7 +2888,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			}, nil,
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			Host:        newBareMetalHost("myhost", nil, bmh.StateNone, nil, false, "metadata", false),
+			Host:        newBareMetalHost("myhost", nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
 			ExpectError: true,
 		}),
 	)
@@ -3574,7 +3574,7 @@ var _ = Describe("Metal3Machine manager", func() {
 
 	type testCaseNodeReuseLabelMatches struct {
 		Machine                  *clusterv1.Machine
-		Host                     *bmh.BareMetalHost
+		Host                     *bmov1alpha1.BareMetalHost
 		expectNodeReuseLabelName string
 		expectNodeReuseLabel     bool
 		expectMatch              bool
@@ -3610,7 +3610,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			expectMatch: false,
 		}),
 		Entry("Should return false if host labels is nil", testCaseNodeReuseLabelMatches{
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: nil,
 				},
@@ -3633,7 +3633,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "kcp-test1",
 					Labels: map[string]string{
@@ -3662,7 +3662,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "kcp-test1",
 					Labels: map[string]string{
@@ -3689,7 +3689,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "kcp-test1",
 					Labels: map[string]string{
@@ -3709,7 +3709,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "md-test1",
 					Labels: map[string]string{
@@ -3729,7 +3729,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "md-test1",
 					Labels: map[string]string{
@@ -3743,7 +3743,7 @@ var _ = Describe("Metal3Machine manager", func() {
 	)
 
 	type testCaseNodeReuseLabelExists struct {
-		Host                 *bmh.BareMetalHost
+		Host                 *bmov1alpha1.BareMetalHost
 		expectNodeReuseLabel bool
 	}
 	DescribeTable("Test NodeReuseLabelExists",
@@ -3768,7 +3768,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			}
 		},
 		Entry("Node reuse label exists on the host", testCaseNodeReuseLabelExists{
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						nodeReuseLabelName: kcpName,
@@ -3779,7 +3779,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			expectNodeReuseLabel: true,
 		}),
 		Entry("Node reuse label does not exist on the host", testCaseNodeReuseLabelExists{
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{},
 				},
@@ -3791,7 +3791,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			expectNodeReuseLabel: false,
 		}),
 		Entry("Should return false if host Labels is nil", testCaseNodeReuseLabelExists{
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: nil,
 				},
@@ -4323,7 +4323,7 @@ func setupSchemeMm() *runtime.Scheme {
 	if err := infrav1.AddToScheme(s); err != nil {
 		panic(err)
 	}
-	if err := bmh.AddToScheme(s); err != nil {
+	if err := bmov1alpha1.AddToScheme(s); err != nil {
 		panic(err)
 	}
 	if err := corev1.AddToScheme(s); err != nil {
@@ -4450,14 +4450,14 @@ func newMetal3Machine(name string,
 }
 
 func newBareMetalHost(name string,
-	spec *bmh.BareMetalHostSpec,
-	state bmh.ProvisioningState,
-	status *bmh.BareMetalHostStatus,
+	spec *bmov1alpha1.BareMetalHostSpec,
+	state bmov1alpha1.ProvisioningState,
+	status *bmov1alpha1.BareMetalHostStatus,
 	powerOn bool,
 	autoCleanMode string,
-	clusterlabel bool) *bmh.BareMetalHost {
+	clusterlabel bool) *bmov1alpha1.BareMetalHost {
 	if name == "" {
-		return &bmh.BareMetalHost{
+		return &bmov1alpha1.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespaceName,
 			},
@@ -4481,20 +4481,20 @@ func newBareMetalHost(name string,
 	}
 
 	if spec == nil {
-		return &bmh.BareMetalHost{
+		return &bmov1alpha1.BareMetalHost{
 			ObjectMeta: *objMeta,
 		}
 	}
-	spec.AutomatedCleaningMode = bmh.AutomatedCleaningMode(autoCleanMode)
+	spec.AutomatedCleaningMode = bmov1alpha1.AutomatedCleaningMode(autoCleanMode)
 
 	if status != nil {
 		status.Provisioning.State = state
 		status.PoweredOn = powerOn
 	} else {
-		status = &bmh.BareMetalHostStatus{}
+		status = &bmov1alpha1.BareMetalHostStatus{}
 	}
 
-	return &bmh.BareMetalHost{
+	return &bmov1alpha1.BareMetalHost{
 		ObjectMeta: *objMeta,
 		Spec:       *spec,
 		Status:     *status,

--- a/baremetal/metal3machinetemplate_manager.go
+++ b/baremetal/metal3machinetemplate_manager.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/pkg/errors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,16 +38,16 @@ type TemplateManagerInterface interface {
 type MachineTemplateManager struct {
 	client client.Client
 
-	Metal3MachineList     *capm3.Metal3MachineList
-	Metal3MachineTemplate *capm3.Metal3MachineTemplate
+	Metal3MachineList     *infrav1.Metal3MachineList
+	Metal3MachineTemplate *infrav1.Metal3MachineTemplate
 	Log                   logr.Logger
 }
 
 // NewMachineTemplateManager returns a new helper for managing a metal3MachineTemplate.
 func NewMachineTemplateManager(client client.Client,
-	metal3MachineTemplate *capm3.Metal3MachineTemplate,
+	metal3MachineTemplate *infrav1.Metal3MachineTemplate,
 
-	metal3MachineList *capm3.Metal3MachineList,
+	metal3MachineList *infrav1.Metal3MachineList,
 	metal3MachineTemplateLog logr.Logger) (*MachineTemplateManager, error) {
 	return &MachineTemplateManager{
 		client: client,
@@ -64,7 +64,7 @@ func (m *MachineTemplateManager) UpdateAutomatedCleaningMode(ctx context.Context
 	m.Log.Info("Fetching metal3Machine objects")
 
 	// get list of metal3Machine objects
-	m3ms := &capm3.Metal3MachineList{}
+	m3ms := &infrav1.Metal3MachineList{}
 	// without this ListOption, all namespaces would be included in the listing
 	opts := &client.ListOptions{
 		Namespace: m.Metal3MachineTemplate.Namespace,
@@ -74,7 +74,7 @@ func (m *MachineTemplateManager) UpdateAutomatedCleaningMode(ctx context.Context
 		return errors.Wrap(err, "failed to list metal3Machines")
 	}
 
-	matchedM3Machines := []*capm3.Metal3Machine{}
+	matchedM3Machines := []*infrav1.Metal3Machine{}
 
 	// Fetch metal3Machines belonging to the same metal3MachineTemplate
 	for i := range m3ms.Items {

--- a/baremetal/metal3machinetemplate_manager_test.go
+++ b/baremetal/metal3machinetemplate_manager_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/go-logr/logr"
 
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -35,8 +35,8 @@ import (
 var _ = Describe("Metal3MachineTemplate manager", func() {
 
 	type testCaseUpdate struct {
-		M3MachineTemplate *capm3.Metal3MachineTemplate
-		M3MachineList     *capm3.Metal3MachineList
+		M3MachineTemplate *infrav1.Metal3MachineTemplate
+		M3MachineList     *infrav1.Metal3MachineList
 		ExpectedValue     *string
 	}
 
@@ -61,7 +61,7 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 					Name:      m3m.Name,
 					Namespace: m3m.Namespace,
 				}
-				updatedM3M := capm3.Metal3Machine{}
+				updatedM3M := infrav1.Metal3Machine{}
 				err = fakeClient.Get(context.TODO(), key, &updatedM3M)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(updatedM3M.Spec.AutomatedCleaningMode).To(Equal(tc.ExpectedValue))
@@ -69,30 +69,30 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 		},
 		Entry("Disk cleaning disabled", testCaseUpdate{
 			ExpectedValue: utils.StringPtr("disabled"),
-			M3MachineTemplate: &capm3.Metal3MachineTemplate{
+			M3MachineTemplate: &infrav1.Metal3MachineTemplate{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: capm3.GroupVersion.String(),
+					APIVersion: infrav1.GroupVersion.String(),
 					Kind:       "Metal3MachineTemplate",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
 					Namespace: "foo",
 				},
-				Spec: capm3.Metal3MachineTemplateSpec{
-					Template: capm3.Metal3MachineTemplateResource{
-						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeDisabled),
+				Spec: infrav1.Metal3MachineTemplateSpec{
+					Template: infrav1.Metal3MachineTemplateResource{
+						Spec: infrav1.Metal3MachineSpec{
+							AutomatedCleaningMode: utils.StringPtr(infrav1.CleaningModeDisabled),
 						},
 					},
 				},
 			},
-			M3MachineList: &capm3.Metal3MachineList{
+			M3MachineList: &infrav1.Metal3MachineList{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: capm3.GroupVersion.String(),
+					APIVersion: infrav1.GroupVersion.String(),
 					Kind:       "Metal3MachineList",
 				},
 				ListMeta: metav1.ListMeta{},
-				Items: []capm3.Metal3Machine{
+				Items: []infrav1.Metal3Machine{
 					{
 						TypeMeta: metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{
@@ -100,11 +100,11 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 							Namespace: "foo",
 							Annotations: map[string]string{
 								"cluster.x-k8s.io/cloned-from-name":      "abc",
-								"cluster.x-k8s.io/cloned-from-groupkind": capm3.ClonedFromGroupKind,
+								"cluster.x-k8s.io/cloned-from-groupkind": infrav1.ClonedFromGroupKind,
 							},
 						},
-						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeMetadata),
+						Spec: infrav1.Metal3MachineSpec{
+							AutomatedCleaningMode: utils.StringPtr(infrav1.CleaningModeMetadata),
 						},
 					},
 					{
@@ -114,11 +114,11 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 							Namespace: "foo",
 							Annotations: map[string]string{
 								"cluster.x-k8s.io/cloned-from-name":      "abc",
-								"cluster.x-k8s.io/cloned-from-groupkind": capm3.ClonedFromGroupKind,
+								"cluster.x-k8s.io/cloned-from-groupkind": infrav1.ClonedFromGroupKind,
 							},
 						},
-						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeMetadata),
+						Spec: infrav1.Metal3MachineSpec{
+							AutomatedCleaningMode: utils.StringPtr(infrav1.CleaningModeMetadata),
 						},
 					},
 					{
@@ -128,11 +128,11 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 							Namespace: "foo",
 							Annotations: map[string]string{
 								"cluster.x-k8s.io/cloned-from-name":      "abc",
-								"cluster.x-k8s.io/cloned-from-groupkind": capm3.ClonedFromGroupKind,
+								"cluster.x-k8s.io/cloned-from-groupkind": infrav1.ClonedFromGroupKind,
 							},
 						},
-						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeMetadata),
+						Spec: infrav1.Metal3MachineSpec{
+							AutomatedCleaningMode: utils.StringPtr(infrav1.CleaningModeMetadata),
 						},
 					},
 				},
@@ -140,30 +140,30 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 		}),
 		Entry("Disk cleaning enabled", testCaseUpdate{
 			ExpectedValue: utils.StringPtr("metadata"),
-			M3MachineTemplate: &capm3.Metal3MachineTemplate{
+			M3MachineTemplate: &infrav1.Metal3MachineTemplate{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: capm3.GroupVersion.String(),
+					APIVersion: infrav1.GroupVersion.String(),
 					Kind:       "Metal3MachineTemplate",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
 					Namespace: "foo",
 				},
-				Spec: capm3.Metal3MachineTemplateSpec{
-					Template: capm3.Metal3MachineTemplateResource{
-						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeMetadata),
+				Spec: infrav1.Metal3MachineTemplateSpec{
+					Template: infrav1.Metal3MachineTemplateResource{
+						Spec: infrav1.Metal3MachineSpec{
+							AutomatedCleaningMode: utils.StringPtr(infrav1.CleaningModeMetadata),
 						},
 					},
 				},
 			},
-			M3MachineList: &capm3.Metal3MachineList{
+			M3MachineList: &infrav1.Metal3MachineList{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: capm3.GroupVersion.String(),
+					APIVersion: infrav1.GroupVersion.String(),
 					Kind:       "Metal3MachineList",
 				},
 				ListMeta: metav1.ListMeta{},
-				Items: []capm3.Metal3Machine{
+				Items: []infrav1.Metal3Machine{
 					{
 						TypeMeta: metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{
@@ -171,11 +171,11 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 							Namespace: "foo",
 							Annotations: map[string]string{
 								"cluster.x-k8s.io/cloned-from-name":      "abc",
-								"cluster.x-k8s.io/cloned-from-groupkind": capm3.ClonedFromGroupKind,
+								"cluster.x-k8s.io/cloned-from-groupkind": infrav1.ClonedFromGroupKind,
 							},
 						},
-						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeDisabled),
+						Spec: infrav1.Metal3MachineSpec{
+							AutomatedCleaningMode: utils.StringPtr(infrav1.CleaningModeDisabled),
 						},
 					},
 					{
@@ -185,11 +185,11 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 							Namespace: "foo",
 							Annotations: map[string]string{
 								"cluster.x-k8s.io/cloned-from-name":      "abc",
-								"cluster.x-k8s.io/cloned-from-groupkind": capm3.ClonedFromGroupKind,
+								"cluster.x-k8s.io/cloned-from-groupkind": infrav1.ClonedFromGroupKind,
 							},
 						},
-						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeDisabled),
+						Spec: infrav1.Metal3MachineSpec{
+							AutomatedCleaningMode: utils.StringPtr(infrav1.CleaningModeDisabled),
 						},
 					},
 					{
@@ -199,11 +199,11 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 							Namespace: "foo",
 							Annotations: map[string]string{
 								"cluster.x-k8s.io/cloned-from-name":      "abc",
-								"cluster.x-k8s.io/cloned-from-groupkind": capm3.ClonedFromGroupKind,
+								"cluster.x-k8s.io/cloned-from-groupkind": infrav1.ClonedFromGroupKind,
 							},
 						},
-						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeDisabled),
+						Spec: infrav1.Metal3MachineSpec{
+							AutomatedCleaningMode: utils.StringPtr(infrav1.CleaningModeDisabled),
 						},
 					},
 				},
@@ -211,30 +211,30 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 		}),
 		Entry("Don't synchronize M3Machines which are not part of the M3MTemplate ", testCaseUpdate{
 			ExpectedValue: utils.StringPtr("metadata"),
-			M3MachineTemplate: &capm3.Metal3MachineTemplate{
+			M3MachineTemplate: &infrav1.Metal3MachineTemplate{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: capm3.GroupVersion.String(),
+					APIVersion: infrav1.GroupVersion.String(),
 					Kind:       "Metal3MachineTemplate",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
 					Namespace: "foo",
 				},
-				Spec: capm3.Metal3MachineTemplateSpec{
-					Template: capm3.Metal3MachineTemplateResource{
-						Spec: capm3.Metal3MachineSpec{
+				Spec: infrav1.Metal3MachineTemplateSpec{
+					Template: infrav1.Metal3MachineTemplateResource{
+						Spec: infrav1.Metal3MachineSpec{
 							AutomatedCleaningMode: utils.StringPtr("disabled"),
 						},
 					},
 				},
 			},
-			M3MachineList: &capm3.Metal3MachineList{
+			M3MachineList: &infrav1.Metal3MachineList{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: capm3.GroupVersion.String(),
+					APIVersion: infrav1.GroupVersion.String(),
 					Kind:       "Metal3MachineList",
 				},
 				ListMeta: metav1.ListMeta{},
-				Items: []capm3.Metal3Machine{
+				Items: []infrav1.Metal3Machine{
 					{
 						TypeMeta: metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{
@@ -242,11 +242,11 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 							Namespace: "foo",
 							Annotations: map[string]string{
 								"cluster.x-k8s.io/cloned-from-name":      "xyz",
-								"cluster.x-k8s.io/cloned-from-groupkind": capm3.ClonedFromGroupKind,
+								"cluster.x-k8s.io/cloned-from-groupkind": infrav1.ClonedFromGroupKind,
 							},
 						},
-						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeMetadata),
+						Spec: infrav1.Metal3MachineSpec{
+							AutomatedCleaningMode: utils.StringPtr(infrav1.CleaningModeMetadata),
 						},
 					},
 				},

--- a/baremetal/metal3remediation_manager.go
+++ b/baremetal/metal3remediation_manager.go
@@ -27,7 +27,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/cache"
 
-	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -48,8 +48,8 @@ type RemediationManagerInterface interface {
 	TimeToRemediate(timeout time.Duration) (bool, time.Duration)
 	SetRebootAnnotation(ctx context.Context) error
 	SetUnhealthyAnnotation(ctx context.Context) error
-	GetUnhealthyHost(ctx context.Context) (*bmh.BareMetalHost, *patch.Helper, error)
-	OnlineStatus(host *bmh.BareMetalHost) bool
+	GetUnhealthyHost(ctx context.Context) (*bmov1alpha1.BareMetalHost, *patch.Helper, error)
+	OnlineStatus(host *bmov1alpha1.BareMetalHost) bool
 	GetRemediationType() infrav1.RemediationType
 	RetryLimitIsSet() bool
 	SetRemediationPhase(phase string)
@@ -133,8 +133,8 @@ func (r *RemediationManager) SetRebootAnnotation(ctx context.Context) error {
 	}
 
 	r.Log.Info("Adding Reboot annotation to host", host.Name)
-	rebootMode := bmh.RebootAnnotationArguments{}
-	rebootMode.Mode = bmh.RebootModeHard
+	rebootMode := bmov1alpha1.RebootAnnotationArguments{}
+	rebootMode.Mode = bmov1alpha1.RebootModeHard
 	marshalledMode, err := json.Marshal(rebootMode)
 
 	if err != nil {
@@ -162,7 +162,7 @@ func (r *RemediationManager) SetUnhealthyAnnotation(ctx context.Context) error {
 
 // GetUnhealthyHost gets the associated host for unhealthy machine. Returns nil if not found. Assumes the
 // host is in the same namespace as the unhealthy machine.
-func (r *RemediationManager) GetUnhealthyHost(ctx context.Context) (*bmh.BareMetalHost, *patch.Helper, error) {
+func (r *RemediationManager) GetUnhealthyHost(ctx context.Context) (*bmov1alpha1.BareMetalHost, *patch.Helper, error) {
 	host, err := getUnhealthyHost(ctx, r.Metal3Machine, r.Client, r.Log)
 	if err != nil || host == nil {
 		return host, nil, err
@@ -173,7 +173,7 @@ func (r *RemediationManager) GetUnhealthyHost(ctx context.Context) (*bmh.BareMet
 
 func getUnhealthyHost(ctx context.Context, m3Machine *infrav1.Metal3Machine, cl client.Client,
 	rLog logr.Logger,
-) (*bmh.BareMetalHost, error) {
+) (*bmov1alpha1.BareMetalHost, error) {
 	annotations := m3Machine.ObjectMeta.GetAnnotations()
 	if annotations == nil {
 		err := fmt.Errorf("unable to get %s annotations", m3Machine.Name)
@@ -190,7 +190,7 @@ func getUnhealthyHost(ctx context.Context, m3Machine *infrav1.Metal3Machine, cl 
 		return nil, err
 	}
 
-	host := bmh.BareMetalHost{}
+	host := bmov1alpha1.BareMetalHost{}
 	key := client.ObjectKey{
 		Name:      hostName,
 		Namespace: hostNamespace,
@@ -206,7 +206,7 @@ func getUnhealthyHost(ctx context.Context, m3Machine *infrav1.Metal3Machine, cl 
 }
 
 // OnlineStatus returns hosts Online field value.
-func (r *RemediationManager) OnlineStatus(host *bmh.BareMetalHost) bool {
+func (r *RemediationManager) OnlineStatus(host *bmov1alpha1.BareMetalHost) bool {
 	return host.Spec.Online
 }
 

--- a/baremetal/metal3remediation_manager.go
+++ b/baremetal/metal3remediation_manager.go
@@ -145,7 +145,7 @@ func (r *RemediationManager) SetRebootAnnotation(ctx context.Context) error {
 	return helper.Patch(ctx, host)
 }
 
-// SetUnhealthyAnnotation sets infrav1.UnhealthyAnnotation on unhealthy host.
+// SetUnhealthyAnnotation sets UnhealthyAnnotation annotation on unhealthy host.
 func (r *RemediationManager) SetUnhealthyAnnotation(ctx context.Context) error {
 	host, helper, err := r.GetUnhealthyHost(ctx)
 	if err != nil {

--- a/baremetal/metal3remediation_manager_test.go
+++ b/baremetal/metal3remediation_manager_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -33,8 +33,8 @@ import (
 )
 
 type testCaseRemediationManager struct {
-	Metal3Remediation *capm3.Metal3Remediation
-	Metal3Machine     *capm3.Metal3Machine
+	Metal3Remediation *infrav1.Metal3Remediation
+	Metal3Machine     *infrav1.Metal3Machine
 	Machine           *clusterv1.Machine
 	ExpectSuccess     bool
 }
@@ -64,8 +64,8 @@ var _ = Describe("Metal3Remediation manager", func() {
 				}
 			},
 			Entry("All fields defined", testCaseRemediationManager{
-				Metal3Remediation: &capm3.Metal3Remediation{},
-				Metal3Machine:     &capm3.Metal3Machine{},
+				Metal3Remediation: &infrav1.Metal3Remediation{},
+				Metal3Machine:     &infrav1.Metal3Machine{},
 				Machine:           &clusterv1.Machine{},
 				ExpectSuccess:     true,
 			}),
@@ -88,20 +88,20 @@ var _ = Describe("Metal3Remediation manager", func() {
 			remediationMgr.SetFinalizer()
 
 			Expect(tc.Metal3Remediation.ObjectMeta.Finalizers).To(ContainElement(
-				capm3.RemediationFinalizer,
+				infrav1.RemediationFinalizer,
 			))
 
 			remediationMgr.UnsetFinalizer()
 
 			Expect(tc.Metal3Remediation.ObjectMeta.Finalizers).NotTo(ContainElement(
-				capm3.RemediationFinalizer,
+				infrav1.RemediationFinalizer,
 			))
 		},
 		Entry("No finalizers", testCaseRemediationManager{
-			Metal3Remediation: &capm3.Metal3Remediation{},
+			Metal3Remediation: &infrav1.Metal3Remediation{},
 		}),
 		Entry("Additional finalizers", testCaseRemediationManager{
-			Metal3Remediation: &capm3.Metal3Remediation{
+			Metal3Remediation: &infrav1.Metal3Remediation{
 				ObjectMeta: metav1.ObjectMeta{
 					Finalizers: []string{"foo"},
 				},
@@ -110,7 +110,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 	)
 
 	type testCaseRetryLimitSet struct {
-		Metal3Remediation *capm3.Metal3Remediation
+		Metal3Remediation *infrav1.Metal3Remediation
 		ExpectTrue        bool
 	}
 
@@ -126,9 +126,9 @@ var _ = Describe("Metal3Remediation manager", func() {
 			Expect(retryLimitIsSet).To(Equal(tc.ExpectTrue))
 		},
 		Entry("retry limit is set", testCaseRetryLimitSet{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Spec: capm3.Metal3RemediationSpec{
-					Strategy: &capm3.RemediationStrategy{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Spec: infrav1.Metal3RemediationSpec{
+					Strategy: &infrav1.RemediationStrategy{
 						Type:       "",
 						RetryLimit: 1,
 						Timeout:    &metav1.Duration{},
@@ -138,9 +138,9 @@ var _ = Describe("Metal3Remediation manager", func() {
 			ExpectTrue: true,
 		}),
 		Entry("retry limit is set to 0", testCaseRetryLimitSet{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Spec: capm3.Metal3RemediationSpec{
-					Strategy: &capm3.RemediationStrategy{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Spec: infrav1.Metal3RemediationSpec{
+					Strategy: &infrav1.RemediationStrategy{
 						Type:       "",
 						RetryLimit: 0,
 						Timeout:    &metav1.Duration{},
@@ -150,9 +150,9 @@ var _ = Describe("Metal3Remediation manager", func() {
 			ExpectTrue: false,
 		}),
 		Entry("retry limit is set to less than 0", testCaseRetryLimitSet{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Spec: capm3.Metal3RemediationSpec{
-					Strategy: &capm3.RemediationStrategy{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Spec: infrav1.Metal3RemediationSpec{
+					Strategy: &infrav1.RemediationStrategy{
 						Type:       "",
 						RetryLimit: -1,
 						Timeout:    &metav1.Duration{},
@@ -162,9 +162,9 @@ var _ = Describe("Metal3Remediation manager", func() {
 			ExpectTrue: false,
 		}),
 		Entry("retry limit is not set", testCaseRetryLimitSet{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Spec: capm3.Metal3RemediationSpec{
-					Strategy: &capm3.RemediationStrategy{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Spec: infrav1.Metal3RemediationSpec{
+					Strategy: &infrav1.RemediationStrategy{
 						Type:    "",
 						Timeout: &metav1.Duration{},
 					},
@@ -186,15 +186,15 @@ var _ = Describe("Metal3Remediation manager", func() {
 			Expect(retryLimitIsSet).To(Equal(tc.ExpectTrue))
 		},
 		Entry("retry limit is reached", testCaseRetryLimitSet{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Spec: capm3.Metal3RemediationSpec{
-					Strategy: &capm3.RemediationStrategy{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Spec: infrav1.Metal3RemediationSpec{
+					Strategy: &infrav1.RemediationStrategy{
 						Type:       "",
 						RetryLimit: 1,
 						Timeout:    &metav1.Duration{},
 					},
 				},
-				Status: capm3.Metal3RemediationStatus{
+				Status: infrav1.Metal3RemediationStatus{
 					Phase:          "",
 					RetryCount:     1,
 					LastRemediated: &metav1.Time{},
@@ -203,15 +203,15 @@ var _ = Describe("Metal3Remediation manager", func() {
 			ExpectTrue: true,
 		}),
 		Entry("retry limit is not reached", testCaseRetryLimitSet{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Spec: capm3.Metal3RemediationSpec{
-					Strategy: &capm3.RemediationStrategy{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Spec: infrav1.Metal3RemediationSpec{
+					Strategy: &infrav1.RemediationStrategy{
 						Type:       "",
 						RetryLimit: 1,
 						Timeout:    &metav1.Duration{},
 					},
 				},
-				Status: capm3.Metal3RemediationStatus{
+				Status: infrav1.Metal3RemediationStatus{
 					Phase:          "",
 					RetryCount:     0,
 					LastRemediated: &metav1.Time{},
@@ -220,15 +220,15 @@ var _ = Describe("Metal3Remediation manager", func() {
 			ExpectTrue: false,
 		}),
 		Entry("retry limit is not set so limit is reached", testCaseRetryLimitSet{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Spec: capm3.Metal3RemediationSpec{
-					Strategy: &capm3.RemediationStrategy{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Spec: infrav1.Metal3RemediationSpec{
+					Strategy: &infrav1.RemediationStrategy{
 						Type:       "",
 						RetryLimit: 0,
 						Timeout:    &metav1.Duration{},
 					},
 				},
-				Status: capm3.Metal3RemediationStatus{
+				Status: infrav1.Metal3RemediationStatus{
 					Phase:          "",
 					RetryCount:     0,
 					LastRemediated: &metav1.Time{},
@@ -240,7 +240,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 	type testCaseEnsureRebootAnnotation struct {
 		Host              *bmh.BareMetalHost
-		Metal3Remediation *capm3.Metal3Remediation
+		Metal3Remediation *infrav1.Metal3Remediation
 		ExpectTrue        bool
 	}
 
@@ -277,8 +277,8 @@ var _ = Describe("Metal3Remediation manager", func() {
 	)
 
 	type testCaseGetUnhealthyHost struct {
-		M3Machine         *capm3.Metal3Machine
-		Metal3Remediation *capm3.Metal3Remediation
+		M3Machine         *infrav1.Metal3Machine
+		Metal3Remediation *infrav1.Metal3Remediation
 		ExpectPresent     bool
 	}
 
@@ -310,7 +310,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 			}
 		},
 		Entry("Should find the unhealthy host", testCaseGetUnhealthyHost{
-			M3Machine: &capm3.Metal3Machine{
+			M3Machine: &infrav1.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "mym3machine",
 					Namespace:       namespaceName,
@@ -323,7 +323,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 			ExpectPresent: true,
 		}),
 		Entry("Should not find the unhealthy host", testCaseGetUnhealthyHost{
-			M3Machine: &capm3.Metal3Machine{
+			M3Machine: &infrav1.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "mym3machine",
 					Namespace:       namespaceName,
@@ -336,7 +336,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 			ExpectPresent: false,
 		}),
 		Entry("Should not find the host, annotation is empty", testCaseGetUnhealthyHost{
-			M3Machine: &capm3.Metal3Machine{
+			M3Machine: &infrav1.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "mym3machine",
 					Namespace:       namespaceName,
@@ -347,7 +347,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 			ExpectPresent: false,
 		}),
 		Entry("Should not find the host, annotation is nil", testCaseGetUnhealthyHost{
-			M3Machine: &capm3.Metal3Machine{
+			M3Machine: &infrav1.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "mym3machine",
 					Namespace:       "myns",
@@ -358,7 +358,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 			ExpectPresent: false,
 		}),
 		Entry("Should not find the host, could not parse annotation value", testCaseGetUnhealthyHost{
-			M3Machine: &capm3.Metal3Machine{
+			M3Machine: &infrav1.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "mym3machine",
 					Namespace:       "myns",
@@ -374,7 +374,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 	type testCaseSetAnnotation struct {
 		Host       *bmh.BareMetalHost
-		M3Machine  *capm3.Metal3Machine
+		M3Machine  *infrav1.Metal3Machine
 		ExpectTrue bool
 	}
 
@@ -395,7 +395,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 			}
 		},
 		Entry("Should set the unhealthy annotation", testCaseSetAnnotation{
-			M3Machine: &capm3.Metal3Machine{
+			M3Machine: &infrav1.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "mym3machine",
 					Namespace:       "myns",
@@ -409,13 +409,13 @@ var _ = Describe("Metal3Remediation manager", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "myhost",
 					Namespace:   "myns",
-					Annotations: map[string]string{capm3.UnhealthyAnnotation: ""},
+					Annotations: map[string]string{infrav1.UnhealthyAnnotation: ""},
 				},
 			},
 			ExpectTrue: true,
 		}),
 		Entry("Should not set the unhealthy annotation, annotation is empty", testCaseSetAnnotation{
-			M3Machine: &capm3.Metal3Machine{
+			M3Machine: &infrav1.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "mym3machine",
 					Namespace:       "myns",
@@ -427,13 +427,13 @@ var _ = Describe("Metal3Remediation manager", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "myhost",
 					Namespace:   "myns",
-					Annotations: map[string]string{capm3.UnhealthyAnnotation: ""},
+					Annotations: map[string]string{infrav1.UnhealthyAnnotation: ""},
 				},
 			},
 			ExpectTrue: false,
 		}),
 		Entry("Should not set the unhealthy annotation because of wrong HostAnnotation", testCaseSetAnnotation{
-			M3Machine: &capm3.Metal3Machine{
+			M3Machine: &infrav1.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "mym3machine",
 					Namespace:       "myns",
@@ -447,7 +447,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "myhost",
 					Namespace:   "myns",
-					Annotations: map[string]string{capm3.UnhealthyAnnotation: ""},
+					Annotations: map[string]string{infrav1.UnhealthyAnnotation: ""},
 				},
 			},
 			ExpectTrue: false,
@@ -471,7 +471,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 			}
 		},
 		Entry("Should set the reboot annotation", testCaseSetAnnotation{
-			M3Machine: &capm3.Metal3Machine{
+			M3Machine: &infrav1.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "mym3machine",
 					Namespace:       "myns",
@@ -491,7 +491,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 			ExpectTrue: true,
 		}),
 		Entry("Should not set the reboot annotation, annotation is empty", testCaseSetAnnotation{
-			M3Machine: &capm3.Metal3Machine{
+			M3Machine: &infrav1.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "mym3machine",
 					Namespace:       "myns",
@@ -509,7 +509,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 			ExpectTrue: false,
 		}),
 		Entry("Should not set the reboot annotation because of wrong HostAnnotation", testCaseSetAnnotation{
-			M3Machine: &capm3.Metal3Machine{
+			M3Machine: &infrav1.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "mym3machine",
 					Namespace:       "myns",
@@ -531,8 +531,8 @@ var _ = Describe("Metal3Remediation manager", func() {
 	)
 
 	type testCaseGetRemediationType struct {
-		Metal3Remediation  *capm3.Metal3Remediation
-		RemediationType    *capm3.RemediationType
+		Metal3Remediation  *infrav1.Metal3Remediation
+		RemediationType    *infrav1.RemediationType
 		RemediationTypeSet bool
 	}
 
@@ -545,15 +545,15 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 			remediationType := remediationMgr.GetRemediationType()
 			if tc.RemediationTypeSet {
-				Expect(remediationType).To(Equal(capm3.RebootRemediationStrategy))
+				Expect(remediationType).To(Equal(infrav1.RebootRemediationStrategy))
 			} else {
-				Expect(remediationType).To(Equal(capm3.RemediationType("")))
+				Expect(remediationType).To(Equal(infrav1.RemediationType("")))
 			}
 		},
 		Entry("Remediation strategy type is set to Reboot, should return strategy", testCaseGetRemediationType{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Spec: capm3.Metal3RemediationSpec{
-					Strategy: &capm3.RemediationStrategy{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Spec: infrav1.Metal3RemediationSpec{
+					Strategy: &infrav1.RemediationStrategy{
 						Type:       "Reboot",
 						RetryLimit: 0,
 						Timeout:    &metav1.Duration{},
@@ -563,9 +563,9 @@ var _ = Describe("Metal3Remediation manager", func() {
 			RemediationTypeSet: true,
 		}),
 		Entry("Remediation strategy type is not set should return empty string", testCaseGetRemediationType{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Spec: capm3.Metal3RemediationSpec{
-					Strategy: &capm3.RemediationStrategy{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Spec: infrav1.Metal3RemediationSpec{
+					Strategy: &infrav1.RemediationStrategy{
 						Type:       "",
 						RetryLimit: 0,
 						Timeout:    &metav1.Duration{},
@@ -577,7 +577,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 	)
 
 	type testCaseGetRemediatedTime struct {
-		Metal3Remediation *capm3.Metal3Remediation
+		Metal3Remediation *infrav1.Metal3Remediation
 		Remediated        bool
 	}
 
@@ -596,14 +596,14 @@ var _ = Describe("Metal3Remediation manager", func() {
 			}
 		},
 		Entry("Host is not yet remediated and last remediation timestamp is not set yet", testCaseGetRemediatedTime{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Status: capm3.Metal3RemediationStatus{},
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Status: infrav1.Metal3RemediationStatus{},
 			},
 			Remediated: false,
 		}),
 		Entry("Host is remediated and controller has set the last remediation timestamp", testCaseGetRemediatedTime{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Status: capm3.Metal3RemediationStatus{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Status: infrav1.Metal3RemediationStatus{
 					LastRemediated: &metav1.Time{},
 				},
 			},
@@ -612,7 +612,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 	)
 
 	type testTimeToRemediate struct {
-		Metal3Remediation *capm3.Metal3Remediation
+		Metal3Remediation *infrav1.Metal3Remediation
 		ExpectTrue        bool
 	}
 
@@ -634,15 +634,15 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 		},
 		Entry("Time to remediate reached", testTimeToRemediate{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Spec: capm3.Metal3RemediationSpec{
-					Strategy: &capm3.RemediationStrategy{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Spec: infrav1.Metal3RemediationSpec{
+					Strategy: &infrav1.RemediationStrategy{
 						Type:       "",
 						RetryLimit: 1,
 						Timeout:    &metav1.Duration{Duration: 600 * time.Second},
 					},
 				},
-				Status: capm3.Metal3RemediationStatus{
+				Status: infrav1.Metal3RemediationStatus{
 					Phase:          "",
 					RetryCount:     1,
 					LastRemediated: &metav1.Time{Time: time.Now().Add(time.Duration(-700) * time.Second)},
@@ -651,15 +651,15 @@ var _ = Describe("Metal3Remediation manager", func() {
 			ExpectTrue: true,
 		}),
 		Entry("Time to remediate is not reached because of LastRemediated is nil", testTimeToRemediate{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Spec: capm3.Metal3RemediationSpec{
-					Strategy: &capm3.RemediationStrategy{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Spec: infrav1.Metal3RemediationSpec{
+					Strategy: &infrav1.RemediationStrategy{
 						Type:       "",
 						RetryLimit: 1,
 						Timeout:    &metav1.Duration{Duration: 600 * time.Second},
 					},
 				},
-				Status: capm3.Metal3RemediationStatus{
+				Status: infrav1.Metal3RemediationStatus{
 					Phase:          "",
 					RetryCount:     1,
 					LastRemediated: nil,
@@ -668,15 +668,15 @@ var _ = Describe("Metal3Remediation manager", func() {
 			ExpectTrue: false,
 		}),
 		Entry("Time to remediate is not reached, LastRemediated + Timeout is greater than current time", testTimeToRemediate{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Spec: capm3.Metal3RemediationSpec{
-					Strategy: &capm3.RemediationStrategy{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Spec: infrav1.Metal3RemediationSpec{
+					Strategy: &infrav1.RemediationStrategy{
 						Type:       "",
 						RetryLimit: 1,
 						Timeout:    &metav1.Duration{Duration: 600 * time.Second},
 					},
 				},
-				Status: capm3.Metal3RemediationStatus{
+				Status: infrav1.Metal3RemediationStatus{
 					Phase:          "",
 					RetryCount:     1,
 					LastRemediated: &metav1.Time{Time: time.Now()},
@@ -687,7 +687,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 	)
 
 	type testCaseGetTimeout struct {
-		Metal3Remediation *capm3.Metal3Remediation
+		Metal3Remediation *infrav1.Metal3Remediation
 		TimeoutSet        bool
 	}
 
@@ -706,17 +706,17 @@ var _ = Describe("Metal3Remediation manager", func() {
 			}
 		},
 		Entry("Timeout is not set", testCaseGetTimeout{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Spec: capm3.Metal3RemediationSpec{
-					Strategy: &capm3.RemediationStrategy{},
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Spec: infrav1.Metal3RemediationSpec{
+					Strategy: &infrav1.RemediationStrategy{},
 				},
 			},
 			TimeoutSet: false,
 		}),
 		Entry("Timeout is set", testCaseGetTimeout{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Spec: capm3.Metal3RemediationSpec{
-					Strategy: &capm3.RemediationStrategy{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Spec: infrav1.Metal3RemediationSpec{
+					Strategy: &infrav1.RemediationStrategy{
 						Type:       "",
 						RetryLimit: 0,
 						Timeout:    &metav1.Duration{},
@@ -734,16 +734,16 @@ var _ = Describe("Metal3Remediation manager", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			remediationMgr.SetRemediationPhase(capm3.PhaseRunning)
+			remediationMgr.SetRemediationPhase(infrav1.PhaseRunning)
 
 			Expect(tc.Metal3Remediation.Status.Phase).To(Equal("Running"))
 		},
 		Entry("No phase", testCaseRemediationManager{
-			Metal3Remediation: &capm3.Metal3Remediation{},
+			Metal3Remediation: &infrav1.Metal3Remediation{},
 		}),
 		Entry("Overwride excisting phase", testCaseRemediationManager{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Status: capm3.Metal3RemediationStatus{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Status: infrav1.Metal3RemediationStatus{
 					Phase: "Waiting",
 				},
 			},
@@ -763,11 +763,11 @@ var _ = Describe("Metal3Remediation manager", func() {
 			Expect(tc.Metal3Remediation.Status.LastRemediated).ShouldNot(BeNil())
 		},
 		Entry("No timestamp set", testCaseRemediationManager{
-			Metal3Remediation: &capm3.Metal3Remediation{},
+			Metal3Remediation: &infrav1.Metal3Remediation{},
 		}),
 		Entry("Overwride excisting time", testCaseRemediationManager{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Status: capm3.Metal3RemediationStatus{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Status: infrav1.Metal3RemediationStatus{
 					LastRemediated: &metav1.Time{},
 				},
 			},
@@ -787,18 +787,18 @@ var _ = Describe("Metal3Remediation manager", func() {
 			Expect(tc.Metal3Remediation.Status.RetryCount).To(Equal(newCount))
 		},
 		Entry("RetryCount is not set", testCaseRemediationManager{
-			Metal3Remediation: &capm3.Metal3Remediation{},
+			Metal3Remediation: &infrav1.Metal3Remediation{},
 		}),
 		Entry("RetryCount is 0", testCaseRemediationManager{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Status: capm3.Metal3RemediationStatus{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Status: infrav1.Metal3RemediationStatus{
 					RetryCount: 0,
 				},
 			},
 		}),
 		Entry("RetryCount is 2", testCaseRemediationManager{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Status: capm3.Metal3RemediationStatus{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Status: infrav1.Metal3RemediationStatus{
 					RetryCount: 2,
 				},
 			},
@@ -806,7 +806,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 	)
 
 	type testCaseGetRemediationPhase struct {
-		Metal3Remediation *capm3.Metal3Remediation
+		Metal3Remediation *infrav1.Metal3Remediation
 		Succeed           bool
 	}
 
@@ -820,13 +820,13 @@ var _ = Describe("Metal3Remediation manager", func() {
 			phase := remediationMgr.GetRemediationPhase()
 
 			if tc.Succeed {
-				if phase == capm3.PhaseRunning {
+				if phase == infrav1.PhaseRunning {
 					Expect(tc.Metal3Remediation.Status.Phase).Should(ContainSubstring("Running"))
 				}
-				if phase == capm3.PhaseWaiting {
+				if phase == infrav1.PhaseWaiting {
 					Expect(tc.Metal3Remediation.Status.Phase).Should(ContainSubstring("Waiting"))
 				}
-				if phase == capm3.PhaseDeleting {
+				if phase == infrav1.PhaseDeleting {
 					Expect(tc.Metal3Remediation.Status.Phase).Should(ContainSubstring("Deleting machine"))
 				}
 			} else {
@@ -837,36 +837,36 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 		},
 		Entry("No phase set", testCaseGetRemediationPhase{
-			Metal3Remediation: &capm3.Metal3Remediation{},
+			Metal3Remediation: &infrav1.Metal3Remediation{},
 			Succeed:           false,
 		}),
 		Entry("Phase is set to Running", testCaseGetRemediationPhase{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Status: capm3.Metal3RemediationStatus{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Status: infrav1.Metal3RemediationStatus{
 					Phase: "Running",
 				},
 			},
 			Succeed: true,
 		}),
 		Entry("Phase is set to Waiting", testCaseGetRemediationPhase{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Status: capm3.Metal3RemediationStatus{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Status: infrav1.Metal3RemediationStatus{
 					Phase: "Waiting",
 				},
 			},
 			Succeed: true,
 		}),
 		Entry("Phase is set to Deleting", testCaseGetRemediationPhase{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Status: capm3.Metal3RemediationStatus{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Status: infrav1.Metal3RemediationStatus{
 					Phase: "Deleting machine",
 				},
 			},
 			Succeed: true,
 		}),
 		Entry("Phase is set to something else", testCaseGetRemediationPhase{
-			Metal3Remediation: &capm3.Metal3Remediation{
-				Status: capm3.Metal3RemediationStatus{
+			Metal3Remediation: &infrav1.Metal3Remediation{
+				Status: infrav1.Metal3RemediationStatus{
 					Phase: "test",
 				},
 			},

--- a/baremetal/metal3remediation_manager_test.go
+++ b/baremetal/metal3remediation_manager_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
-	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -239,7 +239,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 	)
 
 	type testCaseEnsureRebootAnnotation struct {
-		Host              *bmh.BareMetalHost
+		Host              *bmov1alpha1.BareMetalHost
 		Metal3Remediation *infrav1.Metal3Remediation
 		ExpectTrue        bool
 	}
@@ -259,16 +259,16 @@ var _ = Describe("Metal3Remediation manager", func() {
 			}
 		},
 		Entry(" Online field in spec is set to false", testCaseEnsureRebootAnnotation{
-			Host: &bmh.BareMetalHost{
-				Spec: bmh.BareMetalHostSpec{
+			Host: &bmov1alpha1.BareMetalHost{
+				Spec: bmov1alpha1.BareMetalHostSpec{
 					Online: false,
 				},
 			},
 			ExpectTrue: false,
 		}),
 		Entry(" Online field in spec is set to true", testCaseEnsureRebootAnnotation{
-			Host: &bmh.BareMetalHost{
-				Spec: bmh.BareMetalHostSpec{
+			Host: &bmov1alpha1.BareMetalHost{
+				Spec: bmov1alpha1.BareMetalHostSpec{
 					Online: true,
 				},
 			},
@@ -284,7 +284,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 	DescribeTable("Test GetUnhealthyHost",
 		func(tc testCaseGetUnhealthyHost) {
-			host := bmh.BareMetalHost{
+			host := bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: namespaceName,
@@ -373,7 +373,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 	)
 
 	type testCaseSetAnnotation struct {
-		Host       *bmh.BareMetalHost
+		Host       *bmov1alpha1.BareMetalHost
 		M3Machine  *infrav1.Metal3Machine
 		ExpectTrue bool
 	}
@@ -405,7 +405,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 					},
 				},
 			},
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "myhost",
 					Namespace:   "myns",
@@ -423,7 +423,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 					Annotations:     map[string]string{},
 				},
 			},
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "myhost",
 					Namespace:   "myns",
@@ -443,7 +443,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 					},
 				},
 			},
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "myhost",
 					Namespace:   "myns",
@@ -481,7 +481,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 					},
 				},
 			},
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "myhost",
 					Namespace:   "myns",
@@ -499,7 +499,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 					Annotations:     map[string]string{},
 				},
 			},
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "myhost",
 					Namespace:   "myns",
@@ -519,7 +519,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 					},
 				},
 			},
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "myhost",
 					Namespace:   "myns",

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -27,7 +27,7 @@ import (
 
 	_ "github.com/go-logr/logr"
 	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -78,7 +78,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cfg).ToNot(BeNil())
 
-		err = capm3.AddToScheme(scheme.Scheme)
+		err = infrav1.AddToScheme(scheme.Scheme)
 		Expect(err).NotTo(HaveOccurred())
 
 		err = ipamv1.AddToScheme(scheme.Scheme)
@@ -123,7 +123,7 @@ func setupScheme() *runtime.Scheme {
 	if err := clusterv1.AddToScheme(s); err != nil {
 		panic(err)
 	}
-	if err := capm3.AddToScheme(s); err != nil {
+	if err := infrav1.AddToScheme(s); err != nil {
 		panic(err)
 	}
 	if err := ipamv1.AddToScheme(s); err != nil {
@@ -162,19 +162,19 @@ func newCluster(clusterName string) *clusterv1.Cluster {
 }
 
 func newMetal3Cluster(baremetalName string, ownerRef *metav1.OwnerReference,
-	spec *capm3.Metal3ClusterSpec, status *capm3.Metal3ClusterStatus) *capm3.Metal3Cluster {
+	spec *infrav1.Metal3ClusterSpec, status *infrav1.Metal3ClusterStatus) *infrav1.Metal3Cluster {
 	if spec == nil {
-		spec = &capm3.Metal3ClusterSpec{}
+		spec = &infrav1.Metal3ClusterSpec{}
 	}
 	if status == nil {
-		status = &capm3.Metal3ClusterStatus{}
+		status = &infrav1.Metal3ClusterStatus{}
 	}
 	ownerRefs := []metav1.OwnerReference{}
 	if ownerRef != nil {
 		ownerRefs = []metav1.OwnerReference{*ownerRef}
 	}
 
-	return &capm3.Metal3Cluster{
+	return &infrav1.Metal3Cluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "Metal3Cluster",
 		},

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	_ "github.com/go-logr/logr"
-	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -132,7 +132,7 @@ func setupScheme() *runtime.Scheme {
 	if err := corev1.AddToScheme(s); err != nil {
 		panic(err)
 	}
-	if err := bmh.SchemeBuilder.AddToScheme(s); err != nil {
+	if err := bmov1alpha1.SchemeBuilder.AddToScheme(s); err != nil {
 		panic(err)
 	}
 	return s

--- a/baremetal/utils.go
+++ b/baremetal/utils.go
@@ -23,7 +23,7 @@ import (
 	// comment for go-lint.
 	"github.com/go-logr/logr"
 
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -191,7 +191,7 @@ func deleteSecret(ctx context.Context, cl client.Client, name string,
 func fetchM3DataTemplate(ctx context.Context,
 	templateRef *corev1.ObjectReference, cl client.Client, mLog logr.Logger,
 	clusterName string,
-) (*capm3.Metal3DataTemplate, error) {
+) (*infrav1.Metal3DataTemplate, error) {
 	// If the user did not specify a DataTemplate, just keep going.
 	if templateRef == nil {
 		return nil, nil
@@ -201,7 +201,7 @@ func fetchM3DataTemplate(ctx context.Context,
 	}
 
 	// Fetch the Metal3 metadata.
-	metal3DataTemplate := &capm3.Metal3DataTemplate{}
+	metal3DataTemplate := &infrav1.Metal3DataTemplate{}
 	metal3DataTemplateName := types.NamespacedName{
 		Namespace: templateRef.Namespace,
 		Name:      templateRef.Name,
@@ -225,9 +225,9 @@ func fetchM3DataTemplate(ctx context.Context,
 
 func fetchM3DataClaim(ctx context.Context, cl client.Client, mLog logr.Logger,
 	name, namespace string,
-) (*capm3.Metal3DataClaim, error) {
+) (*infrav1.Metal3DataClaim, error) {
 	// Fetch the Metal3DataClaim.
-	m3DataClaim := &capm3.Metal3DataClaim{}
+	m3DataClaim := &infrav1.Metal3DataClaim{}
 	metal3DataClaimName := types.NamespacedName{
 		Namespace: namespace,
 		Name:      name,
@@ -245,9 +245,9 @@ func fetchM3DataClaim(ctx context.Context, cl client.Client, mLog logr.Logger,
 
 func fetchM3Data(ctx context.Context, cl client.Client, mLog logr.Logger,
 	name, namespace string,
-) (*capm3.Metal3Data, error) {
+) (*infrav1.Metal3Data, error) {
 	// Fetch the Metal3Data.
-	m3Data := &capm3.Metal3Data{}
+	m3Data := &infrav1.Metal3Data{}
 	metal3DataName := types.NamespacedName{
 		Namespace: namespace,
 		Name:      name,
@@ -264,11 +264,11 @@ func fetchM3Data(ctx context.Context, cl client.Client, mLog logr.Logger,
 }
 
 func getM3Machine(ctx context.Context, cl client.Client, mLog logr.Logger,
-	name, namespace string, dataTemplate *capm3.Metal3DataTemplate,
+	name, namespace string, dataTemplate *infrav1.Metal3DataTemplate,
 	requeueifNotFound bool,
-) (*capm3.Metal3Machine, error) {
+) (*infrav1.Metal3Machine, error) {
 	// Get the Metal3Machine.
-	tmpM3Machine := &capm3.Metal3Machine{}
+	tmpM3Machine := &infrav1.Metal3Machine{}
 	key := client.ObjectKey{
 		Name:      name,
 		Namespace: namespace,

--- a/baremetal/utils_test.go
+++ b/baremetal/utils_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/utils/pointer"
@@ -113,41 +113,41 @@ var _ = Describe("Metal3 manager utils", func() {
 	})
 
 	type testCaseUpdate struct {
-		TestObject     *capm3.Metal3Machine
-		ExistingObject *capm3.Metal3Machine
+		TestObject     *infrav1.Metal3Machine
+		ExistingObject *infrav1.Metal3Machine
 		ExpectedError  bool
 	}
 
 	type testCasePatch struct {
-		TestObject     *capm3.Metal3Machine
-		ExistingObject *capm3.Metal3Machine
+		TestObject     *infrav1.Metal3Machine
+		ExistingObject *infrav1.Metal3Machine
 		ExpectedError  bool
 		CreateObject   bool
 	}
 
-	var testObject = &capm3.Metal3Machine{
+	var testObject = &infrav1.Metal3Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "abc",
 			Namespace: namespaceName,
 		},
-		Spec: capm3.Metal3MachineSpec{
+		Spec: infrav1.Metal3MachineSpec{
 			ProviderID:            pointer.StringPtr("abcdef"),
 			AutomatedCleaningMode: pointer.StringPtr("metadata"),
 		},
-		Status: capm3.Metal3MachineStatus{
+		Status: infrav1.Metal3MachineStatus{
 			Ready: true,
 		},
 	}
 
-	var existingObject = &capm3.Metal3Machine{
+	var existingObject = &infrav1.Metal3Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "abc",
 			Namespace: namespaceName,
 		},
-		Spec: capm3.Metal3MachineSpec{
+		Spec: infrav1.Metal3MachineSpec{
 			ProviderID: pointer.StringPtr("abcdefg"),
 		},
-		Status: capm3.Metal3MachineStatus{
+		Status: infrav1.Metal3MachineStatus{
 			Ready: true,
 		},
 	}
@@ -160,7 +160,7 @@ var _ = Describe("Metal3 manager utils", func() {
 			if tc.CreateObject {
 				err = k8sClient.Create(context.TODO(), tc.ExistingObject)
 				Expect(err).NotTo(HaveOccurred())
-				m3m := capm3.Metal3Machine{}
+				m3m := infrav1.Metal3Machine{}
 				err = k8sClient.Get(context.TODO(),
 					client.ObjectKey{
 						Name:      tc.ExistingObject.Name,
@@ -193,7 +193,7 @@ var _ = Describe("Metal3 manager utils", func() {
 
 				if tc.CreateObject {
 					// verify that the object was updated
-					savedObject := capm3.Metal3Machine{}
+					savedObject := infrav1.Metal3Machine{}
 					err = k8sClient.Get(context.TODO(),
 						client.ObjectKey{
 							Name:      tc.TestObject.Name,
@@ -239,7 +239,7 @@ var _ = Describe("Metal3 manager utils", func() {
 			if tc.ExistingObject != nil {
 				err := k8sClient.Create(context.TODO(), tc.ExistingObject)
 				Expect(err).NotTo(HaveOccurred())
-				m3m := capm3.Metal3Machine{}
+				m3m := infrav1.Metal3Machine{}
 				err = k8sClient.Get(context.TODO(),
 					client.ObjectKey{
 						Name:      tc.ExistingObject.Name,
@@ -259,7 +259,7 @@ var _ = Describe("Metal3 manager utils", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(obj.Spec).To(Equal(tc.TestObject.Spec))
 				Expect(obj.Status).To(Equal(tc.TestObject.Status))
-				savedObject := capm3.Metal3Machine{}
+				savedObject := infrav1.Metal3Machine{}
 				err = k8sClient.Get(context.TODO(),
 					client.ObjectKey{
 						Name:      tc.TestObject.Name,
@@ -306,7 +306,7 @@ var _ = Describe("Metal3 manager utils", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(obj.Spec).To(Equal(tc.TestObject.Spec))
 				Expect(obj.Status).To(Equal(tc.TestObject.Status))
-				savedObject := capm3.Metal3Machine{}
+				savedObject := infrav1.Metal3Machine{}
 				err = k8sClient.Get(context.TODO(),
 					client.ObjectKey{
 						Name:      tc.TestObject.Name,
@@ -375,7 +375,7 @@ var _ = Describe("Metal3 manager utils", func() {
 							{
 								Name:       "ghij",
 								Kind:       "Metal3Machine",
-								APIVersion: capm3.GroupVersion.String(),
+								APIVersion: infrav1.GroupVersion.String(),
 								UID:        "7df7fe8e-9cdb-4c57-8144-0a30bf6b9496",
 							},
 						},
@@ -390,7 +390,7 @@ var _ = Describe("Metal3 manager utils", func() {
 			ownerRef := []metav1.OwnerReference{{
 				Name:       "abcd",
 				Kind:       "Metal3Machine",
-				APIVersion: capm3.GroupVersion.String(),
+				APIVersion: infrav1.GroupVersion.String(),
 				UID:        "7df7fe8e-9cdb-4c57-8144-0a30bf6b9496",
 			}}
 			content := map[string][]byte{
@@ -458,7 +458,7 @@ var _ = Describe("Metal3 manager utils", func() {
 	)
 
 	type testCaseFetchM3DataTemplate struct {
-		DataTemplate  *capm3.Metal3DataTemplate
+		DataTemplate  *infrav1.Metal3DataTemplate
 		ClusterName   string
 		TemplateRef   *corev1.ObjectReference
 		ExpectError   bool
@@ -513,12 +513,12 @@ var _ = Describe("Metal3 manager utils", func() {
 			ExpectError: true,
 		}),
 		Entry("Object with wrong cluster", testCaseFetchM3DataTemplate{
-			DataTemplate: &capm3.Metal3DataTemplate{
+			DataTemplate: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
 					Namespace: namespaceName,
 				},
-				Spec: capm3.Metal3DataTemplateSpec{
+				Spec: infrav1.Metal3DataTemplateSpec{
 					ClusterName: "abc",
 				},
 			},
@@ -530,12 +530,12 @@ var _ = Describe("Metal3 manager utils", func() {
 			ExpectError: true,
 		}),
 		Entry("Object with correct cluster", testCaseFetchM3DataTemplate{
-			DataTemplate: &capm3.Metal3DataTemplate{
+			DataTemplate: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
 					Namespace: namespaceName,
 				},
-				Spec: capm3.Metal3DataTemplateSpec{
+				Spec: infrav1.Metal3DataTemplateSpec{
 					ClusterName: "abc",
 				},
 			},
@@ -548,7 +548,7 @@ var _ = Describe("Metal3 manager utils", func() {
 	)
 
 	type testCaseFetchM3Data struct {
-		Data          *capm3.Metal3Data
+		Data          *infrav1.Metal3Data
 		Name          string
 		Namespace     string
 		ExpectError   bool
@@ -592,7 +592,7 @@ var _ = Describe("Metal3 manager utils", func() {
 			ExpectRequeue: true,
 		}),
 		Entry("Object exists", testCaseFetchM3Data{
-			Data: &capm3.Metal3Data{
+			Data: &infrav1.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
 					Namespace: namespaceName,
@@ -604,10 +604,10 @@ var _ = Describe("Metal3 manager utils", func() {
 	)
 
 	type testCaseGetM3Machine struct {
-		Machine       *capm3.Metal3Machine
+		Machine       *infrav1.Metal3Machine
 		Name          string
 		Namespace     string
-		DataTemplate  *capm3.Metal3DataTemplate
+		DataTemplate  *infrav1.Metal3DataTemplate
 		ExpectError   bool
 		ExpectRequeue bool
 		ExpectEmpty   bool
@@ -649,7 +649,7 @@ var _ = Describe("Metal3 manager utils", func() {
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists", testCaseGetM3Machine{
-			Machine: &capm3.Metal3Machine{
+			Machine: &infrav1.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
 					Namespace: namespaceName,
@@ -659,16 +659,16 @@ var _ = Describe("Metal3 manager utils", func() {
 			Namespace: namespaceName,
 		}),
 		Entry("Object exists, dataTemplate nil", testCaseGetM3Machine{
-			Machine: &capm3.Metal3Machine{
+			Machine: &infrav1.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
 					Namespace: namespaceName,
 				},
-				Spec: capm3.Metal3MachineSpec{
+				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: nil,
 				},
 			},
-			DataTemplate: &capm3.Metal3DataTemplate{
+			DataTemplate: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
 					Namespace: namespaceName,
@@ -679,19 +679,19 @@ var _ = Describe("Metal3 manager utils", func() {
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists, dataTemplate name mismatch", testCaseGetM3Machine{
-			Machine: &capm3.Metal3Machine{
+			Machine: &infrav1.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
 					Namespace: namespaceName,
 				},
-				Spec: capm3.Metal3MachineSpec{
+				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
 						Name:      "abcd",
 						Namespace: namespaceName,
 					},
 				},
 			},
-			DataTemplate: &capm3.Metal3DataTemplate{
+			DataTemplate: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
 					Namespace: namespaceName,
@@ -702,19 +702,19 @@ var _ = Describe("Metal3 manager utils", func() {
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists, dataTemplate namespace mismatch", testCaseGetM3Machine{
-			Machine: &capm3.Metal3Machine{
+			Machine: &infrav1.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
 					Namespace: namespaceName,
 				},
-				Spec: capm3.Metal3MachineSpec{
+				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
 						Name:      "abc",
 						Namespace: "defg",
 					},
 				},
 			},
-			DataTemplate: &capm3.Metal3DataTemplate{
+			DataTemplate: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
 					Namespace: namespaceName,

--- a/controllers/metal3cluster_controller_integration_test.go
+++ b/controllers/metal3cluster_controller_integration_test.go
@@ -27,7 +27,7 @@ import (
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/cluster-api/util/conditions"
 
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -50,7 +50,7 @@ var _ = Describe("Reconcile metal3Cluster", func() {
 
 	DescribeTable("Reconcile tests metal3Cluster",
 		func(tc TestCaseReconcileBMC) {
-			testclstr := &capm3.Metal3Cluster{}
+			testclstr := &infrav1.Metal3Cluster{}
 			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(tc.Objects...).Build()
 
 			r := &Metal3ClusterReconciler{
@@ -138,8 +138,7 @@ var _ = Describe("Reconcile metal3Cluster", func() {
 					newMetal3Cluster(metal3ClusterName, bmcOwnerRef(), nil, nil, nil, false),
 					newCluster(clusterName, nil, nil),
 				},
-				ErrorExpected: true,
-				//ErrorType:           &capm3.APIEndPointError{},
+				ErrorExpected:       true,
 				RequeueExpected:     false,
 				ErrorReasonExpected: true,
 				ErrorReason:         capierrors.InvalidConfigurationClusterError,
@@ -157,7 +156,7 @@ var _ = Describe("Reconcile metal3Cluster", func() {
 				RequeueExpected: false,
 				ConditionsExpected: clusterv1.Conditions{
 					clusterv1.Condition{
-						Type:   capm3.BaremetalInfrastructureReadyCondition,
+						Type:   infrav1.BaremetalInfrastructureReadyCondition,
 						Status: corev1.ConditionTrue,
 					},
 					clusterv1.Condition{
@@ -199,7 +198,7 @@ var _ = Describe("Reconcile metal3Cluster", func() {
 		Entry("Should reconcileDelete when deletion timestamp is set.",
 			TestCaseReconcileBMC{
 				Objects: []client.Object{
-					&capm3.Metal3Cluster{
+					&infrav1.Metal3Cluster{
 						TypeMeta: metav1.TypeMeta{
 							Kind: "Metal3Cluster",
 						},
@@ -221,7 +220,7 @@ var _ = Describe("Reconcile metal3Cluster", func() {
 		Entry("reconcileDelete should wait for metal3machine",
 			TestCaseReconcileBMC{
 				Objects: []client.Object{
-					&capm3.Metal3Cluster{
+					&infrav1.Metal3Cluster{
 						TypeMeta: metav1.TypeMeta{
 							Kind: "Metal3Cluster",
 						},

--- a/controllers/metal3data_controller.go
+++ b/controllers/metal3data_controller.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	"github.com/pkg/errors"
@@ -61,7 +61,7 @@ func (r *Metal3DataReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	metadataLog := r.Log.WithName(dataControllerName).WithValues("metal3-data", req.NamespacedName)
 
 	// Fetch the Metal3Data instance.
-	capm3Metadata := &capm3.Metal3Data{}
+	capm3Metadata := &infrav1.Metal3Data{}
 
 	if err := r.Client.Get(ctx, req.NamespacedName, capm3Metadata); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -148,7 +148,7 @@ func (r *Metal3DataReconciler) reconcileDelete(ctx context.Context,
 // SetupWithManager will add watches for this controller.
 func (r *Metal3DataReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&capm3.Metal3Data{}).
+		For(&infrav1.Metal3Data{}).
 		Watches(
 			&source.Kind{Type: &ipamv1.IPClaim{}},
 			handler.EnqueueRequestsFromMapFunc(r.Metal3IPClaimToMetal3Data),
@@ -171,7 +171,7 @@ func (r *Metal3DataReconciler) Metal3IPClaimToMetal3Data(obj client.Object) []ct
 				r.Log.Error(err, "failed to parse the API version")
 				continue
 			}
-			if aGV.Group != capm3.GroupVersion.Group {
+			if aGV.Group != infrav1.GroupVersion.Group {
 				continue
 			}
 			requests = append(requests, ctrl.Request{

--- a/controllers/metal3data_controller_test.go
+++ b/controllers/metal3data_controller_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/golang/mock/gomock"
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
 	baremetal_mocks "github.com/metal3-io/cluster-api-provider-metal3/baremetal/mocks"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
@@ -62,7 +62,7 @@ var _ = Describe("Metal3Data manager", func() {
 			expectError          bool
 			expectRequeue        bool
 			expectManager        bool
-			m3d                  *capm3.Metal3Data
+			m3d                  *infrav1.Metal3Data
 			cluster              *clusterv1.Cluster
 			managerError         bool
 			reconcileNormal      bool
@@ -144,17 +144,17 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			Entry("Metal3Data not found", testCaseReconcile{}),
 			Entry("Missing cluster label", testCaseReconcile{
-				m3d: &capm3.Metal3Data{
+				m3d: &infrav1.Metal3Data{
 					ObjectMeta: testObjectMeta,
 				},
 			}),
 			Entry("Cluster not found", testCaseReconcile{
-				m3d: &capm3.Metal3Data{
+				m3d: &infrav1.Metal3Data{
 					ObjectMeta: testObjectMetaWithLabel,
 				},
 			}),
 			Entry("Deletion, Cluster not found", testCaseReconcile{
-				m3d: &capm3.Metal3Data{
+				m3d: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc",
 						Namespace: namespaceName,
@@ -167,7 +167,7 @@ var _ = Describe("Metal3Data manager", func() {
 				expectManager: true,
 			}),
 			Entry("Deletion, release requeue", testCaseReconcile{
-				m3d: &capm3.Metal3Data{
+				m3d: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc",
 						Namespace: namespaceName,
@@ -182,7 +182,7 @@ var _ = Describe("Metal3Data manager", func() {
 				releaseLeasesRequeue: true,
 			}),
 			Entry("Deletion, release error", testCaseReconcile{
-				m3d: &capm3.Metal3Data{
+				m3d: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc",
 						Namespace: namespaceName,
@@ -197,7 +197,7 @@ var _ = Describe("Metal3Data manager", func() {
 				releaseLeasesError: true,
 			}),
 			Entry("Paused cluster", testCaseReconcile{
-				m3d: &capm3.Metal3Data{
+				m3d: &infrav1.Metal3Data{
 					ObjectMeta: testObjectMetaWithLabel,
 				},
 				cluster: &clusterv1.Cluster{
@@ -209,7 +209,7 @@ var _ = Describe("Metal3Data manager", func() {
 				expectRequeue: true,
 			}),
 			Entry("Error in manager", testCaseReconcile{
-				m3d: &capm3.Metal3Data{
+				m3d: &infrav1.Metal3Data{
 					ObjectMeta: testObjectMetaWithLabel,
 				},
 				cluster: &clusterv1.Cluster{
@@ -218,7 +218,7 @@ var _ = Describe("Metal3Data manager", func() {
 				managerError: true,
 			}),
 			Entry("Reconcile normal error", testCaseReconcile{
-				m3d: &capm3.Metal3Data{
+				m3d: &infrav1.Metal3Data{
 					ObjectMeta: testObjectMetaWithLabel,
 				},
 				cluster: &clusterv1.Cluster{
@@ -229,7 +229,7 @@ var _ = Describe("Metal3Data manager", func() {
 				expectManager:        true,
 			}),
 			Entry("Reconcile normal no error", testCaseReconcile{
-				m3d: &capm3.Metal3Data{
+				m3d: &infrav1.Metal3Data{
 					ObjectMeta: testObjectMetaWithLabel,
 				},
 				cluster: &clusterv1.Cluster{
@@ -389,12 +389,12 @@ var _ = Describe("Metal3Data manager", func() {
 		Entry("OwnerRefs", testCaseMetal3IPClaimToMetal3Data{
 			ownerRefs: []metav1.OwnerReference{
 				{
-					APIVersion: capm3.GroupVersion.String(),
+					APIVersion: infrav1.GroupVersion.String(),
 					Kind:       "Metal3Data",
 					Name:       "abc",
 				},
 				{
-					APIVersion: capm3.GroupVersion.String(),
+					APIVersion: infrav1.GroupVersion.String(),
 					Kind:       "Metal3DataClaim",
 					Name:       "bcd",
 				},

--- a/controllers/metal3datatemplate_controller.go
+++ b/controllers/metal3datatemplate_controller.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -67,7 +67,7 @@ func (r *Metal3DataTemplateReconciler) Reconcile(ctx context.Context, req ctrl.R
 	metadataLog := r.Log.WithName(dataTemplateControllerName).WithValues("metal3-datatemplate", req.NamespacedName)
 
 	// Fetch the Metal3DataTemplate instance.
-	capm3DataTemplate := &capm3.Metal3DataTemplate{}
+	capm3DataTemplate := &infrav1.Metal3DataTemplate{}
 
 	if err := r.Client.Get(ctx, req.NamespacedName, capm3DataTemplate); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -162,9 +162,9 @@ func (r *Metal3DataTemplateReconciler) reconcileDelete(ctx context.Context,
 // SetupWithManager will add watches for this controller.
 func (r *Metal3DataTemplateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&capm3.Metal3DataTemplate{}).
+		For(&infrav1.Metal3DataTemplate{}).
 		Watches(
-			&source.Kind{Type: &capm3.Metal3DataClaim{}},
+			&source.Kind{Type: &infrav1.Metal3DataClaim{}},
 			handler.EnqueueRequestsFromMapFunc(r.Metal3DataClaimToMetal3DataTemplate),
 		).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
@@ -175,7 +175,7 @@ func (r *Metal3DataTemplateReconciler) SetupWithManager(ctx context.Context, mgr
 // Metal3DataTemplate if the event is for a
 // Metal3DataClaim and that Metal3DataClaim references a Metal3DataTemplate.
 func (r *Metal3DataTemplateReconciler) Metal3DataClaimToMetal3DataTemplate(obj client.Object) []ctrl.Request {
-	if m3dc, ok := obj.(*capm3.Metal3DataClaim); ok {
+	if m3dc, ok := obj.(*infrav1.Metal3DataClaim); ok {
 		if m3dc.Spec.Template.Name != "" {
 			namespace := m3dc.Spec.Template.Namespace
 			if namespace == "" {

--- a/controllers/metal3datatemplate_controller_test.go
+++ b/controllers/metal3datatemplate_controller_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/golang/mock/gomock"
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
 	baremetal_mocks "github.com/metal3-io/cluster-api-provider-metal3/baremetal/mocks"
 	"github.com/pkg/errors"
@@ -46,7 +46,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		expectError          bool
 		expectRequeue        bool
 		expectManager        bool
-		m3dt                 *capm3.Metal3DataTemplate
+		m3dt                 *infrav1.Metal3DataTemplate
 		cluster              *clusterv1.Cluster
 		managerError         bool
 		reconcileNormal      bool
@@ -131,39 +131,39 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		},
 		Entry("Metal3DataTemplate not found", testCaseReconcile{}),
 		Entry("Cluster not found", testCaseReconcile{
-			m3dt: &capm3.Metal3DataTemplate{
+			m3dt: &infrav1.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta,
-				Spec:       capm3.Metal3DataTemplateSpec{ClusterName: "abc"},
+				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
 			},
 		}),
 		Entry("Deletion, Cluster not found", testCaseReconcile{
-			m3dt: &capm3.Metal3DataTemplate{
+			m3dt: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "abc",
 					Namespace:         namespaceName,
 					DeletionTimestamp: &timestampNow,
 				},
-				Spec: capm3.Metal3DataTemplateSpec{ClusterName: "abc"},
+				Spec: infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
 			},
 			expectManager: true,
 		}),
 		Entry("Deletion, Cluster not found, error", testCaseReconcile{
-			m3dt: &capm3.Metal3DataTemplate{
+			m3dt: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "abc",
 					Namespace:         namespaceName,
 					DeletionTimestamp: &timestampNow,
 				},
-				Spec: capm3.Metal3DataTemplateSpec{ClusterName: "abc"},
+				Spec: infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
 			},
 			expectManager:        true,
 			reconcileDeleteError: true,
 			expectError:          true,
 		}),
 		Entry("Paused cluster", testCaseReconcile{
-			m3dt: &capm3.Metal3DataTemplate{
+			m3dt: &infrav1.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta,
-				Spec:       capm3.Metal3DataTemplateSpec{ClusterName: "abc"},
+				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
 			},
 			cluster: &clusterv1.Cluster{
 				ObjectMeta: testObjectMeta,
@@ -175,9 +175,9 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			expectManager: true,
 		}),
 		Entry("Error in manager", testCaseReconcile{
-			m3dt: &capm3.Metal3DataTemplate{
+			m3dt: &infrav1.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta,
-				Spec:       capm3.Metal3DataTemplateSpec{ClusterName: "abc"},
+				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
 			},
 			cluster: &clusterv1.Cluster{
 				ObjectMeta: testObjectMeta,
@@ -185,9 +185,9 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			managerError: true,
 		}),
 		Entry("Reconcile normal error", testCaseReconcile{
-			m3dt: &capm3.Metal3DataTemplate{
+			m3dt: &infrav1.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta,
-				Spec:       capm3.Metal3DataTemplateSpec{ClusterName: "abc"},
+				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
 			},
 			cluster: &clusterv1.Cluster{
 				ObjectMeta: testObjectMeta,
@@ -197,9 +197,9 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			expectManager:        true,
 		}),
 		Entry("Reconcile normal no error", testCaseReconcile{
-			m3dt: &capm3.Metal3DataTemplate{
+			m3dt: &infrav1.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta,
-				Spec:       capm3.Metal3DataTemplateSpec{ClusterName: "abc"},
+				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
 			},
 			cluster: &clusterv1.Cluster{
 				ObjectMeta: testObjectMeta,
@@ -324,7 +324,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 	)
 
 	type TestCaseM3DCToM3DT struct {
-		DataClaim     *capm3.Metal3DataClaim
+		DataClaim     *infrav1.Metal3DataClaim
 		ExpectRequest bool
 	}
 
@@ -356,18 +356,18 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		},
 		Entry("No Metal3DataTemplate in Spec",
 			TestCaseM3DCToM3DT{
-				DataClaim: &capm3.Metal3DataClaim{
+				DataClaim: &infrav1.Metal3DataClaim{
 					ObjectMeta: testObjectMeta,
-					Spec:       capm3.Metal3DataClaimSpec{},
+					Spec:       infrav1.Metal3DataClaimSpec{},
 				},
 				ExpectRequest: false,
 			},
 		),
 		Entry("Metal3DataTemplate in Spec, with namespace",
 			TestCaseM3DCToM3DT{
-				DataClaim: &capm3.Metal3DataClaim{
+				DataClaim: &infrav1.Metal3DataClaim{
 					ObjectMeta: testObjectMeta,
-					Spec: capm3.Metal3DataClaimSpec{
+					Spec: infrav1.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
 							Name:      "abc",
 							Namespace: namespaceName,
@@ -379,9 +379,9 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		),
 		Entry("Metal3DataTemplate in Spec, no namespace",
 			TestCaseM3DCToM3DT{
-				DataClaim: &capm3.Metal3DataClaim{
+				DataClaim: &infrav1.Metal3DataClaim{
 					ObjectMeta: testObjectMeta,
-					Spec: capm3.Metal3DataClaimSpec{
+					Spec: infrav1.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
 							Name: "abc",
 						},

--- a/controllers/metal3labelsync_controller.go
+++ b/controllers/metal3labelsync_controller.go
@@ -79,7 +79,7 @@ func (r *Metal3LabelSyncReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	controllerLog := r.Log.WithName(labelSyncControllerName).WithValues("metal3-label-sync", req.NamespacedName)
 
 	// We need to get the NodeRef from the CAPI Machine object:
-	// bmov1alpha1.ConsumerRef --> Metal3Machine.OwnerRef --> Machine.NodeRef
+	// BareMetalHost.ConsumerRef --> Metal3Machine.OwnerRef --> Machine.NodeRef
 
 	host := &bmov1alpha1.BareMetalHost{}
 	if err := r.Client.Get(ctx, req.NamespacedName, host); err != nil {
@@ -196,7 +196,7 @@ func (r *Metal3LabelSyncReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{RequeueAfter: requeueAfter}, err
 	}
 	controllerLog.Info("Finished synchronizing labels between BaremetalHost and Node")
-	// Always requeue to ensure label sync runs periodically for each bmov1alpha1. This is necessary to catch any label updates to the Node that are synchronized through the bmov1alpha1.
+	// Always requeue to ensure label sync runs periodically for each BareMetalHost. This is necessary to catch any label updates to the Node that are synchronized through the BareMetalHost.
 	return ctrl.Result{RequeueAfter: bmhSyncInterval}, nil
 }
 

--- a/controllers/metal3labelsync_controller_test.go
+++ b/controllers/metal3labelsync_controller_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/go-logr/logr"
 
 	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -297,9 +297,9 @@ var _ = Describe("Metal3LabelSync controller", func() {
 	)
 	type TestCaseMetal3ClusterToBMHs struct {
 		Cluster        *clusterv1.Cluster
-		M3Cluster      *capm3.Metal3Cluster
+		M3Cluster      *infrav1.Metal3Cluster
 		Machine        *clusterv1.Machine
-		M3Machine      *capm3.Metal3Machine
+		M3Machine      *infrav1.Metal3Machine
 		ExpectRequests []ctrl.Request
 	}
 
@@ -347,7 +347,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 				Name:       metal3machineName,
 				Namespace:  namespaceName,
 				Kind:       "Metal3Machine",
-				APIVersion: capm3.GroupVersion.String(),
+				APIVersion: infrav1.GroupVersion.String(),
 			},
 		}
 		notMetal3MachineSpec := bmh.BareMetalHostSpec{
@@ -355,7 +355,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 				Name:       metal3machineName,
 				Namespace:  namespaceName,
 				Kind:       "notMetal3Machine",
-				APIVersion: "not" + capm3.GroupVersion.String(),
+				APIVersion: "not" + infrav1.GroupVersion.String(),
 			},
 		}
 		annotation := map[string]string{
@@ -371,15 +371,15 @@ var _ = Describe("Metal3LabelSync controller", func() {
 				Name:       metal3ClusterName,
 				Namespace:  namespaceName,
 				Kind:       "Metal3Cluster",
-				APIVersion: capm3.GroupVersion.String(),
+				APIVersion: infrav1.GroupVersion.String(),
 			},
 		}
 		type testCaseReconcile struct {
 			host            *bmh.BareMetalHost
 			machine         *clusterv1.Machine
-			metal3Machine   *capm3.Metal3Machine
+			metal3Machine   *infrav1.Metal3Machine
 			cluster         *clusterv1.Cluster
-			metal3Cluster   *capm3.Metal3Cluster
+			metal3Cluster   *infrav1.Metal3Cluster
 			expectError     bool
 			expectRequeue   bool
 			expectLabelsync map[string]string

--- a/controllers/metal3labelsync_controller_test.go
+++ b/controllers/metal3labelsync_controller_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 
-	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
 	. "github.com/onsi/ginkgo"
@@ -169,7 +169,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 
 	type TestCaseSynchronizeLabelSyncSetsOnNode struct {
 		PrefixSet      map[string]struct{}
-		Host           *bmh.BareMetalHost
+		Host           *bmov1alpha1.BareMetalHost
 		Node           *corev1.Node
 		ExpectedResult map[string]string
 	}
@@ -186,7 +186,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 			PrefixSet: map[string]struct{}{
 				"foo.metal3.io": {},
 			},
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"foo.metal3.io/bar": "blue",
@@ -208,7 +208,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 			PrefixSet: map[string]struct{}{
 				"foo.metal3.io": {},
 			},
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"foo.metal3.io/bar": "blue",
@@ -229,7 +229,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 				"foo.metal3.io": {},
 				"boo.metal3.io": {},
 			},
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"foo.metal3.io/bar":  "blue",
@@ -255,7 +255,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 				"foo.metal3.io": {},
 				"boo.metal3.io": {},
 			},
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"foo.metal3.io/bar": "blue",
@@ -276,7 +276,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 		}),
 		Entry("Empty prefix set, do nothing", TestCaseSynchronizeLabelSyncSetsOnNode{
 			PrefixSet: map[string]struct{}{},
-			Host: &bmh.BareMetalHost{
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"some.bmh-label.io/blah": "gray", // ignore
@@ -342,7 +342,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 		Labels := map[string]string{
 			"foo.metal3.io/bar": "blue",
 		}
-		metal3MachineSpec := bmh.BareMetalHostSpec{
+		metal3MachineSpec := bmov1alpha1.BareMetalHostSpec{
 			ConsumerRef: &corev1.ObjectReference{
 				Name:       metal3machineName,
 				Namespace:  namespaceName,
@@ -350,7 +350,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 				APIVersion: infrav1.GroupVersion.String(),
 			},
 		}
-		notMetal3MachineSpec := bmh.BareMetalHostSpec{
+		notMetal3MachineSpec := bmov1alpha1.BareMetalHostSpec{
 			ConsumerRef: &corev1.ObjectReference{
 				Name:       metal3machineName,
 				Namespace:  namespaceName,
@@ -375,7 +375,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 			},
 		}
 		type testCaseReconcile struct {
-			host            *bmh.BareMetalHost
+			host            *bmov1alpha1.BareMetalHost
 			machine         *clusterv1.Machine
 			metal3Machine   *infrav1.Metal3Machine
 			cluster         *clusterv1.Cluster
@@ -524,7 +524,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 		)
 		type TestCaseReconcileBMHLabels struct {
 			PrefixSet   map[string]struct{}
-			Host        *bmh.BareMetalHost
+			Host        *bmov1alpha1.BareMetalHost
 			Machine     *clusterv1.Machine
 			Cluster     *clusterv1.Cluster
 			ExpectError bool

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
 	"github.com/pkg/errors"
@@ -334,7 +334,7 @@ func (r *Metal3MachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 			handler.EnqueueRequestsFromMapFunc(r.Metal3DataToMetal3Machines),
 		).
 		Watches(
-			&source.Kind{Type: &bmh.BareMetalHost{}},
+			&source.Kind{Type: &bmov1alpha1.BareMetalHost{}},
 			handler.EnqueueRequestsFromMapFunc(r.BareMetalHostToMetal3Machines),
 		).
 		Complete(r)
@@ -419,7 +419,7 @@ func (r *Metal3MachineReconciler) Metal3ClusterToMetal3Machines(o client.Object)
 // BareMetalHostToMetal3Machines will return a reconcile request for a Metal3Machine if the event is for a
 // BareMetalHost and that BareMetalHost references a Metal3Machine.
 func (r *Metal3MachineReconciler) BareMetalHostToMetal3Machines(obj client.Object) []ctrl.Request {
-	if host, ok := obj.(*bmh.BareMetalHost); ok {
+	if host, ok := obj.(*bmov1alpha1.BareMetalHost); ok {
 		if host.Spec.ConsumerRef != nil &&
 			host.Spec.ConsumerRef.Kind == Metal3Machine &&
 			host.Spec.ConsumerRef.GroupVersionKind().Group == infrav1.GroupVersion.Group {

--- a/controllers/metal3machine_controller_integration_test.go
+++ b/controllers/metal3machine_controller_integration_test.go
@@ -34,7 +34,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -122,8 +122,8 @@ func userDataSecret() *corev1.Secret {
 	}
 }
 
-func m3mSpecWithSecret() *capm3.Metal3MachineSpec {
-	return &capm3.Metal3MachineSpec{
+func m3mSpecWithSecret() *infrav1.Metal3MachineSpec {
+	return &infrav1.Metal3MachineSpec{
 		UserData: &corev1.SecretReference{
 			Name:      metal3machineName + "-user-data",
 			Namespace: namespaceName,
@@ -131,7 +131,7 @@ func m3mSpecWithSecret() *capm3.Metal3MachineSpec {
 	}
 }
 
-func metal3machineWithOwnerRefs() *capm3.Metal3Machine {
+func metal3machineWithOwnerRefs() *infrav1.Metal3Machine {
 	return newMetal3Machine(
 		metal3machineName, m3mMetaWithOwnerRef(), nil, nil, false,
 	)
@@ -182,7 +182,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 		func(tc TestCaseReconcile) {
 			testmachine := &clusterv1.Machine{}
 			testcluster := &clusterv1.Cluster{}
-			testBMmachine := &capm3.Metal3Machine{}
+			testBMmachine := &infrav1.Metal3Machine{}
 			testBMHost := &bmh.BareMetalHost{}
 
 			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(tc.Objects...).Build()
@@ -245,7 +245,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 				Expect(objMeta.Labels[clusterv1.ClusterLabelName]).NotTo(BeNil())
 			}
 			if tc.CheckBMFinalizer {
-				Expect(baremetal.Contains(testBMmachine.Finalizers, capm3.MachineFinalizer)).To(BeTrue())
+				Expect(baremetal.Contains(testBMmachine.Finalizers, infrav1.MachineFinalizer)).To(BeTrue())
 			}
 			if tc.CheckBMState {
 				Expect(testBMmachine.Status.Ready).To(BeTrue())
@@ -352,9 +352,9 @@ var _ = Describe("Reconcile metal3machine", func() {
 				ClusterInfraReady: false,
 				ConditionsExpected: clusterv1.Conditions{
 					clusterv1.Condition{
-						Type:   capm3.AssociateBMHCondition,
+						Type:   infrav1.AssociateBMHCondition,
 						Status: corev1.ConditionFalse,
-						Reason: capm3.WaitingForClusterInfrastructureReason,
+						Reason: infrav1.WaitingForClusterInfrastructureReason,
 					},
 					clusterv1.Condition{
 						Type:   clusterv1.ReadyCondition,
@@ -379,9 +379,9 @@ var _ = Describe("Reconcile metal3machine", func() {
 				CheckBootStrapReady: false,
 				ConditionsExpected: clusterv1.Conditions{
 					clusterv1.Condition{
-						Type:   capm3.AssociateBMHCondition,
+						Type:   infrav1.AssociateBMHCondition,
 						Status: corev1.ConditionFalse,
-						Reason: capm3.WaitingForBootstrapReadyReason,
+						Reason: infrav1.WaitingForBootstrapReadyReason,
 					},
 					clusterv1.Condition{
 						Type:   clusterv1.ReadyCondition,
@@ -461,10 +461,10 @@ var _ = Describe("Reconcile metal3machine", func() {
 			TestCaseReconcile{
 				Objects: []client.Object{
 					newMetal3Machine(metal3machineName, m3mMetaWithAnnotation(),
-						&capm3.Metal3MachineSpec{
+						&infrav1.Metal3MachineSpec{
 							ProviderID: &providerID,
 						},
-						&capm3.Metal3MachineStatus{
+						&infrav1.Metal3MachineStatus{
 							Ready: true,
 						},
 						false,
@@ -493,8 +493,8 @@ var _ = Describe("Reconcile metal3machine", func() {
 				Objects: []client.Object{
 
 					newMetal3Machine(
-						metal3machineName, m3mMetaWithOwnerRef(), &capm3.Metal3MachineSpec{
-							Image: capm3.Image{
+						metal3machineName, m3mMetaWithOwnerRef(), &infrav1.Metal3MachineSpec{
+							Image: infrav1.Image{
 								Checksum: "abcd",
 								URL:      "abcd",
 								// Checking the pointers,
@@ -533,8 +533,8 @@ var _ = Describe("Reconcile metal3machine", func() {
 				Objects: []client.Object{
 
 					newMetal3Machine(
-						metal3machineName, m3mMetaWithOwnerRef(), &capm3.Metal3MachineSpec{
-							Image: capm3.Image{
+						metal3machineName, m3mMetaWithOwnerRef(), &infrav1.Metal3MachineSpec{
+							Image: infrav1.Image{
 								Checksum: "abcd",
 								URL:      "abcd",
 								// No ChecksumType and DiskFormat given to test without them
@@ -567,8 +567,8 @@ var _ = Describe("Reconcile metal3machine", func() {
 				Objects: []client.Object{
 					newMetal3Machine(
 						metal3machineName, m3mMetaWithAnnotation(),
-						&capm3.Metal3MachineSpec{
-							Image: capm3.Image{
+						&infrav1.Metal3MachineSpec{
+							Image: infrav1.Image{
 								Checksum: "abcd",
 								URL:      "abcd",
 							},
@@ -597,11 +597,11 @@ var _ = Describe("Reconcile metal3machine", func() {
 				CheckBootStrapReady: true,
 				ConditionsExpected: clusterv1.Conditions{
 					clusterv1.Condition{
-						Type:   capm3.AssociateBMHCondition,
+						Type:   infrav1.AssociateBMHCondition,
 						Status: corev1.ConditionTrue,
 					},
 					clusterv1.Condition{
-						Type:   capm3.KubernetesNodeReadyCondition,
+						Type:   infrav1.KubernetesNodeReadyCondition,
 						Status: corev1.ConditionTrue,
 					},
 					clusterv1.Condition{
@@ -618,9 +618,9 @@ var _ = Describe("Reconcile metal3machine", func() {
 				Objects: []client.Object{
 					newMetal3Machine(
 						metal3machineName, m3mMetaWithAnnotation(),
-						&capm3.Metal3MachineSpec{
+						&infrav1.Metal3MachineSpec{
 							ProviderID: pointer.StringPtr(providerID),
-							Image: capm3.Image{
+							Image: infrav1.Image{
 								Checksum: "abcd",
 								URL:      "abcd",
 							},
@@ -659,11 +659,11 @@ var _ = Describe("Reconcile metal3machine", func() {
 				CheckBMProviderIDUnchanged: true,
 				ConditionsExpected: clusterv1.Conditions{
 					clusterv1.Condition{
-						Type:   capm3.AssociateBMHCondition,
+						Type:   infrav1.AssociateBMHCondition,
 						Status: corev1.ConditionTrue,
 					},
 					clusterv1.Condition{
-						Type:   capm3.KubernetesNodeReadyCondition,
+						Type:   infrav1.KubernetesNodeReadyCondition,
 						Status: corev1.ConditionTrue,
 					},
 					clusterv1.Condition{
@@ -679,8 +679,8 @@ var _ = Describe("Reconcile metal3machine", func() {
 		Entry("Should requeue when bootstrap data is available, ProviderID is not given, BMH is provisioning",
 			TestCaseReconcile{
 				Objects: []client.Object{
-					newMetal3Machine(metal3machineName, m3mMetaWithAnnotation(), &capm3.Metal3MachineSpec{
-						Image: capm3.Image{
+					newMetal3Machine(metal3machineName, m3mMetaWithAnnotation(), &infrav1.Metal3MachineSpec{
+						Image: infrav1.Image{
 							Checksum: "abcd",
 							URL:      "abcd",
 						},
@@ -723,13 +723,13 @@ var _ = Describe("Reconcile metal3machine", func() {
 				CheckBootStrapReady:     true,
 				ConditionsExpected: clusterv1.Conditions{
 					clusterv1.Condition{
-						Type:   capm3.AssociateBMHCondition,
+						Type:   infrav1.AssociateBMHCondition,
 						Status: corev1.ConditionTrue,
 					},
 					clusterv1.Condition{
-						Type:   capm3.KubernetesNodeReadyCondition,
+						Type:   infrav1.KubernetesNodeReadyCondition,
 						Status: corev1.ConditionFalse,
-						Reason: capm3.SettingProviderIDOnNodeFailedReason,
+						Reason: infrav1.SettingProviderIDOnNodeFailedReason,
 					},
 					clusterv1.Condition{
 						Type:   clusterv1.ReadyCondition,
@@ -806,7 +806,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 							Name:       metal3machineName,
 							Namespace:  namespaceName,
 							Kind:       "Metal3Machine",
-							APIVersion: capm3.GroupVersion.String(),
+							APIVersion: infrav1.GroupVersion.String(),
 						},
 						Online:                true,
 						AutomatedCleaningMode: "metadata",

--- a/controllers/metal3machine_controller_integration_test.go
+++ b/controllers/metal3machine_controller_integration_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 
-	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -183,7 +183,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 			testmachine := &clusterv1.Machine{}
 			testcluster := &clusterv1.Cluster{}
 			testBMmachine := &infrav1.Metal3Machine{}
-			testBMHost := &bmh.BareMetalHost{}
+			testBMHost := &bmov1alpha1.BareMetalHost{}
 
 			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(tc.Objects...).Build()
 			mockCapiClientGetter := func(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) (
@@ -507,9 +507,9 @@ var _ = Describe("Reconcile metal3machine", func() {
 					machineWithBootstrap(),
 					newCluster(clusterName, nil, nil),
 					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
-					newBareMetalHost(nil, &bmh.BareMetalHostStatus{
-						Provisioning: bmh.ProvisionStatus{
-							State: bmh.StateAvailable,
+					newBareMetalHost(nil, &bmov1alpha1.BareMetalHostStatus{
+						Provisioning: bmov1alpha1.ProvisionStatus{
+							State: bmov1alpha1.StateAvailable,
 						},
 					}, nil, false),
 				},
@@ -545,9 +545,9 @@ var _ = Describe("Reconcile metal3machine", func() {
 					machineWithBootstrap(),
 					newCluster(clusterName, nil, nil),
 					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
-					newBareMetalHost(nil, &bmh.BareMetalHostStatus{
-						Provisioning: bmh.ProvisionStatus{
-							State: bmh.StateReady,
+					newBareMetalHost(nil, &bmov1alpha1.BareMetalHostStatus{
+						Provisioning: bmov1alpha1.ProvisionStatus{
+							State: bmov1alpha1.StateReady,
 						},
 					}, nil, false),
 				},
@@ -561,7 +561,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 			},
 		),
 		//Given: Machine(with Bootstrap data), M3Machine (Annotation Given, no provider ID), BMH (provisioned)
-		//Expected: No Error, BMH.Spec.ProviderID is set properly based on the UID
+		//Expected: No Error, bmov1alpha1.Spec.ProviderID is set properly based on the UID
 		Entry("Should set ProviderID when bootstrap data is available, ProviderID is not given, BMH is provisioned",
 			TestCaseReconcile{
 				Objects: []client.Object{
@@ -612,7 +612,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 			},
 		),
 		//Given: Machine(with Bootstrap data), M3Machine (Annotation Given, provider ID set), BMH (provisioned)
-		//Expected: No Error, BMH.Spec.ProviderID is set properly (unchanged)
+		//Expected: No Error, bmov1alpha1.Spec.ProviderID is set properly (unchanged)
 		Entry("Should set ProviderID when bootstrap data is available, ProviderID is given, BMH is provisioned",
 			TestCaseReconcile{
 				Objects: []client.Object{
@@ -675,7 +675,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 		),
 		//Given: Machine(with Bootstrap data), M3Machine (Annotation Given, no provider ID), BMH (provisioning)
 		//Expected: No Error, Requeue expected
-		//		BMH.Spec.ProviderID is not set based on the UID since BMH is in provisioning
+		//		bmov1alpha1.Spec.ProviderID is not set based on the UID since BMH is in provisioning
 		Entry("Should requeue when bootstrap data is available, ProviderID is not given, BMH is provisioning",
 			TestCaseReconcile{
 				Objects: []client.Object{
@@ -688,9 +688,9 @@ var _ = Describe("Reconcile metal3machine", func() {
 					machineWithBootstrap(),
 					newCluster(clusterName, nil, nil),
 					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
-					newBareMetalHost(nil, &bmh.BareMetalHostStatus{
-						Provisioning: bmh.ProvisionStatus{
-							State: bmh.StateProvisioning,
+					newBareMetalHost(nil, &bmov1alpha1.BareMetalHostStatus{
+						Provisioning: bmov1alpha1.ProvisionStatus{
+							State: bmov1alpha1.StateProvisioning,
 						},
 					}, nil, false),
 				},
@@ -801,7 +801,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 					machineWithInfra(),
 					newCluster(clusterName, nil, nil),
 					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
-					newBareMetalHost(&bmh.BareMetalHostSpec{
+					newBareMetalHost(&bmov1alpha1.BareMetalHostSpec{
 						ConsumerRef: &corev1.ObjectReference{
 							Name:       metal3machineName,
 							Namespace:  namespaceName,
@@ -810,7 +810,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 						},
 						Online:                true,
 						AutomatedCleaningMode: "metadata",
-					}, &bmh.BareMetalHostStatus{}, nil, false),
+					}, &bmov1alpha1.BareMetalHostStatus{}, nil, false),
 				},
 				ErrorExpected:           false,
 				RequeueExpected:         true,

--- a/controllers/metal3machine_controller_integration_test.go
+++ b/controllers/metal3machine_controller_integration_test.go
@@ -561,7 +561,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 			},
 		),
 		//Given: Machine(with Bootstrap data), M3Machine (Annotation Given, no provider ID), BMH (provisioned)
-		//Expected: No Error, bmov1alpha1.Spec.ProviderID is set properly based on the UID
+		//Expected: No Error, BMH.Spec.ProviderID is set properly based on the UID
 		Entry("Should set ProviderID when bootstrap data is available, ProviderID is not given, BMH is provisioned",
 			TestCaseReconcile{
 				Objects: []client.Object{
@@ -612,7 +612,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 			},
 		),
 		//Given: Machine(with Bootstrap data), M3Machine (Annotation Given, provider ID set), BMH (provisioned)
-		//Expected: No Error, bmov1alpha1.Spec.ProviderID is set properly (unchanged)
+		//Expected: No Error, BMH.Spec.ProviderID is set properly (unchanged)
 		Entry("Should set ProviderID when bootstrap data is available, ProviderID is given, BMH is provisioned",
 			TestCaseReconcile{
 				Objects: []client.Object{
@@ -673,9 +673,9 @@ var _ = Describe("Reconcile metal3machine", func() {
 				},
 			},
 		),
-		//Given: Machine(with Bootstrap data), M3Machine (Annotation Given, no provider ID), BMH (provisioning)
-		//Expected: No Error, Requeue expected
-		//		bmov1alpha1.Spec.ProviderID is not set based on the UID since BMH is in provisioning
+		// Given: Machine(with Bootstrap data), M3Machine (Annotation Given, no provider ID), BMH (provisioning)
+		// Expected: No Error, Requeue expected
+		// BMH.Spec.ProviderID is not set based on the UID since BMH is in provisioning
 		Entry("Should requeue when bootstrap data is available, ProviderID is not given, BMH is provisioning",
 			TestCaseReconcile{
 				Objects: []client.Object{

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
 	baremetal_mocks "github.com/metal3-io/cluster-api-provider-metal3/baremetal/mocks"
 	"github.com/pkg/errors"
@@ -76,8 +76,8 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 	// Bootstrap data not ready, we'll requeue, not call anything else
 	m.EXPECT().IsBootstrapReady().Return(!tc.BootstrapNotReady)
 	if tc.BootstrapNotReady {
-		m.EXPECT().SetConditionMetal3MachineToFalse(capm3.AssociateBMHCondition,
-			capm3.WaitingForBootstrapReadyReason, clusterv1.ConditionSeverityInfo, "")
+		m.EXPECT().SetConditionMetal3MachineToFalse(infrav1.AssociateBMHCondition,
+			infrav1.WaitingForBootstrapReadyReason, clusterv1.ConditionSeverityInfo, "")
 		m.EXPECT().AssociateM3Metadata(context.TODO()).MaxTimes(0)
 		m.EXPECT().HasAnnotation().MaxTimes(0)
 		m.EXPECT().GetProviderIDAndBMHID().MaxTimes(0)
@@ -92,7 +92,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		// if associate fails, we do not go further
 		if tc.AssociateFails {
 			m.EXPECT().Associate(context.TODO()).Return(errors.New("Failed"))
-			m.EXPECT().SetConditionMetal3MachineToFalse(capm3.AssociateBMHCondition, capm3.AssociateBMHFailedReason, clusterv1.ConditionSeverityError, gomock.Any())
+			m.EXPECT().SetConditionMetal3MachineToFalse(infrav1.AssociateBMHCondition, infrav1.AssociateBMHFailedReason, clusterv1.ConditionSeverityError, gomock.Any())
 			m.EXPECT().AssociateM3Metadata(context.TODO()).MaxTimes(0)
 			m.EXPECT().Update(context.TODO()).MaxTimes(0)
 			m.EXPECT().GetProviderIDAndBMHID().MaxTimes(0)
@@ -103,7 +103,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		m.EXPECT().Associate(context.TODO()).Return(nil)
 	}
 
-	m.EXPECT().SetConditionMetal3MachineToTrue(capm3.AssociateBMHCondition)
+	m.EXPECT().SetConditionMetal3MachineToTrue(infrav1.AssociateBMHCondition)
 	m.EXPECT().AssociateM3Metadata(context.TODO()).Return(nil)
 	m.EXPECT().Update(context.TODO())
 
@@ -115,7 +115,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		)
 		m.EXPECT().SetProviderID(bmhuid).MaxTimes(0)
 		m.EXPECT().SetError(gomock.Any(), gomock.Any())
-		m.EXPECT().SetConditionMetal3MachineToFalse(capm3.KubernetesNodeReadyCondition, capm3.MissingBMHReason, clusterv1.ConditionSeverityError, gomock.Any())
+		m.EXPECT().SetConditionMetal3MachineToFalse(infrav1.KubernetesNodeReadyCondition, infrav1.MissingBMHReason, clusterv1.ConditionSeverityError, gomock.Any())
 		return m
 	}
 
@@ -140,8 +140,8 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 				Return(errors.New("Failed"))
 			m.EXPECT().SetProviderID(string(bmhuid)).MaxTimes(0)
 			m.EXPECT().SetError(gomock.Any(), gomock.Any())
-			m.EXPECT().SetConditionMetal3MachineToFalse(capm3.KubernetesNodeReadyCondition,
-				capm3.SettingProviderIDOnNodeFailedReason, clusterv1.ConditionSeverityError, gomock.Any())
+			m.EXPECT().SetConditionMetal3MachineToFalse(infrav1.KubernetesNodeReadyCondition,
+				infrav1.SettingProviderIDOnNodeFailedReason, clusterv1.ConditionSeverityError, gomock.Any())
 			return m
 		}
 
@@ -344,7 +344,7 @@ var _ = Describe("Metal3Machine manager", func() {
 
 	type TestCaseMetal3ClusterToM3M struct {
 		Cluster       *clusterv1.Cluster
-		M3Cluster     *capm3.Metal3Cluster
+		M3Cluster     *infrav1.Metal3Cluster
 		Machine0      *clusterv1.Machine
 		Machine1      *clusterv1.Machine
 		Machine2      *clusterv1.Machine
@@ -411,7 +411,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Metal3Cluster To Metal3Machines, No metal3Cluster, No reconciliation",
 			TestCaseMetal3ClusterToM3M{
 				Cluster:       newCluster("my-other-cluster", nil, nil),
-				M3Cluster:     &capm3.Metal3Cluster{},
+				M3Cluster:     &infrav1.Metal3Cluster{},
 				Machine0:      newMachine(clusterName, "my-machine-0", "my-metal3-machine-0", ""),
 				Machine1:      newMachine(clusterName, "my-machine-1", "my-metal3-machine-1", ""),
 				Machine2:      newMachine(clusterName, "my-machine-2", "", ""),
@@ -458,7 +458,7 @@ var _ = Describe("Metal3Machine manager", func() {
 							Name:       "someothermachine",
 							Namespace:  namespaceName,
 							Kind:       "Metal3Machine",
-							APIVersion: capm3.GroupVersion.String(),
+							APIVersion: infrav1.GroupVersion.String(),
 						},
 					},
 				},
@@ -492,11 +492,11 @@ var _ = Describe("Metal3Machine manager", func() {
 			if tc.OwnerRef != nil {
 				ownerRefs = append(ownerRefs, *tc.OwnerRef)
 			}
-			dataClaim := &capm3.Metal3DataClaim{
+			dataClaim := &infrav1.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					OwnerReferences: ownerRefs,
 				},
-				Spec: capm3.Metal3DataClaimSpec{},
+				Spec: infrav1.Metal3DataClaimSpec{},
 			}
 			obj := client.Object(dataClaim)
 			reqs := r.Metal3DataClaimToMetal3Machines(obj)
@@ -525,7 +525,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				OwnerRef: &metav1.OwnerReference{
 					Name:       "abc",
 					Kind:       "Metal3Machine",
-					APIVersion: capm3.GroupVersion.String(),
+					APIVersion: infrav1.GroupVersion.String(),
 				},
 				ExpectRequest: true,
 			},
@@ -535,7 +535,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				OwnerRef: &metav1.OwnerReference{
 					Name:       "abc",
 					Kind:       "sdfousdf",
-					APIVersion: capm3.GroupVersion.String(),
+					APIVersion: infrav1.GroupVersion.String(),
 				},
 				ExpectRequest: false,
 			},
@@ -545,7 +545,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				OwnerRef: &metav1.OwnerReference{
 					Name:       "abc",
 					Kind:       "Metal3Machine",
-					APIVersion: capm3.GroupVersion.Group + "/v1blah1",
+					APIVersion: infrav1.GroupVersion.Group + "/v1blah1",
 				},
 				ExpectRequest: true,
 			},
@@ -555,7 +555,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				OwnerRef: &metav1.OwnerReference{
 					Name:       "abc",
 					Kind:       "Metal3Machine",
-					APIVersion: "foo.bar/" + capm3.GroupVersion.Version,
+					APIVersion: "foo.bar/" + infrav1.GroupVersion.Version,
 				},
 				ExpectRequest: false,
 			},
@@ -567,7 +567,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Machine       *clusterv1.Machine
 		Machine1      *clusterv1.Machine
 		Machine2      *clusterv1.Machine
-		M3Machine     *capm3.Metal3Machine
+		M3Machine     *infrav1.Metal3Machine
 		ExpectRequest bool
 	}
 
@@ -588,7 +588,7 @@ var _ = Describe("Metal3Machine manager", func() {
 
 			if tc.ExpectRequest {
 				Expect(len(reqs)).To(Equal(1), "Expected 1 request, found %d", len(reqs))
-				req := capm3.Metal3Machine{}
+				req := infrav1.Metal3Machine{}
 				err := fakeClient.Get(context.TODO(), reqs[0].NamespacedName, &req)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -629,7 +629,7 @@ var _ = Describe("Metal3Machine manager", func() {
 
 	DescribeTable("test Metal3DataToMetal3Machines",
 		func(tc testCaseMetal3DataToMetal3Machines) {
-			ipClaim := &capm3.Metal3Data{
+			ipClaim := &infrav1.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:       namespaceName,
 					OwnerReferences: tc.ownerRefs,
@@ -649,12 +649,12 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("OwnerRefs", testCaseMetal3DataToMetal3Machines{
 			ownerRefs: []metav1.OwnerReference{
 				{
-					APIVersion: capm3.GroupVersion.String(),
+					APIVersion: infrav1.GroupVersion.String(),
 					Kind:       "Metal3Machine",
 					Name:       "abc",
 				},
 				{
-					APIVersion: capm3.GroupVersion.String(),
+					APIVersion: infrav1.GroupVersion.String(),
 					Kind:       "Metal3DataClaim",
 					Name:       "bcd",
 				},

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/golang/mock/gomock"
-	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
 	baremetal_mocks "github.com/metal3-io/cluster-api-provider-metal3/baremetal/mocks"
@@ -421,7 +421,7 @@ var _ = Describe("Metal3Machine manager", func() {
 	)
 
 	type TestCaseBMHToM3M struct {
-		Host          *bmh.BareMetalHost
+		Host          *bmov1alpha1.BareMetalHost
 		ExpectRequest bool
 	}
 
@@ -448,12 +448,12 @@ var _ = Describe("Metal3Machine manager", func() {
 		// Given machine, but no metal3machine resource
 		Entry("BareMetalHost To Metal3Machines",
 			TestCaseBMHToM3M{
-				Host: &bmh.BareMetalHost{
+				Host: &bmov1alpha1.BareMetalHost{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "host1",
 						Namespace: namespaceName,
 					},
-					Spec: bmh.BareMetalHostSpec{
+					Spec: bmov1alpha1.BareMetalHostSpec{
 						ConsumerRef: &corev1.ObjectReference{
 							Name:       "someothermachine",
 							Namespace:  namespaceName,
@@ -468,12 +468,12 @@ var _ = Describe("Metal3Machine manager", func() {
 		// Given machine, but no metal3machine resource
 		Entry("BareMetalHost To Metal3Machines, no ConsumerRef",
 			TestCaseBMHToM3M{
-				Host: &bmh.BareMetalHost{
+				Host: &bmov1alpha1.BareMetalHost{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "host1",
 						Namespace: namespaceName,
 					},
-					Spec: bmh.BareMetalHostSpec{},
+					Spec: bmov1alpha1.BareMetalHostSpec{},
 				},
 				ExpectRequest: false,
 			},

--- a/controllers/metal3machinetemplate_controller.go
+++ b/controllers/metal3machinetemplate_controller.go
@@ -17,7 +17,7 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -55,7 +55,7 @@ func (r *Metal3MachineTemplateReconciler) Reconcile(ctx context.Context, req ctr
 	m3templateLog := r.Log.WithName(templateControllerName).WithValues("metal3-machine-template", req.NamespacedName)
 
 	// Fetch the Metal3MachineTemplate instance.
-	metal3MachineTemplate := &capm3.Metal3MachineTemplate{}
+	metal3MachineTemplate := &infrav1.Metal3MachineTemplate{}
 
 	if err := r.Client.Get(ctx, req.NamespacedName, metal3MachineTemplate); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -79,7 +79,7 @@ func (r *Metal3MachineTemplateReconciler) Reconcile(ctx context.Context, req ctr
 	}()
 
 	// Fetch the Metal3MachineList
-	m3machinelist := &capm3.Metal3MachineList{}
+	m3machinelist := &infrav1.Metal3MachineList{}
 
 	if err := r.Client.List(ctx, m3machinelist); err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "unable to fetch Metal3MachineList")
@@ -117,9 +117,9 @@ func (r *Metal3MachineTemplateReconciler) reconcileNormal(ctx context.Context,
 // SetupWithManager will add watches for Metal3MachineTemplate controller.
 func (r *Metal3MachineTemplateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&capm3.Metal3MachineTemplate{}).
+		For(&infrav1.Metal3MachineTemplate{}).
 		Watches(
-			&source.Kind{Type: &capm3.Metal3Machine{}},
+			&source.Kind{Type: &infrav1.Metal3Machine{}},
 			handler.EnqueueRequestsFromMapFunc(r.Metal3MachinesToMetal3MachineTemplate),
 		).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
@@ -130,8 +130,8 @@ func (r *Metal3MachineTemplateReconciler) SetupWithManager(ctx context.Context, 
 // requests for reconciliation of Metal3MachineTemplates.
 func (r *Metal3MachineTemplateReconciler) Metal3MachinesToMetal3MachineTemplate(o client.Object) []ctrl.Request {
 	result := []ctrl.Request{}
-	if m3m, ok := o.(*capm3.Metal3Machine); ok {
-		if m3m.Annotations[clonedFromGroupKind] == "" && m3m.Annotations[clonedFromGroupKind] != capm3.ClonedFromGroupKind {
+	if m3m, ok := o.(*infrav1.Metal3Machine); ok {
+		if m3m.Annotations[clonedFromGroupKind] == "" && m3m.Annotations[clonedFromGroupKind] != infrav1.ClonedFromGroupKind {
 			return nil
 		}
 		result = append(result, ctrl.Request{

--- a/controllers/metal3machinetemplate_controller_test.go
+++ b/controllers/metal3machinetemplate_controller_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/golang/mock/gomock"
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
 	baremetal_mocks "github.com/metal3-io/cluster-api-provider-metal3/baremetal/mocks"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,7 +42,7 @@ type commonTestCase struct {
 	testRequest                       ctrl.Request
 	expectedResult                    ctrl.Result
 	expectedError                     *string
-	m3mTemplate                       *capm3.Metal3MachineTemplate
+	m3mTemplate                       *infrav1.Metal3MachineTemplate
 	shouldUpdateAutomatedCleaningMode bool
 }
 
@@ -76,8 +76,8 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 		},
 	}
 	type TestCaseM3MtoM3MT struct {
-		M3Machine     *capm3.Metal3Machine
-		M3MTemplate   *capm3.Metal3MachineTemplate
+		M3Machine     *infrav1.Metal3Machine
+		M3MTemplate   *infrav1.Metal3MachineTemplate
 		ExpectRequest bool
 	}
 	DescribeTable("Metal3Machine To Metal3MachineTemplate tests",
@@ -89,7 +89,7 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 			if tc.ExpectRequest {
 				Expect(len(reqs)).To(Equal(1), "Expected 1 request, found %d", len(reqs))
 				Expect(tc.M3Machine.Annotations[clonedFromName]).To(Equal(tc.M3MTemplate.Name))
-				Expect(tc.M3Machine.Annotations[clonedFromGroupKind]).To(Equal(capm3.ClonedFromGroupKind))
+				Expect(tc.M3Machine.Annotations[clonedFromGroupKind]).To(Equal(infrav1.ClonedFromGroupKind))
 				Expect(tc.M3Machine.Namespace).To(Equal(tc.M3MTemplate.Namespace))
 			} else {
 				Expect(len(reqs)).To(Equal(0), "Expected 0 request, found %d", len(reqs))
@@ -97,7 +97,7 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 		},
 		Entry("Reconciliation should not be requested due to missing reference to a template",
 			TestCaseM3MtoM3MT{
-				M3Machine: &capm3.Metal3Machine{
+				M3Machine: &infrav1.Metal3Machine{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "machine-1",
@@ -106,23 +106,23 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 							baremetal.HostAnnotation: namespaceName + "/myhost",
 						},
 					},
-					Spec: capm3.Metal3MachineSpec{
-						AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeDisabled),
+					Spec: infrav1.Metal3MachineSpec{
+						AutomatedCleaningMode: utils.StringPtr(infrav1.CleaningModeDisabled),
 					},
 				},
-				M3MTemplate: &capm3.Metal3MachineTemplate{
+				M3MTemplate: &infrav1.Metal3MachineTemplate{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: capm3.GroupVersion.String(),
+						APIVersion: infrav1.GroupVersion.String(),
 						Kind:       "Metal3MachineTemplate",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      name,
 						Namespace: namespace,
 					},
-					Spec: capm3.Metal3MachineTemplateSpec{
-						Template: capm3.Metal3MachineTemplateResource{
-							Spec: capm3.Metal3MachineSpec{
-								AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeDisabled),
+					Spec: infrav1.Metal3MachineTemplateSpec{
+						Template: infrav1.Metal3MachineTemplateResource{
+							Spec: infrav1.Metal3MachineSpec{
+								AutomatedCleaningMode: utils.StringPtr(infrav1.CleaningModeDisabled),
 							},
 						},
 					},
@@ -132,33 +132,33 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 		),
 		Entry("Reconciliation should be requested",
 			TestCaseM3MtoM3MT{
-				M3Machine: &capm3.Metal3Machine{
+				M3Machine: &infrav1.Metal3Machine{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "machine-1",
 						Namespace: namespace,
 						Annotations: map[string]string{
 							"cluster.x-k8s.io/cloned-from-name":      name,
-							"cluster.x-k8s.io/cloned-from-groupkind": capm3.ClonedFromGroupKind,
+							"cluster.x-k8s.io/cloned-from-groupkind": infrav1.ClonedFromGroupKind,
 						},
 					},
-					Spec: capm3.Metal3MachineSpec{
-						AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeDisabled),
+					Spec: infrav1.Metal3MachineSpec{
+						AutomatedCleaningMode: utils.StringPtr(infrav1.CleaningModeDisabled),
 					},
 				},
-				M3MTemplate: &capm3.Metal3MachineTemplate{
+				M3MTemplate: &infrav1.Metal3MachineTemplate{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: capm3.GroupVersion.String(),
+						APIVersion: infrav1.GroupVersion.String(),
 						Kind:       "Metal3MachineTemplate",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      name,
 						Namespace: namespace,
 					},
-					Spec: capm3.Metal3MachineTemplateSpec{
-						Template: capm3.Metal3MachineTemplateResource{
-							Spec: capm3.Metal3MachineSpec{
-								AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeDisabled),
+					Spec: infrav1.Metal3MachineTemplateSpec{
+						Template: infrav1.Metal3MachineTemplateResource{
+							Spec: infrav1.Metal3MachineSpec{
+								AutomatedCleaningMode: utils.StringPtr(infrav1.CleaningModeDisabled),
 							},
 						},
 					},

--- a/controllers/metal3remediation_controller_test.go
+++ b/controllers/metal3remediation_controller_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
-	"github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
 	baremetal_mocks "github.com/metal3-io/cluster-api-provider-metal3/baremetal/mocks"
@@ -75,7 +75,7 @@ func setReconcileNormalRemediationExpectations(ctrl *gomock.Controller,
 		m.EXPECT().SetUnhealthyAnnotation(context.TODO()).MaxTimes(0)
 	}
 
-	bmh := &v1alpha1.BareMetalHost{}
+	bmh := &bmov1alpha1.BareMetalHost{}
 	if tc.GetUnhealthyHostFails {
 		m.EXPECT().GetUnhealthyHost(context.TODO()).Return(nil, nil, fmt.Errorf("can't find foo_bmh"))
 		return m

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -70,7 +70,7 @@ func init() {
 	_ = infrav1.AddToScheme(scheme.Scheme)
 	_ = ipamv1.AddToScheme(scheme.Scheme)
 	_ = corev1.AddToScheme(scheme.Scheme)
-	_ = bmh.SchemeBuilder.AddToScheme(scheme.Scheme)
+	_ = bmov1alpha1.SchemeBuilder.AddToScheme(scheme.Scheme)
 }
 
 func setupScheme() *runtime.Scheme {
@@ -87,7 +87,7 @@ func setupScheme() *runtime.Scheme {
 	if err := corev1.AddToScheme(s); err != nil {
 		panic(err)
 	}
-	if err := bmh.SchemeBuilder.AddToScheme(s); err != nil {
+	if err := bmov1alpha1.SchemeBuilder.AddToScheme(s); err != nil {
 		panic(err)
 	}
 
@@ -368,23 +368,23 @@ func newMetal3Machine(name string, meta *metav1.ObjectMeta,
 	}
 }
 
-func newBareMetalHost(spec *bmh.BareMetalHostSpec,
-	status *bmh.BareMetalHostStatus, labels map[string]string, paused bool,
-) *bmh.BareMetalHost {
+func newBareMetalHost(spec *bmov1alpha1.BareMetalHostSpec,
+	status *bmov1alpha1.BareMetalHostStatus, labels map[string]string, paused bool,
+) *bmov1alpha1.BareMetalHost {
 	if spec == nil {
-		spec = &bmh.BareMetalHostSpec{}
+		spec = &bmov1alpha1.BareMetalHostSpec{}
 	}
 	if status == nil {
-		status = &bmh.BareMetalHostStatus{
-			Provisioning: bmh.ProvisionStatus{
-				State: bmh.StateProvisioned,
+		status = &bmov1alpha1.BareMetalHostStatus{
+			Provisioning: bmov1alpha1.ProvisionStatus{
+				State: bmov1alpha1.StateProvisioned,
 			},
 		}
 	}
-	bmh := &bmh.BareMetalHost{
+	bmh := &bmov1alpha1.BareMetalHost{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "BareMetalHost",
-			APIVersion: bmh.GroupVersion.String(),
+			APIVersion: bmov1alpha1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bmh-0",

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -67,7 +67,7 @@ func init() {
 	// Register required object kinds with global scheme.
 	_ = apiextensionsv1.AddToScheme(scheme.Scheme)
 	_ = clusterv1.AddToScheme(scheme.Scheme)
-	_ = capm3.AddToScheme(scheme.Scheme)
+	_ = infrav1.AddToScheme(scheme.Scheme)
 	_ = ipamv1.AddToScheme(scheme.Scheme)
 	_ = corev1.AddToScheme(scheme.Scheme)
 	_ = bmh.SchemeBuilder.AddToScheme(scheme.Scheme)
@@ -78,7 +78,7 @@ func setupScheme() *runtime.Scheme {
 	if err := clusterv1.AddToScheme(s); err != nil {
 		panic(err)
 	}
-	if err := capm3.AddToScheme(s); err != nil {
+	if err := infrav1.AddToScheme(s); err != nil {
 		panic(err)
 	}
 	if err := ipamv1.AddToScheme(s); err != nil {
@@ -114,7 +114,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cfg).ToNot(BeNil())
 
-		err = capm3.AddToScheme(scheme.Scheme)
+		err = infrav1.AddToScheme(scheme.Scheme)
 		Expect(err).NotTo(HaveOccurred())
 
 		err = apiextensionsv1.AddToScheme(scheme.Scheme)
@@ -146,7 +146,7 @@ func clusterPauseSpec() *clusterv1.ClusterSpec {
 			Name:       metal3ClusterName,
 			Namespace:  namespaceName,
 			Kind:       "Metal3Cluster",
-			APIVersion: capm3.GroupVersion.String(),
+			APIVersion: infrav1.GroupVersion.String(),
 		},
 	}
 }
@@ -162,9 +162,9 @@ func m3mObjectMetaWithOwnerRef() *metav1.ObjectMeta {
 	}
 }
 
-func bmcSpec() *capm3.Metal3ClusterSpec {
-	return &capm3.Metal3ClusterSpec{
-		ControlPlaneEndpoint: capm3.APIEndpoint{
+func bmcSpec() *infrav1.Metal3ClusterSpec {
+	return &infrav1.Metal3ClusterSpec{
+		ControlPlaneEndpoint: infrav1.APIEndpoint{
 			Host: "192.168.111.249",
 			Port: 6443,
 		},
@@ -203,7 +203,7 @@ func newCluster(clusterName string, spec *clusterv1.ClusterSpec, status *cluster
 				Name:       metal3ClusterName,
 				Namespace:  namespaceName,
 				Kind:       "Metal3Cluster",
-				APIVersion: capm3.GroupVersion.String(),
+				APIVersion: infrav1.GroupVersion.String(),
 			},
 		}
 	}
@@ -226,12 +226,12 @@ func newCluster(clusterName string, spec *clusterv1.ClusterSpec, status *cluster
 	}
 }
 
-func newMetal3Cluster(baremetalName string, ownerRef *metav1.OwnerReference, spec *capm3.Metal3ClusterSpec, status *capm3.Metal3ClusterStatus, annotation map[string]string, pausedAnnotation bool) *capm3.Metal3Cluster {
+func newMetal3Cluster(baremetalName string, ownerRef *metav1.OwnerReference, spec *infrav1.Metal3ClusterSpec, status *infrav1.Metal3ClusterStatus, annotation map[string]string, pausedAnnotation bool) *infrav1.Metal3Cluster {
 	if spec == nil {
-		spec = &capm3.Metal3ClusterSpec{}
+		spec = &infrav1.Metal3ClusterSpec{}
 	}
 	if status == nil {
-		status = &capm3.Metal3ClusterStatus{}
+		status = &infrav1.Metal3ClusterStatus{}
 	}
 	ownerRefs := []metav1.OwnerReference{}
 	if ownerRef != nil {
@@ -262,10 +262,10 @@ func newMetal3Cluster(baremetalName string, ownerRef *metav1.OwnerReference, spe
 		objMeta.Annotations = annotation
 	}
 
-	return &capm3.Metal3Cluster{
+	return &infrav1.Metal3Cluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Metal3Cluster",
-			APIVersion: capm3.GroupVersion.String(),
+			APIVersion: infrav1.GroupVersion.String(),
 		},
 		ObjectMeta: *objMeta,
 		Spec:       *spec,
@@ -293,7 +293,7 @@ func newMachine(clusterName, machineName string, metal3machineName string, nodeR
 			Name:       metal3machineName,
 			Namespace:  namespaceName,
 			Kind:       "Metal3Machine",
-			APIVersion: capm3.GroupVersion.String(),
+			APIVersion: infrav1.GroupVersion.String(),
 		}
 	}
 	if nodeRefName != "" {
@@ -305,11 +305,11 @@ func newMachine(clusterName, machineName string, metal3machineName string, nodeR
 	return machine
 }
 
-func newMetal3MachineTemplate(m3mTemplateName string, namespace string, annotations map[string]string) *capm3.Metal3MachineTemplate {
-	return &capm3.Metal3MachineTemplate{
+func newMetal3MachineTemplate(m3mTemplateName string, namespace string, annotations map[string]string) *infrav1.Metal3MachineTemplate {
+	return &infrav1.Metal3MachineTemplate{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Metal3MachineTemplate",
-			APIVersion: capm3.GroupVersion.String(),
+			APIVersion: infrav1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        m3mTemplateName,
@@ -320,9 +320,9 @@ func newMetal3MachineTemplate(m3mTemplateName string, namespace string, annotati
 }
 
 func newMetal3Machine(name string, meta *metav1.ObjectMeta,
-	spec *capm3.Metal3MachineSpec, status *capm3.Metal3MachineStatus,
+	spec *infrav1.Metal3MachineSpec, status *infrav1.Metal3MachineStatus,
 	pausedAnnotation bool,
-) *capm3.Metal3Machine {
+) *infrav1.Metal3Machine {
 	if meta == nil {
 		meta = &metav1.ObjectMeta{
 			Name:            name,
@@ -351,16 +351,16 @@ func newMetal3Machine(name string, meta *metav1.ObjectMeta,
 
 	meta.Name = name
 	if spec == nil {
-		spec = &capm3.Metal3MachineSpec{}
+		spec = &infrav1.Metal3MachineSpec{}
 	}
 	if status == nil {
-		status = &capm3.Metal3MachineStatus{}
+		status = &infrav1.Metal3MachineStatus{}
 	}
 
-	return &capm3.Metal3Machine{
+	return &infrav1.Metal3Machine{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Metal3Machine",
-			APIVersion: capm3.GroupVersion.String(),
+			APIVersion: infrav1.GroupVersion.String(),
 		},
 		ObjectMeta: *meta,
 		Spec:       *spec,

--- a/main.go
+++ b/main.go
@@ -26,9 +26,9 @@ import (
 
 	bmoapis "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1alpha5 "github.com/metal3-io/cluster-api-provider-metal3/api/v1alpha5"
-	infrav1beta1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
-	capm3remote "github.com/metal3-io/cluster-api-provider-metal3/baremetal/remote"
+	infraremote "github.com/metal3-io/cluster-api-provider-metal3/baremetal/remote"
 	"github.com/metal3-io/cluster-api-provider-metal3/controllers"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	"github.com/spf13/pflag"
@@ -66,7 +66,7 @@ var (
 func init() {
 	_ = scheme.AddToScheme(myscheme)
 	_ = ipamv1.AddToScheme(myscheme)
-	_ = infrav1beta1.AddToScheme(myscheme)
+	_ = infrav1.AddToScheme(myscheme)
 	_ = infrav1alpha5.AddToScheme(myscheme)
 	_ = clusterv1.AddToScheme(myscheme)
 	_ = bmoapis.AddToScheme(myscheme)
@@ -248,7 +248,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		Client:           mgr.GetClient(),
 		ManagerFactory:   baremetal.NewManagerFactory(mgr.GetClient()),
 		Log:              ctrl.Log.WithName("controllers").WithName("Metal3Machine"),
-		CapiClientGetter: capm3remote.NewClusterClient,
+		CapiClientGetter: infraremote.NewClusterClient,
 		WatchFilterValue: watchFilterValue,
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Metal3MachineReconciler")
@@ -289,7 +289,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		Client:           mgr.GetClient(),
 		ManagerFactory:   baremetal.NewManagerFactory(mgr.GetClient()),
 		Log:              ctrl.Log.WithName("controllers").WithName("Metal3LabelSync"),
-		CapiClientGetter: capm3remote.NewClusterClient,
+		CapiClientGetter: infraremote.NewClusterClient,
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Metal3LabelSyncReconciler")
 		os.Exit(1)
@@ -315,42 +315,42 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 }
 
 func setupWebhooks(mgr ctrl.Manager) {
-	if err := (&infrav1beta1.Metal3Cluster{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrav1.Metal3Cluster{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Metal3Cluster")
 		os.Exit(1)
 	}
 
-	if err := (&infrav1beta1.Metal3Machine{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrav1.Metal3Machine{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Metal3Machine")
 		os.Exit(1)
 	}
 
-	if err := (&infrav1beta1.Metal3MachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrav1.Metal3MachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Metal3MachineTemplate")
 		os.Exit(1)
 	}
 
-	if err := (&infrav1beta1.Metal3DataTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrav1.Metal3DataTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Metal3DataTemplate")
 		os.Exit(1)
 	}
 
-	if err := (&infrav1beta1.Metal3Data{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrav1.Metal3Data{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Metal3Data")
 		os.Exit(1)
 	}
 
-	if err := (&infrav1beta1.Metal3DataClaim{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrav1.Metal3DataClaim{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Metal3DataClaim")
 		os.Exit(1)
 	}
 
-	if err := (&infrav1beta1.Metal3Remediation{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrav1.Metal3Remediation{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Metal3Remediation")
 		os.Exit(1)
 	}
 
-	if err := (&infrav1beta1.Metal3RemediationTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrav1.Metal3RemediationTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Metal3RemediationTemplate")
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"time"
 
-	bmoapis "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1alpha5 "github.com/metal3-io/cluster-api-provider-metal3/api/v1alpha5"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
@@ -69,7 +69,7 @@ func init() {
 	_ = infrav1.AddToScheme(myscheme)
 	_ = infrav1alpha5.AddToScheme(myscheme)
 	_ = clusterv1.AddToScheme(myscheme)
-	_ = bmoapis.AddToScheme(myscheme)
+	_ = bmov1alpha1.AddToScheme(myscheme)
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	bmo "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -92,7 +92,7 @@ func downloadFile(filePath string, url string) error {
 }
 
 // filterBmhsByProvisioningState returns a filtered list of BaremetalHost objects in certain provisioning state.
-func filterBmhsByProvisioningState(bmhs []bmo.BareMetalHost, state bmo.ProvisioningState) (result []bmo.BareMetalHost) {
+func filterBmhsByProvisioningState(bmhs []bmov1alpha1.BareMetalHost, state bmov1alpha1.ProvisioningState) (result []bmov1alpha1.BareMetalHost) {
 	for _, bmh := range bmhs {
 		if bmh.Status.Provisioning.State == state {
 			result = append(result, bmh)
@@ -112,7 +112,7 @@ func filterMachinesByPhase(machines []clusterv1.Machine, phase string) (result [
 }
 
 // annotateBmh annotates BaremetalHost with a given key and value.
-func annotateBmh(ctx context.Context, client client.Client, host bmo.BareMetalHost, key string, value *string) {
+func annotateBmh(ctx context.Context, client client.Client, host bmov1alpha1.BareMetalHost, key string, value *string) {
 	helper, err := patch.NewHelper(&host, client)
 	Expect(err).NotTo(HaveOccurred())
 	annotations := host.GetAnnotations()
@@ -129,7 +129,7 @@ func annotateBmh(ctx context.Context, client client.Client, host bmo.BareMetalHo
 }
 
 // deleteNodeReuseLabelFromHost deletes nodeReuseLabelName from the host if it exists.
-func deleteNodeReuseLabelFromHost(ctx context.Context, client client.Client, host bmo.BareMetalHost, nodeReuseLabelName string) {
+func deleteNodeReuseLabelFromHost(ctx context.Context, client client.Client, host bmov1alpha1.BareMetalHost, nodeReuseLabelName string) {
 	helper, err := patch.NewHelper(&host, client)
 	Expect(err).NotTo(HaveOccurred())
 	labels := host.GetLabels()

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	bmo "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -155,7 +155,7 @@ func initScheme() *runtime.Scheme {
 	framework.TryAddDefaultSchemes(sc)
 	Expect(clusterv1alpha4.AddToScheme(sc))
 	Expect(bmo.AddToScheme(sc)).To(Succeed())
-	Expect(capm3.AddToScheme(sc)).To(Succeed())
+	Expect(infrav1.AddToScheme(sc)).To(Succeed())
 
 	return sc
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	bmo "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -154,7 +154,7 @@ func initScheme() *runtime.Scheme {
 	sc := runtime.NewScheme()
 	framework.TryAddDefaultSchemes(sc)
 	Expect(clusterv1alpha4.AddToScheme(sc))
-	Expect(bmo.AddToScheme(sc)).To(Succeed())
+	Expect(bmov1alpha1.AddToScheme(sc)).To(Succeed())
 	Expect(infrav1.AddToScheme(sc)).To(Succeed())
 
 	return sc

--- a/test/e2e/inspection_test.go
+++ b/test/e2e/inspection_test.go
@@ -1,7 +1,7 @@
 package e2e
 
 import (
-	bmo "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
@@ -24,11 +24,11 @@ func inspection() {
 	bootstrapClient := bootstrapClusterProxy.GetClient()
 
 	Logf("Request inspection for all Available BMHs via API")
-	availableBMHList := bmo.BareMetalHostList{}
+	availableBMHList := bmov1alpha1.BareMetalHostList{}
 	Expect(bootstrapClient.List(ctx, &availableBMHList, client.InNamespace(namespace))).To(Succeed())
 	Logf("Request inspection for all Available BMHs via API")
 	for _, bmh := range availableBMHList.Items {
-		if bmh.Status.Provisioning.State == bmo.StateAvailable {
+		if bmh.Status.Provisioning.State == bmov1alpha1.StateAvailable {
 			annotateBmh(ctx, bootstrapClient, bmh, inspectAnnotation, pointer.String(""))
 		}
 	}
@@ -40,7 +40,7 @@ func inspection() {
 			Logf("Error: %v", err)
 			return err
 		}
-		inspectingBMHs := filterBmhsByProvisioningState(bmhs, bmo.StateInspecting)
+		inspectingBMHs := filterBmhsByProvisioningState(bmhs, bmov1alpha1.StateInspecting)
 		if len(inspectingBMHs) != numberOfAvailableBMHs {
 			return errors.Errorf("Waiting for %v BMHs to be in Inspecting state, but got %v", numberOfAvailableBMHs, len(inspectingBMHs))
 		}
@@ -54,7 +54,7 @@ func inspection() {
 			Logf("Error: %v", err)
 			return err
 		}
-		availableBMHs := filterBmhsByProvisioningState(bmhs, bmo.StateAvailable)
+		availableBMHs := filterBmhsByProvisioningState(bmhs, bmov1alpha1.StateAvailable)
 		if len(availableBMHs) != numberOfAvailableBMHs {
 			return errors.Errorf("Waiting for %v BMHs to be in Available state, but got %v", numberOfAvailableBMHs, len(availableBMHs))
 		}

--- a/test/e2e/node_reuse_test.go
+++ b/test/e2e/node_reuse_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	bmo "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -465,7 +465,7 @@ func getProvisionedBmhNamesUuids(clusterClient client.Client) []string {
 }
 
 func updateNodeReuse(nodeReuse bool, m3machineTemplateName string, clusterClient client.Client) {
-	m3machineTemplate := capm3.Metal3MachineTemplate{}
+	m3machineTemplate := infrav1.Metal3MachineTemplate{}
 	Expect(clusterClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: m3machineTemplateName}, &m3machineTemplate)).To(Succeed())
 	helper, err := patch.NewHelper(&m3machineTemplate, clusterClient)
 	Expect(err).NotTo(HaveOccurred())
@@ -491,7 +491,7 @@ func pointMDtoM3mt(m3mtname, mdName string, clusterClient client.Client) {
 }
 
 func updateBootImage(m3machineTemplateName string, clusterClient client.Client, imageURL string, imageChecksum string, checksumType string, imageFormat string) {
-	m3machineTemplate := capm3.Metal3MachineTemplate{}
+	m3machineTemplate := infrav1.Metal3MachineTemplate{}
 	Expect(clusterClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: m3machineTemplateName}, &m3machineTemplate)).To(Succeed())
 	helper, err := patch.NewHelper(&m3machineTemplate, clusterClient)
 	Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/pivoting_test.go
+++ b/test/e2e/pivoting_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	bmo "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -134,7 +134,7 @@ func pivoting() {
 
 	By("Check if metal3machines become ready.")
 	Eventually(func() error {
-		m3Machines := &capm3.Metal3MachineList{}
+		m3Machines := &infrav1.Metal3MachineList{}
 		if err := targetCluster.GetClient().List(ctx, m3Machines, client.InNamespace(namespace)); err != nil {
 			return err
 		}
@@ -363,7 +363,7 @@ func rePivoting() {
 
 	By("Check if metal3machines become ready.")
 	Eventually(func() error {
-		m3Machines := &capm3.Metal3MachineList{}
+		m3Machines := &infrav1.Metal3MachineList{}
 		if err := bootstrapClusterProxy.GetClient().List(ctx, m3Machines, client.InNamespace(namespace)); err != nil {
 			return err
 		}

--- a/test/e2e/pivoting_test.go
+++ b/test/e2e/pivoting_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	bmo "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,7 +120,7 @@ func pivoting() {
 
 	By("Check if BMH is in provisioned state")
 	Eventually(func() error {
-		bmhList := &bmo.BareMetalHostList{}
+		bmhList := &bmov1alpha1.BareMetalHostList{}
 		if err := targetCluster.GetClient().List(ctx, bmhList, client.InNamespace(namespace)); err != nil {
 			return err
 		}
@@ -353,7 +353,7 @@ func rePivoting() {
 
 	By("Check if BMH is in provisioned state")
 	Eventually(func(g Gomega) {
-		bmhList := &bmo.BareMetalHostList{}
+		bmhList := &bmov1alpha1.BareMetalHostList{}
 		g.Expect(bootstrapClusterProxy.GetClient().List(ctx, bmhList, client.InNamespace(namespace))).To(Succeed())
 		for _, bmh := range bmhList.Items {
 			g.Expect(bmh.WasProvisioned()).To(BeTrue())

--- a/test/e2e/remediation_test.go
+++ b/test/e2e/remediation_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	bmo "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,7 +50,7 @@ func remediation() {
 	Expect(controlplaneM3Machines).To(HaveLen(int(controlPlaneMachineCount)))
 	Expect(workerM3Machines).To(HaveLen(int(workerMachineCount)))
 
-	getBmhFromM3Machine := func(m3Machine infrav1.Metal3Machine) (result bmo.BareMetalHost) {
+	getBmhFromM3Machine := func(m3Machine infrav1.Metal3Machine) (result bmov1alpha1.BareMetalHost) {
 		Expect(bootstrapClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: metal3MachineToBmhName(m3Machine)}, &result)).To(Succeed())
 		return result
 	}
@@ -100,7 +100,7 @@ func remediation() {
 			Logf("Error: %v", err)
 			return err
 		}
-		g.Expect(filterBmhsByProvisioningState(bmhs, bmo.StateAvailable)).To(HaveLen(newReplicaCount + len(workerM3Machines)))
+		g.Expect(filterBmhsByProvisioningState(bmhs, bmov1alpha1.StateAvailable)).To(HaveLen(newReplicaCount + len(workerM3Machines)))
 		return nil
 	}, e2eConfig.GetIntervals(specName, "wait-machine-remediation")...).Should(Succeed())
 
@@ -118,7 +118,7 @@ func remediation() {
 	Logf("Waiting for worker BMH to be in Available state")
 	Eventually(func(g Gomega) error {
 		g.Expect(bootstrapClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: workerBmh.Name}, &workerBmh)).To(Succeed())
-		g.Expect(workerBmh.Status.Provisioning.State).To(Equal(bmo.StateAvailable))
+		g.Expect(workerBmh.Status.Provisioning.State).To(Equal(bmov1alpha1.StateAvailable))
 		return nil
 	}, e2eConfig.GetIntervals(specName, "wait-machine-remediation")...).Should(Succeed())
 
@@ -129,7 +129,7 @@ func remediation() {
 			Logf("Error: %v", err)
 			return err
 		}
-		provisioningBMHs := filterBmhsByProvisioningState(bmhs, bmo.StateProvisioned)
+		provisioningBMHs := filterBmhsByProvisioningState(bmhs, bmov1alpha1.StateProvisioned)
 		if len(provisioningBMHs) != 2 {
 			return errors.New("Waiting for 2 BMHs to be Provisioned")
 		}
@@ -146,7 +146,7 @@ func remediation() {
 			Logf("Error: %v", err)
 			return err
 		}
-		g.Expect(filterBmhsByProvisioningState(bmhs, bmo.StateProvisioning)).To(HaveLen(1))
+		g.Expect(filterBmhsByProvisioningState(bmhs, bmov1alpha1.StateProvisioning)).To(HaveLen(1))
 		return nil
 	}, e2eConfig.GetIntervals(specName, "wait-machine-remediation")...)
 
@@ -157,8 +157,8 @@ func remediation() {
 			Logf("Error: %v", err)
 			return err
 		}
-		Expect(filterBmhsByProvisioningState(bmhs, bmo.StateProvisioned)).To(HaveLen(3))
-		Expect(filterBmhsByProvisioningState(bmhs, bmo.StateProvisioning)).To(HaveLen(1))
+		Expect(filterBmhsByProvisioningState(bmhs, bmov1alpha1.StateProvisioned)).To(HaveLen(3))
+		Expect(filterBmhsByProvisioningState(bmhs, bmov1alpha1.StateProvisioning)).To(HaveLen(1))
 		return nil
 	}, e2eConfig.GetIntervals(specName, "monitor-provisioning")...)
 
@@ -172,7 +172,7 @@ func remediation() {
 			Logf("Error: %v", err)
 			return err
 		}
-		g.Expect(filterBmhsByProvisioningState(bmhs, bmo.StateProvisioned)).To(HaveLen(allMachinesCount))
+		g.Expect(filterBmhsByProvisioningState(bmhs, bmov1alpha1.StateProvisioned)).To(HaveLen(allMachinesCount))
 		return nil
 	}, e2eConfig.GetIntervals(specName, "wait-machine-remediation")...)
 
@@ -191,9 +191,9 @@ func remediation() {
 
 	By("Waiting for 2 BMHs to be in Available state")
 	Eventually(func(g Gomega) error {
-		bmhs := bmo.BareMetalHostList{}
+		bmhs := bmov1alpha1.BareMetalHostList{}
 		g.Expect(bootstrapClient.List(ctx, &bmhs, client.InNamespace(namespace))).To(Succeed())
-		g.Expect(filterBmhsByProvisioningState(bmhs.Items, bmo.StateAvailable)).To(HaveLen(2))
+		g.Expect(filterBmhsByProvisioningState(bmhs.Items, bmov1alpha1.StateAvailable)).To(HaveLen(2))
 		return nil
 	}, e2eConfig.GetIntervals(specName, "wait-machine-remediation")...).Should(Succeed())
 
@@ -255,8 +255,8 @@ func remediation() {
 			Logf("Error: %v", err)
 			return err
 		}
-		filtered := filterBmhsByProvisioningState(bmhs, bmo.StateAvailable)
-		Logf("There are %d BMHs in state %s", len(filtered), bmo.StateAvailable)
+		filtered := filterBmhsByProvisioningState(bmhs, bmov1alpha1.StateAvailable)
+		Logf("There are %d BMHs in state %s", len(filtered), bmov1alpha1.StateAvailable)
 		g.Expect(filtered).To(HaveLen(2))
 		return nil
 	}, e2eConfig.GetIntervals(specName, "wait-machine-remediation")...).Should(Succeed())
@@ -274,9 +274,9 @@ func remediation() {
 
 	Byf("Waiting for all %d BMHs to be Provisioned", allMachinesCount)
 	Eventually(func(g Gomega) {
-		bmhs := bmo.BareMetalHostList{}
+		bmhs := bmov1alpha1.BareMetalHostList{}
 		g.Expect(bootstrapClient.List(ctx, &bmhs, client.InNamespace(namespace))).To(Succeed())
-		g.Expect(filterBmhsByProvisioningState(bmhs.Items, bmo.StateProvisioned)).To(HaveLen(allMachinesCount))
+		g.Expect(filterBmhsByProvisioningState(bmhs.Items, bmov1alpha1.StateProvisioned)).To(HaveLen(allMachinesCount))
 	}, e2eConfig.GetIntervals(specName, "wait-machine-remediation")...).Should(Succeed())
 
 	Byf("Waiting for all %d machines to be Running", allMachinesCount)
@@ -290,7 +290,7 @@ func remediation() {
 }
 
 type bmhToMachine struct {
-	baremetalhost *bmo.BareMetalHost
+	baremetalhost *bmov1alpha1.BareMetalHost
 	metal3machine *infrav1.Metal3Machine
 }
 type bmhToMachineSlice []bmhToMachine
@@ -302,7 +302,7 @@ func (btm bmhToMachine) String() string {
 	)
 }
 
-func (btms bmhToMachineSlice) getBMHs() (hosts []bmo.BareMetalHost) {
+func (btms bmhToMachineSlice) getBMHs() (hosts []bmov1alpha1.BareMetalHost) {
 	for _, ms := range btms {
 		if ms.baremetalhost != nil {
 			hosts = append(hosts, *ms.baremetalhost)
@@ -351,7 +351,7 @@ func metal3MachineToBmhName(m3machine infrav1.Metal3Machine) string {
 }
 
 // Derives the name of a VM created by metal3-dev-env from the name of a BareMetalHost object.
-func bmhToVMName(host bmo.BareMetalHost) string {
+func bmhToVMName(host bmov1alpha1.BareMetalHost) string {
 	return strings.ReplaceAll(host.Name, "-", "_")
 }
 
@@ -385,8 +385,8 @@ func listVms(state vmState) []string {
 	return lines[:i]
 }
 
-func getAllBmhs(ctx context.Context, c client.Client, namespace, specName string) ([]bmo.BareMetalHost, error) {
-	bmhs := bmo.BareMetalHostList{}
+func getAllBmhs(ctx context.Context, c client.Client, namespace, specName string) ([]bmov1alpha1.BareMetalHost, error) {
+	bmhs := bmov1alpha1.BareMetalHostList{}
 	err := c.List(ctx, &bmhs, client.InNamespace(namespace))
 	return bmhs.Items, err
 }

--- a/test/e2e/upgrade_management_cluster_test.go
+++ b/test/e2e/upgrade_management_cluster_test.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"strings"
 
-	bmo "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -171,7 +171,7 @@ func upgradeManagementCluster() {
 
 	By("Check if BMH is in provisioned state")
 	Eventually(func() error {
-		bmhList := &bmo.BareMetalHostList{}
+		bmhList := &bmov1alpha1.BareMetalHostList{}
 		if err := upgradeClusterClient.List(ctx, bmhList, client.InNamespace(namespace)); err != nil {
 			return err
 		}
@@ -193,7 +193,7 @@ func upgradeManagementCluster() {
 	Eventually(func(g Gomega) {
 		bmhs, err := getAllBmhs(ctx, upgradeClusterClient, namespace, specName)
 		g.Expect(err).To(BeNil())
-		g.Expect(filterBmhsByProvisioningState(bmhs, bmo.StateAvailable)).To(HaveLen(2))
+		g.Expect(filterBmhsByProvisioningState(bmhs, bmov1alpha1.StateAvailable)).To(HaveLen(2))
 	}, e2eConfig.GetIntervals(specName, "wait-bmh-available")...).Should(Succeed())
 
 	/*-------------------------------*


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR extends the list of imports with aliases for CAPM3 (both v1beta1 and v1alpha5 api) and BMO in **importas** linter configuration in order to unify them in the whole codebase. After this change all:

-  `capm3` v1beta1 api imports are renamed to `infrav1` which looks reasonable since it is clearer for newcomers to the codebase and aligns the patterns we have for other imports, i.e for capi (clusterv1). Also, other providers, CAPA has the same [configuration](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/.golangci.yml#L83-L84) for aws imports  
- `bmo`/`bmh` imports are unified and renamed to `bmov1alpha1`
