### PR TITLE
Parameterize hard coded object/resource names in tests

### DIFF
--- a/baremetal/metal3datatemplate_manager_test.go
+++ b/baremetal/metal3datatemplate_manager_test.go
@@ -301,10 +301,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			},
 			dataClaims: []*infrav1.Metal3DataClaim{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
-						Namespace: namespaceName,
-					},
+					ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 					Spec: infrav1.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
 							Name:      "abc",

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -142,6 +143,7 @@ func testObjectMeta(name string, namespace string, uid string) metav1.ObjectMeta
 	return metav1.ObjectMeta{
 		Name:      name,
 		Namespace: namespace,
+		UID:       types.UID(uid),
 	}
 }
 

--- a/baremetal/utils_test.go
+++ b/baremetal/utils_test.go
@@ -338,10 +338,7 @@ var _ = Describe("Metal3 manager utils", func() {
 		func(secretExists bool) {
 			if secretExists {
 				err := k8sClient.Create(context.TODO(), &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
-						Namespace: namespaceName,
-					},
+					ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 				})
 				Expect(err).NotTo(HaveOccurred())
 			}
@@ -349,10 +346,7 @@ var _ = Describe("Metal3 manager utils", func() {
 			if secretExists {
 				Expect(err).NotTo(HaveOccurred())
 				err = k8sClient.Delete(context.TODO(), &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
-						Namespace: namespaceName,
-					},
+					ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 				})
 				Expect(err).NotTo(HaveOccurred())
 			} else {

--- a/controllers/metal3data_controller_test.go
+++ b/controllers/metal3data_controller_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Metal3Data manager", func() {
 
 				req := reconcile.Request{
 					NamespacedName: types.NamespacedName{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 					},
 				}
@@ -132,7 +132,7 @@ var _ = Describe("Metal3Data manager", func() {
 			Entry("Missing cluster label", testCaseReconcile{
 				m3d: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 					},
 				},
@@ -140,7 +140,7 @@ var _ = Describe("Metal3Data manager", func() {
 			Entry("Cluster not found", testCaseReconcile{
 				m3d: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
 							clusterv1.ClusterLabelName: "abc",
@@ -151,7 +151,7 @@ var _ = Describe("Metal3Data manager", func() {
 			Entry("Deletion, Cluster not found", testCaseReconcile{
 				m3d: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
 							clusterv1.ClusterLabelName: "abc",
@@ -164,7 +164,7 @@ var _ = Describe("Metal3Data manager", func() {
 			Entry("Deletion, release requeue", testCaseReconcile{
 				m3d: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
 							clusterv1.ClusterLabelName: "abc",
@@ -179,7 +179,7 @@ var _ = Describe("Metal3Data manager", func() {
 			Entry("Deletion, release error", testCaseReconcile{
 				m3d: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
 							clusterv1.ClusterLabelName: "abc",
@@ -194,16 +194,16 @@ var _ = Describe("Metal3Data manager", func() {
 			Entry("Paused cluster", testCaseReconcile{
 				m3d: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
-							clusterv1.ClusterLabelName: "abc",
+							clusterv1.ClusterLabelName: clusterName,
 						},
 					},
 				},
 				cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      clusterName,
 						Namespace: namespaceName,
 					},
 					Spec: clusterv1.ClusterSpec{
@@ -215,16 +215,16 @@ var _ = Describe("Metal3Data manager", func() {
 			Entry("Error in manager", testCaseReconcile{
 				m3d: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
-							clusterv1.ClusterLabelName: "abc",
+							clusterv1.ClusterLabelName: clusterName,
 						},
 					},
 				},
 				cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      clusterName,
 						Namespace: namespaceName,
 					},
 				},
@@ -233,16 +233,16 @@ var _ = Describe("Metal3Data manager", func() {
 			Entry("Reconcile normal error", testCaseReconcile{
 				m3d: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
-							clusterv1.ClusterLabelName: "abc",
+							clusterv1.ClusterLabelName: clusterName,
 						},
 					},
 				},
 				cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      clusterName,
 						Namespace: namespaceName,
 					},
 				},
@@ -253,16 +253,16 @@ var _ = Describe("Metal3Data manager", func() {
 			Entry("Reconcile normal no error", testCaseReconcile{
 				m3d: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
-							clusterv1.ClusterLabelName: "abc",
+							clusterv1.ClusterLabelName: clusterName,
 						},
 					},
 				},
 				cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      clusterName,
 						Namespace: namespaceName,
 					},
 				},

--- a/controllers/metal3datatemplate_controller_test.go
+++ b/controllers/metal3datatemplate_controller_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 
 			req := reconcile.Request{
 				NamespacedName: types.NamespacedName{
-					Name:      "abc",
+					Name:      metal3DataTemplateName,
 					Namespace: namespaceName,
 				},
 			}
@@ -132,29 +132,29 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		Entry("Metal3DataTemplate not found", testCaseReconcile{}),
 		Entry("Cluster not found", testCaseReconcile{
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
 				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
 			},
 		}),
 		Entry("Deletion, Cluster not found", testCaseReconcile{
 			m3dt: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "abc",
+					Name:              metal3DataTemplateName,
 					Namespace:         namespaceName,
 					DeletionTimestamp: &timestampNow,
 				},
-				Spec: infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
+				Spec: infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
 			expectManager: true,
 		}),
 		Entry("Deletion, Cluster not found, error", testCaseReconcile{
 			m3dt: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "abc",
+					Name:              metal3DataTemplateName,
 					Namespace:         namespaceName,
 					DeletionTimestamp: &timestampNow,
 				},
-				Spec: infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
+				Spec: infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
 			expectManager:        true,
 			reconcileDeleteError: true,
@@ -162,11 +162,11 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		}),
 		Entry("Paused cluster", testCaseReconcile{
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
+				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
 			cluster: &clusterv1.Cluster{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(clusterName, namespaceName, ""),
 				Spec: clusterv1.ClusterSpec{
 					Paused: true,
 				},
@@ -176,21 +176,21 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		}),
 		Entry("Error in manager", testCaseReconcile{
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
+				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
 			cluster: &clusterv1.Cluster{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(clusterName, namespaceName, ""),
 			},
 			managerError: true,
 		}),
 		Entry("Reconcile normal error", testCaseReconcile{
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
+				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
 			cluster: &clusterv1.Cluster{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(clusterName, namespaceName, ""),
 			},
 			reconcileNormal:      true,
 			reconcileNormalError: true,
@@ -198,11 +198,11 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		}),
 		Entry("Reconcile normal no error", testCaseReconcile{
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
+				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
 			cluster: &clusterv1.Cluster{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(clusterName, namespaceName, ""),
 			},
 			reconcileNormal: true,
 			expectManager:   true,
@@ -357,11 +357,8 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		Entry("No Metal3DataTemplate in Spec",
 			TestCaseM3DCToM3DT{
 				DataClaim: &infrav1.Metal3DataClaim{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
-						Namespace: namespaceName,
-					},
-					Spec: infrav1.Metal3DataClaimSpec{},
+					ObjectMeta: testObjectMeta(metal3DataClaimName, namespaceName, ""),
+					Spec:       infrav1.Metal3DataClaimSpec{},
 				},
 				ExpectRequest: false,
 			},
@@ -369,10 +366,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		Entry("Metal3DataTemplate in Spec, with namespace",
 			TestCaseM3DCToM3DT{
 				DataClaim: &infrav1.Metal3DataClaim{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
-						Namespace: namespaceName,
-					},
+					ObjectMeta: testObjectMeta(metal3DataClaimName, namespaceName, ""),
 					Spec: infrav1.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
 							Name:      "abc",
@@ -386,10 +380,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		Entry("Metal3DataTemplate in Spec, no namespace",
 			TestCaseM3DCToM3DT{
 				DataClaim: &infrav1.Metal3DataClaim{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
-						Namespace: namespaceName,
-					},
+					ObjectMeta: testObjectMeta(metal3DataClaimName, namespaceName, ""),
 					Spec: infrav1.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
 							Name: "abc",

--- a/controllers/metal3labelsync_controller_test.go
+++ b/controllers/metal3labelsync_controller_test.go
@@ -330,7 +330,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 				ExpectRequests: []ctrl.Request{
 					{
 						NamespacedName: types.NamespacedName{
-							Name:      "myhost",
+							Name:      baremetalHostName,
 							Namespace: namespaceName,
 						},
 					},
@@ -423,7 +423,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 				}
 				req := reconcile.Request{
 					NamespacedName: types.NamespacedName{
-						Name:      "bmh-0",
+						Name:      baremetalHostName,
 						Namespace: namespaceName,
 					},
 				}
@@ -582,7 +582,7 @@ func m3mObjectMeta() *metav1.ObjectMeta {
 			clusterv1.ClusterLabelName: clusterName,
 		},
 		Annotations: map[string]string{
-			baremetal.HostAnnotation: namespaceName + "/myhost",
+			baremetal.HostAnnotation: namespaceName + "/" + baremetalHostName,
 		},
 	}
 }

--- a/controllers/metal3machine_controller_integration_test.go
+++ b/controllers/metal3machine_controller_integration_test.go
@@ -67,7 +67,7 @@ func m3mOwnerRefs() []metav1.OwnerReference {
 
 func m3mMetaWithOwnerRef() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
-		Name:            "abc",
+		Name:            metal3machineName,
 		Namespace:       namespaceName,
 		OwnerReferences: m3mOwnerRefs(),
 		Annotations:     map[string]string{},
@@ -76,7 +76,7 @@ func m3mMetaWithOwnerRef() *metav1.ObjectMeta {
 
 func m3mMetaWithDeletion() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
-		Name:              "abc",
+		Name:              metal3machineName,
 		Namespace:         namespaceName,
 		DeletionTimestamp: &deletionTimestamp,
 		OwnerReferences:   m3mOwnerRefs(),
@@ -86,23 +86,23 @@ func m3mMetaWithDeletion() *metav1.ObjectMeta {
 
 func m3mMetaWithAnnotation() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
-		Name:            "abc",
+		Name:            metal3machineName,
 		Namespace:       namespaceName,
 		OwnerReferences: m3mOwnerRefs(),
 		Annotations: map[string]string{
-			baremetal.HostAnnotation: namespaceName + "/bmh-0",
+			baremetal.HostAnnotation: namespaceName + "/" + baremetalHostName,
 		},
 	}
 }
 
 func m3mMetaWithAnnotationDeletion() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
-		Name:              "abc",
+		Name:              metal3machineName,
 		Namespace:         namespaceName,
 		DeletionTimestamp: &deletionTimestamp,
 		OwnerReferences:   m3mOwnerRefs(),
 		Annotations: map[string]string{
-			baremetal.HostAnnotation: namespaceName + "/bmh-0",
+			baremetal.HostAnnotation: namespaceName + "/" + baremetalHostName,
 		},
 	}
 }
@@ -212,7 +212,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 			objMeta := testmachine.ObjectMeta
 			_ = fakeClient.Get(context.TODO(), *getKey(clusterName), testcluster)
 			_ = fakeClient.Get(context.TODO(), *getKey(metal3machineName), testBMmachine)
-			_ = fakeClient.Get(context.TODO(), *getKey("bmh-0"), testBMHost)
+			_ = fakeClient.Get(context.TODO(), *getKey(baremetalHostName), testBMHost)
 
 			if tc.ErrorExpected {
 				Expect(err).To(HaveOccurred())
@@ -582,7 +582,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 				TargetObjects: []runtime.Object{
 					&corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "node-0",
+							Name: nodeName1,
 						},
 						Spec: corev1.NodeSpec{
 							ProviderID: providerID,
@@ -634,7 +634,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 				TargetObjects: []runtime.Object{
 					&corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "node-0",
+							Name: nodeName1,
 						},
 						Spec: corev1.NodeSpec{
 							ProviderID: providerID,
@@ -642,7 +642,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 					},
 					&corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "node-1",
+							Name: nodeName2,
 							Labels: map[string]string{
 								baremetal.ProviderLabelPrefix: string(bmhuid),
 							},
@@ -753,7 +753,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 				TargetObjects: []runtime.Object{
 					&corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "node-0",
+							Name: nodeName1,
 							Labels: map[string]string{
 								baremetal.ProviderLabelPrefix: string(bmhuid),
 							},

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -450,7 +450,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			TestCaseBMHToM3M{
 				Host: &bmov1alpha1.BareMetalHost{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "host1",
+						Name:      baremetalHostName,
 						Namespace: namespaceName,
 					},
 					Spec: bmov1alpha1.BareMetalHostSpec{
@@ -470,7 +470,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			TestCaseBMHToM3M{
 				Host: &bmov1alpha1.BareMetalHost{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "host1",
+						Name:      baremetalHostName,
 						Namespace: namespaceName,
 					},
 					Spec: bmov1alpha1.BareMetalHostSpec{},
@@ -523,7 +523,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Metal3Machine in ownerRef",
 			TestCaseM3DToM3M{
 				OwnerRef: &metav1.OwnerReference{
-					Name:       "abc",
+					Name:       metal3machineName,
 					Kind:       "Metal3Machine",
 					APIVersion: infrav1.GroupVersion.String(),
 				},
@@ -543,7 +543,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Wrong Version, should work",
 			TestCaseM3DToM3M{
 				OwnerRef: &metav1.OwnerReference{
-					Name:       "abc",
+					Name:       metal3machineName,
 					Kind:       "Metal3Machine",
 					APIVersion: infrav1.GroupVersion.Group + "/v1blah1",
 				},
@@ -553,7 +553,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Wrong Group, should not work",
 			TestCaseM3DToM3M{
 				OwnerRef: &metav1.OwnerReference{
-					Name:       "abc",
+					Name:       metal3machineName,
 					Kind:       "Metal3Machine",
 					APIVersion: "foo.bar/" + infrav1.GroupVersion.Version,
 				},

--- a/controllers/metal3machinetemplate_controller_test.go
+++ b/controllers/metal3machinetemplate_controller_test.go
@@ -100,10 +100,10 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 				M3Machine: &infrav1.Metal3Machine{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "machine-1",
-						Namespace: "bar",
+						Name:      machineName,
+						Namespace: namespaceName,
 						Annotations: map[string]string{
-							baremetal.HostAnnotation: namespaceName + "/myhost",
+							baremetal.HostAnnotation: namespaceName + "/" + baremetalHostName,
 						},
 					},
 					Spec: infrav1.Metal3MachineSpec{
@@ -135,7 +135,7 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 				M3Machine: &infrav1.Metal3Machine{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "machine-1",
+						Name:      machineName,
 						Namespace: namespace,
 						Annotations: map[string]string{
 							"cluster.x-k8s.io/cloned-from-name":      name,

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -53,11 +53,17 @@ var testEnv *envtest.Environment
 var timestampNow = metav1.Now()
 
 const (
+	baremetalHostName         = "testbaremetalhost"
+	namespaceName             = "controllerns"
+	metal3DataName            = "testmetal3Data"
+	metal3DataTemplateName    = "testmetal3DataTemplate"
+	metal3DataClaimName       = "testmetal3DataClaim"
+	nodeName1                 = "testNodeNam-1"
+	nodeName2                 = "testNodeNam-2"
 	clusterName               = "controllerns_testCluster"
 	metal3ClusterName         = "controllerns_testmetal3Cluster"
 	machineName               = "controllerns_testMachine"
 	metal3machineName         = "controllerns_testmetal3machine"
-	namespaceName             = "controllerns"
 	metal3machineTemplateName = "controllerns_testmetal3machinetemplate"
 )
 
@@ -388,7 +394,7 @@ func newBareMetalHost(bmhName string, spec *bmov1alpha1.BareMetalHostSpec,
 			APIVersion: bmov1alpha1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      bmhName,
+			Name:      baremetalHostName,
 			Namespace: namespaceName,
 			UID:       bmhuid,
 		},


### PR DESCRIPTION
As discussed in https://github.com/metal3-io/cluster-api-provider-metal3/pull/563#discussion_r831825842, the resource names in the unit tests are hard coded. 

This PR parameterizes these values. It also removes the centrally defined objects such as the following. 
```
    testObjectMeta = metav1.ObjectMeta{
        Name:     "",
        Namespace: namespaceName,
    }
```
The problem we are facing is that `testObjectMeta` is used for any resource, such as metal3Machine, Machine, cluster and so on. This creates a problem when a specific test cases needs to change the name or namespace. 