### PR TITLE
🌱 Reuse capi upgrade test function

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -58,19 +58,11 @@ source "${M3_DEV_ENV_PATH}/lib/ironic_basic_auth.sh"
 # shellcheck disable=SC1091,SC1090
 source "${M3_DEV_ENV_PATH}/lib/ironic_tls_setup.sh"
 
-if [[ ${GINKGO_FOCUS:-} == "upgrade" ]]; then
-  export CAPI_FROM_RELEASE="${CAPIRELEASE}"
-  export CAPI_TO_RELEASE="${CAPI_TO_RELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v1.2.")}"
-
-  export CAPM3_FROM_RELEASE="${CAPM3RELEASE}"
-  export CAPM3_TO_RELEASE="${CAPM3_TO_RELEASE:-$(get_latest_release "${CAPM3RELEASEPATH}" "v1.2.")}"
-else
-  export CAPI_FROM_RELEASE="${CAPI_FROM_RELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v0.4.")}"
-  export CAPI_TO_RELEASE="${CAPIRELEASE}"
-
-  export CAPM3_FROM_RELEASE="${CAPM3_FROM_RELEASE:-$(get_latest_release "${CAPM3RELEASEPATH}" "v0.5.")}"
-  export CAPM3_TO_RELEASE="${CAPM3RELEASE}"
-fi
+# Parameterize e2e_config
+export CAPI_FROM_RELEASE="${CAPI_FROM_RELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v0.4.")}"
+export CAPI_TO_RELEASE="${CAPIRELEASE}"
+export CAPM3_FROM_RELEASE="${CAPM3_FROM_RELEASE:-$(get_latest_release "${CAPM3RELEASEPATH}" "v0.5.")}"
+export CAPM3_TO_RELEASE="${CAPM3RELEASE}"
 
 # image for live iso testing
 export LIVE_ISO_IMAGE="https://artifactory.nordix.org/artifactory/metal3/images/iso/minimal_linux_live-v2.iso"

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -61,23 +61,13 @@ export CAPM3_VERSION=${CAPM3_VERSION:-"v1beta1"}
 export M3PATH=${M3PATH:-"${HOME}/go/src/github.com/metal3-io"}
 export CAPM3_LOCAL_IMAGE="${CAPM3PATH}"
 
+export PATH=$PATH:$HOME/.krew/bin
+
 # Upgrade test environment vars and config
 if [[ ${GINKGO_FOCUS:-} == "upgrade" ]]; then
-    export CAPI_VERSION="v1alpha4"
-    export CAPM3_VERSION="v1alpha5"
-    # Ironic and BMO images to start from. They will then upgrade to main/latest
-    export IRONIC_TAG="capm3-v0.5.5"
-    export BAREMETAL_OPERATOR_TAG="capm3-v0.5.5"
+  export NUM_NODES=${NUM_NODES:-"5"} 
 fi
-# Override project infra vars that point to
-# the current branch to build capm3 image and crds
-if [[ "${CAPM3_VERSION}" == "v1alpha5" ]]; then
-    export CAPM3BRANCH="release-0.5"
-    # This var is set in project infra to use the current repo location for
-    # building CAPM3 image while upgrade needs an old version
-    unset CAPM3_LOCAL_IMAGE
-    export CAPM3PATH="${M3PATH}/cluster-api-provider-metal3"
-fi
+
 if [[ "${IMAGE_OS}" == "ubuntu" ]]; then
   export UPGRADED_IMAGE_NAME="UBUNTU_22.04_NODE_IMAGE_K8S_${UPGRADED_K8S_VERSION}.qcow2"
   export UPGRADED_RAW_IMAGE_NAME="UBUNTU_22.04_NODE_IMAGE_K8S_${UPGRADED_K8S_VERSION}-raw.img"

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -110,6 +110,9 @@ variables:
   CNI: "/tmp/calico.yaml"
   KUBERNETES_VERSION: "v1.24.0"
   UPGRADED_K8S_VERSION: "v1.24.1"
