### PR TITLE
 🐛 Handle node search based on label even when bmhID of providerID is overriden.

### DIFF
--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -2575,7 +2575,7 @@ var _ = Describe("Metal3Machine manager", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 
-				err = machineMgr.SetNodeProviderID(context.TODO(), tc.HostID,
+				err = machineMgr.SetNodeProviderID(context.TODO(), &tc.HostID,
 					&tc.ExpectedProviderID, m,
 				)
 
@@ -2668,7 +2668,7 @@ var _ = Describe("Metal3Machine manager", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 
-				err = machineMgr.SetNodeProviderID(context.TODO(), tc.HostID,
+				err = machineMgr.SetNodeProviderID(context.TODO(), &tc.HostID,
 					&tc.ExpectedProviderID, m,
 				)
 

--- a/baremetal/mocks/zz_generated.metal3machine_manager.go
+++ b/baremetal/mocks/zz_generated.metal3machine_manager.go
@@ -251,7 +251,7 @@ func (mr *MockMachineManagerInterfaceMockRecorder) SetFinalizer() *gomock.Call {
 }
 
 // SetNodeProviderID mocks base method.
-func (m *MockMachineManagerInterface) SetNodeProviderID(arg0 context.Context, arg1 string, arg2 *string, arg3 baremetal.ClientGetter) error {
+func (m *MockMachineManagerInterface) SetNodeProviderID(arg0 context.Context, arg1, arg2 *string, arg3 baremetal.ClientGetter) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetNodeProviderID", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-logr/logr"
 	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
@@ -263,13 +262,10 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 				"failed to get the providerID for the metal3machine", errType,
 			)
 		}
-		if bmhID != nil {
-			providerID = fmt.Sprintf("%s%s", baremetal.ProviderIDPrefix, *bmhID)
-		}
 	}
-	if bmhID != nil {
+	if providerID != "" || bmhID != nil {
 		// Set the providerID on the node if no Cloud provider
-		err = machineMgr.SetNodeProviderID(ctx, *bmhID, &providerID, r.CapiClientGetter)
+		err = machineMgr.SetNodeProviderID(ctx, bmhID, &providerID, r.CapiClientGetter)
 		if err != nil {
 			machineMgr.SetConditionMetal3MachineToFalse(infrav1.KubernetesNodeReadyCondition, infrav1.SettingProviderIDOnNodeFailedReason, clusterv1.ConditionSeverityError, err.Error())
 			return checkMachineError(machineMgr, err,

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -121,11 +121,13 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 
 	// The ID is available (GetBaremetalHostID did not return nil)
 	if tc.BMHIDSet {
+		provID := providerID
 		if tc.GetProviderIDFails {
 			m.EXPECT().GetProviderIDAndBMHID().Return("", nil)
 			m.EXPECT().GetBaremetalHostID(context.TODO()).Return(
 				pointer.StringPtr(string(bmhuid)), nil,
 			)
+			provID = ""
 		} else {
 			m.EXPECT().GetProviderIDAndBMHID().Return(
 				providerID, pointer.StringPtr(string(bmhuid)),
@@ -136,7 +138,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		// if we fail to set it on the node, we do not go further
 		if tc.SetNodeProviderIDFails {
 			m.EXPECT().
-				SetNodeProviderID(context.TODO(), string(bmhuid), &providerID, nil).
+				SetNodeProviderID(context.TODO(), gomock.Eq(pointer.StringPtr(string(bmhuid))), gomock.Eq(&provID), nil).
 				Return(errors.New("Failed"))
 			m.EXPECT().SetProviderID(string(bmhuid)).MaxTimes(0)
 			m.EXPECT().SetError(gomock.Any(), gomock.Any())
@@ -147,9 +149,9 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 
 		// we successfully set it on the node
 		m.EXPECT().
-			SetNodeProviderID(context.TODO(), string(bmhuid), &providerID, nil).
+			SetNodeProviderID(context.TODO(), gomock.Eq(pointer.StringPtr(string(bmhuid))), gomock.Eq(&provID), nil).
 			Return(nil)
-		m.EXPECT().SetProviderID(providerID)
+		m.EXPECT().SetProviderID(provID)
 
 		// We did not get an id (got nil), so we'll requeue and not go further
 	} else {
@@ -157,7 +159,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		m.EXPECT().GetBaremetalHostID(context.TODO()).Return(nil, nil)
 
 		m.EXPECT().
-			SetNodeProviderID(context.TODO(), bmhuid, &providerID, nil).
+			SetNodeProviderID(context.TODO(), gomock.Eq(pointer.StringPtr(string(bmhuid))), gomock.Eq(&providerID), nil).
 			MaxTimes(0)
 	}
 
@@ -266,7 +268,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				ExpectRequeue: false,
 				GetBMHIDFails: true,
 			}),
-			Entry("BMH ID set", reconcileNormalTestCase{
+			Entry("BMH ID set, GetProviderID fails", reconcileNormalTestCase{
 				ExpectError:   false,
 				ExpectRequeue: false,
 				BMHIDSet:      true,


### PR DESCRIPTION
currently, the controller is using the new providerID format to do a label based search of the node.
This does not work if  a node with the old providerID `(metal3://bmhID) `was wrongly overwritten with the new format providerID.

This PR fixes this issue and updates tests accordingly.