### PR TITLE
🌱Deprecate golint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,7 +21,6 @@ linters:
     - godot
     - gofmt
     - goimports
-    - golint
     - gosimple
     - govet
     - importas
@@ -111,12 +110,6 @@ linters-settings:
     go: "1.17"
 issues:
   exclude-rules:
-    - path: api/v1alpha4/types\.go
-      linters:
-        - golint
-    - path: test/e2e
-      linters:
-        - golint
     - path: test/e2e
       linters:
         - gosec
@@ -167,6 +160,6 @@ issues:
       text: "ST1016: methods on the same type should have the same receiver name"
       path: .*(api|types)\/.*\/conversion.*\.go$
   include:
-  - EXC0002 # include "missing comments" issues from golint
+  - EXC0002 # include "missing comments" issues from golangci-lint
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/hack/ensure-golangci-lint.sh
+++ b/hack/ensure-golangci-lint.sh
@@ -18,5 +18,5 @@ else
     --entrypoint sh \
     --workdir /capm3 \
     docker.io/golang:1.17 \
-    /capm3/hack/golint.sh
+    /capm3/hack/ensure-golangci-lint.sh
 fi;


### PR DESCRIPTION
Get rid of golint since golint is deprecated and revive is the substitute.
