### PR TITLE
🌱 Don't write hardware details into statusAnnotation

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -257,6 +257,12 @@ func (m *MachineManager) SetPauseAnnotation(ctx context.Context) error {
 		)
 		return errors.Wrap(err, "failed to marshall status annotation")
 	}
+	obj := map[string]interface{}{}
+	if err := json.Unmarshal(newAnnotation, &obj); err != nil {
+		return errors.Wrap(err, "failed to unmarshall status annotation")
+	}
+	delete(obj, "hardware")
+	newAnnotation, _ = json.Marshal(obj)
 	host.Annotations[bmov1alpha1.StatusAnnotation] = string(newAnnotation)
 	return helper.Patch(ctx, host)
 }

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -864,6 +864,16 @@ var _ = Describe("Metal3Machine manager", func() {
 				Expect(statusPresent).To(BeTrue())
 				annotation, err := json.Marshal(&tc.Host.Status)
 				Expect(err).To(BeNil())
+				// (Note) manager code marshals the inspection data stored in annotation,
+				// which causes alphabetically reordering of keys. Since we are marshaling
+				// only the annotation, the status value here doesn't match the marshaled
+				// annotation data, because it wasn't re-ordered by the JSON marshaller.
+				// That's why we are marshaling status data as well so that its fields are
+				// also alphabetically reordered to match the annotation keys style..
+				obj := map[string]interface{}{}
+				err = json.Unmarshal(annotation, &obj)
+				Expect(err).To(BeNil())
+				annotation, _ = json.Marshal(obj)
 				Expect(status).To(Equal(string(annotation)))
 			} else {
 				Expect(statusPresent).To(BeFalse())


### PR DESCRIPTION
**What this PR does / why we need it**:
Don't write hardware details into `statusAnnotation`, because we don't need to move
inspection data to the target cluster via annotation anymore but do it instead via
hardwareData CRD, which is implemented in https://github.com/metal3-io/baremetal-operator/pull/1099.
Partially fixes https://github.com/metal3-io/cluster-api-provider-metal3/issues/266
