### PR TITLE
:bug: Fix recursion in deleteOwnerRefFromList

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -1394,7 +1394,7 @@ func deleteOwnerRefFromList(refList []metav1.OwnerReference,
 	}
 	refListLen := len(refList) - 1
 	refList[index] = refList[refListLen]
-	refList, err = deleteOwnerRefFromList(refList[:refListLen-1], objType, objMeta)
+	refList, err = deleteOwnerRefFromList(refList[:refListLen], objType, objMeta)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
In the recursive call of deleteOwnerRefFromList there is used the
variable refListLen := len(refList) - 1. However, in the recursive call
we use refListLen - 1, so that we have len(refList) - 2 in the end. It
should only be len(refList) - 1 though.

**Which issue(s) this PR fixes**
Fixes #565
