### PR TITLE
:seedling: Increase judgment to avoid panic

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -1052,7 +1052,7 @@ func (m *MachineManager) nodeReuseLabelExists(ctx context.Context, host *bmov1al
 
 // getBMCSecret will return the BMCSecret associated with BMH.
 func (m *MachineManager) getBMCSecret(ctx context.Context, host *bmov1alpha1.BareMetalHost) (*corev1.Secret, error) {
-	if host.Spec.BMC.CredentialsName == "" {
+	if host == nil || host.Spec.BMC.CredentialsName == "" {
 		return nil, nil
 	}
 	tmpBMCSecret := corev1.Secret{}


### PR DESCRIPTION
Signed-off-by: Zhou Hao <zhouhao@fujitsu.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Avoid panic when host is nil.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
