### PR TITLE
🌱 Add host nil log info to machine manager Delete function

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -502,8 +502,12 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if host == nil {
+		m.Log.Info("host not found for metal3machine %s", m.Metal3Machine.Name)
+		return nil
+	}
 
-	if host != nil && host.Spec.ConsumerRef != nil {
+	if host.Spec.ConsumerRef != nil {
 		// don't remove the ConsumerRef if it references some other  metal3 machine
 		if !consumerRefMatches(host.Spec.ConsumerRef, m.Metal3Machine) {
 			m.Log.Info("host already associated with another metal3 machine",


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

When deleting a metal3 machine, print log info if the host is not found.

Signed-off-by: Zhou Hao <zhouhao@fujitsu.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
