### PR TITLE
🌱 Add gosec file and related changes in release-0.5 branch

### DIFF
--- a/baremetal/metal3datatemplate_manager.go
+++ b/baremetal/metal3datatemplate_manager.go
@@ -193,6 +193,7 @@ func (m *DataTemplateManager) UpdateDatas(ctx context.Context) (int, error) {
 
 	// Iterate over the Metal3Data objects to find all indexes and objects
 	for _, dataClaim := range dataClaimObjects.Items {
+		dataClaim := dataClaim
 		// If DataTemplate does not point to this object, discard
 		if dataClaim.Spec.Template.Name != m.DataTemplate.Name {
 			continue

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -849,6 +849,7 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmh.BareMetalHost, *p
 	availableHostsWithNodeReuse := []*bmh.BareMetalHost{}
 
 	for i, host := range hosts.Items {
+		host := host
 		if host.Spec.ConsumerRef != nil && consumerRefMatches(host.Spec.ConsumerRef, m.Metal3Machine) {
 			m.Log.Info("Found host with existing ConsumerRef", "host", host.Name)
 			helper, err := patch.NewHelper(&hosts.Items[i], m.client)
@@ -1294,6 +1295,7 @@ func (m *MachineManager) SetNodeProviderID(ctx context.Context, bmhID, providerI
 		return &RequeueAfterError{RequeueAfter: requeueAfter}
 	}
 	for _, node := range nodes.Items {
+		node := node
 		if node.Spec.ProviderID == providerID {
 			continue
 		}

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -18,9 +18,10 @@ package baremetal
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"strings"
 	"time"
 
@@ -900,8 +901,7 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmh.BareMetalHost, *p
 		return nil, nil, nil
 	}
 
-	// choose a host
-	rand.Seed(time.Now().Unix())
+	// choose a host.
 	var chosenHost *bmh.BareMetalHost
 
 	// If there are hosts with nodeReuseLabelName:
@@ -920,7 +920,9 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmh.BareMetalHost, *p
 			// If host is found in `Ready` state, pick it
 			if len(hostsInAvailableStateWithNodeReuse) != 0 {
 				m.Log.Info(fmt.Sprintf("Found %v host(s) with nodeReuseLabelName in Ready/Available state, choosing the host %v", len(hostsInAvailableStateWithNodeReuse), host.Name))
-				chosenHost = hostsInAvailableStateWithNodeReuse[rand.Intn(len(hostsInAvailableStateWithNodeReuse))]
+				rHost, _ := rand.Int(rand.Reader, big.NewInt(int64(len(hostsInAvailableStateWithNodeReuse))))
+				randomHost := rHost.Int64()
+				chosenHost = hostsInAvailableStateWithNodeReuse[randomHost]
 			} else if len(hostsInNotAvailableStateWithNodeReuse) != 0 {
 				m.Log.Info(fmt.Sprintf("Found %v host(s) with nodeReuseLabelName in %v state, requeuing the host %v", len(hostsInNotAvailableStateWithNodeReuse), host.Status.Provisioning.State, host.Name))
 				return nil, nil, &RequeueAfterError{RequeueAfter: requeueAfter}
@@ -930,7 +932,9 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmh.BareMetalHost, *p
 		// If there are no hosts with nodeReuseLabelName, fall back
 		// to the current flow and select hosts randomly.
 		m.Log.Info(fmt.Sprintf("%d host(s) available, choosing a random host", len(availableHosts)))
-		chosenHost = availableHosts[rand.Intn(len(availableHosts))]
+		rHost, _ := rand.Int(rand.Reader, big.NewInt(int64(len(availableHosts))))
+		randomHost := rHost.Int64()
+		chosenHost = availableHosts[randomHost]
 	}
 
 	helper, err := patch.NewHelper(chosenHost, m.client)

--- a/hack/gosec.sh
+++ b/hack/gosec.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -eux
+
+IS_CONTAINER=${IS_CONTAINER:-false}
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+  export XDG_CACHE_HOME="/tmp/.cache"
+
+  gosec -severity medium --confidence medium -quiet ./...
+else
+  "${CONTAINER_RUNTIME}" run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/capm3:ro,z" \
+    --entrypoint sh \
+    --workdir /capm3 \
+    registry.hub.docker.com/securego/gosec:latest \
+    /capm3/hack/gosec.sh
+fi;

--- a/hack/gosec.sh
+++ b/hack/gosec.sh
@@ -8,7 +8,7 @@ CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 if [ "${IS_CONTAINER}" != "false" ]; then
   export XDG_CACHE_HOME="/tmp/.cache"
 
-  gosec -severity medium --confidence medium -quiet ./...
+  gosec -exclude=G107 -severity medium -confidence medium -quiet -concurrency 8 ./...
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -29,7 +29,7 @@ func Logf(format string, a ...interface{}) {
 }
 
 func LogFromFile(logFile string) {
-	data, err := os.ReadFile(logFile)
+	data, err := os.ReadFile(filepath.Clean(logFile))
 	Expect(err).To(BeNil(), "No log file found")
 	Logf(string(data))
 }
@@ -65,8 +65,8 @@ func dumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterPr
 	}
 }
 
-func downloadFile(filepath string, url string) error {
-
+// downloadFile will download a url and store it in local filepath.
+func downloadFile(filePath string, url string) error {
 	// Get the data
 	resp, err := http.Get(url)
 	if err != nil {
@@ -75,7 +75,7 @@ func downloadFile(filepath string, url string) error {
 	defer resp.Body.Close()
 
 	// Create the file
-	out, err := os.Create(filepath)
+	out, err := os.Create(filepath.Clean(filePath))
 	if err != nil {
 		return err
 	}

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -79,7 +79,10 @@ func downloadFile(filePath string, url string) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() {
+		err := out.Close()
+		Expect(err).To(BeNil(), "Error closing file")
+	}()
 
 	// Write the body to file
 	_, err = io.Copy(out, resp.Body)


### PR DESCRIPTION
- [Add gosec file for go security checks](https://github.com/metal3-io/cluster-api-provider-metal3/commit/be2c770f7e7d421298d8c02813701450065b3159)

- [Use crypto/rand instead of math/rand](https://github.com/metal3-io/cluster-api-provider-metal3/commit/7a6747d6c18c58e56b57f374ec76e351d7351f81)
 
- [Reassign loop variable to address gosec G601](https://github.com/metal3-io/cluster-api-provider-metal3/commit/22e3edd51f099e1beb954d0d0d4c79663db5cef2)
 
- [Cleanup bad filepath using filepath.Clean](https://github.com/metal3-io/cluster-api-provider-metal3/commit/31d76469e8660fb3bb023fd39005e923ba1c8db3)
 
- [Fix unsafe defer call to file.Close()](https://github.com/metal3-io/cluster-api-provider-metal3/commit/ab30c48124b1f2ffca4b56275ec43c9b91eb7025)
 
- [Exclude rule G107 and include concurrency](https://github.com/metal3-io/cluster-api-provider-metal3/commit/33e42c5afce453876cd6db6c12d915dd383dfe68)