### PR TITLE
✨ Introduce an additional providerID format and set providerID from nodes when noCloudProvider is set to false

### DIFF
--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -1196,7 +1196,7 @@ func renderMetaData(m3d *capm3.Metal3Data, m3dt *capm3.Metal3DataTemplate,
 	for _, entry := range m3dt.Spec.MetaData.Strings {
 		metadata[entry.Key] = entry.Value
 	}
-	providerid := fmt.Sprintf("%s/%s/%s", m3dt.GetNamespace(), bmh.GetUID(), m3m.GetUID())
+	providerid := fmt.Sprintf("%s/%s/%s", m3m.GetNamespace(), bmh.GetName(), m3m.GetName())
 	metadata["providerid"] = providerid
 	return yaml.Marshal(metadata)
 }

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -2659,7 +2659,7 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			expectedMetaData: map[string]string{
 				"String-1":     "String-1",
-				"providerid":   fmt.Sprintf("%s/%s/%s", namespaceName, bmhuid, m3muid),
+				"providerid":   fmt.Sprintf("%s/%s/%s", namespaceName, "bmh-abc", "metal3machine-abc"),
 				"ObjectName-1": "machine-abc",
 				"ObjectName-2": "metal3machine-abc",
 				"ObjectName-3": "bmh-abc",

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -91,7 +91,7 @@ type MachineManagerInterface interface {
 	Update(context.Context) error
 	HasAnnotation() bool
 	GetProviderIDAndBMHID() (string, *string)
-	SetNodeProviderID(context.Context, string, string, ClientGetter) error
+	SetNodeProviderID(context.Context, string, *string, ClientGetter) error
 	SetProviderID(string)
 	SetPauseAnnotation(context.Context) error
 	RemovePauseAnnotation(context.Context) error
@@ -1317,40 +1317,76 @@ func (m *MachineManager) GetProviderIDAndBMHID() (string, *string) {
 type ClientGetter func(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) (clientcorev1.CoreV1Interface, error)
 
 // SetNodeProviderID sets the metal3 provider ID on the kubernetes node.
-func (m *MachineManager) SetNodeProviderID(ctx context.Context, bmhID, providerID string, clientFactory ClientGetter) error {
-	if !m.Metal3Cluster.Spec.NoCloudProvider {
-		return nil
-	}
+func (m *MachineManager) SetNodeProviderID(ctx context.Context, bmhID string, providerIDOnM3M *string, clientFactory ClientGetter) error {
+	// todo: bmhID should not be trusted and needs to removed from the signature.
 	corev1Remote, err := clientFactory(ctx, m.client, m.Cluster)
 	if err != nil {
 		return errors.Wrap(err, "Error creating a remote client")
 	}
+	namespace := m.Metal3Machine.GetNamespace()
+	m3mName := m.Metal3Machine.GetName()
+	bmhName, err := m.getBmhNameFromM3Machine()
+	if err != nil {
+		m.Log.Info("unable to retrieve BMH name from Metal3Machine")
+		return &RequeueAfterError{RequeueAfter: requeueAfter}
+	}
 
-	nodeLabel := fmt.Sprintf("%s=%v", ProviderLabelPrefix, bmhID)
-	nodes, nodesCount, err := m.getNodesWithLabel(ctx, nodeLabel, clientFactory)
+	providerIDLegacy := fmt.Sprintf("metal3://%s", bmhID)
+	providerIDNew := fmt.Sprintf("metal3://%s/%s/%s", namespace, bmhName, m3mName)
+
+	if !m.Metal3Cluster.Spec.NoCloudProvider {
+		matchingNodesCount, err := m.getMatchingNodesWithoutLabelCount(ctx, providerIDLegacy, providerIDNew, providerIDOnM3M, clientFactory)
+		if matchingNodesCount > 1 {
+			m.Log.Info("More than one node using the same providerID")
+			return errors.Wrap(err, "More than one node using the same providerID")
+		}
+		if err != nil {
+			m.Log.Info("error retrieving node, requeuing")
+			return &RequeueAfterError{RequeueAfter: requeueAfter}
+		}
+		if matchingNodesCount == 0 {
+			// The node could either be still running cloud-init or
+			// kubernetes has not set the node.spec.ProviderID field yet.
+			m.Log.Info("Some target nodes do not have spec.providerID field set yet, requeuing")
+			return &RequeueAfterError{RequeueAfter: requeueAfter}
+		}
+		return nil
+	}
+	nodeLabel := fmt.Sprintf("%s=%s", ProviderLabelPrefix, bmhID)
+	nodes, countNodesWithLabel, err := m.getNodesWithLabel(ctx, nodeLabel, clientFactory)
 	if err != nil {
 		m.Log.Info("error retrieving node, requeuing")
 		return &RequeueAfterError{RequeueAfter: requeueAfter}
 	}
-	if nodesCount == 0 {
+	if countNodesWithLabel == 0 {
 		// The node could either be still running cloud-init or have been
 		// deleted manually. TODO: handle a manual deletion case.
-		m.Log.Info("Target node is not found, requeuing")
+		m.Log.Info("requeuing, could not find node with label: ", nodeLabel)
 		return &RequeueAfterError{RequeueAfter: requeueAfter}
 	}
+	if countNodesWithLabel > 1 {
+		return errors.Wrap(err, fmt.Sprintf("Found multiple target nodes with the same label: (%s)", nodeLabel))
+	}
+	var nodeVar corev1.Node
 	for _, node := range nodes.Items {
-		node := node
-		if node.Spec.ProviderID == providerID {
-			continue
+		providerIDOnNode := node.Spec.ProviderID
+		if providerIDOnNode == "" {
+			node.Spec.ProviderID = providerIDNew
+		} else if providerIDOnNode == providerIDNew {
+			*providerIDOnM3M = providerIDNew
+		} else if providerIDOnNode == providerIDLegacy {
+			*providerIDOnM3M = providerIDLegacy
+		} else {
+			m.Log.Info("node using unsupported providerID format", providerIDOnNode)
+			return errors.Wrap(err, "node using unsupported providerID format")
 		}
-		node.Spec.ProviderID = providerID
-		_, err = corev1Remote.Nodes().Update(ctx, &node, metav1.UpdateOptions{})
+		nodeVar = node
+		_, err = corev1Remote.Nodes().Update(ctx, &nodeVar, metav1.UpdateOptions{})
 		if err != nil {
-			return errors.Wrap(err, "unable to update the target node")
+			return errors.Wrap(err, "unable to update the target node with providerID")
 		}
 	}
 	m.Log.Info("ProviderID set on target node")
-
 	return nil
 }
 
@@ -1722,6 +1758,18 @@ func (m *MachineManager) getMachineSet(ctx context.Context) (*clusterv1.MachineS
 	return nil, errors.New("MachineSet is not found")
 }
 
+// getBmhNameFromM3Machine retrieves bmhName from m3m annotations.
+func (m *MachineManager) getBmhNameFromM3Machine() (string, error) {
+	annotationValue := m.Metal3Machine.ObjectMeta.GetAnnotations()[HostAnnotation]
+	valueParts := strings.Split(annotationValue, "/")
+	if (len(valueParts) < 2) || (valueParts[0] != m.Metal3Machine.GetNamespace()) {
+		errMessage := fmt.Sprintf("unable to retrieve bmh name from metal3machine: %s , using annotation: %s", m.Metal3Machine.GetName(), annotationValue)
+		return "", errors.New(errMessage)
+	}
+	bmhName := valueParts[1]
+	return bmhName, nil
+}
+
 // getNodesWithLabel gets kubernetes nodes with a given label.
 func (m *MachineManager) getNodesWithLabel(ctx context.Context, nodeLabel string, clientFactory ClientGetter) (*corev1.NodeList, int, error) {
 	corev1Remote, err := clientFactory(ctx, m.client, m.Cluster)
@@ -1729,9 +1777,11 @@ func (m *MachineManager) getNodesWithLabel(ctx context.Context, nodeLabel string
 		return nil, 0, errors.Wrap(err, "Error creating a remote client")
 	}
 	nodesCount := 0
-	nodes, err := corev1Remote.Nodes().List(ctx, metav1.ListOptions{
+	filter := metav1.ListOptions{
 		LabelSelector: nodeLabel,
-	})
+	}
+
+	nodes, err := corev1Remote.Nodes().List(ctx, filter)
 	if err != nil {
 		m.Log.Info(fmt.Sprintf("error while retrieving nodes with label (%s): %v", nodeLabel, err))
 		return nil, 0, err
@@ -1740,4 +1790,85 @@ func (m *MachineManager) getNodesWithLabel(ctx context.Context, nodeLabel string
 		nodesCount = len(nodes.Items)
 	}
 	return nodes, nodesCount, err
+}
+
+// getMatchingNodesWithoutLabelCount tLabel gets kubernetes nodes based on their Spec.providerID field.
+func (m *MachineManager) getMatchingNodesWithoutLabelCount(ctx context.Context, providerIDLegacy, providerIDNew string, providerIDonM3M *string, clientFactory ClientGetter) (int, error) {
+	corev1Remote, err := clientFactory(ctx, m.client, m.Cluster)
+	matchingNodesCount := 0
+	if err != nil {
+		return matchingNodesCount, errors.Wrap(err, "Error creating a remote client")
+	}
+
+	filter := metav1.ListOptions{}
+	nodes, err := corev1Remote.Nodes().List(ctx, filter)
+	if err != nil {
+		m.Log.Info(fmt.Sprintf("error while retrieving nodes: %v", err))
+		return matchingNodesCount, err
+	}
+	// kubernetes nodes with their providerID and name fields set
+	validNodes := make(map[string][]string)
+	matchingNodeProviderID := ""
+	for _, node := range nodes.Items {
+		providerIDOnNode := node.Spec.ProviderID
+		if providerIDOnNode == "" {
+			m.Log.Info("no providerID value found on node: ", node.GetName())
+		} else if providerIDOnNode == providerIDNew {
+			matchingNodeProviderID = providerIDNew
+		} else if providerIDOnNode == providerIDLegacy {
+			matchingNodeProviderID = providerIDLegacy
+		} else {
+			m.Log.Info("The node: ", node.GetName(), " does not match expected providerID: ", providerIDOnNode, "Considering other nodes ...")
+		}
+		if providerIDOnNode != "" && node.GetName() != "" {
+			validNodes[providerIDOnNode] = append(validNodes[providerIDOnNode], node.GetName())
+		}
+	}
+	err = m.duplicateProviderIDsExist(validNodes, providerIDLegacy, providerIDNew)
+	if err != nil {
+		// There are, at least, two nodes. Details are in err
+		return 2, err
+	}
+	if matchingNodeProviderID != "" {
+		*providerIDonM3M = matchingNodeProviderID
+		return 1, nil
+	}
+	return matchingNodesCount, nil
+}
+
+// duplicateProviderIDsExist determnes if a providerID is already in use by other nodes.
+func (m *MachineManager) duplicateProviderIDsExist(validNodes map[string][]string, providerIDLegacy, providerIDNew string) error {
+	duplicateUsageCounter := 0
+	var duplicateNodes []string
+	nodeName := strings.Split(strings.TrimPrefix(providerIDNew, "metal3://"), "/")[1]
+	if nodeName == "" {
+		nodeName = "unknown node"
+	}
+	for providerID, nodes := range validNodes {
+		matchingNodes := strings.Join(nodes, ",")
+		// verify if the same providerId is not consumed twice. Example:
+		// legacy provider-id: metal3://d668eb95-5df6-4c10-a01a-fc69f4299fc6
+		// new format provider-id:   metal3://metal3/node-0/test-controlplane-xyz
+		// The above two providerIDs are the same and would consume the same bmh node,
+		// the former using uuid and the latter using a name.
+		// The check below prevents such double providerID consumptions.
+		if providerID == providerIDLegacy || strings.Contains(providerID, nodeName) {
+			duplicateUsageCounter++
+			duplicateNodes = append(duplicateNodes, nodes...)
+		}
+		// duplicates due to the same, at least, two instances of legacy OR new OR unknown formats being used in multiple nodes.
+		if len(nodes) > 1 {
+			errMsg := fmt.Sprintf("providerID %s is in use by multiple nodes: (%s)", providerID, matchingNodes)
+			m.Log.Info(errMsg)
+			return errors.New(errMsg)
+		}
+	}
+	// duplicates due to both the legacy AND new providerIDs being used by multiple nodes.
+	if duplicateUsageCounter > 1 {
+		duplicateNodesNames := strings.Join(duplicateNodes, ",")
+		errMsg := fmt.Sprintf("both providerIDs (%s and %s) cannot be used at the same time by node: (%s)", providerIDLegacy, providerIDNew, duplicateNodesNames)
+		m.Log.Info(errMsg)
+		return errors.New(errMsg)
+	}
+	return nil
 }

--- a/baremetal/mocks/zz_generated.metal3machine_manager.go
+++ b/baremetal/mocks/zz_generated.metal3machine_manager.go
@@ -251,7 +251,7 @@ func (mr *MockMachineManagerInterfaceMockRecorder) SetFinalizer() *gomock.Call {
 }
 
 // SetNodeProviderID mocks base method.
-func (m *MockMachineManagerInterface) SetNodeProviderID(arg0 context.Context, arg1, arg2 string, arg3 baremetal.ClientGetter) error {
+func (m *MockMachineManagerInterface) SetNodeProviderID(arg0 context.Context, arg1 string, arg2 *string, arg3 baremetal.ClientGetter) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetNodeProviderID", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -55,7 +55,7 @@ const (
 	bmhuid            = "22222222-9845-4c48-9e49-c74be387f57c"
 )
 
-var providerid = fmt.Sprintf("%s/%s/%s", namespaceName, bmhuid, m3muid)
+var providerid = fmt.Sprintf("%s/%s/%s", namespaceName, "abc", "abc")
 
 func TestManagers(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -269,7 +269,7 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 	}
 	if bmhID != nil {
 		// Set the providerID on the node if no Cloud provider
-		err = machineMgr.SetNodeProviderID(ctx, *bmhID, providerID, r.CapiClientGetter)
+		err = machineMgr.SetNodeProviderID(ctx, *bmhID, &providerID, r.CapiClientGetter)
 		if err != nil {
 			machineMgr.SetConditionMetal3MachineToFalse(capm3.KubernetesNodeReadyCondition, capm3.SettingProviderIDOnNodeFailedReason, clusterv1.ConditionSeverityError, err.Error())
 			return checkMachineError(machineMgr, err,

--- a/controllers/metal3machine_controller_integration_test.go
+++ b/controllers/metal3machine_controller_integration_test.go
@@ -579,6 +579,16 @@ var _ = Describe("Reconcile metal3machine", func() {
 					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
 					newBareMetalHost(nil, nil, nil, false),
 				},
+				TargetObjects: []runtime.Object{
+					&corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-0",
+						},
+						Spec: corev1.NodeSpec{
+							ProviderID: providerID,
+						},
+					},
+				},
 				ErrorExpected:       false,
 				RequeueExpected:     false,
 				ClusterInfraReady:   true,
@@ -620,6 +630,25 @@ var _ = Describe("Reconcile metal3machine", func() {
 					newCluster(clusterName, nil, nil),
 					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
 					newBareMetalHost(nil, nil, nil, false),
+				},
+				TargetObjects: []runtime.Object{
+					&corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-0",
+						},
+						Spec: corev1.NodeSpec{
+							ProviderID: providerID,
+						},
+					},
+					&corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-1",
+							Labels: map[string]string{
+								baremetal.ProviderLabelPrefix: string(bmhuid),
+							},
+						},
+						Spec: corev1.NodeSpec{},
+					},
 				},
 				ErrorExpected:              false,
 				RequeueExpected:            false,
@@ -724,7 +753,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 				TargetObjects: []runtime.Object{
 					&corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "bmh-0",
+							Name: "node-0",
 							Labels: map[string]string{
 								baremetal.ProviderLabelPrefix: string(bmhuid),
 							},

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -136,7 +136,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		// if we fail to set it on the node, we do not go further
 		if tc.SetNodeProviderIDFails {
 			m.EXPECT().
-				SetNodeProviderID(context.TODO(), string(bmhuid), providerID, nil).
+				SetNodeProviderID(context.TODO(), string(bmhuid), &providerID, nil).
 				Return(errors.New("Failed"))
 			m.EXPECT().SetProviderID(string(bmhuid)).MaxTimes(0)
 			m.EXPECT().SetError(gomock.Any(), gomock.Any())
@@ -147,7 +147,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 
 		// we successfully set it on the node
 		m.EXPECT().
-			SetNodeProviderID(context.TODO(), string(bmhuid), providerID, nil).
+			SetNodeProviderID(context.TODO(), string(bmhuid), &providerID, nil).
 			Return(nil)
 		m.EXPECT().SetProviderID(providerID)
 
@@ -157,7 +157,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		m.EXPECT().GetBaremetalHostID(context.TODO()).Return(nil, nil)
 
 		m.EXPECT().
-			SetNodeProviderID(context.TODO(), bmhuid, providerID, nil).
+			SetNodeProviderID(context.TODO(), bmhuid, &providerID, nil).
 			MaxTimes(0)
 	}
 


### PR DESCRIPTION
This PR has three main goals.

**(1)providerID from nodes when noCloudProvider is set to false**

With `Metal3Cluster.Spec.NoCloudProvider` set to `false`.  The source of truth for the `providerID` is the node.
And, the `providerID` field on the `Metal3Machine` should be updated accordingly.

**(2) A new providerID format**

This PR also introduced a new providerID format. The are now two supported providerID formats.
Suppose, we have a bmh named node-0, then the two providerIDs formats are shown below.
```
metal3://d668eb95-5df6-4c10-a01a-fc69f4299fc6
metal3://metal3/node-0/test-controlplane-xyz
```

**(3) preventing  duplicate usage of a providerID**
This PR prevents a providerID from being used by multiple nodes at the same time. To this end, both formats of a given providerID are treated as one and should not be used simultaneously. 