### PR TITLE
:seedling: Add judgment before output log

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -1046,7 +1046,9 @@ func (m *MachineManager) nodeReuseLabelExists(ctx context.Context, host *bmov1al
 		return false
 	}
 	_, ok := host.Labels[nodeReuseLabelName]
-	m.Log.Info(fmt.Sprintf("nodeReuseLabelName exists on the host %v", host.Name))
+	if ok {
+		m.Log.Info(fmt.Sprintf("nodeReuseLabelName exists on the host %v", host.Name))
+	}
 	return ok
 }
 


### PR DESCRIPTION
Signed-off-by: Zhou Hao <zhouhao@fujitsu.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Confirm that the host contains nodeReuseLabelName and then output the relevant log information.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
