### PR TITLE
🌱Add e2e tests for ephemeral cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ E2E_CONTAINERS ?= quay.io/metal3-io/cluster-api-provider-metal3 quay.io/metal3-i
 
 SKIP_CLEANUP ?= false
 UPGRADE_TEST ?= false
+EPHEMERAL_TEST ?= false
 SKIP_CREATE_MGMT_CLUSTER ?= true
 
 # Exported to the cluster templates
@@ -167,6 +168,7 @@ e2e-tests: e2e-substitutions cluster-templates ## This target should be called f
 		-e2e.config="$(E2E_CONF_FILE_ENVSUBST)" \
 		-e2e.skip-resource-cleanup=$(SKIP_CLEANUP) \
 		-e2e.trigger-upgrade-test=$(UPGRADE_TEST) \
+		-e2e.trigger-ephemeral-test=$(EPHEMERAL_TEST) \
 		-e2e.use-existing-cluster=$(SKIP_CREATE_MGMT_CLUSTER)
 	rm $(E2E_CONF_FILE_ENVSUBST)
 

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -54,6 +54,7 @@ REPO_ROOT=$(realpath "$REPO_ROOT")
 
 # Get correct CAPM3 path when testing locally
 export UPGRADE_TEST=${UPGRADE_TEST:-false}
+export EPHEMERAL_TEST=${EPHEMERAL_TEST:-false}
 if ! $UPGRADE_TEST; then
   # Copy the current CAPM3 repo to the Go source directory
   rm -rf "${M3PATH}/cluster-api-provider-metal3" # To avoid 'permission denied' error when overriding .git/

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -47,6 +47,9 @@ var (
 
 	// upgradeTest triggers only e2e upgrade test if true.
 	upgradeTest bool
+
+	// ephemeralTest triggers only e2e test in ephemeral cluster if true.
+	ephemeralTest bool
 )
 
 // Test suite global vars.
@@ -76,6 +79,7 @@ func init() {
 	flag.StringVar(&artifactFolder, "e2e.artifacts-folder", "", "folder where e2e test artifact should be stored")
 	flag.BoolVar(&skipCleanup, "e2e.skip-resource-cleanup", false, "if true, the resource cleanup after tests will be skipped")
 	flag.BoolVar(&upgradeTest, "e2e.trigger-upgrade-test", false, "if true, the e2e upgrade test will be triggered and other tests will be skipped")
+	flag.BoolVar(&ephemeralTest, "e2e.trigger-ephemeral-test", false, "if true, all e2e tests run in the ephemeral cluster without pivoting to the target cluster")
 	flag.BoolVar(&useExistingCluster, "e2e.use-existing-cluster", true, "if true, the test uses the current cluster instead of creating a new one (default discovery rules apply)")
 	flag.StringVar(&kubeconfigPath, "e2e.kubeconfig-path", os.Getenv("HOME")+"/.kube/config", "if e2e.use-existing-cluster is true, path to the kubeconfig file")
 	e2eTestsPath = getE2eTestsPath()

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -77,12 +77,20 @@ var _ = Describe("Workload cluster creation", func() {
 				cluster = result.Cluster
 				targetCluster = bootstrapClusterProxy.GetWorkloadCluster(ctx, namespace, clusterName)
 				remediation()
-				pivoting()
-				upgradeBMO()
-				upgradeIronic()
-				certRotation()
-				nodeReuse()
-				rePivoting()
+				if !ephemeralTest {
+					pivoting()
+					upgradeBMO(targetCluster.GetClientSet())
+					upgradeIronic(targetCluster.GetClientSet())
+					certRotation(targetCluster.GetClientSet(), targetCluster.GetClient())
+					nodeReuse(targetCluster.GetClient())
+					rePivoting()
+				} else {
+					upgradeBMO(bootstrapClusterProxy.GetClientSet())
+					upgradeIronic(bootstrapClusterProxy.GetClientSet())
+					certRotation(bootstrapClusterProxy.GetClientSet(), bootstrapClusterProxy.GetClient())
+					nodeReuse(bootstrapClusterProxy.GetClient())
+
+				}
 			}
 		})
 	})

--- a/test/e2e/upgrade_baremetal_operator_test.go
+++ b/test/e2e/upgrade_baremetal_operator_test.go
@@ -5,13 +5,13 @@ import (
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
-func upgradeBMO() {
+func upgradeBMO(clientSet *kubernetes.Clientset) {
 	Logf("Starting BMO containers upgrade tests")
 	var (
 		namePrefix = e2eConfig.GetVariable("NAMEPREFIX")
-		clientSet  = targetCluster.GetClientSet()
 		// BMO and Ironic share namespace
 		bmoNamespace      = e2eConfig.GetVariable("IRONIC_NAMESPACE")
 		bmoDeployName     = namePrefix + "-controller-manager"

--- a/test/e2e/upgrade_ironic_test.go
+++ b/test/e2e/upgrade_ironic_test.go
@@ -5,13 +5,13 @@ import (
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
-func upgradeIronic() {
+func upgradeIronic(clientSet *kubernetes.Clientset) {
 	Logf("Starting ironic containers upgrade tests")
 	var (
 		namePrefix        = e2eConfig.GetVariable("NAMEPREFIX")
-		clientSet         = targetCluster.GetClientSet()
 		ironicNamespace   = e2eConfig.GetVariable("IRONIC_NAMESPACE")
 		ironicDeployName  = namePrefix + "-ironic"
 		containerRegistry = e2eConfig.GetVariable("CONTAINER_REGISTRY")
@@ -32,12 +32,8 @@ func upgradeIronic() {
 	for i, container := range deploy.Spec.Template.Spec.Containers {
 		switch container.Name {
 		case
-			// TODO(dtantsur): remove api and conductor once
-			// they're fully replaced by the all-in-one ironic
 			"ironic",
-			"ironic-api",
 			"ironic-dnsmasq",
-			"ironic-conductor",
 			"ironic-log-watch",
 			"ironic-inspector":
 			deploy.Spec.Template.Spec.Containers[i].Image = containerRegistry + "/metal3-io/ironic:" + ironicImageTag


### PR DESCRIPTION
This PR will introduce e2e test for ephemeral cluster such as ironic upgrade, bmo upgrade, cert rotation and node reuse tests.
