### PR TITLE
Define ObjectMeta metav1.ObjectMeta at Test case level for baremetal package tests

### DIFF
--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -150,7 +150,7 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("requeue error", testCaseReconcile{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3DataSpec{
 					Template: *testObjectReference,
 				},
@@ -252,7 +252,7 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("No Metal3DataTemplate", testCaseCreateSecrets{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3DataSpec{
 					Template: *testObjectReference,
 				},
@@ -261,17 +261,17 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("No Metal3Machine in owner refs", testCaseCreateSecrets{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3DataSpec{
 					Template: *testObjectReference,
 					Claim:    *testObjectReference,
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			dataClaim: &infrav1.Metal3DataClaim{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			expectError: true,
@@ -285,7 +285,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			dataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR,
@@ -302,10 +302,10 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			m3m: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: testObjectReference,
 				},
@@ -325,10 +325,10 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			m3m: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			dataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR,
@@ -345,7 +345,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					MetaData: &infrav1.MetaData{
 						Strings: []infrav1.MetaDataString{
@@ -372,7 +372,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3m: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: testObjectReference,
 				},
@@ -406,7 +406,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					MetaData: &infrav1.MetaData{
 						Strings: []infrav1.MetaDataString{
@@ -457,10 +457,10 @@ var _ = Describe("Metal3Data manager", func() {
 				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			machine: &clusterv1.Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			bmh: &bmov1alpha1.BareMetalHost{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			expectReady:         true,
 			expectedMetadata:    pointer.StringPtr(fmt.Sprintf("String-1: String-1\nproviderid: %s\n", providerid)),
@@ -475,7 +475,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					MetaData: &infrav1.MetaData{
 						Strings: []infrav1.MetaDataString{
@@ -502,7 +502,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3m: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: testObjectReference,
 				},
@@ -522,7 +522,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					MetaData: &infrav1.MetaData{
 						Strings: []infrav1.MetaDataString{
@@ -565,7 +565,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			machine: &clusterv1.Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			dataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR,
@@ -2931,7 +2931,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			DataClaim: &infrav1.Metal3DataClaim{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			ExpectError: true,
@@ -2951,7 +2951,7 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("Object exists", testCaseGetM3Machine{
 			Machine: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			Data: &infrav1.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR,
@@ -2966,13 +2966,13 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("Object exists, dataTemplate nil", testCaseGetM3Machine{
 			Machine: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: nil,
 				},
 			},
 			DataTemplate: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			Data: &infrav1.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR,
@@ -2988,7 +2988,7 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("Object exists, dataTemplate name mismatch", testCaseGetM3Machine{
 			Machine: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
 						Name:      "abcd",
@@ -2997,7 +2997,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			DataTemplate: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			Data: &infrav1.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR,
@@ -3013,7 +3013,7 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("Object exists, dataTemplate namespace mismatch", testCaseGetM3Machine{
 			Machine: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
 						Name:      "abc",
@@ -3022,7 +3022,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			DataTemplate: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			Data: &infrav1.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR,

--- a/baremetal/metal3datatemplate_manager_test.go
+++ b/baremetal/metal3datatemplate_manager_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		}),
 		Entry("indexes", testGetIndexes{
 			template: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec:       infrav1.Metal3DataTemplateSpec{},
 			},
 			indexes: []*infrav1.Metal3Data{

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -48,8 +48,8 @@ var k8sClient client.Client
 var testEnv *envtest.Environment
 
 const (
-	clusterName       = "testCluster"
-	metal3ClusterName = "testmetal3Cluster"
+	clusterName       = "baremetal_testCluster"
+	metal3ClusterName = "baremetal_testmetal3Cluster"
 	namespaceName     = "baremetalns"
 	m3muid            = "11111111-9845-4321-1234-c74be387f57c"
 	bmhuid            = "22222222-9845-4c48-9e49-c74be387f57c"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -32,6 +32,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -410,5 +411,6 @@ func testObjectMeta(name string, namespace string, uid string) metav1.ObjectMeta
 	return metav1.ObjectMeta{
 		Name:      name,
 		Namespace: namespace,
+		UID:       types.UID(uid),
 	}
 }


### PR DESCRIPTION
This PR is specific to the **baremetal** package and is required before parameterizing hard coded resource names.
It mainly removes objects such as the following.

```
    testObjectMeta = metav1.ObjectMeta{
        Name:     "",
        Namespace: namespaceName,
    }
```

The problem we are facing is that objects such as testObjectMeta are used for any resource, such as metal3Machine, Machine, cluster and so on. This creates a problem when a specific test cases needs to change the name or namespace.