### PR TITLE
🌱 Leave BMO and Ironic configmaps alone

### DIFF
--- a/test/e2e/upgrade_management_cluster_test.go
+++ b/test/e2e/upgrade_management_cluster_test.go
@@ -146,9 +146,6 @@ func upgradeManagementCluster() {
 		_, err = upgradeClusterClientSet.CoreV1().Namespaces().Create(ctx, ironicNamespace, metav1.CreateOptions{})
 		Expect(err).To(BeNil(), "Unable to create the Ironic namespace")
 
-		By("Configure Ironic Configmap")
-		configureIronicConfigmap(true)
-
 		By("Add labels to BMO CRDs")
 		labelBMOCRDs(nil)
 
@@ -157,11 +154,6 @@ func upgradeManagementCluster() {
 
 		By("Install Ironic in the target cluster")
 		installIronicBMO(upgradeClusterProxy, "true", "false")
-
-		By("Restore original BMO configmap")
-		restoreBMOConfigmap()
-		By("Reinstate Ironic Configmap")
-		configureIronicConfigmap(false)
 
 		By("Add labels to BMO CRDs in the target cluster")
 		labelBMOCRDs(upgradeClusterProxy)


### PR DESCRIPTION
**What this PR does / why we need it**:

These configmaps are created/edited from metal3-dev-env when setting up
the environment. It is better to let them stay as they are to avoid
conflicts and mistakes. They are cleaned/reset every time the bootstrap
cluster is lanuched anyway.

Wait for https://github.com/metal3-io/metal3-dev-env/pull/975 before merging this.
