### PR TITLE
🐛Fix node reuse test for e2e ephemeral cluster tests

### DIFF
--- a/test/e2e/node_reuse_test.go
+++ b/test/e2e/node_reuse_test.go
@@ -139,7 +139,7 @@ func nodeReuse(clusterClient client.Client) {
 	Eventually(
 		func(g Gomega) {
 			machines := &clusterv1.MachineList{}
-			g.Expect(targetCluster.GetClient().List(ctx, machines, client.InNamespace(namespace))).To(Succeed())
+			g.Expect(clusterClient.List(ctx, machines, client.InNamespace(namespace))).To(Succeed())
 			deletingCount := 0
 			for _, machine := range machines.Items {
 				Expect(machine.Status.GetTypedPhase() == clusterv1.MachinePhaseProvisioning).To(BeFalse()) // Ensure no machine is provisioning


### PR DESCRIPTION
This PR will fix node reuse test for ephemeral cluster. It was missing the change of clusterClient instead of targetCluster.