### PR TITLE
🌱 Add kubesec for CAPM3

### DIFF
--- a/.github/workflows/kubesec.yml
+++ b/.github/workflows/kubesec.yml
@@ -1,0 +1,58 @@
+name: Kubesec
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '30 7 * * 3'
+
+jobs:
+  setup:
+    runs-on: ubuntu-20.04
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Collect all yaml
+        id: list_yaml
+        run: |
+          LIST_YAML="$(find * -type f -name '*.yaml' ! -name "clusterctl-cluster.yaml")"
+          echo "::set-output name=value::$(IFS=$','; echo $LIST_YAML | jq -cnR '[inputs | select(length>0)]'; IFS=$'\n')"
+    outputs:
+      matrix: ${{ steps.list_yaml.outputs.value }}
+
+  lint:
+    needs: [ setup ]
+    name: Kubesec
+    runs-on: ubuntu-20.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      matrix:
+        value: ${{ fromJson(needs.setup.outputs.matrix) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run kubesec scanner
+        uses: controlplaneio/kubesec-action@43d0ddff5ffee89a6bb9f29b64cd865411137b14
+        with:
+          input: ${{ matrix.value }}
+          format: template
+          template: template/sarif.tpl
+          output: ${{ matrix.value }}.sarif
+          exit-code: "0"
+
+      - name: Save result into a variable
+        id: save_result
+        run: echo "::set-output name=result::$(cat ${{ matrix.value }}.sarif | jq -c '.runs')"
+
+      - name: Upload Kubesec scan results to GitHub Security tab
+        if: ${{ steps.save_result.outputs.result != '[]' }}
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: ${{ matrix.value }}.sarif

--- a/template/sarif.tpl
+++ b/template/sarif.tpl
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "version": "2.1.0",
+  "runs": [
+    {{- $run_first := true }}
+    {{- range $report_index, $report := . }}
+    {{- if and $report.Valid (not (eq $report.Message "This resource kind is not supported by kubesec")) -}}
+      {{- if $run_first -}}
+        {{- $run_first = false -}}
+      {{ else -}}
+        ,
+      {{- end }}
+    {
+      "tool": {
+        "driver": {
+          "name": "Kubesec",
+          "fullName": "Kubesec Kubernetes Resource Security Policy Validator",
+          "rules": [
+        {{- $rule_first := true }}
+          {{- range .Rules }}
+            {{- if $rule_first -}}
+              {{- $rule_first = false -}}
+            {{ else -}}
+              ,
+            {{- end }}
+            {
+              "id": "{{ .ID }}",
+              "shortDescription": {
+                "text": "{{ .Reason }}"
+              },
+              "messageStrings": {
+                "selector": {
+                  "text": {{ escapeString .Selector | printf "%q" }}
+                }
+              },
+              "properties": {
+                "points": "{{ .Points }}"
+              }
+            }
+          {{- end -}}
+          ]
+        }
+      },
+      "results": [
+      {{- $result_first := true }}
+      {{- range $result_index, $res := joinSlices .Scoring.Advise .Scoring.Critical -}}
+        {{- if $result_first -}}
+          {{- $result_first = false -}}
+        {{ else -}}
+          ,
+        {{- end }}
+        {
+          "ruleId": "{{ $res.ID }}",
+          "level": "warning",
+          "message": {
+            "text": {{ endWithPeriod $res.Reason | printf "%q" }},
+            "properties": {
+              "score": "{{ $res.Points }}",
+              "selector": {{ escapeString $res.Selector | printf "%q" }}
+            }
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "{{ $report.FileName }}"
+                }
+              }
+            }
+          ]
+        }
+      {{- end -}}
+      ],
+      "columnKind": "utf16CodeUnits"
+    }
+  {{- end -}}
+  {{- end }}
+  ]
+}


### PR DESCRIPTION
Kubesec is a security risk analysis tool for Kubernetes manifest files and this PR is going to add a github action script to CAPM3. All the manifest files is going to be scanned by Kubesec weekly.
1.  [Github action test in Nordix](https://github.com/Nordix/cluster-api-provider-metal3/actions/runs/2280892391)
2. [Test result in Nordix](https://github.com/Nordix/cluster-api-provider-metal3/security/code-scanning?query=is%3Aopen+branch%3Aadd-kubesec-moshiur)

**Known issue:**  Kubesec scan on `examples/clusterctl-templates/clusterctl-cluster.yaml` will fail because of two variable used in the file namely:  `${CTLPLANE_KUBEADM_EXTRA_CONFIG} `in line 67 and `${WORKERS_KUBEADM_EXTRA_CONFIG}` in line 152 which includes entries as yaml.  The reason is kubesec is scanning each yaml file content and cannot interpret the value to yaml entries. So we are ignoring that file from the scan.