### PR TITLE
Fix bmhID parsing when providerid is set on the node directly.

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -1306,6 +1306,10 @@ func (m *MachineManager) GetProviderIDAndBMHID() (string, *string) {
 	if providerID == nil {
 		return "", nil
 	}
+	if strings.Contains(*providerID, ProviderIDPrefix) {
+		bmhID := strings.TrimPrefix(*providerID, ProviderIDPrefix)
+		return *providerID, pointer.StringPtr(parseProviderID(bmhID))
+	}
 	return *providerID, pointer.StringPtr(parseProviderID(*providerID))
 }
 


### PR DESCRIPTION
The `GetProviderIDAndBMHID` function is returning the providerID which has the ` providerID(metal://uuid)` format as bmhID which should be just `uuid`.

The problem is more visible when the providerID is directly set on the node itself, making it the source of truth for the providerID field. 

This PR extract the `uuid` part of the providerID.