### PR TITLE
🌱  Add dead link linter github workflow

### DIFF
--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -1,0 +1,21 @@
+name: Check Markdown links
+
+on:
+  push:
+    branches:
+      - add-deadlink-workflow/furkat
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    paths:
+      - '**.md'
+
+jobs:
+  markdown-link-check:
+    name: Broken Links
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        config-file: .markdownlinkcheck.json

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -1,9 +1,6 @@
 name: Check Markdown links
 
 on:
-  push:
-    branches:
-      - add-deadlink-workflow/furkat
   pull_request:
     types: [opened, edited, synchronize, reopened]
     paths:

--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -1,0 +1,17 @@
+{
+    "ignorePatterns": [{
+        "pattern": "^http://localhost"
+    }],
+    "httpHeaders": [{
+        "comment": "Workaround as suggested here: https://github.com/tcort/markdown-link-check/issues/201",
+        "urls": ["https://docs.github.com/"],
+        "headers": {
+            "Accept-Encoding": "zstd, br, gzip, deflate"
+        }
+    }],
+    "timeout": "10s",
+    "retryOn429": true,
+    "retryCount": 5,
+    "fallbackRetryDelay": "30s",
+    "aliveStatusCodes": [200, 206]
+}

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -54,7 +54,7 @@ Then start Tilt:
 make tilt-up
 ```
 
-The Tilt dashboard can be accessed at <http://127.0.0.1:10350>. If tilt is running remotely, it can be accessed using ssh tunneling. An example of ```~/.ssh/config```  is show below.
+The Tilt dashboard can be accessed at <http://localhost:10350>. If tilt is running remotely, it can be accessed using ssh tunneling. An example of ```~/.ssh/config```  is show below.
 
 ```bash
 Host tiltvm
@@ -107,7 +107,7 @@ API (CAPI) repository and configuring Tilt to use `kind` to deploy the cluster
 api management components.
 
 > you may wish to checkout out the correct version of CAPI to match the
-[version used in CAPM3](go.mod)
+[version used in CAPM3](../go.mod)
 
 Note that `tilt up` will be run from the `cluster-api repository` directory and
 the `tilt-settings.json` file will point back to the

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -51,7 +51,7 @@ For version v0.x.y:
    NB: `origin` should be the name of the remote pointing to
    `github.com/metal3-io/cluster-api-provider-metal3`
 1. Run `make release` to build artifacts (the image is automatically built by CI)
-1. [Create a release in GitHub](https://help.github.com/en/github/administering-a-repository/creating-releases)
+1. [Create a release in GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
    that contains the elements listed above that have been created in the `out`
    folder
 1. Create a branch `release-0.x` for a minor release for backports and bug fixes.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add dead link linter github workflow and fix some dead links. This github action fails on broken links when *.md files are modified.


