### PR TITLE
:seedling: Improve the verification of Image

### DIFF
--- a/api/v1beta1/metal3machine_types.go
+++ b/api/v1beta1/metal3machine_types.go
@@ -87,7 +87,8 @@ func (s *Metal3MachineSpec) IsValid() error {
 	if s.Image.URL == "" {
 		missing = append(missing, "Image.URL")
 	}
-	if s.Image.Checksum == "" {
+	// Checksum is not required for live-iso.
+	if (s.Image.DiskFormat == nil || *s.Image.DiskFormat != "live-iso") && s.Image.Checksum == "" {
 		missing = append(missing, "Image.Checksum")
 	}
 	if len(missing) > 0 {
@@ -99,9 +100,11 @@ func (s *Metal3MachineSpec) IsValid() error {
 	if err != nil {
 		invalid = append(invalid, "Image.URL")
 	}
-	_, err = url.ParseRequestURI(s.Image.Checksum)
-	if err != nil {
-		invalid = append(invalid, "Image.Checksum")
+	if s.Image.DiskFormat == nil || *s.Image.DiskFormat != "live-iso" {
+		_, err = url.ParseRequestURI(s.Image.Checksum)
+		if err != nil {
+			invalid = append(invalid, "Image.Checksum")
+		}
 	}
 	if len(invalid) > 0 {
 		return errors.Errorf("Invalid fields from ProviderSpec: %v", invalid)

--- a/api/v1beta1/metal3machine_types_test.go
+++ b/api/v1beta1/metal3machine_types_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestSpecIsValid(t *testing.T) {
+	diskFormat := "live-iso"
 	cases := []struct {
 		Spec          Metal3MachineSpec
 		ErrorExpected bool
@@ -173,6 +174,19 @@ func TestSpecIsValid(t *testing.T) {
 			},
 			ErrorExpected: true,
 			Name:          "Invalid URL Image.Checksum",
+		},
+		{
+			Spec: Metal3MachineSpec{
+				Image: Image{
+					URL:        "http://172.22.0.1/images/rhcos.iso",
+					DiskFormat: &diskFormat,
+				},
+				UserData: &corev1.SecretReference{
+					Name: "worker-user-data",
+				},
+			},
+			ErrorExpected: false,
+			Name:          "Valid spec with live-iso diskFormat",
 		},
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Add verification processing when DiskFormat is live-iso.
Checksum is not required for live-iso.

Signed-off-by: Zhou Hao <zhouhao@fujitsu.com>
