### PR TITLE
🌱 Rearrange e2e upgrade tests

### DIFF
--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -62,13 +62,16 @@ export UPGRADE_TEST=${UPGRADE_TEST:-false}
 if $UPGRADE_TEST; then
     export CAPI_VERSION="v1alpha4"
     export CAPM3_VERSION="v1alpha5"
+    # Ironic and BMO images to start from. They will then upgrade to main/latest
+    export IRONIC_TAG="capm3-v0.5.5"
+    export BAREMETAL_OPERATOR_TAG="capm3-v0.5.5"
 fi
-# Override project infra vars that point to 
+# Override project infra vars that point to
 # the current branch to build capm3 image and crds
-if [[ "${CAPM3_VERSION}" == "v1alpha5" ]]; then 
+if [[ "${CAPM3_VERSION}" == "v1alpha5" ]]; then
     export CAPM3BRANCH="release-0.5"
-    # This var is set in project infra to use the current repo location for 
-    # building CAPM3 image while upgrade needs an old version 
+    # This var is set in project infra to use the current repo location for
+    # building CAPM3 image while upgrade needs an old version
     unset CAPM3_LOCAL_IMAGE
     export CAPM3PATH="${M3PATH}/cluster-api-provider-metal3"
 fi

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -79,8 +79,6 @@ var _ = Describe("Workload cluster creation", func() {
 				remediation()
 				if !ephemeralTest {
 					pivoting()
-					upgradeBMO(targetCluster.GetClientSet())
-					upgradeIronic(targetCluster.GetClientSet())
 					certRotation(targetCluster.GetClientSet(), targetCluster.GetClient())
 					nodeReuse(targetCluster.GetClient())
 					rePivoting()

--- a/test/e2e/upgrade_management_cluster_test.go
+++ b/test/e2e/upgrade_management_cluster_test.go
@@ -251,6 +251,17 @@ func upgradeManagementCluster() {
 
 	By("THE MANAGEMENT CLUSTER WITH OLDER VERSION OF PROVIDERS WORKS!")
 
+	/*--------------------------------------*
+	| Upgrade Ironic and BareMetalOperator  |
+	*---------------------------------------*/
+
+	// TODO: If/when we rework the upgrade test to be able to use CAPI e2e
+	// upgrade test, these two should be included as a PreUpgrade step.
+	// If we do not go that route, we should instead refactor the whole
+	// upgradeManagementCluster function into smaller parts.
+	upgradeIronic(upgradeClusterProxy.GetClientSet())
+	upgradeBMO(upgradeClusterProxy.GetClientSet())
+
 	/*-------------------------------*
 	| Upgrade the management cluster |
 	*--------------------------------*/


### PR DESCRIPTION
**What this PR does / why we need it**:

Move the Ironic and BMO upgrade tests to the e2e upgrade test and run them before the CAPM3 upgrade test.


What should we do about the ephemeral test? Should we still run BMO and Ironic upgrade there? 