+  # INIT_WITH_KUBERNETES_VERSION will be used here
+  # https://github.com/kubernetes-sigs/cluster-api/blob/bb377163f141d69b7a61479756ee96891f6670bd/test/e2e/clusterctl_upgrade.go#L170
+  INIT_WITH_KUBERNETES_VERSION: ${FROM_K8S_VERSION}
   CONTROL_PLANE_MACHINE_COUNT: 3
   WORKER_MACHINE_COUNT: 1
   APIVersion: "infrastructure.cluster.x-k8s.io/${CAPM3_VERSION}"
@@ -129,6 +132,8 @@ variables:
   # Pin Calico version
   CALICO_PATCH_RELEASE: "v3.21.0"
   CALICO_MINOR_RELEASE: "v3.21"
+  # Pin CertManager for upgrade tests
+  CERT_MANAGER_RELEASE: v1.5.3
   # Default vars for the template, those values could be overridden by the env-vars.
   CAPI_VERSION: "v1beta1"
   CAPM3_VERSION: "v1beta1"
@@ -149,6 +154,7 @@ variables:
   IMAGE_CHECKSUM_TYPE: "md5"
   IMAGE_USERNAME: "metal3"
   NODE_DRAIN_TIMEOUT: "0s"
+
 intervals:
   default/wait-controllers: ["5m", "10s"]
   default/wait-cluster: ["20m", "30s"] # The second time to check the availibility of the cluster should happen late, so kcp object has time to be created

