### PR TITLE
Make e2e ginkgo fail fast 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ e2e-tests: e2e-substitutions cluster-templates ## This target should be called f
 		$(CONTAINER_RUNTIME) pull $$image; \
 	done
 	time go test -v -timeout 24h -tags=e2e ./test/e2e/... -args \
-		-ginkgo.v -ginkgo.trace -ginkgo.progress -ginkgo.noColor=$(GINKGO_NOCOLOR) \
+		-ginkgo.v -ginkgo.trace -ginkgo.progress -ginkgo.failFast -ginkgo.noColor=$(GINKGO_NOCOLOR) \
 		-ginkgo.focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) \
 		-e2e.artifacts-folder="$(ARTIFACTS)" \
 		-e2e.config="$(E2E_CONF_FILE_ENVSUBST)" \


### PR DESCRIPTION
Since we have an issue cleaning the cluster if a test failed it is confusing to run the next tests after a failure since they will definitely fail and override some logs, this PR adds fail fast to ginkgo to stop testing once a spec fails