### PR TITLE
🐛 Move dev-env cleaning to the makefile so it get triggered from the pipeline cleaning stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -585,7 +585,10 @@ clean-examples: ## Remove all the temporary files generated in the examples fold
 	rm -rf examples/_out/
 	rm -f examples/provider-components/provider-components-*.yaml
 
+WORKING_DIR = /opt/metal3-dev-env
+M3_DEV_ENV_PATH ?= $(WORKING_DIR)/metal3-dev-env
 clean-e2e:
+	$(MAKE) clean -C $(M3_DEV_ENV_PATH)
 	rm -rf $(E2E_OUT_DIR)
 
 .PHONY: verify

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -74,8 +74,3 @@ fi
 
 # run e2e tests
 make e2e-tests
-
-# Clean devenv
-pushd "${M3_DEV_ENV_PATH}"  || exit 1
-make clean
-popd || exit 1


### PR DESCRIPTION
Currently the e2e CI tarball does not contain the serial-logs because they got cleaned before the logs collection stage.
This PR fix this issue by making the dev-env cleaning triggered from the pipeline cleaning stage after collecting the logs