--- a/test/e2e/upgrade_management_cluster_test.go
+++ b/test/e2e/upgrade_management_cluster_test.go
@@ -1,32 +1,21 @@
 package e2e
 
 import (
-	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 
-	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
-	clusterv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
+	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 	framework "sigs.k8s.io/cluster-api/test/framework"
-	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("When testing cluster upgrade [upgrade]", func() {
-	upgradeManagementCluster()
-})
+const workDir = "/opt/metal3-dev-env/"
 
-func upgradeManagementCluster() {
+var _ = Describe("When testing cluster upgrade v1alpha5 > current [upgrade]", func() {
 	BeforeEach(func() {
 		osType := strings.ToLower(os.Getenv("OS"))
 		Expect(osType).ToNot(Equal(""))
@@ -35,307 +24,131 @@ func upgradeManagementCluster() {
 		// We need to override clusterctl apply log folder to avoid getting our credentials exposed.
 		clusterctlLogFolder = filepath.Join(os.TempDir(), "clusters", bootstrapClusterProxy.GetName())
 	})
-	var (
-		ctx                 = context.TODO()
-		specName            = "metal3"
-		namespace           = "metal3"
-		clusterName         = "test1"
-		workloadClusterName = "test2"
-		clusterctlLogFolder string
-		kubernetesVersion   = e2eConfig.GetVariable(KubernetesVersion)
-	)
-	It("Should create a management cluster and then upgrade capi and capm3", func() {
-		/*---------------------------------------------*
-		| Create a target cluster with v1a4 clusterctl |
-		*----------------------------------------------*/
-		Logf("Starting v1a5 to v1b1 upgrade tests")
-
-		clusterctlBinaryURLTemplate := e2eConfig.GetVariable("INIT_WITH_BINARY")
-		clusterctlBinaryURLReplacer := strings.NewReplacer("{OS}", runtime.GOOS, "{ARCH}", runtime.GOARCH)
-		clusterctlBinaryURL := clusterctlBinaryURLReplacer.Replace(clusterctlBinaryURLTemplate)
-		clusterctlBinaryPath := "/tmp/clusterctltmp"
-
-		Logf("Downloading clusterctl binary from %s", clusterctlBinaryURL)
-		err := downloadFile(clusterctlBinaryPath, clusterctlBinaryURL)
-		Expect(err).ToNot(HaveOccurred(), "failed to download temporary file")
-		defer os.Remove(clusterctlBinaryPath) // clean up
-
-		err = os.Chmod(clusterctlBinaryPath, 0744)
-		Expect(err).ToNot(HaveOccurred(), "failed to chmod temporary file")
-
-		By("Creating a cluster")
-		Logf("Getting the cluster template yaml")
-		upgradeClusterTemplate := clusterctl.ConfigClusterWithBinary(ctx, clusterctlBinaryPath, clusterctl.ConfigClusterInput{
-			KubeconfigPath:       bootstrapClusterProxy.GetKubeconfigPath(),
-			ClusterctlConfigPath: clusterctlConfigPath,
-			// define template variables
-			Namespace:                namespace,
-			ClusterName:              clusterName,
-			KubernetesVersion:        kubernetesVersion,
-			Flavor:                   "ubuntu",
-			ControlPlaneMachineCount: pointer.Int64Ptr(1),
-			WorkerMachineCount:       pointer.Int64Ptr(1),
-			InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
-			// setup clusterctl logs folder
-			LogFolder: clusterctlLogFolder,
-		})
-
-		Expect(upgradeClusterTemplate).ToNot(BeNil(), "Failed to get the cluster template")
-
-		Logf("Applying the cluster template yaml to the cluster")
-
-		Expect(bootstrapClusterProxy.Apply(ctx, upgradeClusterTemplate)).To(Succeed())
-
-		By("Waiting for the machines to be running")
-		// Note: We cannot use waitForNumMachinesInState because these are v1alpha4 Machines!
-		Eventually(func(g Gomega) {
-			n := 0
-			machineList := &clusterv1alpha4.MachineList{}
-			opts := []client.ListOption{
-				client.InNamespace(namespace),
-				client.MatchingLabels{clusterv1.ClusterLabelName: clusterName},
-			}
-			g.Expect(bootstrapClusterProxy.GetClient().List(ctx, machineList, opts...)).To(Succeed())
-			for _, machine := range machineList.Items {
-				if machine.Status.GetTypedPhase() == clusterv1alpha4.MachinePhaseRunning {
-					n++
-				}
-			}
-			g.Expect(n).To(Equal(2))
-		}, e2eConfig.GetIntervals(specName, "wait-worker-nodes")...).Should(Succeed())
-
-		upgradeClusterProxy := bootstrapClusterProxy.GetWorkloadCluster(ctx, namespace, clusterName)
-		upgradeClusterClient := upgradeClusterProxy.GetClient()
-
-		By("Initializing the workload cluster with older versions of providers")
-
-		contract := e2eConfig.GetVariable("CAPI_VERSION")
-
-		clusterctl.InitManagementClusterAndWatchControllerLogs(ctx, clusterctl.InitManagementClusterAndWatchControllerLogsInput{
-			ClusterctlBinaryPath:    clusterctlBinaryPath, // use older version of clusterctl to init the management cluster
-			ClusterProxy:            upgradeClusterProxy,
-			ClusterctlConfigPath:    clusterctlConfigPath,
-			CoreProvider:            e2eConfig.GetProviderLatestVersionsByContract(contract, config.ClusterAPIProviderName)[0],
-			BootstrapProviders:      e2eConfig.GetProviderLatestVersionsByContract(contract, config.KubeadmBootstrapProviderName),
-			ControlPlaneProviders:   e2eConfig.GetProviderLatestVersionsByContract(contract, config.KubeadmControlPlaneProviderName),
-			InfrastructureProviders: e2eConfig.GetProviderLatestVersionsByContract(contract, e2eConfig.InfrastructureProviders()...),
-			LogFolder:               filepath.Join(artifactFolder, "clusters", clusterName),
-		}, e2eConfig.GetIntervals(specName, "wait-controllers")...)
-
-		/*-------------------------------------------------*
-		| Pivot to run ironic/BMO and resources on target |
-		*--------------------------------------------------*/
-		By("Start pivoting")
-		listBareMetalHosts(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
-		listNodes(ctx, upgradeClusterClient)
-
-		By("Remove Ironic containers from the source cluster")
-		ephemeralCluster := os.Getenv("EPHEMERAL_CLUSTER")
-		if ephemeralCluster == KIND {
-			removeIronicContainers()
-		} else {
-			removeIronicDeployment()
+	capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
+		return capi_e2e.ClusterctlUpgradeSpecInput{
+			E2EConfig:                 e2eConfig,
+			ClusterctlConfigPath:      clusterctlConfigPath,
+			BootstrapClusterProxy:     bootstrapClusterProxy,
+			ArtifactFolder:            artifactFolder,
+			SkipCleanup:               true, // TODO(mboukhalfa): Parameterize after merging https://github.com/kubernetes-sigs/cluster-api/pull/7373
+			InitWithProvidersContract: "v1alpha4",
+			InitWithBinary:            e2eConfig.GetVariable("INIT_WITH_BINARY"),
+			PreInit:                   preInitFunc,
+			PreWaitForCluster:         preWaitForCluster,
+			PreUpgrade:                preUpgrade,
+			MgmtFlavor:                osType,
+			WorkloadFlavor:            osType,
 		}
+	})
+})
 
-		By("Create Ironic namespace")
-		upgradeClusterClientSet := upgradeClusterProxy.GetClientSet()
-		ironicNamespace := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: e2eConfig.GetVariable("IRONIC_NAMESPACE"),
-			},
-		}
-		_, err = upgradeClusterClientSet.CoreV1().Namespaces().Create(ctx, ironicNamespace, metav1.CreateOptions{})
-		Expect(err).To(BeNil(), "Unable to create the Ironic namespace")
-
-		By("Add labels to BMO CRDs")
-		labelBMOCRDs(nil)
-
-		By("Install BMO")
-		installIronicBMO(upgradeClusterProxy, "false", "true")
-
-		By("Install Ironic in the target cluster")
-		installIronicBMO(upgradeClusterProxy, "true", "false")
-
-		By("Add labels to BMO CRDs in the target cluster")
-		labelBMOCRDs(upgradeClusterProxy)
-
-		By("Ensure API servers are stable before doing move")
-		Consistently(func() error {
-			kubeSystem := &corev1.Namespace{}
-			return bootstrapClusterProxy.GetClient().Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
-		}, "5s", "100ms").Should(BeNil(), "Failed to assert bootstrap API server stability")
-		Consistently(func() error {
-			kubeSystem := &corev1.Namespace{}
-			return upgradeClusterClient.Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
-		}, "5s", "100ms").Should(BeNil(), "Failed to assert target API server stability")
-		By("Moving the cluster to self hosted")
-
-		cmd := exec.Command(clusterctlBinaryPath, "move", "--to-kubeconfig", upgradeClusterProxy.GetKubeconfigPath(), "-n", namespace, "-v", "10")
+// preWaitForCluster is a hook function that should be called from ClusterctlUpgradeSpec before waiting for the cluster to spin up
+// it creates the needed bmhs in namespace hosting the cluster and export the providerID format for v1alpha5.
+func preWaitForCluster(clusterProxy framework.ClusterProxy, clusterNamespace string, clusterName string) {
+	// Install the split-yaml tool to split our bmhosts_crs.yaml file.
+	installSplitYAML := func() {
+		cmd := exec.Command("bash", "-c", "kubectl krew update; kubectl krew install split-yaml")
 		output, err := cmd.CombinedOutput()
-		Logf("move: %v", string(output))
+		Logf("Download split-yaml:\n %v", string(output))
 		Expect(err).To(BeNil())
+	}
 
-		By("Check that BMHs are in provisioned state")
-		waitForNumBmhInState(ctx, bmov1alpha1.StateProvisioned, waitForNumInput{
-			Client:    upgradeClusterClient,
-			Options:   []client.ListOption{client.InNamespace(namespace)},
-			Replicas:  2,
-			Intervals: e2eConfig.GetIntervals(specName, "wait-bmh-provisioned"),
-		})
-
-		listBareMetalHosts(ctx, upgradeClusterClient, client.InNamespace(namespace))
-		listNodes(ctx, upgradeClusterClient)
-
-		Logf("Apply the available BMHs CRs")
-		cmd = exec.Command("kubectl", "apply", "-f", "/opt/metal3-dev-env/bmhosts_crs.yaml", "-n", namespace, "--kubeconfig", upgradeClusterProxy.GetKubeconfigPath())
-		output, err = cmd.CombinedOutput()
-		Logf("Apply BMHs CRs: %v", string(output))
+	// Split the <fileName> file into <resourceName>.yaml files based on the name of each resource and return list of the filename created
+	// so we can apply limited number on BMH in each namespace.
+	splitYAMLFile := func(fileName string, filePath string) []string {
+		cmd := exec.Command("bash", "-c", fmt.Sprintf("cat %s | kubectl split-yaml -t {{.name}}.yaml -p.", fileName))
+		cmd.Dir = filePath
+		output, err := cmd.CombinedOutput()
+		Logf("splitting %s%s file into multiple files: \n %v", filePath, fileName, string(output))
 		Expect(err).To(BeNil())
+		return strings.Split(string(output), "\n")
+	}
 
-		Logf("Waiting for 2 BMHs to be in Available state")
-		waitForNumBmhInState(ctx, bmov1alpha1.StateAvailable, waitForNumInput{
-			Client:    upgradeClusterClient,
-			Options:   []client.ListOption{client.InNamespace(namespace)},
-			Replicas:  2,
-			Intervals: e2eConfig.GetIntervals(specName, "wait-bmh-available"),
-		})
+	// Create the BMHs needed in the hosting namespace.
+	createBMH := func(clusterProxy framework.ClusterProxy, clusterNamespace string, clusterName string) {
+		installSplitYAML()
+		splitFiles := splitYAMLFile("bmhosts_crs.yaml", workDir)
+		// Check which from which cluster creation this call is coming
+		// if isBootstrapProxy==true then this call when creating the management else we are creating the workload.
+		isBootstrapProxy := !strings.HasPrefix(clusterProxy.GetName(), "clusterctl-upgrade")
+		if isBootstrapProxy {
+			// remove existing bmh from source and apply first 2 in target
+			Logf("remove existing bmh from source")
+			cmd := exec.Command("bash", "-c", "kubectl delete -f bmhosts_crs.yaml  -n metal3")
+			cmd.Dir = workDir
+			output, err := cmd.CombinedOutput()
+			Logf("Remove existing bmhs:\n %v", string(output))
+			Expect(err).To(BeNil())
 
-		listBareMetalHosts(ctx, upgradeClusterClient, client.InNamespace(namespace))
-		listNodes(ctx, upgradeClusterClient)
-
-		/*-------------------------------*
-		| Create a test workload cluster |
-		*--------------------------------*/
-		var (
-			controlPlaneMachineCount = pointer.Int64Ptr(1)
-			workerMachineCount       = pointer.Int64Ptr(1)
-		)
-		// Update CLUSTER_APIENDPOINT_HOST
-		os.Setenv("CLUSTER_APIENDPOINT_HOST", "192.168.111.250")
-
-		By("Creating a test workload cluster")
-
-		Logf("Creating the workload cluster with name %q using (Kubernetes %s, %d control-plane machines, %d worker machines)",
-			workloadClusterName, kubernetesVersion, *controlPlaneMachineCount, *workerMachineCount)
-
-		Logf("Getting the cluster template yaml")
-		workloadClusterTemplate := clusterctl.ConfigClusterWithBinary(ctx, clusterctlBinaryPath, clusterctl.ConfigClusterInput{
-			// pass reference to the management cluster hosting this test
-			KubeconfigPath: upgradeClusterProxy.GetKubeconfigPath(),
-			// pass the clusterctl config file that points to the local provider repository created for this test
-			ClusterctlConfigPath: clusterctlConfigPath,
-
-			// define template variables
-			Namespace:                namespace,
-			ClusterName:              workloadClusterName,
-			Flavor:                   "upgrade-workload",
-			KubernetesVersion:        kubernetesVersion,
-			ControlPlaneMachineCount: controlPlaneMachineCount,
-			WorkerMachineCount:       workerMachineCount,
-			InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
-			// setup clusterctl logs folder
-			LogFolder: filepath.Join(artifactFolder, "clusters", upgradeClusterProxy.GetName()),
-		})
-		Expect(workloadClusterTemplate).ToNot(BeNil(), "Failed to get the cluster template")
-
-		Logf("Applying the cluster template yaml to the cluster")
-		Expect(upgradeClusterProxy.Apply(ctx, workloadClusterTemplate)).To(Succeed())
-
-		By("Waiting for the machines to be running")
-		// Note: We cannot use waitForNumMachinesInState because these are v1alpha4 Machines!
-		Eventually(func(g Gomega) {
-			n := 0
-			machineList := &clusterv1alpha4.MachineList{}
-			opts := []client.ListOption{
-				client.InNamespace(namespace),
-				client.MatchingLabels{clusterv1.ClusterLabelName: workloadClusterName},
+			// Apply secrets and bmhs for [node_0 and node_1] in the management cluster to host the target management cluster
+			for i := 0; i < 4; i++ {
+				resource, err := os.ReadFile(filepath.Join(workDir, splitFiles[i]))
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(clusterProxy.Apply(ctx, resource, []string{"-n", clusterNamespace}...)).ShouldNot(HaveOccurred())
 			}
-			g.Expect(upgradeClusterClient.List(ctx, machineList, opts...)).To(Succeed())
-			for _, machine := range machineList.Items {
-				if machine.Status.GetTypedPhase() == clusterv1alpha4.MachinePhaseRunning {
-					n++
-				}
-			}
-			g.Expect(n).To(Equal(2))
-		}, e2eConfig.GetIntervals(specName, "wait-machine-running")...).Should(Succeed())
-
-		listBareMetalHosts(ctx, upgradeClusterClient, client.InNamespace(namespace))
-
-		By("THE MANAGEMENT CLUSTER WITH OLDER VERSION OF PROVIDERS WORKS!")
-
-		/*--------------------------------------*
-		| Upgrade Ironic and BareMetalOperator  |
-		*---------------------------------------*/
-
-		// TODO: If/when we rework the upgrade test to be able to use CAPI e2e
-		// upgrade test, these two should be included as a PreUpgrade step.
-		// If we do not go that route, we should instead refactor the whole
-		// upgradeManagementCluster function into smaller parts.
-		upgradeIronic(upgradeClusterProxy.GetClientSet())
-		upgradeBMO(upgradeClusterProxy.GetClientSet())
-
-		/*-------------------------------*
-		| Upgrade the management cluster |
-		*--------------------------------*/
-		By("Upgrading providers to the latest version available")
-		By("Get the management cluster images before upgrading")
-		printImages(upgradeClusterProxy)
-
-		Logf("Upgrade management cluster to : %v", clusterv1.GroupVersion.Version)
-		clusterctl.UpgradeManagementClusterAndWait(ctx, clusterctl.UpgradeManagementClusterAndWaitInput{
-			ClusterctlConfigPath: clusterctlConfigPath,
-			ClusterProxy:         upgradeClusterProxy,
-			Contract:             clusterv1.GroupVersion.Version,
-			LogFolder:            filepath.Join(artifactFolder, "clusters", workloadClusterName),
-		}, e2eConfig.GetIntervals(specName, "wait-controllers")...)
-
-		Logf("The target cluster upgraded!")
-
-		By("Get the management cluster images after upgrading")
-		printImages(upgradeClusterProxy)
-
-		By("Upgrade bootstrap cluster")
-		By("Get the management cluster images before upgrading")
-		printImages(bootstrapClusterProxy)
-
-		Logf("Upgrade bootstrap cluster to : %v", clusterv1.GroupVersion.Version)
-		clusterctl.UpgradeManagementClusterAndWait(ctx, clusterctl.UpgradeManagementClusterAndWaitInput{
-			ClusterctlConfigPath: clusterctlConfigPath,
-			ClusterProxy:         bootstrapClusterProxy,
-			Contract:             clusterv1.GroupVersion.Version,
-			LogFolder:            filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName()),
-		}, e2eConfig.GetIntervals(specName, "wait-controllers")...)
-
-		Logf("The source cluster upgraded!")
-
-		By("Get the bootstrap cluster images after upgrading")
-		printImages(bootstrapClusterProxy)
-
-		By("UPGRADE MANAGEMENT CLUSTER PASSED!")
-	})
-
-	AfterEach(func() {
-		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
-	})
-}
-
-func printImages(clusterProxy framework.ClusterProxy) {
-	pods, err := clusterProxy.GetClientSet().CoreV1().Pods("").List(ctx, metav1.ListOptions{})
-	Expect(err).To(BeNil())
-	var images []string
-	for _, pod := range pods.Items {
-		for _, c := range pod.Spec.Containers {
-			exist := false
-			for _, i := range images {
-				if i == c.Image {
-					exist = true
-					break
-				}
-			}
-			if !exist {
-				images = append(images, c.Image)
-				Logf("%v", c.Image)
+		} else {
+			// Apply secrets and bmhs for [node_2, node_3 and node_4] in the management cluster to host workload cluster
+			for i := 4; i < 10; i++ {
+				resource, err := os.ReadFile(filepath.Join(workDir, splitFiles[i]))
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(clusterProxy.Apply(ctx, resource, []string{"-n", clusterNamespace}...)).ShouldNot(HaveOccurred())
 			}
 		}
 	}
+
+	// Create bmhs in the in the namespace that will host the new cluster
+	createBMH(clusterProxy, clusterNamespace, clusterName)
+}
+
+// preInitFunc hook function that should be called from ClusterctlUpgradeSpec before init the management cluster
+// it installs certManager, BMO and Ironic and overrides the default IPs for the workload cluster.
+func preInitFunc(clusterProxy framework.ClusterProxy) {
+	installCertManager := func(clusterProxy framework.ClusterProxy) {
+		certManagerLink := fmt.Sprintf("https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml", e2eConfig.GetVariable("CERT_MANAGER_RELEASE"))
+		err := downloadFile("/tmp/certManager.yaml", certManagerLink)
+		Expect(err).To(BeNil(), "Unable to download certmanager manifest")
+		certManagerYaml, err := os.ReadFile("/tmp/certManager.yaml")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(clusterProxy.Apply(ctx, certManagerYaml)).ShouldNot(HaveOccurred())
+	}
+
+	// install certmanager
+	installCertManager(clusterProxy)
+	// Remove ironic
+	By("Remove Ironic containers from the source cluster")
+	ephemeralCluster := os.Getenv("EPHEMERAL_CLUSTER")
+	if ephemeralCluster == KIND {
+		removeIronicContainers()
+	} else {
+		removeIronicDeployment()
+	}
+	// install bmo
+	By("Install BMO")
+	installIronicBMO(clusterProxy, "false", "true")
+
+	// install ironic
+	By("Install Ironic in the target cluster")
+	installIronicBMO(clusterProxy, "true", "false")
+
+	// Export capi/capm3 versions
+	os.Setenv("CAPI_VERSION", "v1alpha4")
+	os.Setenv("CAPM3_VERSION", "v1alpha5")
+
+	// These exports bellow we need them after applying the management cluster template and before
+	// applying the workload. if exported before it will break creating the management because it uses v1beta1 templates and default IPs.
+	// override the provider id format
+	os.Setenv("PROVIDER_ID_FORMAT", "metal3://{{ ds.meta_data.uuid }}")
+	// override default IPs for the workload cluster
+	os.Setenv("CLUSTER_APIENDPOINT_HOST", "192.168.111.250")
+	os.Setenv("BAREMETALV4_POOL_RANGE_START", "192.168.111.201")
+	os.Setenv("BAREMETALV4_POOL_RANGE_END", "192.168.111.240")
+	os.Setenv("PROVISIONING_POOL_RANGE_START", "172.22.0.201")
+	os.Setenv("PROVISIONING_POOL_RANGE_END", "172.22.0.240")
+}
+
+// preUpgrade hook should be called from ClusterctlUpgradeSpec before upgrading the management cluster
+// it upgrades Ironic and BMO before upgrading the providers.
+func preUpgrade(clusterProxy framework.ClusterProxy) {
+	upgradeIronic(clusterProxy.GetClientSet())
+	upgradeBMO(clusterProxy.GetClientSet())
 }


### PR DESCRIPTION
This PR remove the custom upgrade test and reuse [clusterctl_upgrade](https://github.com/kubernetes-sigs/cluster-api/blob/release-1.2/test/e2e/clusterctl_upgrade.go) test from capi.