### PR TITLE
:seedling: Add url validation to the subfield of image

### DIFF
--- a/api/v1beta1/metal3machine_types.go
+++ b/api/v1beta1/metal3machine_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"net/url"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -90,6 +92,19 @@ func (s *Metal3MachineSpec) IsValid() error {
 	}
 	if len(missing) > 0 {
 		return errors.Errorf("Missing fields from ProviderSpec: %v", missing)
+	}
+
+	invalid := []string{}
+	_, err := url.ParseRequestURI(s.Image.URL)
+	if err != nil {
+		invalid = append(invalid, "Image.URL")
+	}
+	_, err = url.ParseRequestURI(s.Image.Checksum)
+	if err != nil {
+		invalid = append(invalid, "Image.Checksum")
+	}
+	if len(invalid) > 0 {
+		return errors.Errorf("Invalid fields from ProviderSpec: %v", invalid)
 	}
 	return nil
 }

--- a/api/v1beta1/metal3machine_types_test.go
+++ b/api/v1beta1/metal3machine_types_test.go
@@ -148,6 +148,32 @@ func TestSpecIsValid(t *testing.T) {
 			ErrorExpected: false,
 			Name:          "HostSelector Multiple MatchLabels provided",
 		},
+		{
+			Spec: Metal3MachineSpec{
+				Image: Image{
+					URL:      "test url",
+					Checksum: "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2.md5sum",
+				},
+				UserData: &corev1.SecretReference{
+					Name: "worker-user-data",
+				},
+			},
+			ErrorExpected: true,
+			Name:          "Invalid URL Image.URL",
+		},
+		{
+			Spec: Metal3MachineSpec{
+				Image: Image{
+					URL:      "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2",
+					Checksum: "test url",
+				},
+				UserData: &corev1.SecretReference{
+					Name: "worker-user-data",
+				},
+			},
+			ErrorExpected: true,
+			Name:          "Invalid URL Image.Checksum",
+		},
 	}
 
 	for _, tc := range cases {

--- a/controllers/metal3machine_controller_integration_test.go
+++ b/controllers/metal3machine_controller_integration_test.go
@@ -495,8 +495,8 @@ var _ = Describe("Reconcile metal3machine", func() {
 					newMetal3Machine(
 						metal3machineName, m3mMetaWithOwnerRef(), &infrav1.Metal3MachineSpec{
 							Image: infrav1.Image{
-								Checksum: "abcd",
-								URL:      "abcd",
+								Checksum: "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2.md5sum",
+								URL:      "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2",
 								// Checking the pointers,
 								// CheckBMHostProvisioned is true
 								ChecksumType: pointer.StringPtr("sha512"),
@@ -535,8 +535,8 @@ var _ = Describe("Reconcile metal3machine", func() {
 					newMetal3Machine(
 						metal3machineName, m3mMetaWithOwnerRef(), &infrav1.Metal3MachineSpec{
 							Image: infrav1.Image{
-								Checksum: "abcd",
-								URL:      "abcd",
+								Checksum: "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2.md5sum",
+								URL:      "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2",
 								// No ChecksumType and DiskFormat given to test without them
 								// CheckBMHostProvisioned is true
 							},
@@ -569,8 +569,8 @@ var _ = Describe("Reconcile metal3machine", func() {
 						metal3machineName, m3mMetaWithAnnotation(),
 						&infrav1.Metal3MachineSpec{
 							Image: infrav1.Image{
-								Checksum: "abcd",
-								URL:      "abcd",
+								Checksum: "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2.md5sum",
+								URL:      "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2",
 							},
 						}, nil, false,
 					),
@@ -621,8 +621,8 @@ var _ = Describe("Reconcile metal3machine", func() {
 						&infrav1.Metal3MachineSpec{
 							ProviderID: pointer.StringPtr(providerID),
 							Image: infrav1.Image{
-								Checksum: "abcd",
-								URL:      "abcd",
+								Checksum: "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2.md5sum",
+								URL:      "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2",
 							},
 						}, nil, false,
 					),
@@ -681,8 +681,8 @@ var _ = Describe("Reconcile metal3machine", func() {
 				Objects: []client.Object{
 					newMetal3Machine(metal3machineName, m3mMetaWithAnnotation(), &infrav1.Metal3MachineSpec{
 						Image: infrav1.Image{
-							Checksum: "abcd",
-							URL:      "abcd",
+							Checksum: "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2.md5sum",
+							URL:      "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2",
 						},
 					}, nil, false),
 					machineWithBootstrap(),


### PR DESCRIPTION

Signed-off-by: Zhou Hao <zhouhao@fujitsu.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Verify that the values of Image.URL and Image.Checksum are valid urls.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
