### PR TITLE
Back-port to v1alpha5 forward

### DIFF
--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -41,12 +41,6 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-const (
-	m3machine   = "metal3machine"
-	host        = "baremetalhost"
-	capimachine = "machine"
-)
-
 // DataManagerInterface is an interface for a DataManager
 type DataManagerInterface interface {
 	SetFinalizer()

--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -41,7 +41,11 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-const providerIDKey = "provideruid"
+const (
+	m3machine   = "metal3machine"
+	host        = "baremetalhost"
+	capimachine = "machine"
+)
 
 // DataManagerInterface is an interface for a DataManager
 type DataManagerInterface interface {
@@ -1194,12 +1198,6 @@ func renderMetaData(m3d *capm3.Metal3Data, m3dt *capm3.Metal3DataTemplate,
 		metadata[entry.Key] = entry.Value
 	}
 
-	// set provideruid field
-	bmhUID := string(bmh.GetUID())
-	m3mUID := string(m3m.GetUID())
-	provideruid := BuildProviderIDToNodes(bmhUID, m3mUID)
-	metadata[providerIDKey] = provideruid
-
 	return yaml.Marshal(metadata)
 }
 
@@ -1276,12 +1274,4 @@ func fetchM3IPClaim(ctx context.Context, cl client.Client, mLog logr.Logger,
 		}
 	}
 	return metal3IPClaim, nil
-}
-
-// BuildProviderIDToNodes generates providerID by combining bmhuid and m3muid.
-func BuildProviderIDToNodes(bmhuid string, m3muid string) string {
-	parts := strings.Split(m3muid, "-")
-	firstBlock := parts[0]
-	provideruid := fmt.Sprintf("%s_%s", bmhuid, firstBlock)
-	return provideruid
 }

--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -1197,7 +1197,8 @@ func renderMetaData(m3d *capm3.Metal3Data, m3dt *capm3.Metal3DataTemplate,
 	for _, entry := range m3dt.Spec.MetaData.Strings {
 		metadata[entry.Key] = entry.Value
 	}
-
+	providerid := fmt.Sprintf("%s/%s/%s", m3dt.GetNamespace(), bmh.GetUID(), m3m.GetUID())
+	metadata["providerid"] = providerid
 	return yaml.Marshal(metadata)
 }
 

--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -41,6 +41,8 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+const providerIDKey = "provideruid"
+
 // DataManagerInterface is an interface for a DataManager
 type DataManagerInterface interface {
 	SetFinalizer()
@@ -1192,6 +1194,12 @@ func renderMetaData(m3d *capm3.Metal3Data, m3dt *capm3.Metal3DataTemplate,
 		metadata[entry.Key] = entry.Value
 	}
 
+	// set provideruid field
+	bmhUID := string(bmh.GetUID())
+	m3mUID := string(m3m.GetUID())
+	provideruid := BuildProviderIDToNodes(bmhUID, m3mUID)
+	metadata[providerIDKey] = provideruid
+
 	return yaml.Marshal(metadata)
 }
 
@@ -1268,4 +1276,12 @@ func fetchM3IPClaim(ctx context.Context, cl client.Client, mLog logr.Logger,
 		}
 	}
 	return metal3IPClaim, nil
+}
+
+// BuildProviderIDToNodes generates providerID by combining bmhuid and m3muid.
+func BuildProviderIDToNodes(bmhuid string, m3muid string) string {
+	parts := strings.Split(m3muid, "-")
+	firstBlock := parts[0]
+	provideruid := fmt.Sprintf("%s_%s", bmhuid, firstBlock)
+	return provideruid
 }

--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -1197,7 +1197,7 @@ func renderMetaData(m3d *capm3.Metal3Data, m3dt *capm3.Metal3DataTemplate,
 	for _, entry := range m3dt.Spec.MetaData.Strings {
 		metadata[entry.Key] = entry.Value
 	}
-	providerid := fmt.Sprintf("%s/%s/%s", m3dt.GetNamespace(), bmh.GetUID(), m3m.GetUID())
+	providerid := fmt.Sprintf("%s/%s/%s", m3m.GetNamespace(), bmh.GetName(), m3m.GetName())
 	metadata["providerid"] = providerid
 	return yaml.Marshal(metadata)
 }

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -26,7 +26,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	bmo "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1alpha5"
 	infrav1alpha5 "github.com/metal3-io/cluster-api-provider-metal3/api/v1alpha5"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -131,9 +130,9 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 		}),
 		Entry("requeue error", testCaseReconcile{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, m3duid),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Template: *testObjectReference(metal3DataTemplateName),
 				},
 			},
@@ -234,104 +233,104 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 		}),
 		Entry("No Metal3DataTemplate", testCaseCreateSecrets{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, m3duid),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Template: *testObjectReference(metal3DataTemplateName),
 				},
 			},
 			expectRequeue: true,
 		}),
 		Entry("No Metal3Machine in owner refs", testCaseCreateSecrets{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, m3duid),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Template: *testObjectReference(metal3DataTemplateName),
 					Claim:    *testObjectReference(metal3DataClaimName),
 				},
 			},
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
 			},
-			dataClaim: &infrav1.Metal3DataClaim{
+			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMeta(metal3DataClaimName, namespaceName, m3dcuid),
-				Spec:       infrav1.Metal3DataClaimSpec{},
+				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
 			},
 			expectError: true,
 		}),
 		Entry("No Metal3Machine", testCaseCreateSecrets{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Template: *testObjectReference(metal3DataTemplateName),
 					Claim:    *testObjectReference(metal3DataClaimName),
 				},
 			},
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
 			},
-			dataClaim: &infrav1.Metal3DataClaim{
+			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
-				Spec:       infrav1.Metal3DataClaimSpec{},
+				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
 			},
 			expectRequeue: true,
 		}),
 		Entry("No Secret needed", testCaseCreateSecrets{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Template: *testObjectReference(metal3DataTemplateName),
 					Claim:    *testObjectReference(metal3DataClaimName),
 				},
 			},
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
 			},
-			m3m: &infrav1.Metal3Machine{
+			m3m: &infrav1alpha5.Metal3Machine{
 				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, m3muid),
-				Spec: infrav1.Metal3MachineSpec{
+				Spec: infrav1alpha5.Metal3MachineSpec{
 					DataTemplate: testObjectReference(metal3DataTemplateName),
 				},
 			},
-			dataClaim: &infrav1.Metal3DataClaim{
+			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
-				Spec:       infrav1.Metal3DataClaimSpec{},
+				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
 			},
 			expectReady: true,
 		}),
 		Entry("Machine without datatemplate", testCaseCreateSecrets{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Template: *testObjectReference(metal3DataTemplateName),
 					Claim:    *testObjectReference(metal3DataClaimName),
 				},
 			},
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
 			},
-			m3m: &infrav1.Metal3Machine{
+			m3m: &infrav1alpha5.Metal3Machine{
 				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, m3muid),
 			},
-			dataClaim: &infrav1.Metal3DataClaim{
+			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
-				Spec:       infrav1.Metal3DataClaimSpec{},
+				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
 			},
 			expectError: true,
 		}),
 		Entry("secrets exist", testCaseCreateSecrets{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Template: *testObjectReference(metal3DataTemplateName),
 					Claim:    *testObjectReference(metal3DataClaimName),
 				},
 			},
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
-				Spec: infrav1.Metal3DataTemplateSpec{
-					MetaData: &infrav1.MetaData{
-						Strings: []infrav1.MetaDataString{
+				Spec: infrav1alpha5.Metal3DataTemplateSpec{
+					MetaData: &infrav1alpha5.MetaData{
+						Strings: []infrav1alpha5.MetaDataString{
 							{
 								Key:   "String-1",
 								Value: "String-1",
@@ -354,15 +353,15 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 				},
 			},
-			m3m: &infrav1.Metal3Machine{
+			m3m: &infrav1alpha5.Metal3Machine{
 				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, m3muid),
-				Spec: infrav1.Metal3MachineSpec{
+				Spec: infrav1alpha5.Metal3MachineSpec{
 					DataTemplate: testObjectReference(metal3DataTemplateName),
 				},
 			},
-			dataClaim: &infrav1.Metal3DataClaim{
+			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
-				Spec:       infrav1.Metal3DataClaimSpec{},
+				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
 			},
 			metadataSecret: &corev1.Secret{
 				ObjectMeta: testObjectMeta(metal3machineName+"-metadata", namespaceName, ""),
@@ -381,18 +380,18 @@ var _ = Describe("Metal3Data manager", func() {
 			expectedNetworkData: pointer.StringPtr("Bye"),
 		}),
 		Entry("secrets do not exist", testCaseCreateSecrets{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Template: *testObjectReference(metal3DataTemplateName),
 					Claim:    *testObjectReference(metal3DataClaimName),
 				},
 			},
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
-				Spec: infrav1.Metal3DataTemplateSpec{
-					MetaData: &infrav1.MetaData{
-						Strings: []infrav1.MetaDataString{
+				Spec: infrav1alpha5.Metal3DataTemplateSpec{
+					MetaData: &infrav1alpha5.MetaData{
+						Strings: []infrav1alpha5.MetaDataString{
 							{
 								Key:   "String-1",
 								Value: "String-1",
@@ -431,18 +430,18 @@ var _ = Describe("Metal3Data manager", func() {
 						"metal3.io/BareMetalHost": namespaceName + "/" + baremetalhostName,
 					},
 				},
-				Spec: infrav1.Metal3MachineSpec{
+				Spec: infrav1alpha5.Metal3MachineSpec{
 					DataTemplate: testObjectReference(metal3DataTemplateName),
 				},
 			},
-			dataClaim: &infrav1.Metal3DataClaim{
+			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
-				Spec:       infrav1.Metal3DataClaimSpec{},
+				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
 			},
 			machine: &clusterv1.Machine{
 				ObjectMeta: testObjectMeta(machineName, namespaceName, muid),
 			},
-			bmh: &bmov1alpha1.BareMetalHost{
+			bmh: &bmo.BareMetalHost{
 				ObjectMeta: testObjectMeta(baremetalhostName, namespaceName, bmhuid),
 			},
 			expectReady:         true,
@@ -450,18 +449,18 @@ var _ = Describe("Metal3Data manager", func() {
 			expectedNetworkData: pointer.StringPtr("links:\n- ethernet_mac_address: XX:XX:XX:XX:XX:XX\n  id: eth0\n  mtu: 1500\n  type: phy\nnetworks: []\nservices: []\n"),
 		}),
 		Entry("No Machine OwnerRef on M3M", testCaseCreateSecrets{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Template: *testObjectReference(metal3DataTemplateName),
 					Claim:    *testObjectReference(metal3DataClaimName),
 				},
 			},
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
-				Spec: infrav1.Metal3DataTemplateSpec{
-					MetaData: &infrav1.MetaData{
-						Strings: []infrav1.MetaDataString{
+				Spec: infrav1alpha5.Metal3DataTemplateSpec{
+					MetaData: &infrav1alpha5.MetaData{
+						Strings: []infrav1alpha5.MetaDataString{
 							{
 								Key:   "String-1",
 								Value: "String-1",
@@ -484,31 +483,31 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 				},
 			},
-			m3m: &infrav1.Metal3Machine{
+			m3m: &infrav1alpha5.Metal3Machine{
 				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, m3muid),
-				Spec: infrav1.Metal3MachineSpec{
+				Spec: infrav1alpha5.Metal3MachineSpec{
 					DataTemplate: testObjectReference(metal3DataTemplateName),
 				},
 			},
-			dataClaim: &infrav1.Metal3DataClaim{
+			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
-				Spec:       infrav1.Metal3DataClaimSpec{},
+				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
 			},
 			expectRequeue: true,
 		}),
 		Entry("secrets do not exist", testCaseCreateSecrets{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Template: *testObjectReference(metal3DataTemplateName),
 					Claim:    *testObjectReference(metal3DataClaimName),
 				},
 			},
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
-				Spec: infrav1.Metal3DataTemplateSpec{
-					MetaData: &infrav1.MetaData{
-						Strings: []infrav1.MetaDataString{
+				Spec: infrav1alpha5.Metal3DataTemplateSpec{
+					MetaData: &infrav1alpha5.MetaData{
+						Strings: []infrav1alpha5.MetaDataString{
 							{
 								Key:   "String-1",
 								Value: "String-1",
@@ -543,16 +542,16 @@ var _ = Describe("Metal3Data manager", func() {
 						},
 					},
 				},
-				Spec: infrav1.Metal3MachineSpec{
+				Spec: infrav1alpha5.Metal3MachineSpec{
 					DataTemplate: testObjectReference(metal3DataTemplateName),
 				},
 			},
 			machine: &clusterv1.Machine{
 				ObjectMeta: testObjectMeta(machineName, namespaceName, muid),
 			},
-			dataClaim: &infrav1.Metal3DataClaim{
+			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
-				Spec:       infrav1.Metal3DataClaimSpec{},
+				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
 			},
 			expectRequeue: true,
 		}),
@@ -592,9 +591,9 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d: &infrav1alpha5.Metal3Data{},
 		}),
 		Entry("M3dt not found", testCaseReleaseLeases{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Template: corev1.ObjectReference{
 						Name: metal3DataTemplateName,
 					},
@@ -603,15 +602,15 @@ var _ = Describe("Metal3Data manager", func() {
 			expectRequeue: true,
 		}),
 		Entry("M3dt found", testCaseReleaseLeases{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Template: corev1.ObjectReference{
 						Name: metal3DataTemplateName,
 					},
 				},
 			},
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
 			},
 		}),
@@ -636,14 +635,14 @@ var _ = Describe("Metal3Data manager", func() {
 				}
 				objects = append(objects, pool)
 			}
-			m3d := &infrav1.Metal3Data{
+			m3d := &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Metal3Data",
 					APIVersion: infrav1alpha5.GroupVersion.String(),
 				},
 			}
-			m3dt := infrav1.Metal3DataTemplate{
+			m3dt := infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
 				Spec:       tc.m3dtSpec,
 			}
@@ -963,14 +962,14 @@ var _ = Describe("Metal3Data manager", func() {
 				}
 				objects = append(objects, pool)
 			}
-			m3d := &infrav1.Metal3Data{
+			m3d := &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Metal3Data",
 					APIVersion: infrav1alpha5.GroupVersion.String(),
 				},
 			}
-			m3dt := infrav1.Metal3DataTemplate{
+			m3dt := infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName+"-abc", "", ""),
 				Spec:       tc.m3dtSpec,
 			}
@@ -1163,7 +1162,7 @@ var _ = Describe("Metal3Data manager", func() {
 			}
 		},
 		Entry("Already processed", testCaseGetAddressFromPool{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta("", namespaceName, ""),
 			},
 			poolName: testPoolName,
@@ -1175,7 +1174,7 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 		}),
 		Entry("IPClaim not found", testCaseGetAddressFromPool{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 			},
 			poolName: testPoolName,
@@ -1186,7 +1185,7 @@ var _ = Describe("Metal3Data manager", func() {
 			expectClaim:   true,
 		}),
 		Entry("IPClaim without allocation", testCaseGetAddressFromPool{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 			},
 			poolName: testPoolName,
@@ -1199,7 +1198,7 @@ var _ = Describe("Metal3Data manager", func() {
 			expectRequeue: true,
 		}),
 		Entry("IPPool with allocation error", testCaseGetAddressFromPool{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 			},
 			poolName: testPoolName,
@@ -1216,7 +1215,7 @@ var _ = Describe("Metal3Data manager", func() {
 			expectDataError: true,
 		}),
 		Entry("IPAddress not found", testCaseGetAddressFromPool{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 			},
 			poolName: testPoolName,
@@ -1235,7 +1234,7 @@ var _ = Describe("Metal3Data manager", func() {
 			expectRequeue: true,
 		}),
 		Entry("IPAddress found", testCaseGetAddressFromPool{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 			},
 			poolName: testPoolName,
@@ -1320,7 +1319,7 @@ var _ = Describe("Metal3Data manager", func() {
 			}
 		},
 		Entry("Already processed", testCaseReleaseAddressFromPool{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 			},
 			poolName: testPoolName,
@@ -1332,7 +1331,7 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 		}),
 		Entry("Deletion already attempted", testCaseReleaseAddressFromPool{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 			},
 			poolName: testPoolName,
@@ -1344,7 +1343,7 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 		}),
 		Entry("IPClaim not found", testCaseReleaseAddressFromPool{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 			},
 			poolName:      "abc",
@@ -1354,7 +1353,7 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 		}),
 		Entry("IPPool without ownerref", testCaseReleaseAddressFromPool{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Metal3Data",
@@ -1637,9 +1636,9 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 				},
 			},
-			bmh: &bmov1alpha1.BareMetalHost{
+			bmh: &bmo.BareMetalHost{
 				ObjectMeta: testObjectMeta(baremetalhostName, namespaceName, ""),
-				Status:     bmov1alpha1.BareMetalHostStatus{},
+				Status:     bmo.BareMetalHostStatus{},
 			},
 			expectError: true,
 		}),
@@ -1682,9 +1681,9 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 				},
 			},
-			bmh: &bmov1alpha1.BareMetalHost{
+			bmh: &bmo.BareMetalHost{
 				ObjectMeta: testObjectMeta(baremetalhostName, namespaceName, ""),
-				Status:     bmov1alpha1.BareMetalHostStatus{},
+				Status:     bmo.BareMetalHostStatus{},
 			},
 			expectError: true,
 		}),
@@ -1727,9 +1726,9 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 				},
 			},
-			bmh: &bmov1alpha1.BareMetalHost{
+			bmh: &bmo.BareMetalHost{
 				ObjectMeta: testObjectMeta(baremetalhostName, namespaceName, ""),
-				Status:     bmov1alpha1.BareMetalHostStatus{},
+				Status:     bmo.BareMetalHostStatus{},
 			},
 			expectError: true,
 		}),
@@ -2241,11 +2240,11 @@ var _ = Describe("Metal3Data manager", func() {
 			mac: &infrav1alpha5.NetworkLinkEthernetMac{
 				FromHostInterface: pointer.StringPtr("eth1"),
 			},
-			bmh: &bmov1alpha1.BareMetalHost{
+			bmh: &bmo.BareMetalHost{
 				ObjectMeta: testObjectMeta(baremetalhostName, namespaceName, ""),
-				Status: bmov1alpha1.BareMetalHostStatus{
-					HardwareDetails: &bmov1alpha1.HardwareDetails{
-						NIC: []bmov1alpha1.NIC{
+				Status: bmo.BareMetalHostStatus{
+					HardwareDetails: &bmo.HardwareDetails{
+						NIC: []bmo.NIC{
 							{
 								Name: "eth0",
 								MAC:  "XX:XX:XX:XX:XX:XX",
@@ -2266,11 +2265,11 @@ var _ = Describe("Metal3Data manager", func() {
 			mac: &infrav1alpha5.NetworkLinkEthernetMac{
 				FromHostInterface: pointer.StringPtr("eth2"),
 			},
-			bmh: &bmov1alpha1.BareMetalHost{
+			bmh: &bmo.BareMetalHost{
 				ObjectMeta: testObjectMeta(baremetalhostName, namespaceName, ""),
-				Status: bmov1alpha1.BareMetalHostStatus{
-					HardwareDetails: &bmov1alpha1.HardwareDetails{
-						NIC: []bmov1alpha1.NIC{
+				Status: bmo.BareMetalHostStatus{
+					HardwareDetails: &bmo.HardwareDetails{
+						NIC: []bmo.NIC{
 							{
 								Name: "eth0",
 								MAC:  "XX:XX:XX:XX:XX:XX",
@@ -2317,15 +2316,15 @@ var _ = Describe("Metal3Data manager", func() {
 			Expect(outputMap).To(Equal(tc.expectedMetaData))
 		},
 		Entry("Empty", testCaseRenderMetaData{
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName+"-abc", "", ""),
 			},
 			expectedMetaData: nil,
 		}),
 		Entry("Full example", testCaseRenderMetaData{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta("data-abc", namespaceName, ""),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Index: 2,
 				},
 			},
@@ -2577,11 +2576,11 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 		}),
 		Entry("Interface absent", testCaseRenderMetaData{
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName+"-abc", "", ""),
-				Spec: infrav1.Metal3DataTemplateSpec{
-					MetaData: &infrav1.MetaData{
-						FromHostInterfaces: []infrav1.MetaDataHostInterface{
+				Spec: infrav1alpha5.Metal3DataTemplateSpec{
+					MetaData: &infrav1alpha5.MetaData{
+						FromHostInterfaces: []infrav1alpha5.MetaDataHostInterface{
 							{
 								Key:       "Mac-1",
 								Interface: "eth2",
@@ -2590,11 +2589,11 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 				},
 			},
-			bmh: &bmov1alpha1.BareMetalHost{
+			bmh: &bmo.BareMetalHost{
 				ObjectMeta: testObjectMeta(baremetalhostName, namespaceName, ""),
-				Status: bmov1alpha1.BareMetalHostStatus{
-					HardwareDetails: &bmov1alpha1.HardwareDetails{
-						NIC: []bmov1alpha1.NIC{
+				Status: bmo.BareMetalHostStatus{
+					HardwareDetails: &bmo.HardwareDetails{
+						NIC: []bmo.NIC{
 							{
 								Name: "eth0",
 								MAC:  "XX:XX:XX:XX:XX:XX",
@@ -2612,17 +2611,17 @@ var _ = Describe("Metal3Data manager", func() {
 			expectError: true,
 		}),
 		Entry("IP missing", testCaseRenderMetaData{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta("data-abc", namespaceName, ""),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Index: 2,
 				},
 			},
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName+"-abc", "", ""),
-				Spec: infrav1.Metal3DataTemplateSpec{
-					MetaData: &infrav1.MetaData{
-						IPAddressesFromPool: []infrav1.FromPool{
+				Spec: infrav1alpha5.Metal3DataTemplateSpec{
+					MetaData: &infrav1alpha5.MetaData{
+						IPAddressesFromPool: []infrav1alpha5.FromPool{
 							{
 								Key:  "Address-1",
 								Name: "abc",
@@ -2634,17 +2633,17 @@ var _ = Describe("Metal3Data manager", func() {
 			expectError: true,
 		}),
 		Entry("Prefix missing", testCaseRenderMetaData{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta("data-abc", namespaceName, ""),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Index: 2,
 				},
 			},
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName+"-abc", "", ""),
-				Spec: infrav1.Metal3DataTemplateSpec{
-					MetaData: &infrav1.MetaData{
-						PrefixesFromPool: []infrav1.FromPool{
+				Spec: infrav1alpha5.Metal3DataTemplateSpec{
+					MetaData: &infrav1alpha5.MetaData{
+						PrefixesFromPool: []infrav1alpha5.FromPool{
 							{
 								Key:  "Address-1",
 								Name: "abc",
@@ -2656,17 +2655,17 @@ var _ = Describe("Metal3Data manager", func() {
 			expectError: true,
 		}),
 		Entry("Gateway missing", testCaseRenderMetaData{
-			m3d: &infrav1.Metal3Data{
+			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta("data-abc", namespaceName, ""),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Index: 2,
 				},
 			},
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName+"-abc", "", ""),
-				Spec: infrav1.Metal3DataTemplateSpec{
-					MetaData: &infrav1.MetaData{
-						GatewaysFromPool: []infrav1.FromPool{
+				Spec: infrav1alpha5.Metal3DataTemplateSpec{
+					MetaData: &infrav1alpha5.MetaData{
+						GatewaysFromPool: []infrav1alpha5.FromPool{
 							{
 								Key:  "Address-1",
 								Name: "abc",
@@ -2678,11 +2677,11 @@ var _ = Describe("Metal3Data manager", func() {
 			expectError: true,
 		}),
 		Entry("Wrong object in name", testCaseRenderMetaData{
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName+"-abc", "", ""),
-				Spec: infrav1.Metal3DataTemplateSpec{
-					MetaData: &infrav1.MetaData{
-						ObjectNames: []infrav1.MetaDataObjectName{
+				Spec: infrav1alpha5.Metal3DataTemplateSpec{
+					MetaData: &infrav1alpha5.MetaData{
+						ObjectNames: []infrav1alpha5.MetaDataObjectName{
 							{
 								Key:    "ObjectName-3",
 								Object: "baremetalhost2",
@@ -2694,11 +2693,11 @@ var _ = Describe("Metal3Data manager", func() {
 			expectError: true,
 		}),
 		Entry("Wrong object in Label", testCaseRenderMetaData{
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName+"-abc", "", ""),
-				Spec: infrav1.Metal3DataTemplateSpec{
-					MetaData: &infrav1.MetaData{
-						FromLabels: []infrav1.MetaDataFromLabel{
+				Spec: infrav1alpha5.Metal3DataTemplateSpec{
+					MetaData: &infrav1alpha5.MetaData{
+						FromLabels: []infrav1alpha5.MetaDataFromLabel{
 							{
 								Key:    "ObjectName-3",
 								Object: "baremetalhost2",
@@ -2711,11 +2710,11 @@ var _ = Describe("Metal3Data manager", func() {
 			expectError: true,
 		}),
 		Entry("Wrong object in Annotation", testCaseRenderMetaData{
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName+"-abc", "", ""),
-				Spec: infrav1.Metal3DataTemplateSpec{
-					MetaData: &infrav1.MetaData{
-						FromAnnotations: []infrav1.MetaDataFromAnnotation{
+				Spec: infrav1alpha5.Metal3DataTemplateSpec{
+					MetaData: &infrav1alpha5.MetaData{
+						FromAnnotations: []infrav1alpha5.MetaDataFromAnnotation{
 							{
 								Key:        "ObjectName-3",
 								Object:     "baremetalhost2",
@@ -2887,15 +2886,15 @@ var _ = Describe("Metal3Data manager", func() {
 			}
 		},
 		Entry("Object does not exist", testCaseGetM3Machine{
-			Data: &infrav1.Metal3Data{
+			Data: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Claim: *testObjectReference(metal3DataClaimName),
 				},
 			},
-			DataClaim: &infrav1.Metal3DataClaim{
+			DataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
-				Spec:       infrav1.Metal3DataClaimSpec{},
+				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
 			},
 			ExpectRequeue: true,
 		}),
@@ -2912,115 +2911,115 @@ var _ = Describe("Metal3Data manager", func() {
 			ExpectError: true,
 		}),
 		Entry("Dataclaim Spec ownerref unset", testCaseGetM3Machine{
-			Data: &infrav1.Metal3Data{
+			Data: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Claim: *testObjectReference(metal3DataClaimName),
 				},
 			},
-			DataClaim: &infrav1.Metal3DataClaim{
+			DataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMeta(metal3DataClaimName, namespaceName, m3dcuid),
-				Spec:       infrav1.Metal3DataClaimSpec{},
+				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
 			},
 			ExpectError: true,
 		}),
 		Entry("M3Machine not found", testCaseGetM3Machine{
-			Data: &infrav1.Metal3Data{
+			Data: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Claim: *testObjectReference(metal3DataClaimName),
 				},
 			},
-			DataClaim: &infrav1.Metal3DataClaim{
+			DataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
-				Spec:       infrav1.Metal3DataClaimSpec{},
+				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
 			},
 			ExpectRequeue: true,
 		}),
 		Entry("Object exists", testCaseGetM3Machine{
-			Machine: &infrav1.Metal3Machine{
+			Machine: &infrav1alpha5.Metal3Machine{
 				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, m3muid),
 			},
-			Data: &infrav1.Metal3Data{
+			Data: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Claim: *testObjectReference(metal3DataClaimName),
 				},
 			},
-			DataClaim: &infrav1.Metal3DataClaim{
+			DataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
-				Spec:       infrav1.Metal3DataClaimSpec{},
+				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
 			},
 		}),
 		Entry("Object exists, dataTemplate nil", testCaseGetM3Machine{
-			Machine: &infrav1.Metal3Machine{
+			Machine: &infrav1alpha5.Metal3Machine{
 				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, m3muid),
-				Spec: infrav1.Metal3MachineSpec{
+				Spec: infrav1alpha5.Metal3MachineSpec{
 					DataTemplate: nil,
 				},
 			},
-			DataTemplate: &infrav1.Metal3DataTemplate{
+			DataTemplate: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
 			},
-			Data: &infrav1.Metal3Data{
+			Data: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Claim: *testObjectReference(metal3DataClaimName),
 				},
 			},
-			DataClaim: &infrav1.Metal3DataClaim{
+			DataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
-				Spec:       infrav1.Metal3DataClaimSpec{},
+				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
 			},
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists, dataTemplate name mismatch", testCaseGetM3Machine{
-			Machine: &infrav1.Metal3Machine{
+			Machine: &infrav1alpha5.Metal3Machine{
 				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, m3muid),
-				Spec: infrav1.Metal3MachineSpec{
+				Spec: infrav1alpha5.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
 						Name:      "abcd",
 						Namespace: namespaceName,
 					},
 				},
 			},
-			DataTemplate: &infrav1.Metal3DataTemplate{
+			DataTemplate: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
 			},
-			Data: &infrav1.Metal3Data{
+			Data: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Claim: *testObjectReference(metal3DataClaimName),
 				},
 			},
-			DataClaim: &infrav1.Metal3DataClaim{
+			DataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
-				Spec:       infrav1.Metal3DataClaimSpec{},
+				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
 			},
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists, dataTemplate namespace mismatch", testCaseGetM3Machine{
-			Machine: &infrav1.Metal3Machine{
+			Machine: &infrav1alpha5.Metal3Machine{
 				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, m3muid),
-				Spec: infrav1.Metal3MachineSpec{
+				Spec: infrav1alpha5.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
 						Name:      "abc",
 						Namespace: "defg",
 					},
 				},
 			},
-			DataTemplate: &infrav1.Metal3DataTemplate{
+			DataTemplate: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
 			},
-			Data: &infrav1.Metal3Data{
+			Data: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Claim: *testObjectReference(metal3DataClaimName),
 				},
 			},
-			DataClaim: &infrav1.Metal3DataClaim{
+			DataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
-				Spec:       infrav1.Metal3DataClaimSpec{},
+				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
 			},
 			ExpectEmpty: true,
 		}),

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -36,16 +36,12 @@ import (
 	"k8s.io/klog/v2/klogr"
 	"k8s.io/utils/pointer"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha4"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var (
-	testObjectMeta = metav1.ObjectMeta{
-		Name:      "abc",
-		Namespace: namespaceName,
-		UID:       bmhuid,
-	}
 	testObjectMetaWithOR = metav1.ObjectMeta{
 		Name:      "abc",
 		Namespace: namespaceName,
@@ -154,9 +150,9 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 		}),
 		Entry("requeue error", testCaseReconcile{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: testObjectMeta,
-				Spec: infrav1alpha5.Metal3DataSpec{
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3DataSpec{
 					Template: *testObjectReference,
 				},
 			},
@@ -257,28 +253,28 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 		}),
 		Entry("No Metal3DataTemplate", testCaseCreateSecrets{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: testObjectMeta,
-				Spec: infrav1alpha5.Metal3DataSpec{
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3DataSpec{
 					Template: *testObjectReference,
 				},
 			},
 			expectRequeue: true,
 		}),
 		Entry("No Metal3Machine in owner refs", testCaseCreateSecrets{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: testObjectMeta,
-				Spec: infrav1alpha5.Metal3DataSpec{
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3DataSpec{
 					Template: *testObjectReference,
 					Claim:    *testObjectReference,
 				},
 			},
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta,
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
-			dataClaim: &infrav1alpha5.Metal3DataClaim{
-				ObjectMeta: testObjectMeta,
-				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
+			dataClaim: &infrav1.Metal3DataClaim{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			expectError: true,
 		}),
@@ -290,8 +286,8 @@ var _ = Describe("Metal3Data manager", func() {
 					Claim:    *testObjectReference,
 				},
 			},
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta,
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR,
@@ -307,12 +303,12 @@ var _ = Describe("Metal3Data manager", func() {
 					Claim:    *testObjectReference,
 				},
 			},
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta,
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
-			m3m: &infrav1alpha5.Metal3Machine{
-				ObjectMeta: testObjectMeta,
-				Spec: infrav1alpha5.Metal3MachineSpec{
+			m3m: &infrav1.Metal3Machine{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: testObjectReference,
 				},
 			},
@@ -330,11 +326,11 @@ var _ = Describe("Metal3Data manager", func() {
 					Claim:    *testObjectReference,
 				},
 			},
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta,
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
-			m3m: &infrav1alpha5.Metal3Machine{
-				ObjectMeta: testObjectMeta,
+			m3m: &infrav1.Metal3Machine{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR,
@@ -350,11 +346,11 @@ var _ = Describe("Metal3Data manager", func() {
 					Claim:    *testObjectReference,
 				},
 			},
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta,
-				Spec: infrav1alpha5.Metal3DataTemplateSpec{
-					MetaData: &infrav1alpha5.MetaData{
-						Strings: []infrav1alpha5.MetaDataString{
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3DataTemplateSpec{
+					MetaData: &infrav1.MetaData{
+						Strings: []infrav1.MetaDataString{
 							{
 								Key:   "String-1",
 								Value: "String-1",
@@ -377,9 +373,9 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 				},
 			},
-			m3m: &infrav1alpha5.Metal3Machine{
-				ObjectMeta: testObjectMeta,
-				Spec: infrav1alpha5.Metal3MachineSpec{
+			m3m: &infrav1.Metal3Machine{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: testObjectReference,
 				},
 			},
@@ -388,19 +384,13 @@ var _ = Describe("Metal3Data manager", func() {
 				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
 			},
 			metadataSecret: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc-metadata",
-					Namespace: namespaceName,
-				},
+				ObjectMeta: testObjectMeta("abc-metadata", namespaceName, ""),
 				Data: map[string][]byte{
 					"metaData": []byte("Hello"),
 				},
 			},
 			networkdataSecret: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc-networkdata",
-					Namespace: namespaceName,
-				},
+				ObjectMeta: testObjectMeta("abc-networkdata", namespaceName, ""),
 				Data: map[string][]byte{
 					"networkData": []byte("Bye"),
 				},
@@ -417,11 +407,11 @@ var _ = Describe("Metal3Data manager", func() {
 					Claim:    *testObjectReference,
 				},
 			},
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta,
-				Spec: infrav1alpha5.Metal3DataTemplateSpec{
-					MetaData: &infrav1alpha5.MetaData{
-						Strings: []infrav1alpha5.MetaDataString{
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3DataTemplateSpec{
+					MetaData: &infrav1.MetaData{
+						Strings: []infrav1.MetaDataString{
 							{
 								Key:   "String-1",
 								Value: "String-1",
@@ -468,11 +458,11 @@ var _ = Describe("Metal3Data manager", func() {
 				ObjectMeta: testObjectMetaWithOR,
 				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
 			},
-			machine: &capi.Machine{
-				ObjectMeta: testObjectMeta,
+			machine: &clusterv1.Machine{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
-			bmh: &bmo.BareMetalHost{
-				ObjectMeta: testObjectMeta,
+			bmh: &bmov1alpha1.BareMetalHost{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			expectReady:         true,
 			expectedMetadata:    pointer.StringPtr(fmt.Sprintf("String-1: String-1\nproviderid: %s\n", providerid)),
@@ -486,11 +476,11 @@ var _ = Describe("Metal3Data manager", func() {
 					Claim:    *testObjectReference,
 				},
 			},
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta,
-				Spec: infrav1alpha5.Metal3DataTemplateSpec{
-					MetaData: &infrav1alpha5.MetaData{
-						Strings: []infrav1alpha5.MetaDataString{
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3DataTemplateSpec{
+					MetaData: &infrav1.MetaData{
+						Strings: []infrav1.MetaDataString{
 							{
 								Key:   "String-1",
 								Value: "String-1",
@@ -513,9 +503,9 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 				},
 			},
-			m3m: &infrav1alpha5.Metal3Machine{
-				ObjectMeta: testObjectMeta,
-				Spec: infrav1alpha5.Metal3MachineSpec{
+			m3m: &infrav1.Metal3Machine{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: testObjectReference,
 				},
 			},
@@ -533,11 +523,11 @@ var _ = Describe("Metal3Data manager", func() {
 					Claim:    *testObjectReference,
 				},
 			},
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta,
-				Spec: infrav1alpha5.Metal3DataTemplateSpec{
-					MetaData: &infrav1alpha5.MetaData{
-						Strings: []infrav1alpha5.MetaDataString{
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3DataTemplateSpec{
+					MetaData: &infrav1.MetaData{
+						Strings: []infrav1.MetaDataString{
 							{
 								Key:   "String-1",
 								Value: "String-1",
@@ -576,8 +566,8 @@ var _ = Describe("Metal3Data manager", func() {
 					DataTemplate: testObjectReference,
 				},
 			},
-			machine: &capi.Machine{
-				ObjectMeta: testObjectMeta,
+			machine: &clusterv1.Machine{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR,
@@ -621,12 +611,9 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d: &infrav1alpha5.Metal3Data{},
 		}),
 		Entry("M3dt not found", testCaseReleaseLeases{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
-				Spec: infrav1alpha5.Metal3DataSpec{
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3DataSpec{
 					Template: corev1.ObjectReference{
 						Name: "abc",
 					},
@@ -635,22 +622,16 @@ var _ = Describe("Metal3Data manager", func() {
 			expectRequeue: true,
 		}),
 		Entry("M3dt found", testCaseReleaseLeases{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
-				Spec: infrav1alpha5.Metal3DataSpec{
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3DataSpec{
 					Template: corev1.ObjectReference{
 						Name: "abc",
 					},
 				},
 			},
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 		}),
 	)
@@ -667,32 +648,23 @@ var _ = Describe("Metal3Data manager", func() {
 			objects := []client.Object{}
 			for _, poolName := range tc.ipClaims {
 				pool := &ipamv1.IPClaim{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc-" + poolName,
-						Namespace: namespaceName,
-					},
+					ObjectMeta: testObjectMeta("abc-"+poolName, namespaceName, ""),
 					Spec: ipamv1.IPClaimSpec{
 						Pool: *testObjectReference,
 					},
 				}
 				objects = append(objects, pool)
 			}
-			m3d := &infrav1alpha5.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
+			m3d := &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Metal3Data",
 					APIVersion: infrav1alpha5.GroupVersion.String(),
 				},
 			}
-			m3dt := infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
-				Spec: tc.m3dtSpec,
+			m3dt := infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec:       tc.m3dtSpec,
 			}
 			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
 			dataMgr, err := NewDataManager(c, m3d,
@@ -1003,31 +975,23 @@ var _ = Describe("Metal3Data manager", func() {
 			objects := []client.Object{}
 			for _, poolName := range tc.ipClaims {
 				pool := &ipamv1.IPClaim{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc-" + poolName,
-						Namespace: namespaceName,
-					},
+					ObjectMeta: testObjectMeta("abc-"+poolName, namespaceName, ""),
 					Spec: ipamv1.IPClaimSpec{
 						Pool: *testObjectReference,
 					},
 				}
 				objects = append(objects, pool)
 			}
-			m3d := &infrav1alpha5.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
+			m3d := &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Metal3Data",
 					APIVersion: infrav1alpha5.GroupVersion.String(),
 				},
 			}
-			m3dt := infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "datatemplate-abc",
-				},
-				Spec: tc.m3dtSpec,
+			m3dt := infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("datatemplate-abc", "", ""),
+				Spec:       tc.m3dtSpec,
 			}
 			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
 			dataMgr, err := NewDataManager(c, m3d,
@@ -1218,10 +1182,8 @@ var _ = Describe("Metal3Data manager", func() {
 			}
 		},
 		Entry("Already processed", testCaseGetAddressFromPool{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: namespaceName,
-				},
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("", namespaceName, ""),
 			},
 			poolName: "abc",
 			poolAddresses: map[string]addressFromPool{
@@ -1232,11 +1194,8 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 		}),
 		Entry("IPClaim not found", testCaseGetAddressFromPool{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			poolName: "abc",
 			expectedAddresses: map[string]addressFromPool{
@@ -1246,40 +1205,28 @@ var _ = Describe("Metal3Data manager", func() {
 			expectClaim:   true,
 		}),
 		Entry("IPClaim without allocation", testCaseGetAddressFromPool{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			poolName: "abc",
 			expectedAddresses: map[string]addressFromPool{
 				"abc": {},
 			},
 			ipClaim: &ipamv1.IPClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc-abc",
-					Namespace: namespaceName,
-				},
+				ObjectMeta: testObjectMeta("abc-abc", namespaceName, ""),
 			},
 			expectRequeue: true,
 		}),
 		Entry("IPPool with allocation error", testCaseGetAddressFromPool{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			poolName: "abc",
 			expectedAddresses: map[string]addressFromPool{
 				"abc": {},
 			},
 			ipClaim: &ipamv1.IPClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc-abc",
-					Namespace: namespaceName,
-				},
+				ObjectMeta: testObjectMeta("abc-abc", namespaceName, ""),
 				Status: ipamv1.IPClaimStatus{
 					ErrorMessage: pointer.StringPtr("Error happened"),
 				},
@@ -1288,21 +1235,15 @@ var _ = Describe("Metal3Data manager", func() {
 			expectDataError: true,
 		}),
 		Entry("IPAddress not found", testCaseGetAddressFromPool{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			poolName: "abc",
 			expectedAddresses: map[string]addressFromPool{
 				"abc": {},
 			},
 			ipClaim: &ipamv1.IPClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc-abc",
-					Namespace: namespaceName,
-				},
+				ObjectMeta: testObjectMeta("abc-abc", namespaceName, ""),
 				Status: ipamv1.IPClaimStatus{
 					Address: &corev1.ObjectReference{
 						Name:      "abc-192.168.0.11",
@@ -1313,11 +1254,8 @@ var _ = Describe("Metal3Data manager", func() {
 			expectRequeue: true,
 		}),
 		Entry("IPAddress found", testCaseGetAddressFromPool{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			poolName: "abc",
 			expectedAddresses: map[string]addressFromPool{
@@ -1331,10 +1269,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			ipClaim: &ipamv1.IPClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc-abc",
-					Namespace: namespaceName,
-				},
+				ObjectMeta: testObjectMeta("abc-abc", namespaceName, ""),
 				Status: ipamv1.IPClaimStatus{
 					Address: &corev1.ObjectReference{
 						Name:      "abc-192.168.0.10",
@@ -1342,12 +1277,8 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 				},
 			},
-
 			ipAddress: &ipamv1.IPAddress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc-192.168.0.10",
-					Namespace: namespaceName,
-				},
+				ObjectMeta: testObjectMeta("abc-192.168.0.10", namespaceName, ""),
 				Spec: ipamv1.IPAddressSpec{
 					Address: ipamv1.IPAddressStr("192.168.0.10"),
 					Prefix:  26,
@@ -1408,11 +1339,8 @@ var _ = Describe("Metal3Data manager", func() {
 			}
 		},
 		Entry("Already processed", testCaseReleaseAddressFromPool{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			poolName: "abc",
 			poolAddresses: map[string]bool{
@@ -1423,11 +1351,8 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 		}),
 		Entry("Deletion already attempted", testCaseReleaseAddressFromPool{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			poolName: "abc",
 			poolAddresses: map[string]bool{
@@ -1438,11 +1363,8 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 		}),
 		Entry("IPClaim not found", testCaseReleaseAddressFromPool{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			poolName:      "abc",
 			poolAddresses: map[string]bool{},
@@ -1451,11 +1373,8 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 		}),
 		Entry("IPPool without ownerref", testCaseReleaseAddressFromPool{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Metal3Data",
 					APIVersion: infrav1alpha5.GroupVersion.String(),
@@ -1463,10 +1382,7 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			poolName: "abc",
 			ipClaim: &ipamv1.IPClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc-abc",
-					Namespace: namespaceName,
-				},
+				ObjectMeta: testObjectMeta("abc-abc", namespaceName, ""),
 			},
 			expectedAddresses: map[string]bool{
 				"abc": true,
@@ -1740,11 +1656,9 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 				},
 			},
-			bmh: &bmo.BareMetalHost{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bmh-abc",
-				},
-				Status: bmo.BareMetalHostStatus{},
+			bmh: &bmov1alpha1.BareMetalHost{
+				ObjectMeta: testObjectMeta("bmh-abc", namespaceName, ""),
+				Status:     bmov1alpha1.BareMetalHostStatus{},
 			},
 			expectError: true,
 		}),
@@ -1787,11 +1701,9 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 				},
 			},
-			bmh: &bmo.BareMetalHost{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bmh-abc",
-				},
-				Status: bmo.BareMetalHostStatus{},
+			bmh: &bmov1alpha1.BareMetalHost{
+				ObjectMeta: testObjectMeta("bmh-abc", namespaceName, ""),
+				Status:     bmov1alpha1.BareMetalHostStatus{},
 			},
 			expectError: true,
 		}),
@@ -1834,11 +1746,9 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 				},
 			},
-			bmh: &bmo.BareMetalHost{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bmh-abc",
-				},
-				Status: bmo.BareMetalHostStatus{},
+			bmh: &bmov1alpha1.BareMetalHost{
+				ObjectMeta: testObjectMeta("bmh-abc", namespaceName, ""),
+				Status:     bmov1alpha1.BareMetalHostStatus{},
 			},
 			expectError: true,
 		}),
@@ -2350,13 +2260,11 @@ var _ = Describe("Metal3Data manager", func() {
 			mac: &infrav1alpha5.NetworkLinkEthernetMac{
 				FromHostInterface: pointer.StringPtr("eth1"),
 			},
-			bmh: &bmo.BareMetalHost{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bmh-abc",
-				},
-				Status: bmo.BareMetalHostStatus{
-					HardwareDetails: &bmo.HardwareDetails{
-						NIC: []bmo.NIC{
+			bmh: &bmov1alpha1.BareMetalHost{
+				ObjectMeta: testObjectMeta("bmh-abc", namespaceName, ""),
+				Status: bmov1alpha1.BareMetalHostStatus{
+					HardwareDetails: &bmov1alpha1.HardwareDetails{
+						NIC: []bmov1alpha1.NIC{
 							{
 								Name: "eth0",
 								MAC:  "XX:XX:XX:XX:XX:XX",
@@ -2377,13 +2285,11 @@ var _ = Describe("Metal3Data manager", func() {
 			mac: &infrav1alpha5.NetworkLinkEthernetMac{
 				FromHostInterface: pointer.StringPtr("eth2"),
 			},
-			bmh: &bmo.BareMetalHost{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bmh-abc",
-				},
-				Status: bmo.BareMetalHostStatus{
-					HardwareDetails: &bmo.HardwareDetails{
-						NIC: []bmo.NIC{
+			bmh: &bmov1alpha1.BareMetalHost{
+				ObjectMeta: testObjectMeta("bmh-abc", namespaceName, ""),
+				Status: bmov1alpha1.BareMetalHostStatus{
+					HardwareDetails: &bmov1alpha1.HardwareDetails{
+						NIC: []bmov1alpha1.NIC{
 							{
 								Name: "eth0",
 								MAC:  "XX:XX:XX:XX:XX:XX",
@@ -2430,20 +2336,15 @@ var _ = Describe("Metal3Data manager", func() {
 			Expect(outputMap).To(Equal(tc.expectedMetaData))
 		},
 		Entry("Empty", testCaseRenderMetaData{
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "datatemplate-abc",
-				},
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("datatemplate-abc", "", ""),
 			},
 			expectedMetaData: nil,
 		}),
 		Entry("Full example", testCaseRenderMetaData{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "data-abc",
-					Namespace: namespaceName,
-				},
-				Spec: infrav1alpha5.Metal3DataSpec{
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("data-abc", namespaceName, ""),
+				Spec: infrav1.Metal3DataSpec{
 					Index: 2,
 				},
 			},
@@ -2695,13 +2596,11 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 		}),
 		Entry("Interface absent", testCaseRenderMetaData{
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "datatemplate-abc",
-				},
-				Spec: infrav1alpha5.Metal3DataTemplateSpec{
-					MetaData: &infrav1alpha5.MetaData{
-						FromHostInterfaces: []infrav1alpha5.MetaDataHostInterface{
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("datatemplate-abc", "", ""),
+				Spec: infrav1.Metal3DataTemplateSpec{
+					MetaData: &infrav1.MetaData{
+						FromHostInterfaces: []infrav1.MetaDataHostInterface{
 							{
 								Key:       "Mac-1",
 								Interface: "eth2",
@@ -2710,13 +2609,11 @@ var _ = Describe("Metal3Data manager", func() {
 					},
 				},
 			},
-			bmh: &bmo.BareMetalHost{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bmh-abc",
-				},
-				Status: bmo.BareMetalHostStatus{
-					HardwareDetails: &bmo.HardwareDetails{
-						NIC: []bmo.NIC{
+			bmh: &bmov1alpha1.BareMetalHost{
+				ObjectMeta: testObjectMeta("bmh-abc", namespaceName, ""),
+				Status: bmov1alpha1.BareMetalHostStatus{
+					HardwareDetails: &bmov1alpha1.HardwareDetails{
+						NIC: []bmov1alpha1.NIC{
 							{
 								Name: "eth0",
 								MAC:  "XX:XX:XX:XX:XX:XX",
@@ -2734,22 +2631,17 @@ var _ = Describe("Metal3Data manager", func() {
 			expectError: true,
 		}),
 		Entry("IP missing", testCaseRenderMetaData{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "data-abc",
-					Namespace: namespaceName,
-				},
-				Spec: infrav1alpha5.Metal3DataSpec{
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("data-abc", namespaceName, ""),
+				Spec: infrav1.Metal3DataSpec{
 					Index: 2,
 				},
 			},
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "datatemplate-abc",
-				},
-				Spec: infrav1alpha5.Metal3DataTemplateSpec{
-					MetaData: &infrav1alpha5.MetaData{
-						IPAddressesFromPool: []infrav1alpha5.FromPool{
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("datatemplate-abc", "", ""),
+				Spec: infrav1.Metal3DataTemplateSpec{
+					MetaData: &infrav1.MetaData{
+						IPAddressesFromPool: []infrav1.FromPool{
 							{
 								Key:  "Address-1",
 								Name: "abc",
@@ -2761,22 +2653,17 @@ var _ = Describe("Metal3Data manager", func() {
 			expectError: true,
 		}),
 		Entry("Prefix missing", testCaseRenderMetaData{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "data-abc",
-					Namespace: namespaceName,
-				},
-				Spec: infrav1alpha5.Metal3DataSpec{
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("data-abc", namespaceName, ""),
+				Spec: infrav1.Metal3DataSpec{
 					Index: 2,
 				},
 			},
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "datatemplate-abc",
-				},
-				Spec: infrav1alpha5.Metal3DataTemplateSpec{
-					MetaData: &infrav1alpha5.MetaData{
-						PrefixesFromPool: []infrav1alpha5.FromPool{
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("datatemplate-abc", "", ""),
+				Spec: infrav1.Metal3DataTemplateSpec{
+					MetaData: &infrav1.MetaData{
+						PrefixesFromPool: []infrav1.FromPool{
 							{
 								Key:  "Address-1",
 								Name: "abc",
@@ -2788,22 +2675,17 @@ var _ = Describe("Metal3Data manager", func() {
 			expectError: true,
 		}),
 		Entry("Gateway missing", testCaseRenderMetaData{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "data-abc",
-					Namespace: namespaceName,
-				},
-				Spec: infrav1alpha5.Metal3DataSpec{
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("data-abc", namespaceName, ""),
+				Spec: infrav1.Metal3DataSpec{
 					Index: 2,
 				},
 			},
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "datatemplate-abc",
-				},
-				Spec: infrav1alpha5.Metal3DataTemplateSpec{
-					MetaData: &infrav1alpha5.MetaData{
-						GatewaysFromPool: []infrav1alpha5.FromPool{
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("datatemplate-abc", "", ""),
+				Spec: infrav1.Metal3DataTemplateSpec{
+					MetaData: &infrav1.MetaData{
+						GatewaysFromPool: []infrav1.FromPool{
 							{
 								Key:  "Address-1",
 								Name: "abc",
@@ -2815,13 +2697,11 @@ var _ = Describe("Metal3Data manager", func() {
 			expectError: true,
 		}),
 		Entry("Wrong object in name", testCaseRenderMetaData{
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "datatemplate-abc",
-				},
-				Spec: infrav1alpha5.Metal3DataTemplateSpec{
-					MetaData: &infrav1alpha5.MetaData{
-						ObjectNames: []infrav1alpha5.MetaDataObjectName{
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("datatemplate-abc", "", ""),
+				Spec: infrav1.Metal3DataTemplateSpec{
+					MetaData: &infrav1.MetaData{
+						ObjectNames: []infrav1.MetaDataObjectName{
 							{
 								Key:    "ObjectName-3",
 								Object: "baremetalhost2",
@@ -2833,13 +2713,11 @@ var _ = Describe("Metal3Data manager", func() {
 			expectError: true,
 		}),
 		Entry("Wrong object in Label", testCaseRenderMetaData{
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "datatemplate-abc",
-				},
-				Spec: infrav1alpha5.Metal3DataTemplateSpec{
-					MetaData: &infrav1alpha5.MetaData{
-						FromLabels: []infrav1alpha5.MetaDataFromLabel{
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("datatemplate-abc", "", ""),
+				Spec: infrav1.Metal3DataTemplateSpec{
+					MetaData: &infrav1.MetaData{
+						FromLabels: []infrav1.MetaDataFromLabel{
 							{
 								Key:    "ObjectName-3",
 								Object: "baremetalhost2",
@@ -2852,13 +2730,11 @@ var _ = Describe("Metal3Data manager", func() {
 			expectError: true,
 		}),
 		Entry("Wrong object in Annotation", testCaseRenderMetaData{
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "datatemplate-abc",
-				},
-				Spec: infrav1alpha5.Metal3DataTemplateSpec{
-					MetaData: &infrav1alpha5.MetaData{
-						FromAnnotations: []infrav1alpha5.MetaDataFromAnnotation{
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("datatemplate-abc", "", ""),
+				Spec: infrav1.Metal3DataTemplateSpec{
+					MetaData: &infrav1.MetaData{
+						FromAnnotations: []infrav1.MetaDataFromAnnotation{
 							{
 								Key:        "ObjectName-3",
 								Object:     "baremetalhost2",
@@ -3061,9 +2937,9 @@ var _ = Describe("Metal3Data manager", func() {
 					Claim: *testObjectReference,
 				},
 			},
-			DataClaim: &infrav1alpha5.Metal3DataClaim{
-				ObjectMeta: testObjectMeta,
-				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
+			DataClaim: &infrav1.Metal3DataClaim{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			ExpectError: true,
 		}),
@@ -3081,8 +2957,8 @@ var _ = Describe("Metal3Data manager", func() {
 			ExpectRequeue: true,
 		}),
 		Entry("Object exists", testCaseGetM3Machine{
-			Machine: &infrav1alpha5.Metal3Machine{
-				ObjectMeta: testObjectMeta,
+			Machine: &infrav1.Metal3Machine{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			Data: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR,
@@ -3096,14 +2972,14 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 		}),
 		Entry("Object exists, dataTemplate nil", testCaseGetM3Machine{
-			Machine: &infrav1alpha5.Metal3Machine{
-				ObjectMeta: testObjectMeta,
-				Spec: infrav1alpha5.Metal3MachineSpec{
+			Machine: &infrav1.Metal3Machine{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: nil,
 				},
 			},
-			DataTemplate: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta,
+			DataTemplate: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			Data: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR,
@@ -3118,17 +2994,17 @@ var _ = Describe("Metal3Data manager", func() {
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists, dataTemplate name mismatch", testCaseGetM3Machine{
-			Machine: &infrav1alpha5.Metal3Machine{
-				ObjectMeta: testObjectMeta,
-				Spec: infrav1alpha5.Metal3MachineSpec{
+			Machine: &infrav1.Metal3Machine{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
 						Name:      "abcd",
 						Namespace: namespaceName,
 					},
 				},
 			},
-			DataTemplate: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta,
+			DataTemplate: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			Data: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR,
@@ -3143,17 +3019,17 @@ var _ = Describe("Metal3Data manager", func() {
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists, dataTemplate namespace mismatch", testCaseGetM3Machine{
-			Machine: &infrav1alpha5.Metal3Machine{
-				ObjectMeta: testObjectMeta,
-				Spec: infrav1alpha5.Metal3MachineSpec{
+			Machine: &infrav1.Metal3Machine{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
 						Name:      "abc",
 						Namespace: "defg",
 					},
 				},
 			},
-			DataTemplate: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta,
+			DataTemplate: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			Data: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR,

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -476,7 +476,7 @@ var _ = Describe("Metal3Data manager", func() {
 				ObjectMeta: testObjectMeta,
 			},
 			expectReady:         true,
-			expectedMetadata:    pointer.StringPtr(fmt.Sprintf("String-1: String-1\nprovideruid: %s\n", provideruid)),
+			expectedMetadata:    pointer.StringPtr("String-1: String-1\n"),
 			expectedNetworkData: pointer.StringPtr("links:\n- ethernet_mac_address: XX:XX:XX:XX:XX:XX\n  id: eth0\n  mtu: 1500\n  type: phy\nnetworks: []\nservices: []\n"),
 		}),
 		Entry("No Machine OwnerRef on M3M", testCaseCreateSecrets{

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -41,25 +41,6 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-var (
-	testObjectMetaWithOR = metav1.ObjectMeta{
-		Name:      "abc",
-		Namespace: namespaceName,
-
-		OwnerReferences: []metav1.OwnerReference{
-			{
-				Name:       "abc",
-				Kind:       "Metal3Machine",
-				APIVersion: capm3.GroupVersion.String(),
-				UID:        m3muid,
-			},
-		},
-	}
-	testObjectReference = &corev1.ObjectReference{
-		Name: "abc",
-	}
-)
-
 var _ = Describe("Metal3Data manager", func() {
 	DescribeTable("Test Finalizers",
 		func(data *infrav1alpha5.Metal3Data) {
@@ -151,9 +132,9 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("requeue error", testCaseReconcile{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, m3duid),
 				Spec: infrav1.Metal3DataSpec{
-					Template: *testObjectReference,
+					Template: *testObjectReference(metal3DataTemplateName),
 				},
 			},
 			expectRequeue: true,
@@ -226,7 +207,7 @@ var _ = Describe("Metal3Data manager", func() {
 				tmpSecret := corev1.Secret{}
 				err = c.Get(context.TODO(),
 					client.ObjectKey{
-						Name:      "abc-metadata",
+						Name:      metal3machineName + "-metadata",
 						Namespace: namespaceName,
 					},
 					&tmpSecret,
@@ -238,7 +219,7 @@ var _ = Describe("Metal3Data manager", func() {
 				tmpSecret := corev1.Secret{}
 				err = c.Get(context.TODO(),
 					client.ObjectKey{
-						Name:      "abc-networkdata",
+						Name:      metal3machineName + "-networkdata",
 						Namespace: namespaceName,
 					},
 					&tmpSecret,
@@ -254,100 +235,100 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("No Metal3DataTemplate", testCaseCreateSecrets{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, m3duid),
 				Spec: infrav1.Metal3DataSpec{
-					Template: *testObjectReference,
+					Template: *testObjectReference(metal3DataTemplateName),
 				},
 			},
 			expectRequeue: true,
 		}),
 		Entry("No Metal3Machine in owner refs", testCaseCreateSecrets{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, m3duid),
 				Spec: infrav1.Metal3DataSpec{
-					Template: *testObjectReference,
-					Claim:    *testObjectReference,
+					Template: *testObjectReference(metal3DataTemplateName),
+					Claim:    *testObjectReference(metal3DataClaimName),
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
 			},
 			dataClaim: &infrav1.Metal3DataClaim{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3DataClaimName, namespaceName, m3dcuid),
 				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			expectError: true,
 		}),
 		Entry("No Metal3Machine", testCaseCreateSecrets{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec: infrav1alpha5.Metal3DataSpec{
-					Template: *testObjectReference,
-					Claim:    *testObjectReference,
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
+				Spec: infrav1.Metal3DataSpec{
+					Template: *testObjectReference(metal3DataTemplateName),
+					Claim:    *testObjectReference(metal3DataClaimName),
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
 			},
-			dataClaim: &infrav1alpha5.Metal3DataClaim{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
+			dataClaim: &infrav1.Metal3DataClaim{
+				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
+				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			expectRequeue: true,
 		}),
 		Entry("No Secret needed", testCaseCreateSecrets{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec: infrav1alpha5.Metal3DataSpec{
-					Template: *testObjectReference,
-					Claim:    *testObjectReference,
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
+				Spec: infrav1.Metal3DataSpec{
+					Template: *testObjectReference(metal3DataTemplateName),
+					Claim:    *testObjectReference(metal3DataClaimName),
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
 			},
 			m3m: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, m3muid),
 				Spec: infrav1.Metal3MachineSpec{
-					DataTemplate: testObjectReference,
+					DataTemplate: testObjectReference(metal3DataTemplateName),
 				},
 			},
-			dataClaim: &infrav1alpha5.Metal3DataClaim{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
+			dataClaim: &infrav1.Metal3DataClaim{
+				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
+				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			expectReady: true,
 		}),
 		Entry("Machine without datatemplate", testCaseCreateSecrets{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec: infrav1alpha5.Metal3DataSpec{
-					Template: *testObjectReference,
-					Claim:    *testObjectReference,
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
+				Spec: infrav1.Metal3DataSpec{
+					Template: *testObjectReference(metal3DataTemplateName),
+					Claim:    *testObjectReference(metal3DataClaimName),
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
 			},
 			m3m: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, m3muid),
 			},
-			dataClaim: &infrav1alpha5.Metal3DataClaim{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
+			dataClaim: &infrav1.Metal3DataClaim{
+				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
+				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			expectError: true,
 		}),
 		Entry("secrets exist", testCaseCreateSecrets{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec: infrav1alpha5.Metal3DataSpec{
-					Template: *testObjectReference,
-					Claim:    *testObjectReference,
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
+				Spec: infrav1.Metal3DataSpec{
+					Template: *testObjectReference(metal3DataTemplateName),
+					Claim:    *testObjectReference(metal3DataClaimName),
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					MetaData: &infrav1.MetaData{
 						Strings: []infrav1.MetaDataString{
@@ -374,23 +355,23 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3m: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, m3muid),
 				Spec: infrav1.Metal3MachineSpec{
-					DataTemplate: testObjectReference,
+					DataTemplate: testObjectReference(metal3DataTemplateName),
 				},
 			},
-			dataClaim: &infrav1alpha5.Metal3DataClaim{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
+			dataClaim: &infrav1.Metal3DataClaim{
+				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
+				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			metadataSecret: &corev1.Secret{
-				ObjectMeta: testObjectMeta("abc-metadata", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3machineName+"-metadata", namespaceName, ""),
 				Data: map[string][]byte{
 					"metaData": []byte("Hello"),
 				},
 			},
 			networkdataSecret: &corev1.Secret{
-				ObjectMeta: testObjectMeta("abc-networkdata", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3machineName+"-networkdata", namespaceName, ""),
 				Data: map[string][]byte{
 					"networkData": []byte("Bye"),
 				},
@@ -400,15 +381,15 @@ var _ = Describe("Metal3Data manager", func() {
 			expectedNetworkData: pointer.StringPtr("Bye"),
 		}),
 		Entry("secrets do not exist", testCaseCreateSecrets{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec: infrav1alpha5.Metal3DataSpec{
-					Template: *testObjectReference,
-					Claim:    *testObjectReference,
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
+				Spec: infrav1.Metal3DataSpec{
+					Template: *testObjectReference(metal3DataTemplateName),
+					Claim:    *testObjectReference(metal3DataClaimName),
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					MetaData: &infrav1.MetaData{
 						Strings: []infrav1.MetaDataString{
@@ -436,48 +417,48 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			m3m: &infrav1alpha5.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
+					Name:      metal3machineName,
 					Namespace: namespaceName,
 					UID:       m3muid,
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Name:       "abc",
+							Name:       machineName,
 							Kind:       "Machine",
 							APIVersion: capi.GroupVersion.String(),
 						},
 					},
 					Annotations: map[string]string{
-						"metal3.io/BareMetalHost": namespaceName + "/abc",
+						"metal3.io/BareMetalHost": namespaceName + "/" + baremetalhostName,
 					},
 				},
-				Spec: infrav1alpha5.Metal3MachineSpec{
-					DataTemplate: testObjectReference,
+				Spec: infrav1.Metal3MachineSpec{
+					DataTemplate: testObjectReference(metal3DataTemplateName),
 				},
 			},
-			dataClaim: &infrav1alpha5.Metal3DataClaim{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
+			dataClaim: &infrav1.Metal3DataClaim{
+				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
+				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			machine: &clusterv1.Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(machineName, namespaceName, muid),
 			},
 			bmh: &bmov1alpha1.BareMetalHost{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(baremetalhostName, namespaceName, bmhuid),
 			},
 			expectReady:         true,
 			expectedMetadata:    pointer.StringPtr(fmt.Sprintf("String-1: String-1\nproviderid: %s\n", providerid)),
 			expectedNetworkData: pointer.StringPtr("links:\n- ethernet_mac_address: XX:XX:XX:XX:XX:XX\n  id: eth0\n  mtu: 1500\n  type: phy\nnetworks: []\nservices: []\n"),
 		}),
 		Entry("No Machine OwnerRef on M3M", testCaseCreateSecrets{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec: infrav1alpha5.Metal3DataSpec{
-					Template: *testObjectReference,
-					Claim:    *testObjectReference,
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
+				Spec: infrav1.Metal3DataSpec{
+					Template: *testObjectReference(metal3DataTemplateName),
+					Claim:    *testObjectReference(metal3DataClaimName),
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					MetaData: &infrav1.MetaData{
 						Strings: []infrav1.MetaDataString{
@@ -504,27 +485,27 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3m: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, m3muid),
 				Spec: infrav1.Metal3MachineSpec{
-					DataTemplate: testObjectReference,
+					DataTemplate: testObjectReference(metal3DataTemplateName),
 				},
 			},
-			dataClaim: &infrav1alpha5.Metal3DataClaim{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
+			dataClaim: &infrav1.Metal3DataClaim{
+				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
+				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			expectRequeue: true,
 		}),
 		Entry("secrets do not exist", testCaseCreateSecrets{
-			m3d: &infrav1alpha5.Metal3Data{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec: infrav1alpha5.Metal3DataSpec{
-					Template: *testObjectReference,
-					Claim:    *testObjectReference,
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
+				Spec: infrav1.Metal3DataSpec{
+					Template: *testObjectReference(metal3DataTemplateName),
+					Claim:    *testObjectReference(metal3DataClaimName),
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					MetaData: &infrav1.MetaData{
 						Strings: []infrav1.MetaDataString{
@@ -552,26 +533,26 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			m3m: &infrav1alpha5.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
+					Name:      metal3machineName,
 					Namespace: namespaceName,
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Name:       "abc",
+							Name:       machineName,
 							Kind:       "Machine",
 							APIVersion: capi.GroupVersion.String(),
 						},
 					},
 				},
-				Spec: infrav1alpha5.Metal3MachineSpec{
-					DataTemplate: testObjectReference,
+				Spec: infrav1.Metal3MachineSpec{
+					DataTemplate: testObjectReference(metal3DataTemplateName),
 				},
 			},
 			machine: &clusterv1.Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(machineName, namespaceName, muid),
 			},
-			dataClaim: &infrav1alpha5.Metal3DataClaim{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
+			dataClaim: &infrav1.Metal3DataClaim{
+				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
+				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			expectRequeue: true,
 		}),
@@ -612,10 +593,10 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("M3dt not found", testCaseReleaseLeases{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 				Spec: infrav1.Metal3DataSpec{
 					Template: corev1.ObjectReference{
-						Name: "abc",
+						Name: metal3DataTemplateName,
 					},
 				},
 			},
@@ -623,15 +604,15 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("M3dt found", testCaseReleaseLeases{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 				Spec: infrav1.Metal3DataSpec{
 					Template: corev1.ObjectReference{
-						Name: "abc",
+						Name: metal3DataTemplateName,
 					},
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
 			},
 		}),
 	)
@@ -648,22 +629,22 @@ var _ = Describe("Metal3Data manager", func() {
 			objects := []client.Object{}
 			for _, poolName := range tc.ipClaims {
 				pool := &ipamv1.IPClaim{
-					ObjectMeta: testObjectMeta("abc-"+poolName, namespaceName, ""),
+					ObjectMeta: testObjectMeta(metal3DataName+"-"+poolName, namespaceName, ""),
 					Spec: ipamv1.IPClaimSpec{
-						Pool: *testObjectReference,
+						Pool: *testObjectReference("abc"),
 					},
 				}
 				objects = append(objects, pool)
 			}
 			m3d := &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Metal3Data",
 					APIVersion: infrav1alpha5.GroupVersion.String(),
 				},
 			}
 			m3dt := infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
 				Spec:       tc.m3dtSpec,
 			}
 			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
@@ -975,22 +956,22 @@ var _ = Describe("Metal3Data manager", func() {
 			objects := []client.Object{}
 			for _, poolName := range tc.ipClaims {
 				pool := &ipamv1.IPClaim{
-					ObjectMeta: testObjectMeta("abc-"+poolName, namespaceName, ""),
+					ObjectMeta: testObjectMeta(metal3DataName+"-"+poolName, namespaceName, ""),
 					Spec: ipamv1.IPClaimSpec{
-						Pool: *testObjectReference,
+						Pool: *testObjectReference("abc"),
 					},
 				}
 				objects = append(objects, pool)
 			}
 			m3d := &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Metal3Data",
 					APIVersion: infrav1alpha5.GroupVersion.String(),
 				},
 			}
 			m3dt := infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("datatemplate-abc", "", ""),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName+"-abc", "", ""),
 				Spec:       tc.m3dtSpec,
 			}
 			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
@@ -1013,7 +994,7 @@ var _ = Describe("Metal3Data manager", func() {
 			for _, poolName := range tc.ipClaims {
 				capm3IPPool := &ipamv1.IPClaim{}
 				poolNamespacedName := types.NamespacedName{
-					Name:      "abc-" + poolName,
+					Name:      metal3DataName + "-" + poolName,
 					Namespace: m3d.Namespace,
 				}
 
@@ -1185,48 +1166,48 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d: &infrav1.Metal3Data{
 				ObjectMeta: testObjectMeta("", namespaceName, ""),
 			},
-			poolName: "abc",
+			poolName: testPoolName,
 			poolAddresses: map[string]addressFromPool{
-				"abc": {address: "addr"},
+				testPoolName: {address: "addr"},
 			},
 			expectedAddresses: map[string]addressFromPool{
-				"abc": {address: "addr"},
+				testPoolName: {address: "addr"},
 			},
 		}),
 		Entry("IPClaim not found", testCaseGetAddressFromPool{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 			},
-			poolName: "abc",
+			poolName: testPoolName,
 			expectedAddresses: map[string]addressFromPool{
-				"abc": {},
+				testPoolName: {},
 			},
 			expectRequeue: true,
 			expectClaim:   true,
 		}),
 		Entry("IPClaim without allocation", testCaseGetAddressFromPool{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 			},
-			poolName: "abc",
+			poolName: testPoolName,
 			expectedAddresses: map[string]addressFromPool{
-				"abc": {},
+				testPoolName: {},
 			},
 			ipClaim: &ipamv1.IPClaim{
-				ObjectMeta: testObjectMeta("abc-abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName+"-"+testPoolName, namespaceName, ""),
 			},
 			expectRequeue: true,
 		}),
 		Entry("IPPool with allocation error", testCaseGetAddressFromPool{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 			},
-			poolName: "abc",
+			poolName: testPoolName,
 			expectedAddresses: map[string]addressFromPool{
-				"abc": {},
+				testPoolName: {},
 			},
 			ipClaim: &ipamv1.IPClaim{
-				ObjectMeta: testObjectMeta("abc-abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName+"-"+testPoolName, namespaceName, ""),
 				Status: ipamv1.IPClaimStatus{
 					ErrorMessage: pointer.StringPtr("Error happened"),
 				},
@@ -1236,11 +1217,11 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("IPAddress not found", testCaseGetAddressFromPool{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 			},
-			poolName: "abc",
+			poolName: testPoolName,
 			expectedAddresses: map[string]addressFromPool{
-				"abc": {},
+				testPoolName: {},
 			},
 			ipClaim: &ipamv1.IPClaim{
 				ObjectMeta: testObjectMeta("abc-abc", namespaceName, ""),
@@ -1255,11 +1236,11 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("IPAddress found", testCaseGetAddressFromPool{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 			},
-			poolName: "abc",
+			poolName: testPoolName,
 			expectedAddresses: map[string]addressFromPool{
-				"abc": {
+				testPoolName: {
 					address: ipamv1.IPAddressStr("192.168.0.10"),
 					prefix:  26,
 					gateway: ipamv1.IPAddressStr("192.168.0.1"),
@@ -1269,7 +1250,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			ipClaim: &ipamv1.IPClaim{
-				ObjectMeta: testObjectMeta("abc-abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName+"-"+testPoolName, namespaceName, ""),
 				Status: ipamv1.IPClaimStatus{
 					Address: &corev1.ObjectReference{
 						Name:      "abc-192.168.0.10",
@@ -1340,31 +1321,31 @@ var _ = Describe("Metal3Data manager", func() {
 		},
 		Entry("Already processed", testCaseReleaseAddressFromPool{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 			},
-			poolName: "abc",
+			poolName: testPoolName,
 			poolAddresses: map[string]bool{
-				"abc": true,
+				testPoolName: true,
 			},
 			expectedAddresses: map[string]bool{
-				"abc": true,
+				testPoolName: true,
 			},
 		}),
 		Entry("Deletion already attempted", testCaseReleaseAddressFromPool{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 			},
-			poolName: "abc",
+			poolName: testPoolName,
 			poolAddresses: map[string]bool{
-				"abc": false,
+				testPoolName: false,
 			},
 			expectedAddresses: map[string]bool{
-				"abc": false,
+				testPoolName: false,
 			},
 		}),
 		Entry("IPClaim not found", testCaseReleaseAddressFromPool{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 			},
 			poolName:      "abc",
 			poolAddresses: map[string]bool{},
@@ -1374,18 +1355,18 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("IPPool without ownerref", testCaseReleaseAddressFromPool{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Metal3Data",
 					APIVersion: infrav1alpha5.GroupVersion.String(),
 				},
 			},
-			poolName: "abc",
+			poolName: testPoolName,
 			ipClaim: &ipamv1.IPClaim{
-				ObjectMeta: testObjectMeta("abc-abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName+"-"+testPoolName, namespaceName, ""),
 			},
 			expectedAddresses: map[string]bool{
-				"abc": true,
+				testPoolName: true,
 			},
 		}),
 	)
@@ -1657,7 +1638,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			bmh: &bmov1alpha1.BareMetalHost{
-				ObjectMeta: testObjectMeta("bmh-abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(baremetalhostName, namespaceName, ""),
 				Status:     bmov1alpha1.BareMetalHostStatus{},
 			},
 			expectError: true,
@@ -1702,7 +1683,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			bmh: &bmov1alpha1.BareMetalHost{
-				ObjectMeta: testObjectMeta("bmh-abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(baremetalhostName, namespaceName, ""),
 				Status:     bmov1alpha1.BareMetalHostStatus{},
 			},
 			expectError: true,
@@ -1747,7 +1728,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			bmh: &bmov1alpha1.BareMetalHost{
-				ObjectMeta: testObjectMeta("bmh-abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(baremetalhostName, namespaceName, ""),
 				Status:     bmov1alpha1.BareMetalHostStatus{},
 			},
 			expectError: true,
@@ -2261,7 +2242,7 @@ var _ = Describe("Metal3Data manager", func() {
 				FromHostInterface: pointer.StringPtr("eth1"),
 			},
 			bmh: &bmov1alpha1.BareMetalHost{
-				ObjectMeta: testObjectMeta("bmh-abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(baremetalhostName, namespaceName, ""),
 				Status: bmov1alpha1.BareMetalHostStatus{
 					HardwareDetails: &bmov1alpha1.HardwareDetails{
 						NIC: []bmov1alpha1.NIC{
@@ -2286,7 +2267,7 @@ var _ = Describe("Metal3Data manager", func() {
 				FromHostInterface: pointer.StringPtr("eth2"),
 			},
 			bmh: &bmov1alpha1.BareMetalHost{
-				ObjectMeta: testObjectMeta("bmh-abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(baremetalhostName, namespaceName, ""),
 				Status: bmov1alpha1.BareMetalHostStatus{
 					HardwareDetails: &bmov1alpha1.HardwareDetails{
 						NIC: []bmov1alpha1.NIC{
@@ -2337,7 +2318,7 @@ var _ = Describe("Metal3Data manager", func() {
 		},
 		Entry("Empty", testCaseRenderMetaData{
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("datatemplate-abc", "", ""),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName+"-abc", "", ""),
 			},
 			expectedMetaData: nil,
 		}),
@@ -2350,7 +2331,7 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "datatemplate-abc",
+					Name:      metal3DataTemplateName + "-abc",
 					Namespace: namespaceName,
 				},
 				Spec: infrav1alpha5.Metal3DataTemplateSpec{
@@ -2499,7 +2480,7 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			m3m: &infrav1alpha5.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "metal3machine-abc",
+					Name:      metal3machineName,
 					Namespace: namespaceName,
 					Labels: map[string]string{
 						"M3M":   "Metal3MachineLabel",
@@ -2514,7 +2495,7 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			machine: &capi.Machine{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "machine-abc",
+					Name: machineName,
 					Labels: map[string]string{
 						"Machine": "MachineLabel",
 					},
@@ -2525,7 +2506,7 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			bmh: &bmo.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "bmh-abc",
+					Name:      baremetalhostName,
 					Namespace: namespaceName,
 					Labels: map[string]string{
 						"BMH": "BMHLabel",
@@ -2566,10 +2547,10 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			expectedMetaData: map[string]string{
 				"String-1":     "String-1",
-				"providerid":   fmt.Sprintf("%s/%s/%s", namespaceName, "bmh-abc", "metal3machine-abc"),
-				"ObjectName-1": "machine-abc",
-				"ObjectName-2": "metal3machine-abc",
-				"ObjectName-3": "bmh-abc",
+				"providerid":   fmt.Sprintf("%s/%s/%s", namespaceName, baremetalhostName, metal3machineName),
+				"ObjectName-1": machineName,
+				"ObjectName-2": metal3machineName,
+				"ObjectName-3": baremetalhostName,
 				"Namespace-1":  namespaceName,
 				"Index-1":      "abc14def",
 				"Index-2":      "2",
@@ -2597,7 +2578,7 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("Interface absent", testCaseRenderMetaData{
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("datatemplate-abc", "", ""),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName+"-abc", "", ""),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					MetaData: &infrav1.MetaData{
 						FromHostInterfaces: []infrav1.MetaDataHostInterface{
@@ -2610,7 +2591,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			bmh: &bmov1alpha1.BareMetalHost{
-				ObjectMeta: testObjectMeta("bmh-abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(baremetalhostName, namespaceName, ""),
 				Status: bmov1alpha1.BareMetalHostStatus{
 					HardwareDetails: &bmov1alpha1.HardwareDetails{
 						NIC: []bmov1alpha1.NIC{
@@ -2638,7 +2619,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("datatemplate-abc", "", ""),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName+"-abc", "", ""),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					MetaData: &infrav1.MetaData{
 						IPAddressesFromPool: []infrav1.FromPool{
@@ -2660,7 +2641,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("datatemplate-abc", "", ""),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName+"-abc", "", ""),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					MetaData: &infrav1.MetaData{
 						PrefixesFromPool: []infrav1.FromPool{
@@ -2682,7 +2663,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("datatemplate-abc", "", ""),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName+"-abc", "", ""),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					MetaData: &infrav1.MetaData{
 						GatewaysFromPool: []infrav1.FromPool{
@@ -2698,7 +2679,7 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("Wrong object in name", testCaseRenderMetaData{
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("datatemplate-abc", "", ""),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName+"-abc", "", ""),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					MetaData: &infrav1.MetaData{
 						ObjectNames: []infrav1.MetaDataObjectName{
@@ -2714,7 +2695,7 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("Wrong object in Label", testCaseRenderMetaData{
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("datatemplate-abc", "", ""),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName+"-abc", "", ""),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					MetaData: &infrav1.MetaData{
 						FromLabels: []infrav1.MetaDataFromLabel{
@@ -2731,7 +2712,7 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("Wrong object in Annotation", testCaseRenderMetaData{
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("datatemplate-abc", "", ""),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName+"-abc", "", ""),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					MetaData: &infrav1.MetaData{
 						FromAnnotations: []infrav1.MetaDataFromAnnotation{
@@ -2906,15 +2887,15 @@ var _ = Describe("Metal3Data manager", func() {
 			}
 		},
 		Entry("Object does not exist", testCaseGetM3Machine{
-			Data: &infrav1alpha5.Metal3Data{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec: infrav1alpha5.Metal3DataSpec{
-					Claim: *testObjectReference,
+			Data: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
+				Spec: infrav1.Metal3DataSpec{
+					Claim: *testObjectReference(metal3DataClaimName),
 				},
 			},
-			DataClaim: &infrav1alpha5.Metal3DataClaim{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
+			DataClaim: &infrav1.Metal3DataClaim{
+				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
+				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			ExpectRequeue: true,
 		}),
@@ -2931,71 +2912,71 @@ var _ = Describe("Metal3Data manager", func() {
 			ExpectError: true,
 		}),
 		Entry("Dataclaim Spec ownerref unset", testCaseGetM3Machine{
-			Data: &infrav1alpha5.Metal3Data{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec: infrav1alpha5.Metal3DataSpec{
-					Claim: *testObjectReference,
+			Data: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
+				Spec: infrav1.Metal3DataSpec{
+					Claim: *testObjectReference(metal3DataClaimName),
 				},
 			},
 			DataClaim: &infrav1.Metal3DataClaim{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3DataClaimName, namespaceName, m3dcuid),
 				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			ExpectError: true,
 		}),
 		Entry("M3Machine not found", testCaseGetM3Machine{
-			Data: &infrav1alpha5.Metal3Data{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec: infrav1alpha5.Metal3DataSpec{
-					Claim: *testObjectReference,
+			Data: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
+				Spec: infrav1.Metal3DataSpec{
+					Claim: *testObjectReference(metal3DataClaimName),
 				},
 			},
-			DataClaim: &infrav1alpha5.Metal3DataClaim{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
+			DataClaim: &infrav1.Metal3DataClaim{
+				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
+				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			ExpectRequeue: true,
 		}),
 		Entry("Object exists", testCaseGetM3Machine{
 			Machine: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, m3muid),
 			},
-			Data: &infrav1alpha5.Metal3Data{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec: infrav1alpha5.Metal3DataSpec{
-					Claim: *testObjectReference,
+			Data: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
+				Spec: infrav1.Metal3DataSpec{
+					Claim: *testObjectReference(metal3DataClaimName),
 				},
 			},
-			DataClaim: &infrav1alpha5.Metal3DataClaim{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
+			DataClaim: &infrav1.Metal3DataClaim{
+				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
+				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 		}),
 		Entry("Object exists, dataTemplate nil", testCaseGetM3Machine{
 			Machine: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, m3muid),
 				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: nil,
 				},
 			},
 			DataTemplate: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
 			},
-			Data: &infrav1alpha5.Metal3Data{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec: infrav1alpha5.Metal3DataSpec{
-					Claim: *testObjectReference,
+			Data: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
+				Spec: infrav1.Metal3DataSpec{
+					Claim: *testObjectReference(metal3DataClaimName),
 				},
 			},
-			DataClaim: &infrav1alpha5.Metal3DataClaim{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
+			DataClaim: &infrav1.Metal3DataClaim{
+				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
+				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists, dataTemplate name mismatch", testCaseGetM3Machine{
 			Machine: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, m3muid),
 				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
 						Name:      "abcd",
@@ -3004,23 +2985,23 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			DataTemplate: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
 			},
-			Data: &infrav1alpha5.Metal3Data{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec: infrav1alpha5.Metal3DataSpec{
-					Claim: *testObjectReference,
+			Data: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
+				Spec: infrav1.Metal3DataSpec{
+					Claim: *testObjectReference(metal3DataClaimName),
 				},
 			},
-			DataClaim: &infrav1alpha5.Metal3DataClaim{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
+			DataClaim: &infrav1.Metal3DataClaim{
+				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
+				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists, dataTemplate namespace mismatch", testCaseGetM3Machine{
 			Machine: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, m3muid),
 				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
 						Name:      "abc",
@@ -3029,17 +3010,17 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			DataTemplate: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
 			},
-			Data: &infrav1alpha5.Metal3Data{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec: infrav1alpha5.Metal3DataSpec{
-					Claim: *testObjectReference,
+			Data: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMetaWithOR(metal3DataName, metal3machineName),
+				Spec: infrav1.Metal3DataSpec{
+					Claim: *testObjectReference(metal3DataClaimName),
 				},
 			},
-			DataClaim: &infrav1alpha5.Metal3DataClaim{
-				ObjectMeta: testObjectMetaWithOR,
-				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
+			DataClaim: &infrav1.Metal3DataClaim{
+				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
+				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			ExpectEmpty: true,
 		}),

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -2665,7 +2665,7 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			expectedMetaData: map[string]string{
 				"String-1":     "String-1",
-				"providerid":   fmt.Sprintf("%s/%s/%s", namespaceName, bmhuid, m3muid),
+				"providerid":   fmt.Sprintf("%s/%s/%s", namespaceName, "bmh-abc", "metal3machine-abc"),
 				"ObjectName-1": "machine-abc",
 				"ObjectName-2": "metal3machine-abc",
 				"ObjectName-3": "bmh-abc",

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -19,13 +19,15 @@ package baremetal
 import (
 	"context"
 
-	"gopkg.in/yaml.v2"
+	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
 
 	bmo "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	capm3 "github.com/metal3-io/cluster-api-provider-metal3/api/v1alpha5"
 	infrav1alpha5 "github.com/metal3-io/cluster-api-provider-metal3/api/v1alpha5"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -43,16 +45,18 @@ var (
 	testObjectMeta = metav1.ObjectMeta{
 		Name:      "abc",
 		Namespace: "myns",
+		UID:       bmhuid,
 	}
 	testObjectMetaWithOR = metav1.ObjectMeta{
 		Name:      "abc",
 		Namespace: "myns",
+
 		OwnerReferences: []metav1.OwnerReference{
 			{
 				Name:       "abc",
 				Kind:       "Metal3Machine",
-				APIVersion: infrav1alpha5.GroupVersion.String(),
-				UID:        "a7241a39-4730-44c4-9d81-e70f27a4ce89",
+				APIVersion: capm3.GroupVersion.String(),
+				UID:        m3muid,
 			},
 		},
 	}
@@ -445,6 +449,7 @@ var _ = Describe("Metal3Data manager", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
 					Namespace: "myns",
+					UID:       m3muid,
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Name:       "abc",
@@ -471,7 +476,7 @@ var _ = Describe("Metal3Data manager", func() {
 				ObjectMeta: testObjectMeta,
 			},
 			expectReady:         true,
-			expectedMetadata:    pointer.StringPtr("String-1: String-1\n"),
+			expectedMetadata:    pointer.StringPtr(fmt.Sprintf("String-1: String-1\nprovideruid: %s\n", provideruid)),
 			expectedNetworkData: pointer.StringPtr("links:\n- ethernet_mac_address: XX:XX:XX:XX:XX:XX\n  id: eth0\n  mtu: 1500\n  type: phy\nnetworks: []\nservices: []\n"),
 		}),
 		Entry("No Machine OwnerRef on M3M", testCaseCreateSecrets{
@@ -2454,6 +2459,10 @@ var _ = Describe("Metal3Data manager", func() {
 								Key:   "String-1",
 								Value: "String-1",
 							},
+							{
+								Key:   "provideruid",
+								Value: fmt.Sprintf("%s_11111111", bmhuid),
+							},
 						},
 						ObjectNames: []infrav1alpha5.MetaDataObjectName{
 							{
@@ -2598,6 +2607,7 @@ var _ = Describe("Metal3Data manager", func() {
 						"M3M":   "Metal3MachineLabel",
 						"Empty": "",
 					},
+					UID: m3muid,
 					Annotations: map[string]string{
 						"M3M":   "Metal3MachineAnnotation",
 						"Empty": "",
@@ -2624,6 +2634,7 @@ var _ = Describe("Metal3Data manager", func() {
 					Annotations: map[string]string{
 						"BMH": "BMHAnnotation",
 					},
+					UID: bmhuid,
 				},
 				Status: bmo.BareMetalHostStatus{
 					HardwareDetails: &bmo.HardwareDetails{
@@ -2656,6 +2667,7 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			expectedMetaData: map[string]string{
 				"String-1":     "String-1",
+				"provideruid":  fmt.Sprintf("%s_11111111", bmhuid),
 				"ObjectName-1": "machine-abc",
 				"ObjectName-2": "metal3machine-abc",
 				"ObjectName-3": "bmh-abc",

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -18,6 +18,7 @@ package baremetal
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -474,7 +475,7 @@ var _ = Describe("Metal3Data manager", func() {
 				ObjectMeta: testObjectMeta,
 			},
 			expectReady:         true,
-			expectedMetadata:    pointer.StringPtr("String-1: String-1\n"),
+			expectedMetadata:    pointer.StringPtr(fmt.Sprintf("String-1: String-1\nproviderid: %s\n", providerid)),
 			expectedNetworkData: pointer.StringPtr("links:\n- ethernet_mac_address: XX:XX:XX:XX:XX:XX\n  id: eth0\n  mtu: 1500\n  type: phy\nnetworks: []\nservices: []\n"),
 		}),
 		Entry("No Machine OwnerRef on M3M", testCaseCreateSecrets{
@@ -2448,7 +2449,8 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "datatemplate-abc",
+					Name:      "datatemplate-abc",
+					Namespace: namespaceName,
 				},
 				Spec: infrav1alpha5.Metal3DataTemplateSpec{
 					MetaData: &infrav1alpha5.MetaData{
@@ -2596,7 +2598,8 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			m3m: &infrav1alpha5.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "metal3machine-abc",
+					Name:      "metal3machine-abc",
+					Namespace: namespaceName,
 					Labels: map[string]string{
 						"M3M":   "Metal3MachineLabel",
 						"Empty": "",
@@ -2621,7 +2624,8 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			bmh: &bmo.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "bmh-abc",
+					Name:      "bmh-abc",
+					Namespace: namespaceName,
 					Labels: map[string]string{
 						"BMH": "BMHLabel",
 					},
@@ -2661,6 +2665,7 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			expectedMetaData: map[string]string{
 				"String-1":     "String-1",
+				"providerid":   fmt.Sprintf("%s/%s/%s", namespaceName, bmhuid, m3muid),
 				"ObjectName-1": "machine-abc",
 				"ObjectName-2": "metal3machine-abc",
 				"ObjectName-3": "bmh-abc",

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("requeue error", testCaseReconcile{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3DataSpec{
 					Template: *testObjectReference,
 				},
@@ -254,7 +254,7 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("No Metal3DataTemplate", testCaseCreateSecrets{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3DataSpec{
 					Template: *testObjectReference,
 				},
@@ -263,17 +263,17 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("No Metal3Machine in owner refs", testCaseCreateSecrets{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3DataSpec{
 					Template: *testObjectReference,
 					Claim:    *testObjectReference,
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			dataClaim: &infrav1.Metal3DataClaim{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			expectError: true,
@@ -287,7 +287,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR,
@@ -304,10 +304,10 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			m3m: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: testObjectReference,
 				},
@@ -327,10 +327,10 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			m3m: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR,
@@ -347,7 +347,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					MetaData: &infrav1.MetaData{
 						Strings: []infrav1.MetaDataString{
@@ -374,7 +374,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3m: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: testObjectReference,
 				},
@@ -408,7 +408,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					MetaData: &infrav1.MetaData{
 						Strings: []infrav1.MetaDataString{
@@ -459,10 +459,10 @@ var _ = Describe("Metal3Data manager", func() {
 				Spec:       infrav1alpha5.Metal3DataClaimSpec{},
 			},
 			machine: &clusterv1.Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			bmh: &bmov1alpha1.BareMetalHost{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			expectReady:         true,
 			expectedMetadata:    pointer.StringPtr(fmt.Sprintf("String-1: String-1\nproviderid: %s\n", providerid)),
@@ -477,7 +477,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					MetaData: &infrav1.MetaData{
 						Strings: []infrav1.MetaDataString{
@@ -504,7 +504,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3m: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: testObjectReference,
 				},
@@ -524,7 +524,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					MetaData: &infrav1.MetaData{
 						Strings: []infrav1.MetaDataString{
@@ -567,7 +567,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			machine: &clusterv1.Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR,
@@ -2938,7 +2938,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			DataClaim: &infrav1.Metal3DataClaim{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec:       infrav1.Metal3DataClaimSpec{},
 			},
 			ExpectError: true,
@@ -2958,7 +2958,7 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("Object exists", testCaseGetM3Machine{
 			Machine: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			Data: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR,
@@ -2973,13 +2973,13 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("Object exists, dataTemplate nil", testCaseGetM3Machine{
 			Machine: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: nil,
 				},
 			},
 			DataTemplate: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			Data: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR,
@@ -2995,7 +2995,7 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("Object exists, dataTemplate name mismatch", testCaseGetM3Machine{
 			Machine: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
 						Name:      "abcd",
@@ -3004,7 +3004,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			DataTemplate: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			Data: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR,
@@ -3020,7 +3020,7 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("Object exists, dataTemplate namespace mismatch", testCaseGetM3Machine{
 			Machine: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
 						Name:      "abc",
@@ -3029,7 +3029,7 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			DataTemplate: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 			},
 			Data: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMetaWithOR,

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -19,8 +19,6 @@ package baremetal
 import (
 	"context"
 
-	"fmt"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -2459,10 +2457,6 @@ var _ = Describe("Metal3Data manager", func() {
 								Key:   "String-1",
 								Value: "String-1",
 							},
-							{
-								Key:   "provideruid",
-								Value: fmt.Sprintf("%s_11111111", bmhuid),
-							},
 						},
 						ObjectNames: []infrav1alpha5.MetaDataObjectName{
 							{
@@ -2667,7 +2661,6 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			expectedMetaData: map[string]string{
 				"String-1":     "String-1",
-				"provideruid":  fmt.Sprintf("%s_11111111", bmhuid),
 				"ObjectName-1": "machine-abc",
 				"ObjectName-2": "metal3machine-abc",
 				"ObjectName-3": "bmh-abc",

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -43,12 +43,12 @@ import (
 var (
 	testObjectMeta = metav1.ObjectMeta{
 		Name:      "abc",
-		Namespace: "myns",
+		Namespace: namespaceName,
 		UID:       bmhuid,
 	}
 	testObjectMetaWithOR = metav1.ObjectMeta{
 		Name:      "abc",
-		Namespace: "myns",
+		Namespace: namespaceName,
 
 		OwnerReferences: []metav1.OwnerReference{
 			{
@@ -231,7 +231,7 @@ var _ = Describe("Metal3Data manager", func() {
 				err = c.Get(context.TODO(),
 					client.ObjectKey{
 						Name:      "abc-metadata",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					&tmpSecret,
 				)
@@ -243,7 +243,7 @@ var _ = Describe("Metal3Data manager", func() {
 				err = c.Get(context.TODO(),
 					client.ObjectKey{
 						Name:      "abc-networkdata",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					&tmpSecret,
 				)
@@ -390,7 +390,7 @@ var _ = Describe("Metal3Data manager", func() {
 			metadataSecret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc-metadata",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Data: map[string][]byte{
 					"metaData": []byte("Hello"),
@@ -399,7 +399,7 @@ var _ = Describe("Metal3Data manager", func() {
 			networkdataSecret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc-networkdata",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Data: map[string][]byte{
 					"networkData": []byte("Bye"),
@@ -447,7 +447,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3m: &infrav1alpha5.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 					UID:       m3muid,
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -457,7 +457,7 @@ var _ = Describe("Metal3Data manager", func() {
 						},
 					},
 					Annotations: map[string]string{
-						"metal3.io/BareMetalHost": "myns/abc",
+						"metal3.io/BareMetalHost": namespaceName + "/abc",
 					},
 				},
 				Spec: infrav1alpha5.Metal3MachineSpec{
@@ -563,7 +563,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3m: &infrav1alpha5.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Name:       "abc",
@@ -624,7 +624,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: infrav1alpha5.Metal3DataSpec{
 					Template: corev1.ObjectReference{
@@ -638,7 +638,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: infrav1alpha5.Metal3DataSpec{
 					Template: corev1.ObjectReference{
@@ -649,7 +649,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 		}),
@@ -669,7 +669,7 @@ var _ = Describe("Metal3Data manager", func() {
 				pool := &ipamv1.IPClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc-" + poolName,
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					Spec: ipamv1.IPClaimSpec{
 						Pool: *testObjectReference,
@@ -680,7 +680,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d := &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Metal3Data",
@@ -690,7 +690,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3dt := infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: tc.m3dtSpec,
 			}
@@ -1005,7 +1005,7 @@ var _ = Describe("Metal3Data manager", func() {
 				pool := &ipamv1.IPClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc-" + poolName,
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					Spec: ipamv1.IPClaimSpec{
 						Pool: *testObjectReference,
@@ -1016,7 +1016,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d := &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Metal3Data",
@@ -1220,7 +1220,7 @@ var _ = Describe("Metal3Data manager", func() {
 		Entry("Already processed", testCaseGetAddressFromPool{
 			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 			poolName: "abc",
@@ -1235,7 +1235,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 			poolName: "abc",
@@ -1249,7 +1249,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 			poolName: "abc",
@@ -1259,7 +1259,7 @@ var _ = Describe("Metal3Data manager", func() {
 			ipClaim: &ipamv1.IPClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc-abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 			expectRequeue: true,
@@ -1268,7 +1268,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 			poolName: "abc",
@@ -1278,7 +1278,7 @@ var _ = Describe("Metal3Data manager", func() {
 			ipClaim: &ipamv1.IPClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc-abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Status: ipamv1.IPClaimStatus{
 					ErrorMessage: pointer.StringPtr("Error happened"),
@@ -1291,7 +1291,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 			poolName: "abc",
@@ -1301,12 +1301,12 @@ var _ = Describe("Metal3Data manager", func() {
 			ipClaim: &ipamv1.IPClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc-abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Status: ipamv1.IPClaimStatus{
 					Address: &corev1.ObjectReference{
 						Name:      "abc-192.168.0.11",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 				},
 			},
@@ -1316,7 +1316,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 			poolName: "abc",
@@ -1333,12 +1333,12 @@ var _ = Describe("Metal3Data manager", func() {
 			ipClaim: &ipamv1.IPClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc-abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Status: ipamv1.IPClaimStatus{
 					Address: &corev1.ObjectReference{
 						Name:      "abc-192.168.0.10",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 				},
 			},
@@ -1346,7 +1346,7 @@ var _ = Describe("Metal3Data manager", func() {
 			ipAddress: &ipamv1.IPAddress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc-192.168.0.10",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: ipamv1.IPAddressSpec{
 					Address: ipamv1.IPAddressStr("192.168.0.10"),
@@ -1411,7 +1411,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 			poolName: "abc",
@@ -1426,7 +1426,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 			poolName: "abc",
@@ -1441,7 +1441,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 			poolName:      "abc",
@@ -1454,7 +1454,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Metal3Data",
@@ -1465,7 +1465,7 @@ var _ = Describe("Metal3Data manager", func() {
 			ipClaim: &ipamv1.IPClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc-abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 			expectedAddresses: map[string]bool{
@@ -2441,7 +2441,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "data-abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: infrav1alpha5.Metal3DataSpec{
 					Index: 2,
@@ -2669,7 +2669,7 @@ var _ = Describe("Metal3Data manager", func() {
 				"ObjectName-1": "machine-abc",
 				"ObjectName-2": "metal3machine-abc",
 				"ObjectName-3": "bmh-abc",
-				"Namespace-1":  "myns",
+				"Namespace-1":  namespaceName,
 				"Index-1":      "abc14def",
 				"Index-2":      "2",
 				"Address-1":    "192.168.0.14",
@@ -2737,7 +2737,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "data-abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: infrav1alpha5.Metal3DataSpec{
 					Index: 2,
@@ -2764,7 +2764,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "data-abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: infrav1alpha5.Metal3DataSpec{
 					Index: 2,
@@ -2791,7 +2791,7 @@ var _ = Describe("Metal3Data manager", func() {
 			m3d: &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "data-abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: infrav1alpha5.Metal3DataSpec{
 					Index: 2,
@@ -3123,7 +3123,7 @@ var _ = Describe("Metal3Data manager", func() {
 				Spec: infrav1alpha5.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
 						Name:      "abcd",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 				},
 			},

--- a/baremetal/metal3datatemplate_manager_test.go
+++ b/baremetal/metal3datatemplate_manager_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			expectError: true,
 		}),
 		Entry("no previous ownerref", testCaseSetClusterOwnerRef{
-			template: &infrav1.Metal3DataTemplate{
+			template: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, "", ""),
 			},
 			cluster: &clusterv1.Cluster{
@@ -169,14 +169,14 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			expectedIndexes: map[string]int{},
 		}),
 		Entry("indexes", testGetIndexes{
-			template: &infrav1.Metal3DataTemplate{
+			template: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, m3dtuid),
-				Spec:       infrav1.Metal3DataTemplateSpec{},
+				Spec:       infrav1alpha5.Metal3DataTemplateSpec{},
 			},
 			indexes: []*infrav1alpha5.Metal3Data{
 				{
 					ObjectMeta: testObjectMeta("abc-0", namespaceName, ""),
-					Spec: infrav1.Metal3DataSpec{
+					Spec: infrav1alpha5.Metal3DataSpec{
 						Index:    0,
 						Template: *testObjectReference(metal3DataTemplateName),
 						Claim:    *testObjectReference(metal3DataClaimName),
@@ -184,7 +184,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				},
 				{
 					ObjectMeta: testObjectMeta("bbc-1", namespaceName, ""),
-					Spec: infrav1.Metal3DataSpec{
+					Spec: infrav1alpha5.Metal3DataSpec{
 						Index: 1,
 						Template: corev1.ObjectReference{
 							Name:      "bbc",
@@ -498,16 +498,16 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				Spec:       infrav1alpha5.Metal3DataTemplateSpec{},
 			},
 			indexes: map[int]string{},
-			template2: &infrav1.Metal3DataTemplate{
+			template2: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta("abc1", namespaceName, ""),
-				Spec: infrav1.Metal3DataTemplateSpec{
+				Spec: infrav1alpha5.Metal3DataTemplateSpec{
 					TemplateReference: "abc",
 				},
 				Status: infrav1alpha5.Metal3DataTemplateStatus{
 					Indexes: map[string]int{},
 				},
 			},
-			dataClaim: &infrav1.Metal3DataClaim{
+			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
 			},
 			expectTemplateReference: true,
@@ -518,14 +518,14 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				Spec:       infrav1alpha5.Metal3DataTemplateSpec{},
 			},
 			indexes: map[int]string{},
-			template2: &infrav1.Metal3DataTemplate{
+			template2: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta("abc1", namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{},
-				Status: infrav1.Metal3DataTemplateStatus{
+				Spec:       infrav1alpha5.Metal3DataTemplateSpec{},
+				Status: infrav1alpha5.Metal3DataTemplateStatus{
 					Indexes: map[string]int{},
 				},
 			},
-			dataClaim: &infrav1.Metal3DataClaim{
+			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
 			},
 			expectTemplateReference: false,
@@ -551,7 +551,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 					Indexes: map[string]int{},
 				},
 			},
-			dataClaim: &infrav1.Metal3DataClaim{
+			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
 			},
 			expectTemplateReference:    true,
@@ -578,12 +578,12 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 					Indexes: map[string]int{},
 				},
 			},
-			dataClaim: &infrav1.Metal3DataClaim{
+			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
 			},
-			dataObject: &infrav1.Metal3Data{
+			dataObject: &infrav1alpha5.Metal3Data{
 				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
-				Spec: infrav1.Metal3DataSpec{
+				Spec: infrav1alpha5.Metal3DataSpec{
 					Index: 0,
 					Template: corev1.ObjectReference{
 						Name: "template12",
@@ -660,7 +660,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 					},
 				},
 			},
-			dataClaim: &infrav1.Metal3DataClaim{
+			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
 			},
 			expectedIndexes: map[string]int{
@@ -676,7 +676,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				},
 			},
 			indexes: map[int]string{},
-			dataClaim: &infrav1.Metal3DataClaim{
+			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
 			},
 			expectedIndexes: map[string]int{
@@ -698,7 +698,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				},
 			},
 			indexes: map[int]string{0: "bcd"},
-			dataClaim: &infrav1.Metal3DataClaim{
+			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
 			},
 			expectedIndexes: map[string]int{
@@ -720,7 +720,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				},
 			},
 			indexes: map[int]string{},
-			dataClaim: &infrav1.Metal3DataClaim{
+			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR(metal3DataClaimName, metal3machineName),
 			},
 			datas: []*infrav1alpha5.Metal3Data{
@@ -789,14 +789,14 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			Expect(len(tc.dataClaim.Finalizers)).To(Equal(0))
 		},
 		Entry("Empty Template", testCaseDeleteDatas{
-			template: &infrav1.Metal3DataTemplate{},
-			dataClaim: &infrav1.Metal3DataClaim{
+			template: &infrav1alpha5.Metal3DataTemplate{},
+			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMeta("TestRef", "", ""),
 			},
 		}),
 		Entry("No Deletion needed", testCaseDeleteDatas{
-			template: &infrav1.Metal3DataTemplate{},
-			dataClaim: &infrav1.Metal3DataClaim{
+			template: &infrav1alpha5.Metal3DataTemplate{},
+			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMeta("TestRef", "", ""),
 			},
 			expectedMap: map[int]string{0: "abcd"},
@@ -812,7 +812,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 					},
 				},
 			},
-			dataClaim: &infrav1.Metal3DataClaim{
+			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMeta("TestRef", "", ""),
 			},
 			indexes: map[int]string{
@@ -822,10 +822,10 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			expectedMap:     map[int]string{},
 		}),
 		Entry("Deletion needed", testCaseDeleteDatas{
-			template: &infrav1.Metal3DataTemplate{
+			template: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta("abc", "", ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{},
-				Status: infrav1.Metal3DataTemplateStatus{
+				Spec:       infrav1alpha5.Metal3DataTemplateSpec{},
+				Status: infrav1alpha5.Metal3DataTemplateStatus{
 					Indexes: map[string]int{
 						"TestRef": 0,
 					},

--- a/baremetal/metal3datatemplate_manager_test.go
+++ b/baremetal/metal3datatemplate_manager_test.go
@@ -184,7 +184,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc-0",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					Spec: infrav1alpha5.Metal3DataSpec{
 						Index:    0,
@@ -195,24 +195,24 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bbc-1",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					Spec: infrav1alpha5.Metal3DataSpec{
 						Index: 1,
 						Template: corev1.ObjectReference{
 							Name:      "bbc",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 						Claim: corev1.ObjectReference{
 							Name:      "bbc",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc-2",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					Spec: infrav1alpha5.Metal3DataSpec{
 						Index:    2,
@@ -223,12 +223,12 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc-3",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					Spec: infrav1alpha5.Metal3DataSpec{
 						Index: 3,
 						Template: corev1.ObjectReference{
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 						Claim: corev1.ObjectReference{},
 					},
@@ -245,7 +245,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 
 	var templateMeta = metav1.ObjectMeta{
 		Name:      "abc",
-		Namespace: "myns",
+		Namespace: namespaceName,
 	}
 
 	type testCaseUpdateDatas struct {
@@ -317,67 +317,67 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					Spec: infrav1alpha5.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
 							Name:      "abc",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abcd",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					Spec: infrav1alpha5.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
 							Name:      "abcd",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 					},
 					Status: infrav1alpha5.Metal3DataClaimStatus{
 						RenderedData: &corev1.ObjectReference{
 							Name:      "abc-2",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abce",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					Spec: infrav1alpha5.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
 							Name:      "abc",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 					},
 					Status: infrav1alpha5.Metal3DataClaimStatus{
 						RenderedData: &corev1.ObjectReference{
 							Name:      "abc-2",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "abcf",
-						Namespace:         "myns",
+						Namespace:         namespaceName,
 						DeletionTimestamp: &timeNow,
 					},
 					Spec: infrav1alpha5.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
 							Name:      "abc",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 					},
 					Status: infrav1alpha5.Metal3DataClaimStatus{
 						RenderedData: &corev1.ObjectReference{
 							Name:      "abc-3",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 					},
 				},
@@ -386,16 +386,16 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc-0",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					Spec: infrav1alpha5.Metal3DataSpec{
 						Template: corev1.ObjectReference{
 							Name:      "abc",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 						Claim: corev1.ObjectReference{
 							Name:      "abc",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 						Index: 0,
 					},
@@ -403,16 +403,16 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc-1",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					Spec: infrav1alpha5.Metal3DataSpec{
 						Template: corev1.ObjectReference{
 							Name:      "abc",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 						Claim: corev1.ObjectReference{
 							Name:      "abce",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 						Index: 1,
 					},
@@ -420,16 +420,16 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc-3",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					Spec: infrav1alpha5.Metal3DataSpec{
 						Template: corev1.ObjectReference{
 							Name:      "abc",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 						Claim: corev1.ObjectReference{
 							Name:      "abcf",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 						Index: 3,
 					},
@@ -514,7 +514,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			template2: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc1",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: infrav1alpha5.Metal3DataTemplateSpec{
 					TemplateReference: "abc",
@@ -537,7 +537,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			template2: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc1",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: infrav1alpha5.Metal3DataTemplateSpec{},
 				Status: infrav1alpha5.Metal3DataTemplateStatus{
@@ -553,7 +553,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			template1: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "template1",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: infrav1alpha5.Metal3DataTemplateSpec{},
 			},
@@ -561,7 +561,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			template2: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "template2",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: infrav1alpha5.Metal3DataTemplateSpec{
 					TemplateReference: "template1",
@@ -580,7 +580,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			template1: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "template1",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: infrav1alpha5.Metal3DataTemplateSpec{},
 			},
@@ -588,7 +588,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			template2: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "template2",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: infrav1alpha5.Metal3DataTemplateSpec{
 					TemplateReference: "template1",
@@ -603,7 +603,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			dataObject: &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: infrav1alpha5.Metal3DataSpec{
 					Index: 0,
@@ -749,7 +749,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc-0",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					Spec: infrav1alpha5.Metal3DataSpec{
 						Index: 0,

--- a/baremetal/metal3datatemplate_manager_test.go
+++ b/baremetal/metal3datatemplate_manager_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		}),
 		Entry("indexes", testGetIndexes{
 			template: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta("abc", namespaceName, bmhuid),
 				Spec:       infrav1.Metal3DataTemplateSpec{},
 			},
 			indexes: []*infrav1alpha5.Metal3Data{

--- a/baremetal/metal3datatemplate_manager_test.go
+++ b/baremetal/metal3datatemplate_manager_test.go
@@ -90,15 +90,11 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			expectError: true,
 		}),
 		Entry("no previous ownerref", testCaseSetClusterOwnerRef{
-			template: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "abc",
-				},
+			template: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", "", ""),
 			},
-			cluster: &capi.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "abc-cluster",
-				},
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: testObjectMeta("abc-cluster", "", ""),
 			},
 		}),
 		Entry("previous ownerref", testCaseSetClusterOwnerRef{
@@ -112,10 +108,8 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 					},
 				},
 			},
-			cluster: &capi.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "abc-cluster",
-				},
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: testObjectMeta("abc-cluster", "", ""),
 			},
 		}),
 		Entry("ownerref present", testCaseSetClusterOwnerRef{
@@ -132,10 +126,8 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 					},
 				},
 			},
-			cluster: &capi.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "abc-cluster",
-				},
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: testObjectMeta("abc-cluster", "", ""),
 			},
 		}),
 	)
@@ -176,28 +168,22 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			expectedIndexes: map[string]int{},
 		}),
 		Entry("indexes", testGetIndexes{
-			template: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta,
-				Spec:       infrav1alpha5.Metal3DataTemplateSpec{},
+			template: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec:       infrav1.Metal3DataTemplateSpec{},
 			},
 			indexes: []*infrav1alpha5.Metal3Data{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc-0",
-						Namespace: namespaceName,
-					},
-					Spec: infrav1alpha5.Metal3DataSpec{
+					ObjectMeta: testObjectMeta("abc-0", namespaceName, ""),
+					Spec: infrav1.Metal3DataSpec{
 						Index:    0,
 						Template: *testObjectReference,
 						Claim:    *testObjectReference,
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "bbc-1",
-						Namespace: namespaceName,
-					},
-					Spec: infrav1alpha5.Metal3DataSpec{
+					ObjectMeta: testObjectMeta("bbc-1", namespaceName, ""),
+					Spec: infrav1.Metal3DataSpec{
 						Index: 1,
 						Template: corev1.ObjectReference{
 							Name:      "bbc",
@@ -511,12 +497,9 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				Spec:       infrav1alpha5.Metal3DataTemplateSpec{},
 			},
 			indexes: map[int]string{},
-			template2: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc1",
-					Namespace: namespaceName,
-				},
-				Spec: infrav1alpha5.Metal3DataTemplateSpec{
+			template2: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc1", namespaceName, ""),
+				Spec: infrav1.Metal3DataTemplateSpec{
 					TemplateReference: "abc",
 				},
 				Status: infrav1alpha5.Metal3DataTemplateStatus{
@@ -534,13 +517,10 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				Spec:       infrav1alpha5.Metal3DataTemplateSpec{},
 			},
 			indexes: map[int]string{},
-			template2: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc1",
-					Namespace: namespaceName,
-				},
-				Spec: infrav1alpha5.Metal3DataTemplateSpec{},
-				Status: infrav1alpha5.Metal3DataTemplateStatus{
+			template2: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc1", namespaceName, ""),
+				Spec:       infrav1.Metal3DataTemplateSpec{},
+				Status: infrav1.Metal3DataTemplateStatus{
 					Indexes: map[string]int{},
 				},
 			},
@@ -600,12 +580,9 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			dataClaim: &infrav1alpha5.Metal3DataClaim{
 				ObjectMeta: testObjectMetaWithOR,
 			},
-			dataObject: &infrav1alpha5.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
-				Spec: infrav1alpha5.Metal3DataSpec{
+			dataObject: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3DataSpec{
 					Index: 0,
 					Template: corev1.ObjectReference{
 						Name: "template12",
@@ -811,19 +788,15 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			Expect(len(tc.dataClaim.Finalizers)).To(Equal(0))
 		},
 		Entry("Empty Template", testCaseDeleteDatas{
-			template: &infrav1alpha5.Metal3DataTemplate{},
-			dataClaim: &infrav1alpha5.Metal3DataClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "TestRef",
-				},
+			template: &infrav1.Metal3DataTemplate{},
+			dataClaim: &infrav1.Metal3DataClaim{
+				ObjectMeta: testObjectMeta("TestRef", "", ""),
 			},
 		}),
 		Entry("No Deletion needed", testCaseDeleteDatas{
-			template: &infrav1alpha5.Metal3DataTemplate{},
-			dataClaim: &infrav1alpha5.Metal3DataClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "TestRef",
-				},
+			template: &infrav1.Metal3DataTemplate{},
+			dataClaim: &infrav1.Metal3DataClaim{
+				ObjectMeta: testObjectMeta("TestRef", "", ""),
 			},
 			expectedMap: map[int]string{0: "abcd"},
 			indexes: map[int]string{
@@ -838,10 +811,8 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 					},
 				},
 			},
-			dataClaim: &infrav1alpha5.Metal3DataClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "TestRef",
-				},
+			dataClaim: &infrav1.Metal3DataClaim{
+				ObjectMeta: testObjectMeta("TestRef", "", ""),
 			},
 			indexes: map[int]string{
 				0: "TestRef",
@@ -850,12 +821,10 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			expectedMap:     map[int]string{},
 		}),
 		Entry("Deletion needed", testCaseDeleteDatas{
-			template: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "abc",
-				},
-				Spec: infrav1alpha5.Metal3DataTemplateSpec{},
-				Status: infrav1alpha5.Metal3DataTemplateStatus{
+			template: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", "", ""),
+				Spec:       infrav1.Metal3DataTemplateSpec{},
+				Status: infrav1.Metal3DataTemplateStatus{
 					Indexes: map[string]int{
 						"TestRef": 0,
 					},

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -1267,6 +1267,10 @@ func (m *MachineManager) GetProviderIDAndBMHID() (string, *string) {
 	if providerID == nil {
 		return "", nil
 	}
+	if strings.Contains(*providerID, ProviderIDPrefix) {
+		bmhID := strings.TrimPrefix(*providerID, ProviderIDPrefix)
+		return *providerID, pointer.StringPtr(parseProviderID(bmhID))
+	}
 	return *providerID, pointer.StringPtr(parseProviderID(*providerID))
 }
 

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -62,6 +62,8 @@ const (
 	bmRoleControlPlane  = "control-plane"
 	bmRoleNode          = "node"
 	PausedAnnotationKey = "metal3.io/capm3"
+	ProviderIDPrefix    = "metal3://"
+	ProviderLabelPrefix = "metal3.io/uuid"
 )
 
 // MachineManagerInterface is an interface for a MachineManager
@@ -1281,7 +1283,7 @@ func (m *MachineManager) SetNodeProviderID(ctx context.Context, bmhID, providerI
 		return errors.Wrap(err, "Error creating a remote client")
 	}
 
-	nodeLabel := fmt.Sprintf("metal3.io/uuid=%v", bmhID)
+	nodeLabel := fmt.Sprintf("%s=%v", ProviderLabelPrefix, bmhID)
 	nodes, nodesCount, err := m.getNodesWithLabel(ctx, nodeLabel, clientFactory)
 	if err != nil {
 		m.Log.Info("error retrieving node, requeuing")

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -1281,14 +1281,13 @@ func (m *MachineManager) SetNodeProviderID(ctx context.Context, bmhID, providerI
 		return errors.Wrap(err, "Error creating a remote client")
 	}
 
-	nodes, err := corev1Remote.Nodes().List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("metal3.io/uuid=%v", bmhID),
-	})
+	nodeLabel := fmt.Sprintf("metal3.io/uuid=%v", bmhID)
+	nodes, nodesCount, err := m.getNodesWithLabel(ctx, nodeLabel, clientFactory)
 	if err != nil {
-		m.Log.Info(fmt.Sprintf("error while accessing cluster: %v", err))
+		m.Log.Info("error retrieving node, requeuing")
 		return &RequeueAfterError{RequeueAfter: requeueAfter}
 	}
-	if len(nodes.Items) == 0 {
+	if nodesCount == 0 {
 		// The node could either be still running cloud-init or have been
 		// deleted manually. TODO: handle a manual deletion case
 		m.Log.Info("Target node is not found, requeuing")
@@ -1678,4 +1677,24 @@ func (m *MachineManager) getMachineSet(ctx context.Context) (*capi.MachineSet, e
 		}
 	}
 	return nil, errors.New("MachineSet is not found")
+}
+
+// getNodesWithLabel gets kubernetes nodes with a given label
+func (m *MachineManager) getNodesWithLabel(ctx context.Context, nodeLabel string, clientFactory ClientGetter) (*corev1.NodeList, int, error) {
+	corev1Remote, err := clientFactory(ctx, m.client, m.Cluster)
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "Error creating a remote client")
+	}
+	nodesCount := 0
+	nodes, err := corev1Remote.Nodes().List(ctx, metav1.ListOptions{
+		LabelSelector: nodeLabel,
+	})
+	if err != nil {
+		m.Log.Info(fmt.Sprintf("error while retrieving nodes with label (%s): %v", nodeLabel, err))
+		return nil, 0, err
+	}
+	if nodes != nil {
+		nodesCount = len(nodes.Items)
+	}
+	return nodes, nodesCount, err
 }

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -78,7 +78,7 @@ type MachineManagerInterface interface {
 	Update(context.Context) error
 	HasAnnotation() bool
 	GetProviderIDAndBMHID() (string, *string)
-	SetNodeProviderID(context.Context, string, *string, ClientGetter) error
+	SetNodeProviderID(context.Context, *string, *string, ClientGetter) error
 	SetProviderID(string)
 	SetPauseAnnotation(context.Context) error
 	RemovePauseAnnotation(context.Context) error
@@ -1267,18 +1267,24 @@ func (m *MachineManager) GetProviderIDAndBMHID() (string, *string) {
 	if providerID == nil {
 		return "", nil
 	}
-	if strings.Contains(*providerID, ProviderIDPrefix) {
-		bmhID := strings.TrimPrefix(*providerID, ProviderIDPrefix)
-		return *providerID, pointer.StringPtr(parseProviderID(bmhID))
+	bmhID := *providerID
+	if strings.Contains(bmhID, ProviderIDPrefix) {
+		bmhID = strings.TrimPrefix(bmhID, ProviderIDPrefix)
 	}
-	return *providerID, pointer.StringPtr(parseProviderID(*providerID))
+	// If the providerID is in new format, it does not contain the BMH ID, but
+	// instead contains / to separate the names. In that case we return nil for
+	// the bmh ID to force the controller to fetch it differently.
+	if strings.Contains(bmhID, "/") {
+		return *providerID, nil
+	}
+	return *providerID, pointer.StringPtr(bmhID)
 }
 
 // ClientGetter prototype
 type ClientGetter func(ctx context.Context, c client.Client, cluster *capi.Cluster) (clientcorev1.CoreV1Interface, error)
 
 // SetNodeProviderID sets the metal3 provider ID on the kubernetes node.
-func (m *MachineManager) SetNodeProviderID(ctx context.Context, bmhID string, providerIDOnM3M *string, clientFactory ClientGetter) error {
+func (m *MachineManager) SetNodeProviderID(ctx context.Context, bmhID *string, providerIDOnM3M *string, clientFactory ClientGetter) error {
 	// todo: bmhID should not be trusted and needs to removed from the signature.
 	corev1Remote, err := clientFactory(ctx, m.client, m.Cluster)
 	if err != nil {
@@ -1291,29 +1297,36 @@ func (m *MachineManager) SetNodeProviderID(ctx context.Context, bmhID string, pr
 		m.Log.Info("unable to retrieve BMH name from Metal3Machine")
 		return &RequeueAfterError{RequeueAfter: requeueAfter}
 	}
-
-	providerIDLegacy := fmt.Sprintf("metal3://%s", bmhID)
+	providerIDLegacy := "metal3://unknown"
+	nodeLabel := fmt.Sprintf("%s=unknown", ProviderLabelPrefix)
+	if bmhID != nil {
+		providerIDLegacy = fmt.Sprintf("metal3://%s", *bmhID)
+		nodeLabel = fmt.Sprintf("%s=%s", ProviderLabelPrefix, *bmhID)
+	}
 	providerIDNew := fmt.Sprintf("metal3://%s/%s/%s", namespace, bmhName, m3mName)
 
-	if !m.Metal3Cluster.Spec.NoCloudProvider {
-		matchingNodesCount, err := m.getMatchingNodesWithoutLabelCount(ctx, providerIDLegacy, providerIDNew, providerIDOnM3M, clientFactory)
-		if matchingNodesCount > 1 {
-			m.Log.Info("More than one node using the same providerID")
-			return errors.Wrap(err, "More than one node using the same providerID")
-		}
-		if err != nil {
-			m.Log.Info("error retrieving node, requeuing")
-			return &RequeueAfterError{RequeueAfter: requeueAfter}
-		}
-		if matchingNodesCount == 0 {
-			// The node could either be still running cloud-init or
-			// kubernetes has not set the node.spec.ProviderID field yet.
-			m.Log.Info("Some target nodes do not have spec.providerID field set yet, requeuing")
-			return &RequeueAfterError{RequeueAfter: requeueAfter}
-		}
+	matchingNodesCount, err := m.getMatchingNodesWithoutLabelCount(ctx, providerIDLegacy, providerIDNew, providerIDOnM3M, clientFactory)
+	if matchingNodesCount > 1 {
+		m.Log.Info("More than one node using the same providerID")
+		return errors.Wrap(err, "More than one node using the same providerID")
+	}
+	if err != nil {
+		m.Log.Info("error retrieving node, requeuing")
+		return &RequeueAfterError{RequeueAfter: requeueAfter}
+	}
+	if !m.Metal3Cluster.Spec.NoCloudProvider && matchingNodesCount == 0 {
+		// The node could either be still running cloud-init or
+		// kubernetes has not set the node.spec.ProviderID field yet.
+		m.Log.Info("Some target nodes do not have spec.providerID field set yet, requeuing")
+		return &RequeueAfterError{RequeueAfter: requeueAfter}
+	}
+	if matchingNodesCount == 1 {
 		return nil
 	}
-	nodeLabel := fmt.Sprintf("%s=%s", ProviderLabelPrefix, bmhID)
+	if bmhID == nil {
+		m.Log.Info("requeuing, could not find the BMH ID yet.")
+		return &RequeueAfterError{RequeueAfter: requeueAfter}
+	}
 	nodes, countNodesWithLabel, err := m.getNodesWithLabel(ctx, nodeLabel, clientFactory)
 	if err != nil {
 		m.Log.Info("error retrieving node, requeuing")
@@ -1332,7 +1345,9 @@ func (m *MachineManager) SetNodeProviderID(ctx context.Context, bmhID string, pr
 	for _, node := range nodes.Items {
 		providerIDOnNode := node.Spec.ProviderID
 		if providerIDOnNode == "" {
+			// By default we use the new format, if not set on the node.
 			node.Spec.ProviderID = providerIDNew
+			*providerIDOnM3M = providerIDNew
 		} else if providerIDOnNode == providerIDNew {
 			*providerIDOnM3M = providerIDNew
 		} else if providerIDOnNode == providerIDLegacy {

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -73,7 +73,7 @@ func m3mSpecAll() *capm3.Metal3MachineSpec {
 	return &capm3.Metal3MachineSpec{
 		ProviderID: &ProviderID,
 		UserData: &corev1.SecretReference{
-			Name:      "mym3machine-user-data",
+			Name:      metal3machineName + "-user-data",
 			Namespace: namespaceName,
 		},
 		Image: capm3.Image{
@@ -89,15 +89,15 @@ func m3mSpecAll() *capm3.Metal3MachineSpec {
 func m3mSecretStatus() *capm3.Metal3MachineStatus {
 	return &capm3.Metal3MachineStatus{
 		UserData: &corev1.SecretReference{
-			Name:      "mym3machine-user-data",
+			Name:      metal3machineName + "-user-data",
 			Namespace: namespaceName,
 		},
 		MetaData: &corev1.SecretReference{
-			Name:      "mym3machine-meta-data",
+			Name:      metal3machineName + "-meta-data",
 			Namespace: namespaceName,
 		},
 		NetworkData: &corev1.SecretReference{
-			Name:      "mym3machine-network-data",
+			Name:      metal3machineName + "-network-data",
 			Namespace: namespaceName,
 		},
 	}
@@ -109,7 +109,7 @@ func m3mSecretStatusNil() *capm3.Metal3MachineStatus {
 
 func consumerRef() *corev1.ObjectReference {
 	return &corev1.ObjectReference{
-		Name:       "mym3machine",
+		Name:       metal3machineName,
 		Namespace:  namespaceName,
 		Kind:       "M3Machine",
 		APIVersion: capm3.GroupVersion.String(),
@@ -186,21 +186,21 @@ func bmhSpecNoImg() *bmh.BareMetalHostSpec {
 
 func m3mObjectMetaWithValidAnnotations() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
-		Name:            "mym3machine",
+		Name:            metal3machineName,
 		Namespace:       namespaceName,
 		OwnerReferences: []metav1.OwnerReference{},
 		Labels: map[string]string{
 			capi.ClusterLabelName: clusterName,
 		},
 		Annotations: map[string]string{
-			HostAnnotation: namespaceName + "/myhost",
+			HostAnnotation: namespaceName + "/" + baremetalhostName,
 		},
 	}
 }
 
 func bmhObjectMetaWithValidCAPM3PausedAnnotations() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
-		Name:            "myhost",
+		Name:            baremetalhostName,
 		Namespace:       namespaceName,
 		OwnerReferences: []metav1.OwnerReference{},
 		Labels: map[string]string{
@@ -214,7 +214,7 @@ func bmhObjectMetaWithValidCAPM3PausedAnnotations() *metav1.ObjectMeta {
 
 func bmhObjectMetaWithValidEmptyPausedAnnotations() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
-		Name:            "myhost",
+		Name:            baremetalhostName,
 		Namespace:       namespaceName,
 		OwnerReferences: []metav1.OwnerReference{},
 		Annotations: map[string]string{
@@ -225,7 +225,7 @@ func bmhObjectMetaWithValidEmptyPausedAnnotations() *metav1.ObjectMeta {
 
 func bmhObjectMetaEmptyAnnotations() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
-		Name:            "myhost",
+		Name:            baremetalhostName,
 		Namespace:       namespaceName,
 		OwnerReferences: []metav1.OwnerReference{},
 		Annotations:     map[string]string{},
@@ -234,7 +234,7 @@ func bmhObjectMetaEmptyAnnotations() *metav1.ObjectMeta {
 
 func bmhObjectMetaNoAnnotations() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
-		Name:            "myhost",
+		Name:            baremetalhostName,
 		Namespace:       namespaceName,
 		OwnerReferences: []metav1.OwnerReference{},
 	}
@@ -532,7 +532,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 			Spec: bmh.BareMetalHostSpec{
 				ConsumerRef: &corev1.ObjectReference{
-					Name:       "machine1",
+					Name:       metal3machineName,
 					Namespace:  namespaceName,
 					Kind:       "M3Machine",
 					APIVersion: capm3.GroupVersion.String(),
@@ -637,26 +637,26 @@ var _ = Describe("Metal3Machine manager", func() {
 				}
 			},
 			Entry("Pick host2 which lacks ConsumerRef", testCaseChooseHost{
-				Machine:          newMachine("machine1", "", infrastructureRef2),
+				Machine:          newMachine(machineName, "", infrastructureRef2),
 				Hosts:            []client.Object{&host2, &host1},
 				M3Machine:        m3mconfig2,
 				ExpectedHostName: host2.Name,
 			}),
 			Entry("Pick hostWithNodeReuseLabelSetToKCP, which has a matching nodeReuseLabelName", testCaseChooseHost{
-				Machine:          newMachine("machine1", "", infrastructureRef2),
+				Machine:          newMachine(machineName, "", infrastructureRef2),
 				Hosts:            []client.Object{&hostWithNodeReuseLabelSetToKCP, &host3, &host2},
 				M3Machine:        m3mconfig2,
 				ExpectedHostName: hostWithNodeReuseLabelSetToKCP.Name,
 			}),
 			Entry("Pick hostWithNodeReuseLabelSetToMD, which has a matching nodeReuseLabelName", testCaseChooseHost{
-				Machine:          newMachine("machine1", "", infrastructureRef2),
+				Machine:          newMachine(machineName, "", infrastructureRef2),
 				Hosts:            []client.Object{&hostWithNodeReuseLabelSetToMD, &host3, &host2},
 				M3Machine:        m3mconfig2,
 				ExpectedHostName: hostWithNodeReuseLabelSetToMD.Name,
 			}),
 			Entry("Ignore discoveredHost and pick host2, which lacks a ConsumerRef",
 				testCaseChooseHost{
-					Machine:          newMachine("machine1", "", infrastructureRef2),
+					Machine:          newMachine(machineName, "", infrastructureRef2),
 					Hosts:            []client.Object{&discoveredHost, &host2, &host1},
 					M3Machine:        m3mconfig2,
 					ExpectedHostName: host2.Name,
@@ -664,17 +664,17 @@ var _ = Describe("Metal3Machine manager", func() {
 			),
 			Entry("Ignore hostWithUnhealthyAnnotation and pick host2, which lacks a ConsumerRef",
 				testCaseChooseHost{
-					Machine:          newMachine("machine1", "", infrastructureRef2),
-					Hosts:            []client.Object{&hostWithUnhealthyAnnotation, &host1, &host2},
-					M3Machine:        m3mconfig2,
-					ExpectedHostName: host2.Name,
+					Machine:          newMachine(machineName, "", infrastructureRef),
+					Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithPausedAnnotation, hostWithOtherConsRef, *availableHost}},
+					M3Machine:        m3mconfig,
+					ExpectedHostName: availableHost.Name,
 				},
 			),
-			Entry("Pick host3, which has a matching ConsumerRef", testCaseChooseHost{
-				Machine:          newMachine("machine1", "", infrastructureRef3),
-				Hosts:            []client.Object{&host1, &host3, &host2},
-				M3Machine:        m3mconfig3,
-				ExpectedHostName: host3.Name,
+			Entry("Pick hostWithConRef, which has a matching ConsumerRef", testCaseChooseHost{
+				Machine:          newMachine(machineName, "", infrastructureRef2),
+				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithOtherConsRef, *availableHost, hostWithConRef}},
+				M3Machine:        newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(), nil),
+				ExpectedHostName: hostWithConRef.Name,
 			}),
 			Entry("Two hosts already taken, third is in another namespace",
 				testCaseChooseHost{
@@ -686,49 +686,49 @@ var _ = Describe("Metal3Machine manager", func() {
 			),
 			Entry("Choose hosts with a label, even without a label selector",
 				testCaseChooseHost{
-					Machine:          newMachine("machine1", "", infrastructureRef),
-					Hosts:            []client.Object{&hostWithLabel},
+					Machine:          newMachine(machineName, "", infrastructureRef),
+					Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithLabel}},
 					M3Machine:        m3mconfig,
 					ExpectedHostName: hostWithLabel.Name,
 				},
 			),
 			Entry("Choose hosts with a nodeReuseLabelName set to KCP, even without a label selector",
 				testCaseChooseHost{
-					Machine:          newMachine("machine1", "", infrastructureRef),
+					Machine:          newMachine(machineName, "", infrastructureRef),
 					Hosts:            []client.Object{&hostWithNodeReuseLabelSetToKCP},
 					M3Machine:        m3mconfig,
 					ExpectedHostName: hostWithNodeReuseLabelSetToKCP.Name,
 				},
 			),
 			Entry("Choose the host with the right label", testCaseChooseHost{
-				Machine:          newMachine("machine1", "", infrastructureRef2),
-				Hosts:            []client.Object{&hostWithLabel, &host2},
+				Machine:          newMachine(machineName, "", infrastructureRef2),
+				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithLabel, *availableHost}},
 				M3Machine:        m3mconfig2,
 				ExpectedHostName: hostWithLabel.Name,
 			}),
 			Entry("No host that matches required label", testCaseChooseHost{
-				Machine:          newMachine("machine1", "", infrastructureRef3),
-				Hosts:            []client.Object{&host2, &hostWithLabel},
+				Machine:          newMachine(machineName, "", infrastructureRef3),
+				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*availableHost, hostWithLabel}},
 				M3Machine:        m3mconfig3,
 				ExpectedHostName: "",
 			}),
 			Entry("Host that matches a matchExpression", testCaseChooseHost{
-				Machine:          newMachine("machine1", "", infrastructureRef4),
-				Hosts:            []client.Object{&host2, &hostWithLabel},
+				Machine:          newMachine(machineName, "", infrastructureRef4),
+				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*availableHost, hostWithLabel}},
 				M3Machine:        m3mconfig4,
 				ExpectedHostName: hostWithLabel.Name,
 			}),
 			Entry("No Host available that matches a matchExpression",
 				testCaseChooseHost{
-					Machine:          newMachine("machine1", "", infrastructureRef4),
-					Hosts:            []client.Object{&host2},
+					Machine:          newMachine(machineName, "", infrastructureRef4),
+					Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*availableHost}},
 					M3Machine:        m3mconfig4,
 					ExpectedHostName: "",
 				},
 			),
 			Entry("No host chosen, invalid match expression", testCaseChooseHost{
-				Machine:          newMachine("machine1", "", infrastructureRef5),
-				Hosts:            []client.Object{&host2, &hostWithLabel, &host1},
+				Machine:          newMachine(machineName, "", infrastructureRef5),
+				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*availableHost, hostWithLabel, hostWithOtherConsRef}},
 				M3Machine:        m3mconfig5,
 				ExpectedHostName: "",
 			}),
@@ -787,14 +787,14 @@ var _ = Describe("Metal3Machine manager", func() {
 				ObjectMeta: *bmhObjectMetaWithValidCAPM3PausedAnnotations(),
 				Spec: bmh.BareMetalHostSpec{
 					ConsumerRef: &corev1.ObjectReference{
-						Name:       "mym3machine",
+						Name:       metal3machineName,
 						Namespace:  namespaceName,
 						Kind:       "M3Machine",
 						APIVersion: capm3.GroupVersion.String(),
 					},
 				},
 			},
-			M3Machine: newMetal3Machine("mym3machine", nil, m3mSpec(), nil,
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations()),
 			ExpectPausePresent: true,
 			ExpectError:        false,
@@ -804,14 +804,14 @@ var _ = Describe("Metal3Machine manager", func() {
 				ObjectMeta: *bmhObjectMetaWithValidEmptyPausedAnnotations(),
 				Spec: bmh.BareMetalHostSpec{
 					ConsumerRef: &corev1.ObjectReference{
-						Name:       "mym3machine",
+						Name:       metal3machineName,
 						Namespace:  namespaceName,
 						Kind:       "M3Machine",
 						APIVersion: capm3.GroupVersion.String(),
 					},
 				},
 			},
-			M3Machine: newMetal3Machine("mym3machine", nil, m3mSpec(), nil,
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations()),
 			ExpectPausePresent: true,
 			ExpectError:        false,
@@ -821,7 +821,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				ObjectMeta: *bmhObjectMetaEmptyAnnotations(),
 				Spec: bmh.BareMetalHostSpec{
 					ConsumerRef: &corev1.ObjectReference{
-						Name:       "mym3machine",
+						Name:       metal3machineName,
 						Namespace:  namespaceName,
 						Kind:       "M3Machine",
 						APIVersion: capm3.GroupVersion.String(),
@@ -831,7 +831,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					OperationalStatus: "OK",
 				},
 			},
-			M3Machine: newMetal3Machine("mym3machine", nil, m3mSpec(), nil,
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations()),
 			ExpectPausePresent:  true,
 			ExpectStatusPresent: true,
@@ -881,14 +881,14 @@ var _ = Describe("Metal3Machine manager", func() {
 				ObjectMeta: *bmhObjectMetaWithValidCAPM3PausedAnnotations(),
 				Spec: bmh.BareMetalHostSpec{
 					ConsumerRef: &corev1.ObjectReference{
-						Name:       "mym3machine",
+						Name:       metal3machineName,
 						Namespace:  namespaceName,
 						Kind:       "M3Machine",
 						APIVersion: capm3.GroupVersion.String(),
 					},
 				},
 			},
-			M3Machine: newMetal3Machine("mym3machine", nil, m3mSpec(), nil,
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations()),
 			ExpectPresent: false,
 			ExpectError:   false,
@@ -899,14 +899,14 @@ var _ = Describe("Metal3Machine manager", func() {
 				ObjectMeta: *bmhObjectMetaWithValidEmptyPausedAnnotations(),
 				Spec: bmh.BareMetalHostSpec{
 					ConsumerRef: &corev1.ObjectReference{
-						Name:       "mym3machine",
+						Name:       metal3machineName,
 						Namespace:  namespaceName,
 						Kind:       "M3Machine",
 						APIVersion: capm3.GroupVersion.String(),
 					},
 				},
 			},
-			M3Machine: newMetal3Machine("mym3machine", nil, m3mSpec(), nil,
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations()),
 			ExpectPresent: true,
 			ExpectError:   false,
@@ -917,14 +917,14 @@ var _ = Describe("Metal3Machine manager", func() {
 				ObjectMeta: *bmhObjectMetaNoAnnotations(),
 				Spec: bmh.BareMetalHostSpec{
 					ConsumerRef: &corev1.ObjectReference{
-						Name:       "mym3machine",
+						Name:       metal3machineName,
 						Namespace:  namespaceName,
 						Kind:       "M3Machine",
 						APIVersion: capm3.GroupVersion.String(),
 					},
 				},
 			},
-			M3Machine: newMetal3Machine("mym3machine", nil, m3mSpec(), nil,
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations()),
 			ExpectPresent: false,
 			ExpectError:   false,
@@ -947,7 +947,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			m3mconfig, infrastructureRef := newConfig(tc.UserDataNamespace,
 				map[string]string{}, []capm3.HostSelectorRequirement{},
 			)
-			machine := newMachine("machine1", "", infrastructureRef)
+			machine := newMachine(machineName, "", infrastructureRef)
 
 			machineMgr, err := NewMachineManager(c, nil, nil, machine, m3mconfig,
 				klogr.New(),
@@ -1036,7 +1036,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			m3mconfig, infrastructureRef := newConfig(tc.UserDataNamespace,
 				map[string]string{}, []capm3.HostSelectorRequirement{},
 			)
-			machine := newMachine("machine1", "", infrastructureRef)
+			machine := newMachine(machineName, "", infrastructureRef)
 
 			machineMgr, err := NewMachineManager(c, nil, nil, machine, m3mconfig,
 				klogr.New(),
@@ -1126,16 +1126,16 @@ var _ = Describe("Metal3Machine manager", func() {
 				Expect(result).To(Equal(tc.Expected))
 			},
 			Entry("Failed to find the existing host", testCaseExists{
-				Machine: &capi.Machine{},
-				M3Machine: newMetal3Machine("mym3machine", nil, nil, nil,
+				Machine: &clusterv1.Machine{},
+				M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
 					m3mObjectMetaWithSomeAnnotations(),
 				),
 				Expected: true,
 			}),
 			Entry("Found host even though annotation value is incorrect",
 				testCaseExists{
-					Machine: &capi.Machine{},
-					M3Machine: newMetal3Machine("mym3machine", nil, nil, nil,
+					Machine: &clusterv1.Machine{},
+					M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
 						m3mObjectMetaWithInvalidAnnotations(),
 					),
 					Expected: false,
@@ -1154,7 +1154,7 @@ var _ = Describe("Metal3Machine manager", func() {
 	Describe("Test GetHost", func() {
 		host := bmh.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "myhost",
+				Name:      baremetalhostName,
 				Namespace: namespaceName,
 			},
 		}
@@ -1182,24 +1182,24 @@ var _ = Describe("Metal3Machine manager", func() {
 				}
 			},
 			Entry("Should find the expected host", testCaseGetHost{
-				Machine: &capi.Machine{},
-				M3Machine: newMetal3Machine("mym3machine", nil, nil, nil,
+				Machine: &clusterv1.Machine{},
+				M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
 					m3mObjectMetaWithValidAnnotations(),
 				),
 				ExpectPresent: true,
 			}),
 			Entry("Should not find the host, annotation value incorrect",
 				testCaseGetHost{
-					Machine: &capi.Machine{},
-					M3Machine: newMetal3Machine("mym3machine", nil, nil, nil,
+					Machine: &clusterv1.Machine{},
+					M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
 						m3mObjectMetaWithInvalidAnnotations(),
 					),
 					ExpectPresent: false,
 				},
 			),
 			Entry("Should not find the host, annotation not present", testCaseGetHost{
-				Machine: &capi.Machine{},
-				M3Machine: newMetal3Machine("mym3machine", nil, nil, nil,
+				Machine: &clusterv1.Machine{},
+				M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
 					m3mObjectMetaEmptyAnnotations(),
 				),
 				ExpectPresent: false,
@@ -1242,12 +1242,12 @@ var _ = Describe("Metal3Machine manager", func() {
 		},
 		Entry("Set ProviderID, empty annotations", testCaseGetSetProviderID{
 			Machine: newMachine("", "", nil),
-			M3Machine: newMetal3Machine("mym3machine", nil, m3mSpec(), nil,
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
 				m3mObjectMetaEmptyAnnotations(),
 			),
 			Host: &bmh.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "myhost",
+					Name:      baremetalhostName,
 					Namespace: namespaceName,
 				},
 			},
@@ -1256,12 +1256,12 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Set ProviderID", testCaseGetSetProviderID{
 			Machine: newMachine("", "", nil),
-			M3Machine: newMetal3Machine("mym3machine", nil, m3mSpec(), nil,
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Host: &bmh.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "myhost",
+					Name:      baremetalhostName,
 					Namespace: namespaceName,
 					UID:       Bmhuid,
 				},
@@ -1276,12 +1276,12 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Set ProviderID, wrong state", testCaseGetSetProviderID{
 			Machine: newMachine("", "", nil),
-			M3Machine: newMetal3Machine("mym3machine", nil, m3mSpec(), nil,
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Host: &bmh.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "myhost",
+					Name:      baremetalhostName,
 					Namespace: namespaceName,
 					UID:       Bmhuid,
 				},
@@ -1305,7 +1305,7 @@ var _ = Describe("Metal3Machine manager", func() {
 
 		host := bmh.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "myhost",
+				Name:      baremetalhostName,
 				Namespace: namespaceName,
 			},
 		}
@@ -1334,7 +1334,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 			Entry("Test small functions, worker node", testCaseSmallFunctions{
 				Machine: newMachine("", "", nil),
-				M3Machine: newMetal3Machine("mym3machine", nil, m3mSpec(), nil,
+				M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
 					m3mObjectMetaEmptyAnnotations(),
 				),
 				ExpectCtrlNode: false,
@@ -1346,14 +1346,14 @@ var _ = Describe("Metal3Machine manager", func() {
 						APIVersion: capi.GroupVersion.String(),
 					},
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "mymachine",
+						Name:      machineName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
 							capi.MachineControlPlaneLabelName: "labelHere",
 						},
 					},
 				},
-				M3Machine: newMetal3Machine("mym3machine", nil, m3mSpec(), nil,
+				M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
 					m3mObjectMetaEmptyAnnotations(),
 				),
 				ExpectCtrlNode: true,
@@ -1396,32 +1396,32 @@ var _ = Describe("Metal3Machine manager", func() {
 			}
 		},
 		Entry("Annotation exists and is correct", testCaseEnsureAnnotation{
-			Machine: capi.Machine{},
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, nil,
+			Machine: clusterv1.Machine{},
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			Host: newBareMetalHost("myhost", nil, bmh.StateNone, nil,
-				false, false,
+			Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil,
+				false, "metadata", false,
 			),
 			ExpectAnnotation: true,
 		}),
 		Entry("Annotation exists but is wrong", testCaseEnsureAnnotation{
-			Machine: capi.Machine{},
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, nil,
+			Machine: clusterv1.Machine{},
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
 				m3mObjectMetaWithInvalidAnnotations(),
 			),
-			Host: newBareMetalHost("myhost", nil, bmh.StateNone,
-				nil, false, false,
+			Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone,
+				nil, false, "metadata", false,
 			),
 			ExpectAnnotation: true,
 		}),
 		Entry("Annotations are empty", testCaseEnsureAnnotation{
-			Machine: capi.Machine{},
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, nil,
+			Machine: clusterv1.Machine{},
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
 				m3mObjectMetaEmptyAnnotations(),
 			),
-			Host: newBareMetalHost("myhost", nil, bmh.StateNone,
-				nil, false, false,
+			Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone,
+				nil, false, "metadata", false,
 			),
 			ExpectAnnotation: true,
 		}),
@@ -1430,8 +1430,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine("", nil, nil, nil,
 				m3mObjectMetaNoAnnotations(),
 			),
-			Host: newBareMetalHost("myhost", nil, bmh.StateNone,
-				nil, false, false,
+			Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone,
+				nil, false, "metadata", false,
 			),
 			ExpectAnnotation: true,
 		}),
@@ -1581,11 +1581,11 @@ var _ = Describe("Metal3Machine manager", func() {
 			}
 		},
 		Entry("Deprovisioning needed", testCaseDelete{
-			Host: newBareMetalHost("myhost", bmhSpec(),
-				bmh.StateProvisioned, bmhStatus(), false, true,
+			Host: newBareMetalHost(baremetalhostName, bmhSpec(),
+				bmov1alpha1.StateProvisioned, bmhStatus(), false, "metadata", true,
 			),
-			Machine: newMachine("mymachine", "", nil),
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, "", nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			ExpectedConsumerRef: consumerRef(),
@@ -1593,11 +1593,11 @@ var _ = Describe("Metal3Machine manager", func() {
 			Secret:              newSecret(),
 		}),
 		Entry("No Host status, deprovisioning needed", testCaseDelete{
-			Host: newBareMetalHost("myhost", bmhSpec(), bmh.StateNone,
-				nil, false, true,
+			Host: newBareMetalHost(baremetalhostName, bmhSpec(), bmov1alpha1.StateNone,
+				nil, false, "metadata", true,
 			),
-			Machine: newMachine("mymachine", "", nil),
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, "", nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			ExpectedConsumerRef: consumerRef(),
@@ -1605,22 +1605,22 @@ var _ = Describe("Metal3Machine manager", func() {
 			Secret:              newSecret(),
 		}),
 		Entry("No Host status, no deprovisioning needed", testCaseDelete{
-			Host: newBareMetalHost("myhost", bmhSpecNoImg(), bmh.StateNone, nil,
-				false, true,
+			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(), bmov1alpha1.StateNone, nil,
+				false, "metadata", true,
 			),
-			Machine: newMachine("mymachine", "", nil),
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, "", nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Secret:              newSecret(),
 			ExpectSecretDeleted: true,
 		}),
 		Entry("Deprovisioning in progress", testCaseDelete{
-			Host: newBareMetalHost("myhost", bmhSpecNoImg(),
-				bmh.StateDeprovisioning, bmhStatus(), false, true,
+			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(),
+				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "metadata", true,
 			),
-			Machine: newMachine("mymachine", "", nil),
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, "", nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			ExpectedConsumerRef: consumerRef(),
@@ -1628,11 +1628,11 @@ var _ = Describe("Metal3Machine manager", func() {
 			Secret:              newSecret(),
 		}),
 		Entry("Externally provisioned host should be powered down", testCaseDelete{
-			Host: newBareMetalHost("myhost", bmhSpecNoImg(),
-				bmh.StateExternallyProvisioned, bmhPowerStatus(), true, true,
+			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(),
+				bmov1alpha1.StateExternallyProvisioned, bmhPowerStatus(), true, "metadata", true,
 			),
-			Machine: newMachine("mymachine", "", nil),
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, "", nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			ExpectedConsumerRef: consumerRef(),
@@ -1641,11 +1641,11 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Consumer ref should be removed from externally provisioned host",
 			testCaseDelete{
-				Host: newBareMetalHost("myhost", bmhSpecNoImg(),
-					bmh.StateExternallyProvisioned, bmhPowerStatus(), false, true,
+				Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(),
+					bmov1alpha1.StateExternallyProvisioned, bmhPowerStatus(), false, "metadata", true,
 				),
-				Machine: newMachine("mymachine", "", nil),
-				M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
+				Machine: newMachine(machineName, "", nil),
+				M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 					m3mObjectMetaWithValidAnnotations(),
 				),
 				Secret:              newSecret(),
@@ -1654,11 +1654,11 @@ var _ = Describe("Metal3Machine manager", func() {
 		),
 		Entry("Consumer ref should be removed from unmanaged host",
 			testCaseDelete{
-				Host: newBareMetalHost("myhost", bmhSpecNoImg(),
-					bmh.StateUnmanaged, bmhPowerStatus(), false, true,
+				Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(),
+					bmov1alpha1.StateUnmanaged, bmhPowerStatus(), false, "metadata", true,
 				),
-				Machine: newMachine("mymachine", "", nil),
-				M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
+				Machine: newMachine(machineName, "", nil),
+				M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 					m3mObjectMetaWithValidAnnotations(),
 				),
 				Secret:              newSecret(),
@@ -1666,30 +1666,30 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 		),
 		Entry("Consumer ref should be removed, BMH state is available", testCaseDelete{
-			Host: newBareMetalHost("myhost", bmhSpecNoImg(), bmh.StateAvailable,
-				bmhStatus(), false, true,
+			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(), bmov1alpha1.StateAvailable,
+				bmhStatus(), false, "metadata", true,
 			),
-			Machine: newMachine("mymachine", "", nil),
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, "", nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Secret:              newSecret(),
 			ExpectSecretDeleted: true,
 		}),
 		Entry("Consumer ref should be removed", testCaseDelete{
-			Host: newBareMetalHost("myhost", bmhSpecNoImg(), bmh.StateReady,
-				bmhStatus(), false, true,
+			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(), bmov1alpha1.StateReady,
+				bmhStatus(), false, "metadata", true,
 			),
-			Machine: newMachine("mymachine", "", nil),
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, "", nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Secret:              newSecret(),
 			ExpectSecretDeleted: true,
 		}),
 		Entry("Consumer ref should be removed, secret not deleted", testCaseDelete{
-			Host: newBareMetalHost("myhost", bmhSpecNoImg(), bmh.StateReady,
-				bmhStatus(), false, true,
+			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(), bmov1alpha1.StateReady,
+				bmhStatus(), false, "metadata", true,
 			),
 			Machine: &capi.Machine{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1701,18 +1701,18 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Secret: newSecret(),
 		}),
 		Entry("Consumer ref does not match, so it should not be removed",
 			testCaseDelete{
-				Host: newBareMetalHost("myhost", bmhSpecSomeImg(),
-					bmh.StateProvisioned, bmhStatus(), false, true,
+				Host: newBareMetalHost(baremetalhostName, bmhSpecSomeImg(),
+					bmov1alpha1.StateProvisioned, bmhStatus(), false, "metadata", true,
 				),
 				Machine: newMachine("", "", nil),
-				M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
+				M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 					m3mObjectMetaWithValidAnnotations(),
 				),
 				ExpectedConsumerRef: consumerRefSome(),
@@ -1720,9 +1720,9 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 		),
 		Entry("No consumer ref, so this is a no-op", testCaseDelete{
-			Host:    newBareMetalHost("myhost", nil, bmh.StateNone, nil, false, true),
+			Host:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", true),
 			Machine: newMachine("", "", nil),
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Secret:              newSecret(),
@@ -1731,42 +1731,42 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("No host at all, so this is a no-op", testCaseDelete{
 			Host:    nil,
 			Machine: newMachine("", "", nil),
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Secret:              newSecret(),
 			ExpectSecretDeleted: false,
 		}),
 		Entry("dataSecretName set, deleting secret", testCaseDelete{
-			Host: newBareMetalHost("myhost", bmhSpecNoImg(), bmh.StateNone, nil,
-				false, true,
+			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(), bmov1alpha1.StateNone, nil,
+				false, "metadata", true,
 			),
 			Machine: &clusterv1.Machine{
 				ObjectMeta: testObjectMeta("", namespaceName, ""),
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
-						DataSecretName: pointer.StringPtr("mym3machine-user-data"),
+						DataSecretName: pointer.StringPtr(metal3machineName + "-user-data"),
 					},
 				},
 			},
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatus(),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Secret:              newSecret(),
 			ExpectSecretDeleted: false,
 		}),
 		Entry("Clusterlabel should be removed", testCaseDelete{
-			Machine:                   newMachine("mymachine", "mym3machine", nil),
-			M3Machine:                 newMetal3Machine("mym3machine", nil, m3mSpecAll(), m3mSecretStatus(), m3mObjectMetaWithValidAnnotations()),
-			Host:                      newBareMetalHost("myhost", bmhSpecBMC(), bmh.StateNone, nil, false, true),
+			Machine:                   newMachine(machineName, metal3machineName, nil),
+			M3Machine:                 newMetal3Machine(metal3machineName, nil, m3mSpecAll(), m3mSecretStatus(), m3mObjectMetaWithValidAnnotations()),
+			Host:                      newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", true),
 			BMCSecret:                 newBMCSecret("mycredentials", true),
 			ExpectSecretDeleted:       true,
 			ExpectClusterLabelDeleted: true,
 		}),
 		Entry("PausedAnnotation/CAPM3 should be removed", testCaseDelete{
-			Machine:   newMachine("mymachine", "mym3machine", nil),
-			M3Machine: newMetal3Machine("mym3machine", nil, m3mSpecAll(), m3mSecretStatus(), m3mObjectMetaWithValidAnnotations()),
-			Host: &bmh.BareMetalHost{
+			Machine:   newMachine(machineName, metal3machineName, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpecAll(), m3mSecretStatus(), m3mObjectMetaWithValidAnnotations()),
+			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: *bmhObjectMetaWithValidCAPM3PausedAnnotations(),
 				Spec:       *bmhSpecBMC(),
 				Status: bmh.BareMetalHostStatus{
@@ -1781,19 +1781,19 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectedPausedAnnotationDeleted: true,
 		}),
 		Entry("No clusterLabel in BMH or BMC Secret so this is a no-op ", testCaseDelete{
-			Machine:                   newMachine("mymachine", "mym3machine", nil),
-			M3Machine:                 newMetal3Machine("mym3machine", nil, m3mSpecAll(), m3mSecretStatus(), m3mObjectMetaWithValidAnnotations()),
-			Host:                      newBareMetalHost("myhost", bmhSpecBMC(), bmh.StateNone, nil, false, false),
+			Machine:                   newMachine(machineName, metal3machineName, nil),
+			M3Machine:                 newMetal3Machine(metal3machineName, nil, m3mSpecAll(), m3mSecretStatus(), m3mObjectMetaWithValidAnnotations()),
+			Host:                      newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", false),
 			BMCSecret:                 newBMCSecret("mycredentials", false),
 			ExpectSecretDeleted:       true,
 			ExpectClusterLabelDeleted: false,
 		}),
 		Entry("BMH MetaData, NetworkData and UserData should not be cleaned on deprovisioning", testCaseDelete{
-			Host: newBareMetalHost("myhost", bmhSpecSomeImg(),
-				bmh.StateProvisioned, bmhStatus(), false, true,
+			Host: newBareMetalHost(baremetalhostName, bmhSpecSomeImg(),
+				bmov1alpha1.StateProvisioned, bmhStatus(), false, "metadata", true,
 			),
-			Machine: newMachine("mymachine", "mym3machine", nil),
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, m3mSecretStatusNil(),
+			Machine: newMachine(machineName, metal3machineName, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatusNil(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Secret:              newSecret(),
@@ -1917,7 +1917,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 				Machine: &capi.Machine{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "mymachine",
+						Name:      machineName,
 						Namespace: namespaceName,
 					},
 					Status: capi.MachineStatus{
@@ -1935,7 +1935,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 				M3Machine: capm3.Metal3Machine{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "mym3machine",
+						Name:      metal3machineName,
 						Namespace: namespaceName,
 					},
 					TypeMeta: metav1.TypeMeta{
@@ -1976,14 +1976,14 @@ var _ = Describe("Metal3Machine manager", func() {
 					Host: &bmh.BareMetalHost{},
 					Machine: &capi.Machine{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "mymachine",
+							Name:      machineName,
 							Namespace: namespaceName,
 						},
 						Status: capi.MachineStatus{},
 					},
 					M3Machine: capm3.Metal3Machine{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "mym3machine",
+							Name:      metal3machineName,
 							Namespace: namespaceName,
 						},
 						TypeMeta: metav1.TypeMeta{
@@ -2175,11 +2175,11 @@ var _ = Describe("Metal3Machine manager", func() {
 						),
 						&clusterv1.Machine{}, &capm3.Metal3Machine{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "abc",
+								Name:      metal3machineName,
 								Namespace: namespaceName,
 								UID:       m3muid,
 								Annotations: map[string]string{
-									HostAnnotation: namespaceName + "/myhost",
+									HostAnnotation: namespaceName + "/" + baremetalhostName,
 								},
 							},
 						}, logr.Discard(),
@@ -2232,7 +2232,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 				HostID:               string(bmhuid),
 				ExpectedError:        false,
-				ExpectedProviderID:   fmt.Sprintf("metal3://%s/%s/%s", namespaceName, "myhost", "abc"),
+				ExpectedProviderID:   fmt.Sprintf("metal3://%s/%s/%s", namespaceName, baremetalhostName, metal3machineName),
 				M3MHasHostAnnotation: true,
 			}),
 			Entry("Set target ProviderID, providerID set", testCaseSetNodePoviderID{
@@ -2270,11 +2270,11 @@ var _ = Describe("Metal3Machine manager", func() {
 					),
 					&clusterv1.Machine{}, &capm3.Metal3Machine{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "abc",
+							Name:      metal3machineName,
 							Namespace: namespaceName,
 							UID:       m3muid,
 							Annotations: map[string]string{
-								HostAnnotation: namespaceName + "/myhost",
+								HostAnnotation: namespaceName + "/" + baremetalhostName,
 							},
 						},
 					}, logr.Discard(),
@@ -2453,8 +2453,8 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, nil, nil),
-			BMHost:    newBareMetalHost("myhost", nil, bmh.StateNone, nil, false, false),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil, nil),
+			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
 		}),
 		Entry("Secret set in Machine, different namespace", testCaseGetUserDataSecretName{
 			Secret: &corev1.Secret{
@@ -2481,8 +2481,8 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, nil, nil),
-			BMHost:    newBareMetalHost("myhost", nil, bmh.StateNone, nil, false, false),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil, nil),
+			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
 		}),
 		Entry("Secret in other namespace set in Machine", testCaseGetUserDataSecretName{
 			Secret: &corev1.Secret{
@@ -2513,8 +2513,8 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, nil, nil),
-			BMHost:    newBareMetalHost("myhost", nil, bmh.StateNone, nil, false, false),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil, nil),
+			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
 		}),
 		Entry("UserDataSecretName set in Machine, secret exists", testCaseGetUserDataSecretName{
 			Secret: newSecret(),
@@ -2526,8 +2526,8 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, nil, nil),
-			BMHost:    newBareMetalHost("myhost", nil, bmh.StateNone, nil, false, false),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil, nil),
+			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
 		}),
 		Entry("UserDataSecretName set in Machine, no secret", testCaseGetUserDataSecretName{
 			Machine: &clusterv1.Machine{
@@ -2538,8 +2538,8 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, nil, nil),
-			BMHost:    newBareMetalHost("myhost", nil, bmh.StateNone, nil, false, false),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil, nil),
+			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
 		}),
 	)
 
@@ -2626,11 +2626,11 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Associate empty machine, Metal3 machine spec nil",
 			testCaseAssociate{
 				Machine: newMachine("", "", nil),
-				M3Machine: newMetal3Machine("mym3machine", nil, nil, nil,
+				M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
 					m3mObjectMetaWithValidAnnotations(),
 				),
-				Host: newBareMetalHost("myhost", nil, bmh.StateNone, nil,
-					false, false,
+				Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil,
+					false, "metadata", false,
 				),
 				ExpectRequeue: false,
 			},
@@ -2638,11 +2638,11 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Associate empty machine, Metal3 machine spec set",
 			testCaseAssociate{
 				Machine: newMachine("", "", nil),
-				M3Machine: newMetal3Machine("mym3machine", nil, m3mSpecAll(), nil,
+				M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpecAll(), nil,
 					m3mObjectMetaWithValidAnnotations(),
 				),
-				Host: newBareMetalHost("myhost", bmhSpecBMC(), bmh.StateNone, nil,
-					false, false,
+				Host: newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil,
+					false, "metadata", false,
 				),
 				BMCSecret:      newBMCSecret("mycredentials", false),
 				ExpectRequeue:  false,
@@ -2652,7 +2652,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Associate empty machine, host empty, Metal3 machine spec set",
 			testCaseAssociate{
 				Machine: newMachine("", "", nil),
-				M3Machine: newMetal3Machine("mym3machine", nil, m3mSpecAll(), nil,
+				M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpecAll(), nil,
 					m3mObjectMetaWithValidAnnotations(),
 				),
 				Host:           newBareMetalHost("", nil, bmh.StateNone, nil, false, false),
@@ -2663,7 +2663,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Associate machine, host nil, Metal3 machine spec set, requeue",
 			testCaseAssociate{
 				Machine: newMachine("myUniqueMachine", "", nil),
-				M3Machine: newMetal3Machine("mym3machine", nil, m3mSpecAll(), nil,
+				M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpecAll(), nil,
 					m3mObjectMetaWithValidAnnotations(),
 				),
 				Host:          nil,
@@ -2672,9 +2672,9 @@ var _ = Describe("Metal3Machine manager", func() {
 		),
 		Entry("Associate machine, host set, Metal3 machine spec set, set clusterLabel",
 			testCaseAssociate{
-				Machine:            newMachine("mymachine", "mym3machine", nil),
-				M3Machine:          newMetal3Machine("mym3machine", nil, m3mSpecAll(), nil, nil),
-				Host:               newBareMetalHost("myhost", bmhSpecBMC(), bmh.StateNone, nil, false, false),
+				Machine:            newMachine(machineName, metal3machineName, nil),
+				M3Machine:          newMetal3Machine(metal3machineName, nil, m3mSpecAll(), nil, nil),
+				Host:               newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", false),
 				BMCSecret:          newBMCSecret("mycredentials", false),
 				ExpectClusterLabel: true,
 				ExpectRequeue:      false,
@@ -2683,15 +2683,15 @@ var _ = Describe("Metal3Machine manager", func() {
 		),
 		Entry("Associate machine with DataTemplate missing",
 			testCaseAssociate{
-				Machine: newMachine("mymachine", "mym3machine", nil),
-				M3Machine: newMetal3Machine("mym3machine", nil,
-					&capm3.Metal3MachineSpec{
+				Machine: newMachine(machineName, metal3machineName, nil),
+				M3Machine: newMetal3Machine(metal3machineName, nil,
+					&infrav1.Metal3MachineSpec{
 						DataTemplate: &corev1.ObjectReference{
 							Name:      "abcd",
 							Namespace: namespaceName,
 						},
 						UserData: &corev1.SecretReference{
-							Name:      "mym3machine-user-data",
+							Name:      metal3machineName + "-user-data",
 							Namespace: namespaceName,
 						},
 						Image: capm3.Image{
@@ -2701,7 +2701,7 @@ var _ = Describe("Metal3Machine manager", func() {
 						},
 					}, nil, nil,
 				),
-				Host:               newBareMetalHost("myhost", bmhSpecBMC(), bmh.StateNone, nil, false, false),
+				Host:               newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", false),
 				BMCSecret:          newBMCSecret("mycredentials", false),
 				ExpectClusterLabel: true,
 				ExpectRequeue:      true,
@@ -2710,15 +2710,15 @@ var _ = Describe("Metal3Machine manager", func() {
 		),
 		Entry("Associate machine with DataTemplate and Data ready",
 			testCaseAssociate{
-				Machine: newMachine("mymachine", "mym3machine", nil),
-				M3Machine: newMetal3Machine("mym3machine", nil,
-					&capm3.Metal3MachineSpec{
+				Machine: newMachine(machineName, metal3machineName, nil),
+				M3Machine: newMetal3Machine(metal3machineName, nil,
+					&infrav1.Metal3MachineSpec{
 						DataTemplate: &corev1.ObjectReference{
 							Name:      "abcd",
 							Namespace: namespaceName,
 						},
 						UserData: &corev1.SecretReference{
-							Name:      "mym3machine-user-data",
+							Name:      metal3machineName + "-user-data",
 							Namespace: namespaceName,
 						},
 						Image: capm3.Image{
@@ -2730,7 +2730,7 @@ var _ = Describe("Metal3Machine manager", func() {
 						RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: namespaceName},
 					}, nil,
 				),
-				Host:      newBareMetalHost("myhost", bmhSpecBMC(), bmh.StateNone, nil, false, false),
+				Host:      newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", false),
 				BMCSecret: newBMCSecret("mycredentials", false),
 				Data: &capm3.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
@@ -2786,22 +2786,22 @@ var _ = Describe("Metal3Machine manager", func() {
 			}
 		},
 		Entry("Update machine", testCaseUpdate{
-			Machine: newMachine("mymachine", "", nil),
-			M3Machine: newMetal3Machine("mym3machine", nil, nil, nil,
+			Machine: newMachine(machineName, "", nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			Host: newBareMetalHost("myhost", nil, bmh.StateNone, nil, false, false),
+			Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
 		}),
 		Entry("Update machine, DataTemplate missing", testCaseUpdate{
-			Machine: newMachine("mymachine", "", nil),
-			M3Machine: newMetal3Machine("mym3machine", nil, &capm3.Metal3MachineSpec{
+			Machine: newMachine(machineName, "", nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, &infrav1.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{
 					Name: "abcd",
 				},
 			}, nil,
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			Host:        newBareMetalHost("myhost", nil, bmh.StateNone, nil, false, false),
+			Host:        newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
 			ExpectError: true,
 		}),
 	)
@@ -3138,15 +3138,15 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine("myName", nil, &capm3.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{Name: "abcd"},
 			}, nil, nil),
-			Machine:     newMachine("myName", "myName", nil),
+			Machine:     newMachine(machineName, "myName", nil),
 			expectClaim: true,
 		}),
 		Entry("DataClaim exists", testCaseM3MetaData{
 			M3Machine: newMetal3Machine("myName", nil, &capm3.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{Name: "abcd"},
 			}, nil, nil),
-			Machine: newMachine("myName", "myName", nil),
-			DataClaim: &capm3.Metal3DataClaim{
+			Machine: newMachine(machineName, "myName", nil),
+			DataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myName",
 					Namespace: namespaceName,
@@ -3253,15 +3253,15 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine("myName", nil, &capm3.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{Name: "abcd"},
 			}, nil, nil),
-			Machine:       newMachine("myName", "myName", nil),
+			Machine:       newMachine(machineName, "myName", nil),
 			ExpectRequeue: true,
 		}),
 		Entry("Data claim without status", testCaseM3MetaData{
 			M3Machine: newMetal3Machine("myName", nil, &capm3.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{Name: "abcd"},
 			}, nil, nil),
-			Machine: newMachine("myName", "myName", nil),
-			DataClaim: &capm3.Metal3DataClaim{
+			Machine: newMachine(machineName, "myName", nil),
+			DataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myName",
 					Namespace: namespaceName,
@@ -3273,8 +3273,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine("myName", nil, &capm3.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{Name: "abcd"},
 			}, nil, nil),
-			Machine: newMachine("myName", "myName", nil),
-			DataClaim: &capm3.Metal3DataClaim{
+			Machine: newMachine(machineName, "myName", nil),
+			DataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myName",
 					Namespace: namespaceName,
@@ -3289,8 +3289,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine("myName", nil, &capm3.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{Name: "abcd"},
 			}, nil, nil),
-			Machine: newMachine("myName", "myName", nil),
-			DataClaim: &capm3.Metal3DataClaim{
+			Machine: newMachine(machineName, "myName", nil),
+			DataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myName",
 					Namespace: namespaceName,
@@ -3315,7 +3315,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine("myName", nil, nil, &capm3.Metal3MachineStatus{
 				RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: namespaceName},
 			}, nil),
-			Machine:          newMachine("myName", "myName", nil),
+			Machine:          newMachine(machineName, "myName", nil),
 			ExpectRequeue:    true,
 			ExpectDataStatus: true,
 		}),
@@ -3323,8 +3323,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine("myName", nil, nil, &capm3.Metal3MachineStatus{
 				RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: namespaceName},
 			}, nil),
-			Machine: newMachine("myName", "myName", nil),
-			Data: &capm3.Metal3Data{
+			Machine: newMachine(machineName, "myName", nil),
+			Data: &infrav1.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abcd-0",
 					Namespace: namespaceName,
@@ -3337,8 +3337,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine("myName", nil, nil, &capm3.Metal3MachineStatus{
 				RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: namespaceName},
 			}, nil),
-			Machine: newMachine("myName", "myName", nil),
-			Data: &capm3.Metal3Data{
+			Machine: newMachine(machineName, "myName", nil),
+			Data: &infrav1.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abcd-0",
 					Namespace: namespaceName,
@@ -3354,8 +3354,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine("myName", nil, nil, &capm3.Metal3MachineStatus{
 				RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: namespaceName},
 			}, nil),
-			Machine: newMachine("myName", "myName", nil),
-			Data: &capm3.Metal3Data{
+			Machine: newMachine(machineName, "myName", nil),
+			Data: &infrav1.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abcd-0",
 					Namespace: namespaceName,
@@ -3428,7 +3428,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				MetaData:    &corev1.SecretReference{Name: "abcd"},
 				NetworkData: &corev1.SecretReference{Name: "defg"},
 			}, nil),
-			Machine: newMachine("myName", "myName", nil),
+			Machine: newMachine(machineName, "myName", nil),
 		}),
 		Entry("MetaData and NetworkData set in spec and status", testCaseM3MetaData{
 			M3Machine: newMetal3Machine("myName", nil, &capm3.Metal3MachineSpec{
@@ -3438,7 +3438,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				MetaData:    &corev1.SecretReference{Name: "abcd"},
 				NetworkData: &corev1.SecretReference{Name: "defg"},
 			}, nil),
-			Machine:            newMachine("myName", "myName", nil),
+			Machine:            newMachine(machineName, "myName", nil),
 			ExpectSecretStatus: true,
 		}),
 		Entry("DataClaim not found", testCaseM3MetaData{
@@ -3448,7 +3448,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					Namespace: namespaceName,
 				},
 			}, nil, nil),
-			Machine: newMachine("myName", "myName", nil),
+			Machine: newMachine(machineName, "myName", nil),
 		}),
 		Entry("DataClaim found", testCaseM3MetaData{
 			M3Machine: newMetal3Machine("myName", nil, &capm3.Metal3MachineSpec{
@@ -3457,8 +3457,8 @@ var _ = Describe("Metal3Machine manager", func() {
 					Namespace: namespaceName,
 				},
 			}, nil, nil),
-			Machine: newMachine("myName", "myName", nil),
-			DataClaim: &capm3.Metal3DataClaim{
+			Machine: newMachine(machineName, "myName", nil),
+			DataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myName",
 					Namespace: namespaceName,
@@ -3956,7 +3956,7 @@ func newSecret() *corev1.Secret {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:       "mym3machine-user-data",
+			Name:       metal3machineName + "-user-data",
 			Namespace:  namespaceName,
 			Finalizers: []string{"abcd"},
 		},

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -1741,12 +1741,10 @@ var _ = Describe("Metal3Machine manager", func() {
 			Host: newBareMetalHost("myhost", bmhSpecNoImg(), bmh.StateNone, nil,
 				false, true,
 			),
-			Machine: &capi.Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: namespaceName,
-				},
-				Spec: capi.MachineSpec{
-					Bootstrap: capi.Bootstrap{
+			Machine: &clusterv1.Machine{
+				ObjectMeta: testObjectMeta("", namespaceName, ""),
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
 						DataSecretName: pointer.StringPtr("mym3machine-user-data"),
 					},
 				},
@@ -2447,12 +2445,10 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 				Type: "Opaque",
 			},
-			Machine: &capi.Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: namespaceName,
-				},
-				Spec: capi.MachineSpec{
-					Bootstrap: capi.Bootstrap{
+			Machine: &clusterv1.Machine{
+				ObjectMeta: testObjectMeta("", namespaceName, ""),
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
 						DataSecretName: pointer.StringPtr("Foobar"),
 					},
 				},
@@ -2522,12 +2518,10 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("UserDataSecretName set in Machine, secret exists", testCaseGetUserDataSecretName{
 			Secret: newSecret(),
-			Machine: &capi.Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: namespaceName,
-				},
-				Spec: capi.MachineSpec{
-					Bootstrap: capi.Bootstrap{
+			Machine: &clusterv1.Machine{
+				ObjectMeta: testObjectMeta("", namespaceName, ""),
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
 						DataSecretName: pointer.StringPtr("test-data-secret-name"),
 					},
 				},
@@ -2536,12 +2530,10 @@ var _ = Describe("Metal3Machine manager", func() {
 			BMHost:    newBareMetalHost("myhost", nil, bmh.StateNone, nil, false, false),
 		}),
 		Entry("UserDataSecretName set in Machine, no secret", testCaseGetUserDataSecretName{
-			Machine: &capi.Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: namespaceName,
-				},
-				Spec: capi.MachineSpec{
-					Bootstrap: capi.Bootstrap{
+			Machine: &clusterv1.Machine{
+				ObjectMeta: testObjectMeta("", namespaceName, ""),
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
 						DataSecretName: pointer.StringPtr("test-data-secret-name"),
 					},
 				},
@@ -3891,10 +3883,8 @@ func newBareMetalHost(name string,
 	clusterlabel bool) *bmh.BareMetalHost {
 
 	if name == "" {
-		return &bmh.BareMetalHost{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: namespaceName,
-			},
+		return &bmov1alpha1.BareMetalHost{
+			ObjectMeta: testObjectMeta("", namespaceName, ""),
 		}
 	}
 

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -1235,7 +1235,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				return
 			}
 
-			providerID := fmt.Sprintf("metal3://%s", *bmhID)
+			providerID := fmt.Sprintf("%s%s", ProviderIDPrefix, *bmhID)
 			Expect(*tc.M3Machine.Spec.ProviderID).To(Equal(providerID))
 		},
 		Entry("Set ProviderID, empty annotations", testCaseGetSetProviderID{
@@ -2128,8 +2128,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		},
 		Entry("Empty providerID", testCaseGetProviderIDAndBMHID{}),
 		Entry("Provider ID set", testCaseGetProviderIDAndBMHID{
-			providerID:    pointer.StringPtr(ProviderID),
-			expectedBMHID: string(Bmhuid),
+			providerID:    pointer.StringPtr(fmt.Sprintf("%sabcd", ProviderIDPrefix)),
+			expectedBMHID: "abcd",
 		}),
 	)
 

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -72,7 +72,7 @@ func m3mSpecAll() *capm3.Metal3MachineSpec {
 		ProviderID: &ProviderID,
 		UserData: &corev1.SecretReference{
 			Name:      "mym3machine-user-data",
-			Namespace: "myns",
+			Namespace: namespaceName,
 		},
 		Image: capm3.Image{
 			URL:          testImageURL,
@@ -88,15 +88,15 @@ func m3mSecretStatus() *capm3.Metal3MachineStatus {
 	return &capm3.Metal3MachineStatus{
 		UserData: &corev1.SecretReference{
 			Name:      "mym3machine-user-data",
-			Namespace: "myns",
+			Namespace: namespaceName,
 		},
 		MetaData: &corev1.SecretReference{
 			Name:      "mym3machine-meta-data",
-			Namespace: "myns",
+			Namespace: namespaceName,
 		},
 		NetworkData: &corev1.SecretReference{
 			Name:      "mym3machine-network-data",
-			Namespace: "myns",
+			Namespace: namespaceName,
 		},
 	}
 }
@@ -108,7 +108,7 @@ func m3mSecretStatusNil() *capm3.Metal3MachineStatus {
 func consumerRef() *corev1.ObjectReference {
 	return &corev1.ObjectReference{
 		Name:       "mym3machine",
-		Namespace:  "myns",
+		Namespace:  namespaceName,
 		Kind:       "M3Machine",
 		APIVersion: capm3.GroupVersion.String(),
 	}
@@ -117,7 +117,7 @@ func consumerRef() *corev1.ObjectReference {
 func consumerRefSome() *corev1.ObjectReference {
 	return &corev1.ObjectReference{
 		Name:       "someoneelsesmachine",
-		Namespace:  "myns",
+		Namespace:  namespaceName,
 		Kind:       "M3Machine",
 		APIVersion: capi.GroupVersion.String(),
 	}
@@ -185,13 +185,13 @@ func bmhSpecNoImg() *bmh.BareMetalHostSpec {
 func m3mObjectMetaWithValidAnnotations() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
 		Name:            "mym3machine",
-		Namespace:       "myns",
+		Namespace:       namespaceName,
 		OwnerReferences: []metav1.OwnerReference{},
 		Labels: map[string]string{
 			capi.ClusterLabelName: clusterName,
 		},
 		Annotations: map[string]string{
-			HostAnnotation: "myns/myhost",
+			HostAnnotation: namespaceName + "/myhost",
 		},
 	}
 }
@@ -199,7 +199,7 @@ func m3mObjectMetaWithValidAnnotations() *metav1.ObjectMeta {
 func bmhObjectMetaWithValidCAPM3PausedAnnotations() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
 		Name:            "myhost",
-		Namespace:       "myns",
+		Namespace:       namespaceName,
 		OwnerReferences: []metav1.OwnerReference{},
 		Labels: map[string]string{
 			capi.ClusterLabelName: clusterName,
@@ -213,7 +213,7 @@ func bmhObjectMetaWithValidCAPM3PausedAnnotations() *metav1.ObjectMeta {
 func bmhObjectMetaWithValidEmptyPausedAnnotations() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
 		Name:            "myhost",
-		Namespace:       "myns",
+		Namespace:       namespaceName,
 		OwnerReferences: []metav1.OwnerReference{},
 		Annotations: map[string]string{
 			bmh.PausedAnnotation: "",
@@ -224,7 +224,7 @@ func bmhObjectMetaWithValidEmptyPausedAnnotations() *metav1.ObjectMeta {
 func bmhObjectMetaEmptyAnnotations() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
 		Name:            "myhost",
-		Namespace:       "myns",
+		Namespace:       namespaceName,
 		OwnerReferences: []metav1.OwnerReference{},
 		Annotations:     map[string]string{},
 	}
@@ -233,7 +233,7 @@ func bmhObjectMetaEmptyAnnotations() *metav1.ObjectMeta {
 func bmhObjectMetaNoAnnotations() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
 		Name:            "myhost",
-		Namespace:       "myns",
+		Namespace:       namespaceName,
 		OwnerReferences: []metav1.OwnerReference{},
 	}
 }
@@ -241,10 +241,10 @@ func bmhObjectMetaNoAnnotations() *metav1.ObjectMeta {
 func m3mObjectMetaWithInvalidAnnotations() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
 		Name:            "foobarm3machine",
-		Namespace:       "myns",
+		Namespace:       namespaceName,
 		OwnerReferences: []metav1.OwnerReference{},
 		Annotations: map[string]string{
-			HostAnnotation: "myns/wrongvalue",
+			HostAnnotation: namespaceName + "/wrongvalue",
 		},
 	}
 }
@@ -252,10 +252,10 @@ func m3mObjectMetaWithInvalidAnnotations() *metav1.ObjectMeta {
 func m3mObjectMetaWithSomeAnnotations() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
 		Name:            "m3machine",
-		Namespace:       "myns",
+		Namespace:       namespaceName,
 		OwnerReferences: []metav1.OwnerReference{},
 		Annotations: map[string]string{
-			HostAnnotation: "myns/somehost",
+			HostAnnotation: namespaceName + "/somehost",
 		},
 	}
 }
@@ -263,7 +263,7 @@ func m3mObjectMetaWithSomeAnnotations() *metav1.ObjectMeta {
 func m3mObjectMetaEmptyAnnotations() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
 		Name:            "m3machine",
-		Namespace:       "myns",
+		Namespace:       namespaceName,
 		OwnerReferences: []metav1.OwnerReference{},
 		Annotations:     map[string]string{},
 	}
@@ -272,7 +272,7 @@ func m3mObjectMetaEmptyAnnotations() *metav1.ObjectMeta {
 func m3mObjectMetaNoAnnotations() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
 		Name:            "m3machine",
-		Namespace:       "myns",
+		Namespace:       namespaceName,
 		OwnerReferences: []metav1.OwnerReference{},
 	}
 }
@@ -510,12 +510,12 @@ var _ = Describe("Metal3Machine manager", func() {
 		host1 := bmh.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "host1",
-				Namespace: "myns",
+				Namespace: namespaceName,
 			},
 			Spec: bmh.BareMetalHostSpec{
 				ConsumerRef: &corev1.ObjectReference{
 					Name:       "someothermachine",
-					Namespace:  "myns",
+					Namespace:  namespaceName,
 					Kind:       "M3Machine",
 					APIVersion: capm3.GroupVersion.String(),
 				},
@@ -526,12 +526,12 @@ var _ = Describe("Metal3Machine manager", func() {
 		host3 := bmh.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "host3",
-				Namespace: "myns",
+				Namespace: namespaceName,
 			},
 			Spec: bmh.BareMetalHostSpec{
 				ConsumerRef: &corev1.ObjectReference{
 					Name:       "machine1",
-					Namespace:  "myns",
+					Namespace:  namespaceName,
 					Kind:       "M3Machine",
 					APIVersion: capm3.GroupVersion.String(),
 				},
@@ -546,7 +546,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		discoveredHost := bmh.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "discoveredHost",
-				Namespace: "myns",
+				Namespace: namespaceName,
 			},
 			Status: bmh.BareMetalHostStatus{
 				ErrorMessage: "this host is discovered but not usable",
@@ -555,28 +555,28 @@ var _ = Describe("Metal3Machine manager", func() {
 		hostWithLabel := bmh.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "hostWithLabel",
-				Namespace: "myns",
+				Namespace: namespaceName,
 				Labels:    map[string]string{"key1": "value1"},
 			},
 		}
 		hostWithUnhealthyAnnotation := bmh.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "hostWithUnhealthyAnnotation",
-				Namespace:   "myns",
+				Namespace:   namespaceName,
 				Annotations: map[string]string{capm3.UnhealthyAnnotation: "unhealthy"},
 			},
 		}
 		hostWithNodeReuseLabelSetToKCP := bmh.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "hostWithNodeReuseLabelSetToKCP",
-				Namespace: "myns",
+				Namespace: namespaceName,
 				Labels:    map[string]string{nodeReuseLabelName: "kcp-pool1"},
 			},
 		}
 		hostWithNodeReuseLabelSetToMD := bmh.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "hostWithNodeReuseLabelSetToMD",
-				Namespace: "myns",
+				Namespace: namespaceName,
 				Labels:    map[string]string{nodeReuseLabelName: "md-pool1"},
 			},
 		}
@@ -786,7 +786,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Spec: bmh.BareMetalHostSpec{
 					ConsumerRef: &corev1.ObjectReference{
 						Name:       "mym3machine",
-						Namespace:  "myns",
+						Namespace:  namespaceName,
 						Kind:       "M3Machine",
 						APIVersion: capm3.GroupVersion.String(),
 					},
@@ -803,7 +803,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Spec: bmh.BareMetalHostSpec{
 					ConsumerRef: &corev1.ObjectReference{
 						Name:       "mym3machine",
-						Namespace:  "myns",
+						Namespace:  namespaceName,
 						Kind:       "M3Machine",
 						APIVersion: capm3.GroupVersion.String(),
 					},
@@ -820,7 +820,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Spec: bmh.BareMetalHostSpec{
 					ConsumerRef: &corev1.ObjectReference{
 						Name:       "mym3machine",
-						Namespace:  "myns",
+						Namespace:  namespaceName,
 						Kind:       "M3Machine",
 						APIVersion: capm3.GroupVersion.String(),
 					},
@@ -880,7 +880,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Spec: bmh.BareMetalHostSpec{
 					ConsumerRef: &corev1.ObjectReference{
 						Name:       "mym3machine",
-						Namespace:  "myns",
+						Namespace:  namespaceName,
 						Kind:       "M3Machine",
 						APIVersion: capm3.GroupVersion.String(),
 					},
@@ -898,7 +898,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Spec: bmh.BareMetalHostSpec{
 					ConsumerRef: &corev1.ObjectReference{
 						Name:       "mym3machine",
-						Namespace:  "myns",
+						Namespace:  namespaceName,
 						Kind:       "M3Machine",
 						APIVersion: capm3.GroupVersion.String(),
 					},
@@ -916,7 +916,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Spec: bmh.BareMetalHostSpec{
 					ConsumerRef: &corev1.ObjectReference{
 						Name:       "mym3machine",
-						Namespace:  "myns",
+						Namespace:  namespaceName,
 						Kind:       "M3Machine",
 						APIVersion: capm3.GroupVersion.String(),
 					},
@@ -998,7 +998,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("User data has no namespace", testCaseSetHostSpec{
 			UserDataNamespace:         "",
-			ExpectedUserDataNamespace: "myns",
+			ExpectedUserDataNamespace: namespaceName,
 			Host: newBareMetalHost("host2", nil, bmh.StateNone,
 				nil, false, false,
 			),
@@ -1007,7 +1007,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Externally provisioned, same machine", testCaseSetHostSpec{
 			UserDataNamespace:         "",
-			ExpectedUserDataNamespace: "myns",
+			ExpectedUserDataNamespace: namespaceName,
 			Host: newBareMetalHost("host2", nil, bmh.StateNone,
 				nil, false, false,
 			),
@@ -1017,7 +1017,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Previously provisioned, different image",
 			testCaseSetHostSpec{
 				UserDataNamespace:         "",
-				ExpectedUserDataNamespace: "myns",
+				ExpectedUserDataNamespace: namespaceName,
 				Host: newBareMetalHost("host2", bmhSpecTestImg(),
 					bmh.StateNone, nil, false, false,
 				),
@@ -1068,7 +1068,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("User data has no namespace", testCaseSetHostSpec{
 			UserDataNamespace:         "",
-			ExpectedUserDataNamespace: "myns",
+			ExpectedUserDataNamespace: namespaceName,
 			Host: newBareMetalHost("host2", nil, bmh.StateNone,
 				nil, false, false,
 			),
@@ -1077,7 +1077,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Externally provisioned, same machine", testCaseSetHostSpec{
 			UserDataNamespace:         "",
-			ExpectedUserDataNamespace: "myns",
+			ExpectedUserDataNamespace: namespaceName,
 			Host: newBareMetalHost("host2", nil, bmh.StateNone,
 				nil, false, false,
 			),
@@ -1087,7 +1087,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Previously provisioned, different image",
 			testCaseSetHostSpec{
 				UserDataNamespace:         "",
-				ExpectedUserDataNamespace: "myns",
+				ExpectedUserDataNamespace: namespaceName,
 				Host: newBareMetalHost("host2", bmhSpecTestImg(),
 					bmh.StateNone, nil, false, false,
 				),
@@ -1101,7 +1101,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		host := bmh.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "somehost",
-				Namespace: "myns",
+				Namespace: namespaceName,
 			},
 		}
 		c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(&host).Build()
@@ -1153,7 +1153,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		host := bmh.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "myhost",
-				Namespace: "myns",
+				Namespace: namespaceName,
 			},
 		}
 		c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(&host).Build()
@@ -1246,7 +1246,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			Host: &bmh.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 			ExpectPresent: false,
@@ -1260,7 +1260,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			Host: &bmh.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
-					Namespace: "myns",
+					Namespace: namespaceName,
 					UID:       Bmhuid,
 				},
 				Status: bmh.BareMetalHostStatus{
@@ -1280,7 +1280,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			Host: &bmh.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
-					Namespace: "myns",
+					Namespace: namespaceName,
 					UID:       Bmhuid,
 				},
 				Status: bmh.BareMetalHostStatus{
@@ -1304,7 +1304,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		host := bmh.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "myhost",
-				Namespace: "myns",
+				Namespace: namespaceName,
 			},
 		}
 		c := fakeclient.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(&host).Build()
@@ -1345,7 +1345,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mymachine",
-						Namespace: "myns",
+						Namespace: namespaceName,
 						Labels: map[string]string{
 							capi.MachineControlPlaneLabelName: "labelHere",
 						},
@@ -1741,7 +1741,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			),
 			Machine: &capi.Machine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: capi.MachineSpec{
 					Bootstrap: capi.Bootstrap{
@@ -1854,7 +1854,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Machine: &capi.Machine{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mymachine",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					Status: capi.MachineStatus{
 						Addresses: []capi.MachineAddress{
@@ -1872,7 +1872,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				M3Machine: capm3.Metal3Machine{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mym3machine",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "M3Machine",
@@ -1918,7 +1918,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Machine: &capi.Machine{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mymachine",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					Status: capi.MachineStatus{
 						Addresses: []capi.MachineAddress{
@@ -1936,7 +1936,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				M3Machine: capm3.Metal3Machine{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mym3machine",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "M3Machine",
@@ -1977,14 +1977,14 @@ var _ = Describe("Metal3Machine manager", func() {
 					Machine: &capi.Machine{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "mymachine",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 						Status: capi.MachineStatus{},
 					},
 					M3Machine: capm3.Metal3Machine{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "mym3machine",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 						TypeMeta: metav1.TypeMeta{
 							Kind:       "M3Machine",
@@ -2306,7 +2306,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "Foobar",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Data: map[string][]byte{
 					"value": []byte("FooBar\n"),
@@ -2315,7 +2315,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 			Machine: &capi.Machine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: capi.MachineSpec{
 					Bootstrap: capi.Bootstrap{
@@ -2390,7 +2390,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			Secret: newSecret(),
 			Machine: &capi.Machine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: capi.MachineSpec{
 					Bootstrap: capi.Bootstrap{
@@ -2404,7 +2404,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("UserDataSecretName set in Machine, no secret", testCaseGetUserDataSecretName{
 			Machine: &capi.Machine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: capi.MachineSpec{
 					Bootstrap: capi.Bootstrap{
@@ -2562,11 +2562,11 @@ var _ = Describe("Metal3Machine manager", func() {
 					&capm3.Metal3MachineSpec{
 						DataTemplate: &corev1.ObjectReference{
 							Name:      "abcd",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 						UserData: &corev1.SecretReference{
 							Name:      "mym3machine-user-data",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 						Image: capm3.Image{
 							URL:        testImageURL,
@@ -2589,11 +2589,11 @@ var _ = Describe("Metal3Machine manager", func() {
 					&capm3.Metal3MachineSpec{
 						DataTemplate: &corev1.ObjectReference{
 							Name:      "abcd",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 						UserData: &corev1.SecretReference{
 							Name:      "mym3machine-user-data",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 						Image: capm3.Image{
 							URL:        testImageURL,
@@ -2601,7 +2601,7 @@ var _ = Describe("Metal3Machine manager", func() {
 							DiskFormat: testImageDiskFormat,
 						},
 					}, &capm3.Metal3MachineStatus{
-						RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: "myns"},
+						RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: namespaceName},
 					}, nil,
 				),
 				Host:      newBareMetalHost("myhost", bmhSpecBMC(), bmh.StateNone, nil, false, false),
@@ -2609,7 +2609,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Data: &capm3.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abcd-0",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					Spec: capm3.Metal3DataSpec{
 						MetaData: &corev1.SecretReference{
@@ -3023,7 +3023,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			DataClaim: &capm3.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myName",
-					Namespace: "myns",
+					Namespace: namespaceName,
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Name:       "myName",
@@ -3043,7 +3043,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			DataClaim: &capm3.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myName",
-					Namespace: "myns",
+					Namespace: namespaceName,
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Name:       "myName",
@@ -3055,7 +3055,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Status: capm3.Metal3DataClaimStatus{
 					RenderedData: &corev1.ObjectReference{
 						Name:      "abc",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 				},
 			},
@@ -3092,7 +3092,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			if tc.ExpectDataStatus {
 				Expect(tc.M3Machine.Status.RenderedData).To(Equal(&corev1.ObjectReference{
 					Name:      "abcd-0",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				}))
 			} else {
 				Expect(tc.M3Machine.Status.RenderedData).To(BeNil())
@@ -3138,7 +3138,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			DataClaim: &capm3.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myName",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 			ExpectRequeue: true,
@@ -3151,7 +3151,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			DataClaim: &capm3.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myName",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Status: capm3.Metal3DataClaimStatus{
 					RenderedData: &corev1.ObjectReference{},
@@ -3167,18 +3167,18 @@ var _ = Describe("Metal3Machine manager", func() {
 			DataClaim: &capm3.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myName",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: capm3.Metal3DataClaimSpec{
 					Template: corev1.ObjectReference{
 						Name:      "abcd",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 				},
 				Status: capm3.Metal3DataClaimStatus{
 					RenderedData: &corev1.ObjectReference{
 						Name:      "abcd-0",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 				},
 			},
@@ -3187,7 +3187,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("M3M status set, Data does not exist", testCaseM3MetaData{
 			M3Machine: newMetal3Machine("myName", nil, nil, &capm3.Metal3MachineStatus{
-				RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: "myns"},
+				RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: namespaceName},
 			}, nil),
 			Machine:          newMachine("myName", "myName", nil),
 			ExpectRequeue:    true,
@@ -3195,13 +3195,13 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Data not ready", testCaseM3MetaData{
 			M3Machine: newMetal3Machine("myName", nil, nil, &capm3.Metal3MachineStatus{
-				RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: "myns"},
+				RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: namespaceName},
 			}, nil),
 			Machine: newMachine("myName", "myName", nil),
 			Data: &capm3.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abcd-0",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 			ExpectRequeue:    true,
@@ -3209,13 +3209,13 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Data ready, no secrets", testCaseM3MetaData{
 			M3Machine: newMetal3Machine("myName", nil, nil, &capm3.Metal3MachineStatus{
-				RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: "myns"},
+				RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: namespaceName},
 			}, nil),
 			Machine: newMachine("myName", "myName", nil),
 			Data: &capm3.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abcd-0",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Status: capm3.Metal3DataStatus{
 					Ready: true,
@@ -3226,13 +3226,13 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Data ready with secrets", testCaseM3MetaData{
 			M3Machine: newMetal3Machine("myName", nil, nil, &capm3.Metal3MachineStatus{
-				RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: "myns"},
+				RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: namespaceName},
 			}, nil),
 			Machine: newMachine("myName", "myName", nil),
 			Data: &capm3.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abcd-0",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: capm3.Metal3DataSpec{
 					MetaData: &corev1.SecretReference{
@@ -3319,7 +3319,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine("myName", nil, &capm3.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			}, nil, nil),
 			Machine: newMachine("myName", "myName", nil),
@@ -3328,14 +3328,14 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine("myName", nil, &capm3.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{
 					Name:      "abcd",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			}, nil, nil),
 			Machine: newMachine("myName", "myName", nil),
 			DataClaim: &capm3.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myName",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 		}),
@@ -3638,7 +3638,7 @@ func newConfig(UserDataNamespace string,
 ) (*capm3.Metal3Machine, *corev1.ObjectReference) {
 	config := capm3.Metal3Machine{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "myns",
+			Namespace: namespaceName,
 		},
 		Spec: capm3.Metal3MachineSpec{
 			Image: capm3.Image{
@@ -3673,7 +3673,7 @@ func newConfig(UserDataNamespace string,
 
 	infrastructureRef := &corev1.ObjectReference{
 		Name:       "someothermachine",
-		Namespace:  "myns",
+		Namespace:  namespaceName,
 		Kind:       "M3Machine",
 		APIVersion: capm3.GroupVersion.String(),
 	}
@@ -3698,7 +3698,7 @@ func newMachine(machineName string, metal3machineName string,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      machineName,
-			Namespace: "myns",
+			Namespace: namespaceName,
 		},
 		Spec: capi.MachineSpec{
 			ClusterName:       clusterName,
@@ -3725,7 +3725,7 @@ func newMetal3Machine(name string,
 	if objMeta == nil {
 		objMeta = &metav1.ObjectMeta{
 			Name:      name,
-			Namespace: "myns",
+			Namespace: namespaceName,
 		}
 	}
 
@@ -3759,20 +3759,20 @@ func newBareMetalHost(name string,
 	if name == "" {
 		return &bmh.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "myns",
+				Namespace: namespaceName,
 			},
 		}
 	}
 
 	objMeta := &metav1.ObjectMeta{
 		Name:      name,
-		Namespace: "myns",
+		Namespace: namespaceName,
 	}
 
 	if clusterlabel == true {
 		objMeta = &metav1.ObjectMeta{
 			Name:      name,
-			Namespace: "myns",
+			Namespace: namespaceName,
 			Labels: map[string]string{
 				capi.ClusterLabelName: clusterName,
 				"foo":                 "bar",
@@ -3803,12 +3803,12 @@ func newBareMetalHost(name string,
 func newBMCSecret(name string, clusterlabel bool) *corev1.Secret {
 	objMeta := &metav1.ObjectMeta{
 		Name:      name,
-		Namespace: "myns",
+		Namespace: namespaceName,
 	}
 	if clusterlabel == true {
 		objMeta = &metav1.ObjectMeta{
 			Name:      name,
-			Namespace: "myns",
+			Namespace: namespaceName,
 			Labels: map[string]string{
 				capi.ClusterLabelName: clusterName,
 				"foo":                 "bar",
@@ -3833,7 +3833,7 @@ func newSecret() *corev1.Secret {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "mym3machine-user-data",
-			Namespace:  "myns",
+			Namespace:  namespaceName,
 			Finalizers: []string{"abcd"},
 		},
 		Data: map[string][]byte{

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -2145,17 +2145,18 @@ var _ = Describe("Metal3Machine manager", func() {
 		}
 
 		type testCaseSetNodePoviderID struct {
-			Node               v1.Node
-			HostID             string
-			ExpectedError      bool
-			ExpectedProviderID string
+			TargetObjects        []runtime.Object
+			M3MHasHostAnnotation bool
+			HostID               string
+			ExpectedError        bool
+			ExpectedProviderID   string
 		}
 
 		DescribeTable("Test SetNodeProviderID",
 			func(tc testCaseSetNodePoviderID) {
-				c := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
-				corev1Client := clientfake.NewSimpleClientset(&tc.Node).CoreV1()
-				mockCapiClientGetter := func(ctx context.Context, c client.Client, cluster *capi.Cluster) (
+				fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
+				corev1Client := clientfake.NewSimpleClientset(tc.TargetObjects...).CoreV1()
+				m := func(ctx context.Context, client client.Client, cluster *clusterv1.Cluster) (
 					clientcorev1.CoreV1Interface, error,
 				) {
 					return corev1Client, nil
@@ -2182,24 +2183,32 @@ var _ = Describe("Metal3Machine manager", func() {
 
 				ctx := context.Background()
 				// get the node
-				node, err := corev1Client.Nodes().Get(ctx, tc.Node.Name,
-					metav1.GetOptions{},
-				)
+				nodes, err := corev1Client.Nodes().List(ctx, metav1.ListOptions{})
 				Expect(err).NotTo(HaveOccurred())
-
+				var node corev1.Node
+				for _, currentNode := range nodes.Items {
+					node = currentNode
+					// there is only one node
+					break
+				}
 				Expect(node.Spec.ProviderID).To(Equal(tc.ExpectedProviderID))
 			},
 			Entry("Set target ProviderID, No matching node", testCaseSetNodePoviderID{
-				Node:               v1.Node{},
-				HostID:             string(Bmhuid),
-				ExpectedError:      true,
-				ExpectedProviderID: ProviderID,
+				TargetObjects: []runtime.Object{
+					&corev1.Node{},
+				},
+				HostID:               string(Bmhuid),
+				ExpectedError:        true,
+				ExpectedProviderID:   ProviderID,
+				M3MHasHostAnnotation: true,
 			}),
 			Entry("Set target ProviderID, matching node", testCaseSetNodePoviderID{
-				Node: v1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							ProviderLabelPrefix: string(bmhuid),
+				TargetObjects: []runtime.Object{
+					&corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								ProviderLabelPrefix: string(bmhuid),
+							},
 						},
 					},
 				},
@@ -2208,19 +2217,122 @@ var _ = Describe("Metal3Machine manager", func() {
 				ExpectedProviderID: fmt.Sprintf("%s%s", ProviderIDPrefix, string(bmhuid)),
 			}),
 			Entry("Set target ProviderID, providerID set", testCaseSetNodePoviderID{
-				Node: v1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							ProviderLabelPrefix: string(Bmhuid),
+				TargetObjects: []runtime.Object{
+					&corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								ProviderLabelPrefix: string(Bmhuid),
+							},
+						},
+						Spec: corev1.NodeSpec{
+							ProviderID: ProviderID,
 						},
 					},
-					Spec: v1.NodeSpec{
-						ProviderID: ProviderID,
+				},
+				HostID:               string(Bmhuid),
+				ExpectedError:        false,
+				ExpectedProviderID:   ProviderID,
+				M3MHasHostAnnotation: true,
+			}),
+		)
+		DescribeTable("Test SetNodeProviderID with noCloudProvider set to false",
+			func(tc testCaseSetNodePoviderID) {
+				fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
+				corev1Client := clientfake.NewSimpleClientset(tc.TargetObjects...).CoreV1()
+				m := func(ctx context.Context, client client.Client, cluster *clusterv1.Cluster) (
+					clientcorev1.CoreV1Interface, error,
+				) {
+					return corev1Client, nil
+				}
+
+				machineMgr, err := NewMachineManager(fakeClient, newCluster(clusterName),
+					newMetal3Cluster(metal3ClusterName, bmcOwnerRef,
+						&capm3.Metal3ClusterSpec{NoCloudProvider: false}, nil,
+					),
+					&clusterv1.Machine{}, &capm3.Metal3Machine{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "abc",
+							Namespace: namespaceName,
+							UID:       m3muid,
+							Annotations: map[string]string{
+								HostAnnotation: namespaceName + "/myhost",
+							},
+						},
+					}, logr.Discard(),
+				)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				err = machineMgr.SetNodeProviderID(context.TODO(), tc.HostID,
+					&tc.ExpectedProviderID, m,
+				)
+
+				if tc.ExpectedError {
+					Expect(err).To(HaveOccurred())
+					return
+				}
+				Expect(err).NotTo(HaveOccurred())
+
+				ctx := context.Background()
+				Expect(err).NotTo(HaveOccurred())
+				nodes, err := corev1Client.Nodes().List(ctx, metav1.ListOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				var node corev1.Node
+				for _, currentNode := range nodes.Items {
+					node = currentNode
+					// there is only one node
+					break
+				}
+				Expect(node.Spec.ProviderID).To(Equal(tc.ExpectedProviderID))
+			},
+			Entry("Accept providerID when set on a node", testCaseSetNodePoviderID{
+				TargetObjects: []runtime.Object{
+					&corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{},
+						Spec: corev1.NodeSpec{
+							ProviderID: ProviderID,
+						},
 					},
 				},
 				HostID:             string(Bmhuid),
 				ExpectedError:      false,
 				ExpectedProviderID: ProviderID,
+			}),
+			Entry("Fail when nodes do not have providerID", testCaseSetNodePoviderID{
+				TargetObjects: []runtime.Object{
+					&corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{},
+						Spec:       corev1.NodeSpec{},
+					},
+				},
+				HostID:               string(Bmhuid),
+				ExpectedError:        true,
+				ExpectedProviderID:   ProviderID,
+				M3MHasHostAnnotation: true,
+			}),
+			Entry("Fail when multiple nodes use the same providerID", testCaseSetNodePoviderID{
+				TargetObjects: []runtime.Object{
+					&corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-0",
+						},
+						Spec: corev1.NodeSpec{
+							ProviderID: ProviderID,
+						},
+					},
+					&corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-1",
+						},
+						Spec: corev1.NodeSpec{
+							ProviderID: ProviderID,
+						},
+					},
+				},
+				HostID:               string(Bmhuid),
+				ExpectedError:        true,
+				ExpectedProviderID:   ProviderID,
+				M3MHasHostAnnotation: true,
 			}),
 		)
 	})

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -35,6 +35,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientfake "k8s.io/client-go/kubernetes/fake"
 	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2/klogr"
@@ -55,7 +56,8 @@ const (
 	kcpName                   = "kcp-pool1"
 )
 
-var ProviderID = "metal3://12345ID6789"
+var Bmhuid = types.UID("4d25a2c2-46e4-11ec-81d3-0242ac130003")
+var ProviderID = fmt.Sprintf("metal3://%s", Bmhuid)
 
 var testImageDiskFormat = pointer.StringPtr("raw")
 
@@ -1259,7 +1261,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
-					UID:       "12345ID6789",
+					UID:       Bmhuid,
 				},
 				Status: bmh.BareMetalHostStatus{
 					Provisioning: bmh.ProvisionStatus{
@@ -1279,7 +1281,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
 					Namespace: "myns",
-					UID:       "12345ID6789",
+					UID:       Bmhuid,
 				},
 				Status: bmh.BareMetalHostStatus{
 					Provisioning: bmh.ProvisionStatus{
@@ -2126,8 +2128,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		},
 		Entry("Empty providerID", testCaseGetProviderIDAndBMHID{}),
 		Entry("Provider ID set", testCaseGetProviderIDAndBMHID{
-			providerID:    pointer.StringPtr("metal3://abcd"),
-			expectedBMHID: "abcd",
+			providerID:    pointer.StringPtr(ProviderID),
+			expectedBMHID: string(Bmhuid),
 		}),
 	)
 
@@ -2189,36 +2191,36 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 			Entry("Set target ProviderID, No matching node", testCaseSetNodePoviderID{
 				Node:               v1.Node{},
-				HostID:             "abcd",
+				HostID:             string(Bmhuid),
 				ExpectedError:      true,
-				ExpectedProviderID: "metal3://abcd",
+				ExpectedProviderID: ProviderID,
 			}),
 			Entry("Set target ProviderID, matching node", testCaseSetNodePoviderID{
 				Node: v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"metal3.io/uuid": "abcd",
+							ProviderLabelPrefix: string(bmhuid),
 						},
 					},
 				},
-				HostID:             "abcd",
+				HostID:             string(bmhuid),
 				ExpectedError:      false,
-				ExpectedProviderID: "metal3://abcd",
+				ExpectedProviderID: fmt.Sprintf("%s%s", ProviderIDPrefix, string(bmhuid)),
 			}),
 			Entry("Set target ProviderID, providerID set", testCaseSetNodePoviderID{
 				Node: v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"metal3.io/uuid": "abcd",
+							ProviderLabelPrefix: string(Bmhuid),
 						},
 					},
 					Spec: v1.NodeSpec{
-						ProviderID: "metal3://abcd",
+						ProviderID: ProviderID,
 					},
 				},
-				HostID:             "abcd",
+				HostID:             string(Bmhuid),
 				ExpectedError:      false,
-				ExpectedProviderID: "metal3://abcd",
+				ExpectedProviderID: ProviderID,
 			}),
 		)
 	})

--- a/baremetal/metal3machinetemplate_manager_test.go
+++ b/baremetal/metal3machinetemplate_manager_test.go
@@ -74,10 +74,10 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 					Kind:       "Metal3MachineTemplate",
 				},
 				ObjectMeta: testObjectMeta("abc", "foo", ""),
-				Spec: infrav1.Metal3MachineTemplateSpec{
-					Template: infrav1.Metal3MachineTemplateResource{
-						Spec: infrav1.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr(infrav1.CleaningModeDisabled),
+				Spec: capm3.Metal3MachineTemplateSpec{
+					Template: capm3.Metal3MachineTemplateResource{
+						Spec: capm3.Metal3MachineSpec{
+							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeDisabled),
 						},
 					},
 				},
@@ -142,10 +142,10 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 					Kind:       "Metal3MachineTemplate",
 				},
 				ObjectMeta: testObjectMeta("abc", "foo", ""),
-				Spec: infrav1.Metal3MachineTemplateSpec{
-					Template: infrav1.Metal3MachineTemplateResource{
-						Spec: infrav1.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr(infrav1.CleaningModeMetadata),
+				Spec: capm3.Metal3MachineTemplateSpec{
+					Template: capm3.Metal3MachineTemplateResource{
+						Spec: capm3.Metal3MachineSpec{
+							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeMetadata),
 						},
 					},
 				},
@@ -210,9 +210,9 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 					Kind:       "Metal3MachineTemplate",
 				},
 				ObjectMeta: testObjectMeta("abc", "foo", ""),
-				Spec: infrav1.Metal3MachineTemplateSpec{
-					Template: infrav1.Metal3MachineTemplateResource{
-						Spec: infrav1.Metal3MachineSpec{
+				Spec: capm3.Metal3MachineTemplateSpec{
+					Template: capm3.Metal3MachineTemplateResource{
+						Spec: capm3.Metal3MachineSpec{
 							AutomatedCleaningMode: utils.StringPtr("disabled"),
 						},
 					},

--- a/baremetal/metal3machinetemplate_manager_test.go
+++ b/baremetal/metal3machinetemplate_manager_test.go
@@ -73,14 +73,11 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 					APIVersion: capm3.GroupVersion.String(),
 					Kind:       "Metal3MachineTemplate",
 				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: "foo",
-				},
-				Spec: capm3.Metal3MachineTemplateSpec{
-					Template: capm3.Metal3MachineTemplateResource{
-						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeDisabled),
+				ObjectMeta: testObjectMeta("abc", "foo", ""),
+				Spec: infrav1.Metal3MachineTemplateSpec{
+					Template: infrav1.Metal3MachineTemplateResource{
+						Spec: infrav1.Metal3MachineSpec{
+							AutomatedCleaningMode: utils.StringPtr(infrav1.CleaningModeDisabled),
 						},
 					},
 				},
@@ -144,14 +141,11 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 					APIVersion: capm3.GroupVersion.String(),
 					Kind:       "Metal3MachineTemplate",
 				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: "foo",
-				},
-				Spec: capm3.Metal3MachineTemplateSpec{
-					Template: capm3.Metal3MachineTemplateResource{
-						Spec: capm3.Metal3MachineSpec{
-							AutomatedCleaningMode: utils.StringPtr(capm3.CleaningModeMetadata),
+				ObjectMeta: testObjectMeta("abc", "foo", ""),
+				Spec: infrav1.Metal3MachineTemplateSpec{
+					Template: infrav1.Metal3MachineTemplateResource{
+						Spec: infrav1.Metal3MachineSpec{
+							AutomatedCleaningMode: utils.StringPtr(infrav1.CleaningModeMetadata),
 						},
 					},
 				},
@@ -215,13 +209,10 @@ var _ = Describe("Metal3MachineTemplate manager", func() {
 					APIVersion: capm3.GroupVersion.String(),
 					Kind:       "Metal3MachineTemplate",
 				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: "foo",
-				},
-				Spec: capm3.Metal3MachineTemplateSpec{
-					Template: capm3.Metal3MachineTemplateResource{
-						Spec: capm3.Metal3MachineSpec{
+				ObjectMeta: testObjectMeta("abc", "foo", ""),
+				Spec: infrav1.Metal3MachineTemplateSpec{
+					Template: infrav1.Metal3MachineTemplateResource{
+						Spec: infrav1.Metal3MachineSpec{
 							AutomatedCleaningMode: utils.StringPtr("disabled"),
 						},
 					},

--- a/baremetal/metal3remediation_manager_test.go
+++ b/baremetal/metal3remediation_manager_test.go
@@ -281,7 +281,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 	DescribeTable("Test GetUnhealthyHost",
 		func(tc testCaseGetUnhealthyHost) {
 			host := bmov1alpha1.BareMetalHost{
-				ObjectMeta: testObjectMeta("myhost", namespaceName, ""),
+				ObjectMeta: testObjectMeta(baremetalhostName, namespaceName, ""),
 			}
 			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(&host).Build()
 
@@ -305,11 +305,11 @@ var _ = Describe("Metal3Remediation manager", func() {
 		Entry("Should find the unhealthy host", testCaseGetUnhealthyHost{
 			M3Machine: &capm3.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            "mym3machine",
+					Name:            metal3machineName,
 					Namespace:       namespaceName,
 					OwnerReferences: []metav1.OwnerReference{},
 					Annotations: map[string]string{
-						HostAnnotation: namespaceName + "/myhost",
+						HostAnnotation: namespaceName + "/" + baremetalhostName,
 					},
 				},
 			},
@@ -318,7 +318,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 		Entry("Should not find the unhealthy host", testCaseGetUnhealthyHost{
 			M3Machine: &capm3.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            "mym3machine",
+					Name:            metal3machineName,
 					Namespace:       namespaceName,
 					OwnerReferences: []metav1.OwnerReference{},
 					Annotations: map[string]string{
@@ -331,7 +331,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 		Entry("Should not find the host, annotation not present", testCaseGetUnhealthyHost{
 			M3Machine: &capm3.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            "mym3machine",
+					Name:            metal3machineName,
 					Namespace:       namespaceName,
 					OwnerReferences: []metav1.OwnerReference{},
 					Annotations:     map[string]string{},

--- a/baremetal/metal3remediation_manager_test.go
+++ b/baremetal/metal3remediation_manager_test.go
@@ -280,14 +280,10 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 	DescribeTable("Test GetUnhealthyHost",
 		func(tc testCaseGetUnhealthyHost) {
-			host := bmh.BareMetalHost{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "myhost",
-					Namespace: namespaceName,
-				},
+			host := bmov1alpha1.BareMetalHost{
+				ObjectMeta: testObjectMeta("myhost", namespaceName, ""),
 			}
-
-			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(&host).Build()
+			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(&host).Build()
 
 			remediationMgr, err := NewRemediationManager(c, nil, tc.M3Machine, nil,
 				klogr.New(),

--- a/baremetal/metal3remediation_manager_test.go
+++ b/baremetal/metal3remediation_manager_test.go
@@ -280,10 +280,10 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 	DescribeTable("Test GetUnhealthyHost",
 		func(tc testCaseGetUnhealthyHost) {
-			host := bmov1alpha1.BareMetalHost{
+			host := bmh.BareMetalHost{
 				ObjectMeta: testObjectMeta(baremetalhostName, namespaceName, ""),
 			}
-			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(&host).Build()
+			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(&host).Build()
 
 			remediationMgr, err := NewRemediationManager(c, nil, tc.M3Machine, nil,
 				klogr.New(),

--- a/baremetal/metal3remediation_manager_test.go
+++ b/baremetal/metal3remediation_manager_test.go
@@ -283,7 +283,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 			host := bmh.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			}
 
@@ -310,10 +310,10 @@ var _ = Describe("Metal3Remediation manager", func() {
 			M3Machine: &capm3.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "mym3machine",
-					Namespace:       "myns",
+					Namespace:       namespaceName,
 					OwnerReferences: []metav1.OwnerReference{},
 					Annotations: map[string]string{
-						HostAnnotation: "myns/myhost",
+						HostAnnotation: namespaceName + "/myhost",
 					},
 				},
 			},
@@ -323,10 +323,10 @@ var _ = Describe("Metal3Remediation manager", func() {
 			M3Machine: &capm3.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "mym3machine",
-					Namespace:       "myns",
+					Namespace:       namespaceName,
 					OwnerReferences: []metav1.OwnerReference{},
 					Annotations: map[string]string{
-						HostAnnotation: "myns/wronghostname",
+						HostAnnotation: namespaceName + "/wronghostname",
 					},
 				},
 			},
@@ -336,7 +336,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 			M3Machine: &capm3.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "mym3machine",
-					Namespace:       "myns",
+					Namespace:       namespaceName,
 					OwnerReferences: []metav1.OwnerReference{},
 					Annotations:     map[string]string{},
 				},

--- a/baremetal/mocks/zz_generated.metal3machine_manager.go
+++ b/baremetal/mocks/zz_generated.metal3machine_manager.go
@@ -221,7 +221,7 @@ func (mr *MockMachineManagerInterfaceMockRecorder) SetFinalizer() *gomock.Call {
 }
 
 // SetNodeProviderID mocks base method.
-func (m *MockMachineManagerInterface) SetNodeProviderID(arg0 context.Context, arg1, arg2 string, arg3 baremetal.ClientGetter) error {
+func (m *MockMachineManagerInterface) SetNodeProviderID(arg0 context.Context, arg1 string, arg2 *string, arg3 baremetal.ClientGetter) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetNodeProviderID", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)

--- a/baremetal/mocks/zz_generated.metal3machine_manager.go
+++ b/baremetal/mocks/zz_generated.metal3machine_manager.go
@@ -221,7 +221,7 @@ func (mr *MockMachineManagerInterfaceMockRecorder) SetFinalizer() *gomock.Call {
 }
 
 // SetNodeProviderID mocks base method.
-func (m *MockMachineManagerInterface) SetNodeProviderID(arg0 context.Context, arg1 string, arg2 *string, arg3 baremetal.ClientGetter) error {
+func (m *MockMachineManagerInterface) SetNodeProviderID(arg0 context.Context, arg1, arg2 *string, arg3 baremetal.ClientGetter) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetNodeProviderID", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -49,14 +49,25 @@ var k8sClient client.Client
 var testEnv *envtest.Environment
 
 const (
-	clusterName       = "baremetal_testCluster"
-	metal3ClusterName = "baremetal_testmetal3Cluster"
-	namespaceName     = "baremetalns"
-	m3muid            = "11111111-9845-4321-1234-c74be387f57c"
-	bmhuid            = "22222222-9845-4c48-9e49-c74be387f57c"
+	clusterName            = "baremetal-testcluster"
+	machineName            = "baremetal-testmachine"
+	metal3ClusterName      = "baremetal-testmetal3Cluster"
+	metal3machineName      = "baremetal-testmetal3machine"
+	baremetalhostName      = "baremetal-testbaremetalhost"
+	metal3DataTemplateName = "baremetal-testmetal3datatemplate"
+	testPoolName           = "baremetal-testpoolname"
+	metal3DataName         = "baremetal-testmetal3dataname"
+	metal3DataClaimName    = "baremetal-testmetal3dataclaim"
+	namespaceName          = "baremetalns-testns"
+	muid                   = "902b9bf0-42c2-42ef-8315-ab23f07e009a"
+	m3muid                 = "11111111-9845-4321-1234-c74be387f57c"
+	bmhuid                 = "22222222-9845-4c48-9e49-c74be387f57c"
+	m3duid                 = "4f3223fb-1ac1-482c-a4d4-e09f8e6c08f1"
+	m3dcuid                = "d184c4f7-2a64-4537-bf74-f6abd08cb992"
+	m3dtuid                = "9c8facc6-c9e3-4b1c-a038-d8416717fab3"
 )
 
-var providerid = fmt.Sprintf("%s/%s/%s", namespaceName, "abc", "abc")
+var providerid = fmt.Sprintf("%s/%s/%s", namespaceName, baremetalhostName, metal3machineName)
 
 func TestManagers(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -192,5 +203,26 @@ func newMetal3Cluster(baremetalName string, ownerRef *metav1.OwnerReference,
 		},
 		Spec:   *spec,
 		Status: *status,
+	}
+}
+
+func testObjectMetaWithOR(name string, m3mName string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      name,
+		Namespace: namespaceName,
+
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				Name:       m3mName,
+				Kind:       "Metal3Machine",
+				APIVersion: infrav1.GroupVersion.String(),
+				UID:        m3muid,
+			},
+		},
+	}
+}
+func testObjectReference(name string) *corev1.ObjectReference {
+	return &corev1.ObjectReference{
+		Name: name,
 	}
 }

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -56,7 +56,7 @@ const (
 	bmhuid            = "22222222-9845-4c48-9e49-c74be387f57c"
 )
 
-var providerid = fmt.Sprintf("%s/%s/%s", namespaceName, bmhuid, m3muid)
+var providerid = fmt.Sprintf("%s/%s/%s", namespaceName, "abc", "abc")
 
 func TestManagers(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -18,6 +18,7 @@ package baremetal
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -54,6 +55,8 @@ const (
 	m3muid            = "11111111-9845-4321-1234-c74be387f57c"
 	bmhuid            = "22222222-9845-4c48-9e49-c74be387f57c"
 )
+
+var providerid = fmt.Sprintf("%s/%s/%s", namespaceName, bmhuid, m3muid)
 
 func TestManagers(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -51,7 +51,7 @@ var testEnv *envtest.Environment
 const (
 	clusterName       = "testCluster"
 	metal3ClusterName = "testmetal3Cluster"
-	namespaceName     = "testNameSpace"
+	namespaceName     = "baremetalns"
 	m3muid            = "11111111-9845-4321-1234-c74be387f57c"
 	bmhuid            = "22222222-9845-4c48-9e49-c74be387f57c"
 )
@@ -94,7 +94,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(k8sClient).ToNot(BeNil())
 		err = k8sClient.Create(context.TODO(), &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{Name: "myns"},
+			ObjectMeta: metav1.ObjectMeta{Name: namespaceName},
 		})
 		Expect(err).NotTo(HaveOccurred())
 

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -215,7 +215,7 @@ func testObjectMetaWithOR(name string, m3mName string) metav1.ObjectMeta {
 			{
 				Name:       m3mName,
 				Kind:       "Metal3Machine",
-				APIVersion: infrav1.GroupVersion.String(),
+				APIVersion: infrav1alpha5.GroupVersion.String(),
 				UID:        m3muid,
 			},
 		},

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -138,6 +138,13 @@ func setupScheme() *runtime.Scheme {
 	return s
 }
 
+func testObjectMeta(name string, namespace string, uid string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      name,
+		Namespace: namespace,
+	}
+}
+
 func newCluster(clusterName string) *clusterv1.Cluster {
 	return &clusterv1.Cluster{
 		TypeMeta: metav1.TypeMeta{

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -18,11 +18,11 @@ package baremetal
 
 import (
 	"context"
-	"path/filepath"
-	"testing"
-
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"path/filepath"
+	"testing"
 
 	_ "github.com/go-logr/logr"
 	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
@@ -51,7 +51,11 @@ const (
 	clusterName       = "testCluster"
 	metal3ClusterName = "testmetal3Cluster"
 	namespaceName     = "testNameSpace"
+	m3muid            = "11111111-9845-4321-1234-c74be387f57c"
+	bmhuid            = "22222222-9845-4c48-9e49-c74be387f57c"
 )
+
+var provideruid = fmt.Sprintf("%s_11111111", bmhuid)
 
 func TestManagers(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -49,8 +49,8 @@ var k8sClient client.Client
 var testEnv *envtest.Environment
 
 const (
-	clusterName       = "testCluster"
-	metal3ClusterName = "testmetal3Cluster"
+	clusterName       = "baremetal_testCluster"
+	metal3ClusterName = "baremetal_testmetal3Cluster"
 	namespaceName     = "baremetalns"
 	m3muid            = "11111111-9845-4321-1234-c74be387f57c"
 	bmhuid            = "22222222-9845-4c48-9e49-c74be387f57c"

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -18,11 +18,11 @@ package baremetal
 
 import (
 	"context"
-	"fmt"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"path/filepath"
 	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
 	_ "github.com/go-logr/logr"
 	bmh "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
@@ -54,8 +54,6 @@ const (
 	m3muid            = "11111111-9845-4321-1234-c74be387f57c"
 	bmhuid            = "22222222-9845-4c48-9e49-c74be387f57c"
 )
-
-var provideruid = fmt.Sprintf("%s_11111111", bmhuid)
 
 func TestManagers(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/baremetal/utils.go
+++ b/baremetal/utils.go
@@ -308,5 +308,5 @@ func getM3Machine(ctx context.Context, cl client.Client, mLog logr.Logger,
 }
 
 func parseProviderID(providerID string) string {
-	return strings.TrimPrefix(providerID, "metal3://")
+	return strings.TrimPrefix(providerID, ProviderIDPrefix)
 }

--- a/baremetal/utils_test.go
+++ b/baremetal/utils_test.go
@@ -351,7 +351,7 @@ var _ = Describe("Metal3 manager utils", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 			}
-			_, err := checkSecretExists(context.TODO(), k8sClient, "abc", namespaceName)
+			_, err := checkSecretExists(c, context.TODO(), "abc", namespaceName)
 			if secretExists {
 				Expect(err).NotTo(HaveOccurred())
 				err = c.Delete(context.TODO(), &corev1.Secret{
@@ -403,7 +403,7 @@ var _ = Describe("Metal3 manager utils", func() {
 			content := map[string][]byte{
 				"abc": []byte("def"),
 			}
-			err := createSecret(context.TODO(), k8sClient, "abc", namespaceName, "ghi",
+			err := createSecret(c, context.TODO(), "abc", namespaceName, "ghi",
 				ownerRef, content,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -445,7 +445,7 @@ var _ = Describe("Metal3 manager utils", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 
-			err := deleteSecret(context.TODO(), k8sClient, "abc", namespaceName)
+			err := deleteSecret(c, context.TODO(), "abc", namespaceName)
 			Expect(err).NotTo(HaveOccurred())
 			savedSecret := corev1.Secret{}
 			err = c.Get(context.TODO(),
@@ -519,9 +519,9 @@ var _ = Describe("Metal3 manager utils", func() {
 			ExpectError: true,
 		}),
 		Entry("Object with wrong cluster", testCaseFetchM3DataTemplate{
-			DataTemplate: &infrav1.Metal3DataTemplate{
+			DataTemplate: &capm3.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
-				Spec: infrav1.Metal3DataTemplateSpec{
+				Spec: capm3.Metal3DataTemplateSpec{
 					ClusterName: clusterName,
 				},
 			},
@@ -533,9 +533,9 @@ var _ = Describe("Metal3 manager utils", func() {
 			ExpectError: true,
 		}),
 		Entry("Object with correct cluster", testCaseFetchM3DataTemplate{
-			DataTemplate: &infrav1.Metal3DataTemplate{
+			DataTemplate: &capm3.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
-				Spec: infrav1.Metal3DataTemplateSpec{
+				Spec: capm3.Metal3DataTemplateSpec{
 					ClusterName: clusterName,
 				},
 			},
@@ -593,7 +593,7 @@ var _ = Describe("Metal3 manager utils", func() {
 			ExpectRequeue: true,
 		}),
 		Entry("Object exists", testCaseFetchM3Data{
-			Data: &infrav1.Metal3Data{
+			Data: &capm3.Metal3Data{
 				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 			},
 			Name:      metal3DataName,
@@ -648,20 +648,20 @@ var _ = Describe("Metal3 manager utils", func() {
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists", testCaseGetM3Machine{
-			Machine: &infrav1.Metal3Machine{
+			Machine: &capm3.Metal3Machine{
 				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, ""),
 			},
 			Name:      metal3machineName,
 			Namespace: namespaceName,
 		}),
 		Entry("Object exists, dataTemplate nil", testCaseGetM3Machine{
-			Machine: &infrav1.Metal3Machine{
+			Machine: &capm3.Metal3Machine{
 				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, ""),
-				Spec: infrav1.Metal3MachineSpec{
+				Spec: capm3.Metal3MachineSpec{
 					DataTemplate: nil,
 				},
 			},
-			DataTemplate: &infrav1.Metal3DataTemplate{
+			DataTemplate: &capm3.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
 			},
 			Name:        metal3machineName,
@@ -669,16 +669,16 @@ var _ = Describe("Metal3 manager utils", func() {
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists, dataTemplate name mismatch", testCaseGetM3Machine{
-			Machine: &infrav1.Metal3Machine{
+			Machine: &capm3.Metal3Machine{
 				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, ""),
-				Spec: infrav1.Metal3MachineSpec{
+				Spec: capm3.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
 						Name:      "abcd",
 						Namespace: namespaceName,
 					},
 				},
 			},
-			DataTemplate: &infrav1.Metal3DataTemplate{
+			DataTemplate: &capm3.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
 			},
 			Name:        metal3machineName,
@@ -686,16 +686,16 @@ var _ = Describe("Metal3 manager utils", func() {
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists, dataTemplate namespace mismatch", testCaseGetM3Machine{
-			Machine: &infrav1.Metal3Machine{
+			Machine: &capm3.Metal3Machine{
 				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, ""),
-				Spec: infrav1.Metal3MachineSpec{
+				Spec: capm3.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
 						Name:      metal3DataTemplateName,
 						Namespace: "defg",
 					},
 				},
 			},
-			DataTemplate: &infrav1.Metal3DataTemplate{
+			DataTemplate: &capm3.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
 			},
 			Name:        metal3machineName,

--- a/baremetal/utils_test.go
+++ b/baremetal/utils_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -129,7 +130,7 @@ var _ = Describe("Metal3 manager utils", func() {
 	var testObject = &capm3.Metal3Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "abc",
-			Namespace: "myns",
+			Namespace: namespaceName,
 		},
 		Spec: capm3.Metal3MachineSpec{
 			ProviderID:            pointer.StringPtr("abcdef"),
@@ -143,7 +144,7 @@ var _ = Describe("Metal3 manager utils", func() {
 	var existingObject = &capm3.Metal3Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "abc",
-			Namespace: "myns",
+			Namespace: namespaceName,
 		},
 		Spec: capm3.Metal3MachineSpec{
 			ProviderID: pointer.StringPtr("abcdefg"),
@@ -345,18 +346,18 @@ var _ = Describe("Metal3 manager utils", func() {
 				err := c.Create(context.TODO(), &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 				})
 				Expect(err).NotTo(HaveOccurred())
 			}
-			_, err := checkSecretExists(c, context.TODO(), "abc", "myns")
+			_, err := checkSecretExists(context.TODO(), k8sClient, "abc", namespaceName)
 			if secretExists {
 				Expect(err).NotTo(HaveOccurred())
 				err = c.Delete(context.TODO(), &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -376,7 +377,7 @@ var _ = Describe("Metal3 manager utils", func() {
 				err := c.Create(context.TODO(), &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc",
-						Namespace: "myns",
+						Namespace: namespaceName,
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								Name:       "ghij",
@@ -402,7 +403,7 @@ var _ = Describe("Metal3 manager utils", func() {
 			content := map[string][]byte{
 				"abc": []byte("def"),
 			}
-			err := createSecret(c, context.TODO(), "abc", "myns", "ghi",
+			err := createSecret(context.TODO(), k8sClient, "abc", namespaceName, "ghi",
 				ownerRef, content,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -410,7 +411,7 @@ var _ = Describe("Metal3 manager utils", func() {
 			err = c.Get(context.TODO(),
 				client.ObjectKey{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				&savedSecret,
 			)
@@ -424,7 +425,7 @@ var _ = Describe("Metal3 manager utils", func() {
 			err = c.Delete(context.TODO(), &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -440,20 +441,20 @@ var _ = Describe("Metal3 manager utils", func() {
 				err := c.Create(context.TODO(), &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "abc",
-						Namespace:  "myns",
+						Namespace:  namespaceName,
 						Finalizers: []string{"foo.bar/foo"},
 					},
 				})
 				Expect(err).NotTo(HaveOccurred())
 			}
 
-			err := deleteSecret(c, context.TODO(), "abc", "myns")
+			err := deleteSecret(context.TODO(), k8sClient, "abc", namespaceName)
 			Expect(err).NotTo(HaveOccurred())
 			savedSecret := corev1.Secret{}
 			err = c.Get(context.TODO(),
 				client.ObjectKey{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				&savedSecret,
 			)
@@ -507,7 +508,7 @@ var _ = Describe("Metal3 manager utils", func() {
 		Entry("Object does not exist", testCaseFetchM3DataTemplate{
 			TemplateRef: &corev1.ObjectReference{
 				Name:      "abc",
-				Namespace: "myns",
+				Namespace: namespaceName,
 			},
 			ExpectRequeue: true,
 		}),
@@ -524,7 +525,7 @@ var _ = Describe("Metal3 manager utils", func() {
 			DataTemplate: &capm3.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: capm3.Metal3DataTemplateSpec{
 					ClusterName: "abc",
@@ -533,7 +534,7 @@ var _ = Describe("Metal3 manager utils", func() {
 			ClusterName: "def",
 			TemplateRef: &corev1.ObjectReference{
 				Name:      "abc",
-				Namespace: "myns",
+				Namespace: namespaceName,
 			},
 			ExpectError: true,
 		}),
@@ -541,7 +542,7 @@ var _ = Describe("Metal3 manager utils", func() {
 			DataTemplate: &capm3.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: capm3.Metal3DataTemplateSpec{
 					ClusterName: "abc",
@@ -550,7 +551,7 @@ var _ = Describe("Metal3 manager utils", func() {
 			ClusterName: "abc",
 			TemplateRef: &corev1.ObjectReference{
 				Name:      "abc",
-				Namespace: "myns",
+				Namespace: namespaceName,
 			},
 		}),
 	)
@@ -597,18 +598,18 @@ var _ = Describe("Metal3 manager utils", func() {
 		},
 		Entry("Object does not exist", testCaseFetchM3Data{
 			Name:          "abc",
-			Namespace:     "myns",
+			Namespace:     namespaceName,
 			ExpectRequeue: true,
 		}),
 		Entry("Object exists", testCaseFetchM3Data{
 			Data: &capm3.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 			Name:      "abc",
-			Namespace: "myns",
+			Namespace: namespaceName,
 		}),
 	)
 
@@ -655,24 +656,24 @@ var _ = Describe("Metal3 manager utils", func() {
 		},
 		Entry("Object does not exist", testCaseGetM3Machine{
 			Name:        "abc",
-			Namespace:   "myns",
+			Namespace:   namespaceName,
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists", testCaseGetM3Machine{
 			Machine: &capm3.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 			Name:      "abc",
-			Namespace: "myns",
+			Namespace: namespaceName,
 		}),
 		Entry("Object exists, dataTemplate nil", testCaseGetM3Machine{
 			Machine: &capm3.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: capm3.Metal3MachineSpec{
 					DataTemplate: nil,
@@ -681,41 +682,41 @@ var _ = Describe("Metal3 manager utils", func() {
 			DataTemplate: &capm3.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 			Name:        "abc",
-			Namespace:   "myns",
+			Namespace:   namespaceName,
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists, dataTemplate name mismatch", testCaseGetM3Machine{
 			Machine: &capm3.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: capm3.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
 						Name:      "abcd",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 				},
 			},
 			DataTemplate: &capm3.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 			Name:        "abc",
-			Namespace:   "myns",
+			Namespace:   namespaceName,
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists, dataTemplate namespace mismatch", testCaseGetM3Machine{
 			Machine: &capm3.Metal3Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 				Spec: capm3.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
@@ -727,11 +728,11 @@ var _ = Describe("Metal3 manager utils", func() {
 			DataTemplate: &capm3.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			},
 			Name:        "abc",
-			Namespace:   "myns",
+			Namespace:   namespaceName,
 			ExpectEmpty: true,
 		}),
 	)

--- a/baremetal/utils_test.go
+++ b/baremetal/utils_test.go
@@ -19,6 +19,7 @@ package baremetal
 import (
 	"context"
 
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -736,7 +737,7 @@ var _ = Describe("Metal3 manager utils", func() {
 	)
 
 	It("Parses the providerID properly", func() {
-		Expect(parseProviderID("metal3://abcd")).To(Equal("abcd"))
+		Expect(parseProviderID(fmt.Sprintf("%sabcd", ProviderIDPrefix))).To(Equal("abcd"))
 		Expect(parseProviderID("foo://abcd")).To(Equal("foo://abcd"))
 	})
 })

--- a/baremetal/utils_test.go
+++ b/baremetal/utils_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Metal3 manager utils", func() {
 
 	var testObject = &capm3.Metal3Machine{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "abc",
+			Name:      metal3machineName,
 			Namespace: namespaceName,
 		},
 		Spec: capm3.Metal3MachineSpec{
@@ -143,7 +143,7 @@ var _ = Describe("Metal3 manager utils", func() {
 
 	var existingObject = &capm3.Metal3Machine{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "abc",
+			Name:      metal3machineName,
 			Namespace: namespaceName,
 		},
 		Spec: capm3.Metal3MachineSpec{
@@ -504,7 +504,7 @@ var _ = Describe("Metal3 manager utils", func() {
 		},
 		Entry("Object does not exist", testCaseFetchM3DataTemplate{
 			TemplateRef: &corev1.ObjectReference{
-				Name:      "abc",
+				Name:      metal3DataTemplateName,
 				Namespace: namespaceName,
 			},
 			ExpectRequeue: true,
@@ -520,28 +520,28 @@ var _ = Describe("Metal3 manager utils", func() {
 		}),
 		Entry("Object with wrong cluster", testCaseFetchM3DataTemplate{
 			DataTemplate: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
 				Spec: infrav1.Metal3DataTemplateSpec{
-					ClusterName: "abc",
+					ClusterName: clusterName,
 				},
 			},
 			ClusterName: "def",
 			TemplateRef: &corev1.ObjectReference{
-				Name:      "abc",
+				Name:      metal3DataTemplateName,
 				Namespace: namespaceName,
 			},
 			ExpectError: true,
 		}),
 		Entry("Object with correct cluster", testCaseFetchM3DataTemplate{
 			DataTemplate: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
 				Spec: infrav1.Metal3DataTemplateSpec{
-					ClusterName: "abc",
+					ClusterName: clusterName,
 				},
 			},
-			ClusterName: "abc",
+			ClusterName: clusterName,
 			TemplateRef: &corev1.ObjectReference{
-				Name:      "abc",
+				Name:      metal3DataTemplateName,
 				Namespace: namespaceName,
 			},
 		}),
@@ -588,15 +588,15 @@ var _ = Describe("Metal3 manager utils", func() {
 			}
 		},
 		Entry("Object does not exist", testCaseFetchM3Data{
-			Name:          "abc",
+			Name:          metal3machineName,
 			Namespace:     namespaceName,
 			ExpectRequeue: true,
 		}),
 		Entry("Object exists", testCaseFetchM3Data{
 			Data: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 			},
-			Name:      "abc",
+			Name:      metal3DataName,
 			Namespace: namespaceName,
 		}),
 	)
@@ -643,34 +643,34 @@ var _ = Describe("Metal3 manager utils", func() {
 			}
 		},
 		Entry("Object does not exist", testCaseGetM3Machine{
-			Name:        "abc",
+			Name:        metal3machineName,
 			Namespace:   namespaceName,
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists", testCaseGetM3Machine{
 			Machine: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, ""),
 			},
-			Name:      "abc",
+			Name:      metal3machineName,
 			Namespace: namespaceName,
 		}),
 		Entry("Object exists, dataTemplate nil", testCaseGetM3Machine{
 			Machine: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, ""),
 				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: nil,
 				},
 			},
 			DataTemplate: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
 			},
-			Name:        "abc",
+			Name:        metal3machineName,
 			Namespace:   namespaceName,
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists, dataTemplate name mismatch", testCaseGetM3Machine{
 			Machine: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, ""),
 				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
 						Name:      "abcd",
@@ -679,26 +679,26 @@ var _ = Describe("Metal3 manager utils", func() {
 				},
 			},
 			DataTemplate: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
 			},
-			Name:        "abc",
+			Name:        metal3machineName,
 			Namespace:   namespaceName,
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists, dataTemplate namespace mismatch", testCaseGetM3Machine{
 			Machine: &infrav1.Metal3Machine{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3machineName, namespaceName, ""),
 				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
-						Name:      "abc",
+						Name:      metal3DataTemplateName,
 						Namespace: "defg",
 					},
 				},
 			},
 			DataTemplate: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
 			},
-			Name:        "abc",
+			Name:        metal3machineName,
 			Namespace:   namespaceName,
 			ExpectEmpty: true,
 		}),

--- a/baremetal/utils_test.go
+++ b/baremetal/utils_test.go
@@ -422,11 +422,8 @@ var _ = Describe("Metal3 manager utils", func() {
 			Expect(savedSecret.ObjectMeta.OwnerReferences).To(Equal(ownerRef))
 			Expect(savedSecret.Data).To(Equal(content))
 
-			err = c.Delete(context.TODO(), &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
+			err = k8sClient.Delete(context.TODO(), &corev1.Secret{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			})
 			Expect(err).NotTo(HaveOccurred())
 		},
@@ -522,12 +519,9 @@ var _ = Describe("Metal3 manager utils", func() {
 			ExpectError: true,
 		}),
 		Entry("Object with wrong cluster", testCaseFetchM3DataTemplate{
-			DataTemplate: &capm3.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
-				Spec: capm3.Metal3DataTemplateSpec{
+			DataTemplate: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3DataTemplateSpec{
 					ClusterName: "abc",
 				},
 			},
@@ -539,12 +533,9 @@ var _ = Describe("Metal3 manager utils", func() {
 			ExpectError: true,
 		}),
 		Entry("Object with correct cluster", testCaseFetchM3DataTemplate{
-			DataTemplate: &capm3.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
-				Spec: capm3.Metal3DataTemplateSpec{
+			DataTemplate: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3DataTemplateSpec{
 					ClusterName: "abc",
 				},
 			},
@@ -602,11 +593,8 @@ var _ = Describe("Metal3 manager utils", func() {
 			ExpectRequeue: true,
 		}),
 		Entry("Object exists", testCaseFetchM3Data{
-			Data: &capm3.Metal3Data{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
+			Data: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			Name:      "abc",
 			Namespace: namespaceName,
@@ -660,76 +648,55 @@ var _ = Describe("Metal3 manager utils", func() {
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists", testCaseGetM3Machine{
-			Machine: &capm3.Metal3Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
+			Machine: &infrav1.Metal3Machine{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			Name:      "abc",
 			Namespace: namespaceName,
 		}),
 		Entry("Object exists, dataTemplate nil", testCaseGetM3Machine{
-			Machine: &capm3.Metal3Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
-				Spec: capm3.Metal3MachineSpec{
+			Machine: &infrav1.Metal3Machine{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: nil,
 				},
 			},
-			DataTemplate: &capm3.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
+			DataTemplate: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			Name:        "abc",
 			Namespace:   namespaceName,
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists, dataTemplate name mismatch", testCaseGetM3Machine{
-			Machine: &capm3.Metal3Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
-				Spec: capm3.Metal3MachineSpec{
+			Machine: &infrav1.Metal3Machine{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
 						Name:      "abcd",
 						Namespace: namespaceName,
 					},
 				},
 			},
-			DataTemplate: &capm3.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
+			DataTemplate: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			Name:        "abc",
 			Namespace:   namespaceName,
 			ExpectEmpty: true,
 		}),
 		Entry("Object exists, dataTemplate namespace mismatch", testCaseGetM3Machine{
-			Machine: &capm3.Metal3Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
-				Spec: capm3.Metal3MachineSpec{
+			Machine: &infrav1.Metal3Machine{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: infrav1.Metal3MachineSpec{
 					DataTemplate: &corev1.ObjectReference{
 						Name:      "abc",
 						Namespace: "defg",
 					},
 				},
 			},
-			DataTemplate: &capm3.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
+			DataTemplate: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			Name:        "abc",
 			Namespace:   namespaceName,

--- a/controllers/metal3data_controller_test.go
+++ b/controllers/metal3data_controller_test.go
@@ -33,24 +33,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2/klogr"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha4"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-)
-
-var (
-	testObjectMeta = metav1.ObjectMeta{
-		Name:      "abc",
-		Namespace: namespaceName,
-	}
-	testObjectMetaWithLabel = metav1.ObjectMeta{
-		Name:      "abc",
-		Namespace: namespaceName,
-		Labels: map[string]string{
-			capi.ClusterLabelName: "abc",
-		},
-	}
 )
 
 var _ = Describe("Metal3Data manager", func() {
@@ -143,13 +130,22 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			Entry("Metal3Data not found", testCaseReconcile{}),
 			Entry("Missing cluster label", testCaseReconcile{
-				m3d: &infrav1alpha5.Metal3Data{
-					ObjectMeta: testObjectMeta,
+				m3d: &infrav1.Metal3Data{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: namespaceName,
+					},
 				},
 			}),
 			Entry("Cluster not found", testCaseReconcile{
-				m3d: &infrav1alpha5.Metal3Data{
-					ObjectMeta: testObjectMetaWithLabel,
+				m3d: &infrav1.Metal3Data{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: namespaceName,
+						Labels: map[string]string{
+							clusterv1.ClusterLabelName: "abc",
+						},
+					},
 				},
 			}),
 			Entry("Deletion, Cluster not found", testCaseReconcile{
@@ -196,43 +192,79 @@ var _ = Describe("Metal3Data manager", func() {
 				releaseLeasesError: true,
 			}),
 			Entry("Paused cluster", testCaseReconcile{
-				m3d: &infrav1alpha5.Metal3Data{
-					ObjectMeta: testObjectMetaWithLabel,
+				m3d: &infrav1.Metal3Data{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: namespaceName,
+						Labels: map[string]string{
+							clusterv1.ClusterLabelName: "abc",
+						},
+					},
 				},
-				cluster: &capi.Cluster{
-					ObjectMeta: testObjectMeta,
-					Spec: capi.ClusterSpec{
+				cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: namespaceName,
+					},
+					Spec: clusterv1.ClusterSpec{
 						Paused: true,
 					},
 				},
 				expectRequeue: true,
 			}),
 			Entry("Error in manager", testCaseReconcile{
-				m3d: &infrav1alpha5.Metal3Data{
-					ObjectMeta: testObjectMetaWithLabel,
+				m3d: &infrav1.Metal3Data{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: namespaceName,
+						Labels: map[string]string{
+							clusterv1.ClusterLabelName: "abc",
+						},
+					},
 				},
-				cluster: &capi.Cluster{
-					ObjectMeta: testObjectMeta,
+				cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: namespaceName,
+					},
 				},
 				managerError: true,
 			}),
 			Entry("Reconcile normal error", testCaseReconcile{
-				m3d: &infrav1alpha5.Metal3Data{
-					ObjectMeta: testObjectMetaWithLabel,
+				m3d: &infrav1.Metal3Data{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: namespaceName,
+						Labels: map[string]string{
+							clusterv1.ClusterLabelName: "abc",
+						},
+					},
 				},
-				cluster: &capi.Cluster{
-					ObjectMeta: testObjectMeta,
+				cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: namespaceName,
+					},
 				},
 				reconcileNormal:      true,
 				reconcileNormalError: true,
 				expectManager:        true,
 			}),
 			Entry("Reconcile normal no error", testCaseReconcile{
-				m3d: &infrav1alpha5.Metal3Data{
-					ObjectMeta: testObjectMetaWithLabel,
+				m3d: &infrav1.Metal3Data{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: namespaceName,
+						Labels: map[string]string{
+							clusterv1.ClusterLabelName: "abc",
+						},
+					},
 				},
-				cluster: &capi.Cluster{
-					ObjectMeta: testObjectMeta,
+				cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: namespaceName,
+					},
 				},
 				reconcileNormal: true,
 				expectManager:   true,

--- a/controllers/metal3data_controller_test.go
+++ b/controllers/metal3data_controller_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Metal3Data manager", func() {
 
 				req := reconcile.Request{
 					NamespacedName: types.NamespacedName{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 					},
 				}
@@ -132,7 +132,7 @@ var _ = Describe("Metal3Data manager", func() {
 			Entry("Missing cluster label", testCaseReconcile{
 				m3d: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 					},
 				},
@@ -140,7 +140,7 @@ var _ = Describe("Metal3Data manager", func() {
 			Entry("Cluster not found", testCaseReconcile{
 				m3d: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
 							clusterv1.ClusterLabelName: "abc",
@@ -151,7 +151,7 @@ var _ = Describe("Metal3Data manager", func() {
 			Entry("Deletion, Cluster not found", testCaseReconcile{
 				m3d: &infrav1alpha5.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
 							capi.ClusterLabelName: "abc",
@@ -164,7 +164,7 @@ var _ = Describe("Metal3Data manager", func() {
 			Entry("Deletion, release requeue", testCaseReconcile{
 				m3d: &infrav1alpha5.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
 							capi.ClusterLabelName: "abc",
@@ -179,7 +179,7 @@ var _ = Describe("Metal3Data manager", func() {
 			Entry("Deletion, release error", testCaseReconcile{
 				m3d: &infrav1alpha5.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
 							capi.ClusterLabelName: "abc",
@@ -194,16 +194,16 @@ var _ = Describe("Metal3Data manager", func() {
 			Entry("Paused cluster", testCaseReconcile{
 				m3d: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
-							clusterv1.ClusterLabelName: "abc",
+							clusterv1.ClusterLabelName: metal3DataName,
 						},
 					},
 				},
 				cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 					},
 					Spec: clusterv1.ClusterSpec{
@@ -215,16 +215,16 @@ var _ = Describe("Metal3Data manager", func() {
 			Entry("Error in manager", testCaseReconcile{
 				m3d: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
-							clusterv1.ClusterLabelName: "abc",
+							clusterv1.ClusterLabelName: metal3DataName,
 						},
 					},
 				},
 				cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 					},
 				},
@@ -233,16 +233,16 @@ var _ = Describe("Metal3Data manager", func() {
 			Entry("Reconcile normal error", testCaseReconcile{
 				m3d: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
-							clusterv1.ClusterLabelName: "abc",
+							clusterv1.ClusterLabelName: metal3DataName,
 						},
 					},
 				},
 				cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 					},
 				},
@@ -253,16 +253,16 @@ var _ = Describe("Metal3Data manager", func() {
 			Entry("Reconcile normal no error", testCaseReconcile{
 				m3d: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
-							clusterv1.ClusterLabelName: "abc",
+							clusterv1.ClusterLabelName: metal3DataName,
 						},
 					},
 				},
 				cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataName,
 						Namespace: namespaceName,
 					},
 				},

--- a/controllers/metal3data_controller_test.go
+++ b/controllers/metal3data_controller_test.go
@@ -42,11 +42,11 @@ import (
 var (
 	testObjectMeta = metav1.ObjectMeta{
 		Name:      "abc",
-		Namespace: "myns",
+		Namespace: namespaceName,
 	}
 	testObjectMetaWithLabel = metav1.ObjectMeta{
 		Name:      "abc",
-		Namespace: "myns",
+		Namespace: namespaceName,
 		Labels: map[string]string{
 			capi.ClusterLabelName: "abc",
 		},
@@ -123,7 +123,7 @@ var _ = Describe("Metal3Data manager", func() {
 				req := reconcile.Request{
 					NamespacedName: types.NamespacedName{
 						Name:      "abc",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 				}
 				ctx := context.Background()
@@ -156,7 +156,7 @@ var _ = Describe("Metal3Data manager", func() {
 				m3d: &infrav1alpha5.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc",
-						Namespace: "myns",
+						Namespace: namespaceName,
 						Labels: map[string]string{
 							capi.ClusterLabelName: "abc",
 						},
@@ -169,7 +169,7 @@ var _ = Describe("Metal3Data manager", func() {
 				m3d: &infrav1alpha5.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc",
-						Namespace: "myns",
+						Namespace: namespaceName,
 						Labels: map[string]string{
 							capi.ClusterLabelName: "abc",
 						},
@@ -184,7 +184,7 @@ var _ = Describe("Metal3Data manager", func() {
 				m3d: &infrav1alpha5.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "abc",
-						Namespace: "myns",
+						Namespace: namespaceName,
 						Labels: map[string]string{
 							capi.ClusterLabelName: "abc",
 						},
@@ -370,7 +370,7 @@ var _ = Describe("Metal3Data manager", func() {
 		func(tc testCaseMetal3IPClaimToMetal3Data) {
 			ipClaim := &ipamv1.IPClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:       "myns",
+					Namespace:       namespaceName,
 					OwnerReferences: tc.ownerRefs,
 				},
 			}
@@ -407,7 +407,7 @@ var _ = Describe("Metal3Data manager", func() {
 				{
 					NamespacedName: types.NamespacedName{
 						Name:      "abc",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 				},
 			},

--- a/controllers/metal3data_controller_test.go
+++ b/controllers/metal3data_controller_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2/klogr"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha4"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -130,7 +129,7 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			Entry("Metal3Data not found", testCaseReconcile{}),
 			Entry("Missing cluster label", testCaseReconcile{
-				m3d: &infrav1.Metal3Data{
+				m3d: &infrav1alpha5.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      metal3DataName,
 						Namespace: namespaceName,
@@ -138,12 +137,12 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			}),
 			Entry("Cluster not found", testCaseReconcile{
-				m3d: &infrav1.Metal3Data{
+				m3d: &infrav1alpha5.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
-							clusterv1.ClusterLabelName: "abc",
+							capi.ClusterLabelName: "abc",
 						},
 					},
 				},
@@ -192,37 +191,37 @@ var _ = Describe("Metal3Data manager", func() {
 				releaseLeasesError: true,
 			}),
 			Entry("Paused cluster", testCaseReconcile{
-				m3d: &infrav1.Metal3Data{
+				m3d: &infrav1alpha5.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
-							clusterv1.ClusterLabelName: metal3DataName,
+							capi.ClusterLabelName: metal3DataName,
 						},
 					},
 				},
-				cluster: &clusterv1.Cluster{
+				cluster: &capi.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      metal3DataName,
 						Namespace: namespaceName,
 					},
-					Spec: clusterv1.ClusterSpec{
+					Spec: capi.ClusterSpec{
 						Paused: true,
 					},
 				},
 				expectRequeue: true,
 			}),
 			Entry("Error in manager", testCaseReconcile{
-				m3d: &infrav1.Metal3Data{
+				m3d: &infrav1alpha5.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
-							clusterv1.ClusterLabelName: metal3DataName,
+							capi.ClusterLabelName: metal3DataName,
 						},
 					},
 				},
-				cluster: &clusterv1.Cluster{
+				cluster: &capi.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      metal3DataName,
 						Namespace: namespaceName,
@@ -231,16 +230,16 @@ var _ = Describe("Metal3Data manager", func() {
 				managerError: true,
 			}),
 			Entry("Reconcile normal error", testCaseReconcile{
-				m3d: &infrav1.Metal3Data{
+				m3d: &infrav1alpha5.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
-							clusterv1.ClusterLabelName: metal3DataName,
+							capi.ClusterLabelName: metal3DataName,
 						},
 					},
 				},
-				cluster: &clusterv1.Cluster{
+				cluster: &capi.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      metal3DataName,
 						Namespace: namespaceName,
@@ -251,16 +250,16 @@ var _ = Describe("Metal3Data manager", func() {
 				expectManager:        true,
 			}),
 			Entry("Reconcile normal no error", testCaseReconcile{
-				m3d: &infrav1.Metal3Data{
+				m3d: &infrav1alpha5.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      metal3DataName,
 						Namespace: namespaceName,
 						Labels: map[string]string{
-							clusterv1.ClusterLabelName: metal3DataName,
+							capi.ClusterLabelName: metal3DataName,
 						},
 					},
 				},
-				cluster: &clusterv1.Cluster{
+				cluster: &capi.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      metal3DataName,
 						Namespace: namespaceName,

--- a/controllers/metal3datatemplate_controller_test.go
+++ b/controllers/metal3datatemplate_controller_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			req := reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      "abc",
-					Namespace: "myns",
+					Namespace: namespaceName,
 				},
 			}
 			ctx := context.Background()
@@ -139,7 +139,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "abc",
-					Namespace:         "myns",
+					Namespace:         namespaceName,
 					DeletionTimestamp: &timestampNow,
 				},
 				Spec: infrav1alpha5.Metal3DataTemplateSpec{ClusterName: "abc"},
@@ -150,7 +150,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "abc",
-					Namespace:         "myns",
+					Namespace:         namespaceName,
 					DeletionTimestamp: &timestampNow,
 				},
 				Spec: infrav1alpha5.Metal3DataTemplateSpec{ClusterName: "abc"},
@@ -368,7 +368,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 					Spec: infrav1alpha5.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
 							Name:      "abc",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 					},
 				},

--- a/controllers/metal3datatemplate_controller_test.go
+++ b/controllers/metal3datatemplate_controller_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 
 			req := reconcile.Request{
 				NamespacedName: types.NamespacedName{
-					Name:      "abc",
+					Name:      metal3DataTemplateName,
 					Namespace: namespaceName,
 				},
 			}
@@ -131,29 +131,29 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		Entry("Metal3DataTemplate not found", testCaseReconcile{}),
 		Entry("Cluster not found", testCaseReconcile{
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
+				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
 		}),
 		Entry("Deletion, Cluster not found", testCaseReconcile{
 			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "abc",
+					Name:              metal3DataTemplateName,
 					Namespace:         namespaceName,
 					DeletionTimestamp: &timestampNow,
 				},
-				Spec: infrav1alpha5.Metal3DataTemplateSpec{ClusterName: "abc"},
+				Spec: infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
 			expectManager: true,
 		}),
 		Entry("Deletion, Cluster not found, error", testCaseReconcile{
 			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "abc",
+					Name:              metal3DataTemplateName,
 					Namespace:         namespaceName,
 					DeletionTimestamp: &timestampNow,
 				},
-				Spec: infrav1alpha5.Metal3DataTemplateSpec{ClusterName: "abc"},
+				Spec: infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
 			expectManager:        true,
 			reconcileDeleteError: true,
@@ -161,11 +161,11 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		}),
 		Entry("Paused cluster", testCaseReconcile{
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
+				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
 			cluster: &clusterv1.Cluster{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(clusterName, namespaceName, ""),
 				Spec: clusterv1.ClusterSpec{
 					Paused: true,
 				},
@@ -175,21 +175,21 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		}),
 		Entry("Error in manager", testCaseReconcile{
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
+				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
 			cluster: &clusterv1.Cluster{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(clusterName, namespaceName, ""),
 			},
 			managerError: true,
 		}),
 		Entry("Reconcile normal error", testCaseReconcile{
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
+				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
 			cluster: &clusterv1.Cluster{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(clusterName, namespaceName, ""),
 			},
 			reconcileNormal:      true,
 			reconcileNormalError: true,
@@ -197,11 +197,11 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		}),
 		Entry("Reconcile normal no error", testCaseReconcile{
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
+				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
 			cluster: &clusterv1.Cluster{
-				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				ObjectMeta: testObjectMeta(clusterName, namespaceName, ""),
 			},
 			reconcileNormal: true,
 			expectManager:   true,
@@ -356,7 +356,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			TestCaseM3DCToM3DT{
 				DataClaim: &infrav1.Metal3DataClaim{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataClaimName,
 						Namespace: namespaceName,
 					},
 					Spec: infrav1.Metal3DataClaimSpec{},
@@ -368,12 +368,12 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			TestCaseM3DCToM3DT{
 				DataClaim: &infrav1.Metal3DataClaim{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataClaimName,
 						Namespace: namespaceName,
 					},
 					Spec: infrav1.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
-							Name:      "abc",
+							Name:      metal3DataTemplateName,
 							Namespace: namespaceName,
 						},
 					},
@@ -385,12 +385,12 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			TestCaseM3DCToM3DT{
 				DataClaim: &infrav1.Metal3DataClaim{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "abc",
+						Name:      metal3DataClaimName,
 						Namespace: namespaceName,
 					},
 					Spec: infrav1.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
-							Name: "abc",
+							Name: metal3DataTemplateName,
 						},
 					},
 				},

--- a/controllers/metal3datatemplate_controller_test.go
+++ b/controllers/metal3datatemplate_controller_test.go
@@ -130,9 +130,9 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		},
 		Entry("Metal3DataTemplate not found", testCaseReconcile{}),
 		Entry("Cluster not found", testCaseReconcile{
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta,
-				Spec:       infrav1alpha5.Metal3DataTemplateSpec{ClusterName: "abc"},
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
 			},
 		}),
 		Entry("Deletion, Cluster not found", testCaseReconcile{
@@ -160,13 +160,13 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			expectError:          true,
 		}),
 		Entry("Paused cluster", testCaseReconcile{
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta,
-				Spec:       infrav1alpha5.Metal3DataTemplateSpec{ClusterName: "abc"},
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
 			},
-			cluster: &capi.Cluster{
-				ObjectMeta: testObjectMeta,
-				Spec: capi.ClusterSpec{
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec: clusterv1.ClusterSpec{
 					Paused: true,
 				},
 			},
@@ -174,34 +174,34 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			expectManager: true,
 		}),
 		Entry("Error in manager", testCaseReconcile{
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta,
-				Spec:       infrav1alpha5.Metal3DataTemplateSpec{ClusterName: "abc"},
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
 			},
-			cluster: &capi.Cluster{
-				ObjectMeta: testObjectMeta,
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			managerError: true,
 		}),
 		Entry("Reconcile normal error", testCaseReconcile{
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta,
-				Spec:       infrav1alpha5.Metal3DataTemplateSpec{ClusterName: "abc"},
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
 			},
-			cluster: &capi.Cluster{
-				ObjectMeta: testObjectMeta,
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			reconcileNormal:      true,
 			reconcileNormalError: true,
 			expectManager:        true,
 		}),
 		Entry("Reconcile normal no error", testCaseReconcile{
-			m3dt: &infrav1alpha5.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta,
-				Spec:       infrav1alpha5.Metal3DataTemplateSpec{ClusterName: "abc"},
+			m3dt: &infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
+				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: "abc"},
 			},
-			cluster: &capi.Cluster{
-				ObjectMeta: testObjectMeta,
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: testObjectMeta("abc", namespaceName, ""),
 			},
 			reconcileNormal: true,
 			expectManager:   true,
@@ -354,18 +354,24 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		},
 		Entry("No Metal3DataTemplate in Spec",
 			TestCaseM3DCToM3DT{
-				DataClaim: &infrav1alpha5.Metal3DataClaim{
-					ObjectMeta: testObjectMeta,
-					Spec:       infrav1alpha5.Metal3DataClaimSpec{},
+				DataClaim: &infrav1.Metal3DataClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: namespaceName,
+					},
+					Spec: infrav1.Metal3DataClaimSpec{},
 				},
 				ExpectRequest: false,
 			},
 		),
 		Entry("Metal3DataTemplate in Spec, with namespace",
 			TestCaseM3DCToM3DT{
-				DataClaim: &infrav1alpha5.Metal3DataClaim{
-					ObjectMeta: testObjectMeta,
-					Spec: infrav1alpha5.Metal3DataClaimSpec{
+				DataClaim: &infrav1.Metal3DataClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: namespaceName,
+					},
+					Spec: infrav1.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
 							Name:      "abc",
 							Namespace: namespaceName,
@@ -377,9 +383,12 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		),
 		Entry("Metal3DataTemplate in Spec, no namespace",
 			TestCaseM3DCToM3DT{
-				DataClaim: &infrav1alpha5.Metal3DataClaim{
-					ObjectMeta: testObjectMeta,
-					Spec: infrav1alpha5.Metal3DataClaimSpec{
+				DataClaim: &infrav1.Metal3DataClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: namespaceName,
+					},
+					Spec: infrav1.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
 							Name: "abc",
 						},

--- a/controllers/metal3datatemplate_controller_test.go
+++ b/controllers/metal3datatemplate_controller_test.go
@@ -130,9 +130,9 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		},
 		Entry("Metal3DataTemplate not found", testCaseReconcile{}),
 		Entry("Cluster not found", testCaseReconcile{
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
+				Spec:       infrav1alpha5.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
 		}),
 		Entry("Deletion, Cluster not found", testCaseReconcile{
@@ -142,7 +142,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 					Namespace:         namespaceName,
 					DeletionTimestamp: &timestampNow,
 				},
-				Spec: infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
+				Spec: infrav1alpha5.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
 			expectManager: true,
 		}),
@@ -153,20 +153,20 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 					Namespace:         namespaceName,
 					DeletionTimestamp: &timestampNow,
 				},
-				Spec: infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
+				Spec: infrav1alpha5.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
 			expectManager:        true,
 			reconcileDeleteError: true,
 			expectError:          true,
 		}),
 		Entry("Paused cluster", testCaseReconcile{
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
+				Spec:       infrav1alpha5.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
-			cluster: &clusterv1.Cluster{
+			cluster: &capi.Cluster{
 				ObjectMeta: testObjectMeta(clusterName, namespaceName, ""),
-				Spec: clusterv1.ClusterSpec{
+				Spec: capi.ClusterSpec{
 					Paused: true,
 				},
 			},
@@ -174,21 +174,21 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			expectManager: true,
 		}),
 		Entry("Error in manager", testCaseReconcile{
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
+				Spec:       infrav1alpha5.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
-			cluster: &clusterv1.Cluster{
+			cluster: &capi.Cluster{
 				ObjectMeta: testObjectMeta(clusterName, namespaceName, ""),
 			},
 			managerError: true,
 		}),
 		Entry("Reconcile normal error", testCaseReconcile{
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
+				Spec:       infrav1alpha5.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
-			cluster: &clusterv1.Cluster{
+			cluster: &capi.Cluster{
 				ObjectMeta: testObjectMeta(clusterName, namespaceName, ""),
 			},
 			reconcileNormal:      true,
@@ -196,11 +196,11 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			expectManager:        true,
 		}),
 		Entry("Reconcile normal no error", testCaseReconcile{
-			m3dt: &infrav1.Metal3DataTemplate{
+			m3dt: &infrav1alpha5.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
+				Spec:       infrav1alpha5.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
-			cluster: &clusterv1.Cluster{
+			cluster: &capi.Cluster{
 				ObjectMeta: testObjectMeta(clusterName, namespaceName, ""),
 			},
 			reconcileNormal: true,
@@ -354,24 +354,24 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		},
 		Entry("No Metal3DataTemplate in Spec",
 			TestCaseM3DCToM3DT{
-				DataClaim: &infrav1.Metal3DataClaim{
+				DataClaim: &infrav1alpha5.Metal3DataClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      metal3DataClaimName,
 						Namespace: namespaceName,
 					},
-					Spec: infrav1.Metal3DataClaimSpec{},
+					Spec: infrav1alpha5.Metal3DataClaimSpec{},
 				},
 				ExpectRequest: false,
 			},
 		),
 		Entry("Metal3DataTemplate in Spec, with namespace",
 			TestCaseM3DCToM3DT{
-				DataClaim: &infrav1.Metal3DataClaim{
+				DataClaim: &infrav1alpha5.Metal3DataClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      metal3DataClaimName,
 						Namespace: namespaceName,
 					},
-					Spec: infrav1.Metal3DataClaimSpec{
+					Spec: infrav1alpha5.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
 							Name:      metal3DataTemplateName,
 							Namespace: namespaceName,
@@ -383,12 +383,12 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		),
 		Entry("Metal3DataTemplate in Spec, no namespace",
 			TestCaseM3DCToM3DT{
-				DataClaim: &infrav1.Metal3DataClaim{
+				DataClaim: &infrav1alpha5.Metal3DataClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      metal3DataClaimName,
 						Namespace: namespaceName,
 					},
-					Spec: infrav1.Metal3DataClaimSpec{
+					Spec: infrav1alpha5.Metal3DataClaimSpec{
 						Template: corev1.ObjectReference{
 							Name: metal3DataTemplateName,
 						},

--- a/controllers/metal3labelsync_controller_test.go
+++ b/controllers/metal3labelsync_controller_test.go
@@ -322,7 +322,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 					{
 						NamespacedName: types.NamespacedName{
 							Name:      "myhost",
-							Namespace: "myns",
+							Namespace: namespaceName,
 						},
 					},
 				},
@@ -340,7 +340,7 @@ func m3mObjectMeta() *metav1.ObjectMeta {
 			capi.ClusterLabelName: clusterName,
 		},
 		Annotations: map[string]string{
-			baremetal.HostAnnotation: "myns/myhost",
+			baremetal.HostAnnotation: namespaceName + "/myhost",
 		},
 	}
 }

--- a/controllers/metal3labelsync_controller_test.go
+++ b/controllers/metal3labelsync_controller_test.go
@@ -321,7 +321,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 				ExpectRequests: []ctrl.Request{
 					{
 						NamespacedName: types.NamespacedName{
-							Name:      "myhost",
+							Name:      baremetalhostName,
 							Namespace: namespaceName,
 						},
 					},
@@ -340,7 +340,7 @@ func m3mObjectMeta() *metav1.ObjectMeta {
 			capi.ClusterLabelName: clusterName,
 		},
 		Annotations: map[string]string{
-			baremetal.HostAnnotation: namespaceName + "/myhost",
+			baremetal.HostAnnotation: namespaceName + "/" + baremetalhostName,
 		},
 	}
 }

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -247,7 +247,7 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 			)
 		}
 		if bmhID != nil {
-			providerID = fmt.Sprintf("metal3://%s", *bmhID)
+			providerID = fmt.Sprintf("%s%s", baremetal.ProviderIDPrefix, *bmhID)
 		}
 	}
 	if bmhID != nil {

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -246,13 +246,10 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 				"failed to get the providerID for the metal3machine", errType,
 			)
 		}
-		if bmhID != nil {
-			providerID = fmt.Sprintf("%s%s", baremetal.ProviderIDPrefix, *bmhID)
-		}
 	}
-	if bmhID != nil {
+	if providerID != "" || bmhID != nil {
 		// Set the providerID on the node if no Cloud provider
-		err = machineMgr.SetNodeProviderID(ctx, *bmhID, &providerID, r.CapiClientGetter)
+		err = machineMgr.SetNodeProviderID(ctx, bmhID, &providerID, r.CapiClientGetter)
 		if err != nil {
 			return checkMachineError(machineMgr, err,
 				"failed to set the target node providerID", errType,

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -252,7 +252,7 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 	}
 	if bmhID != nil {
 		// Set the providerID on the node if no Cloud provider
-		err = machineMgr.SetNodeProviderID(ctx, *bmhID, providerID, r.CapiClientGetter)
+		err = machineMgr.SetNodeProviderID(ctx, *bmhID, &providerID, r.CapiClientGetter)
 		if err != nil {
 			return checkMachineError(machineMgr, err,
 				"failed to set the target node providerID", errType,

--- a/controllers/metal3machine_controller_integration_test.go
+++ b/controllers/metal3machine_controller_integration_test.go
@@ -47,7 +47,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-var providerID = "metal3:///foo/bar"
+var bmhuid = types.UID("63856098-4b80-11ec-81d3-0242ac130003")
+
+var providerID = fmt.Sprintf("%s%s", baremetal.ProviderIDPrefix, bmhuid)
 
 var bootstrapDataSecretName = "testdatasecret"
 
@@ -237,8 +239,8 @@ var _ = Describe("Reconcile metal3machine", func() {
 			}
 			if tc.CheckBMProviderID {
 				if tc.CheckBMProviderIDUnchanged {
-					Expect(testBMmachine.Spec.ProviderID).NotTo(Equal(pointer.StringPtr(fmt.Sprintf("metal3://%s",
-						string(testBMHost.ObjectMeta.UID)))))
+					Expect(testBMmachine.Spec.ProviderID).NotTo(Equal(fmt.Sprintf("%s%s", baremetal.ProviderIDPrefix,
+						string(testBMHost.ObjectMeta.UID))))
 				} else {
 					Expect(testBMmachine.Spec.ProviderID).To(Equal(pointer.StringPtr(fmt.Sprintf("metal3://%s",
 						string(testBMHost.ObjectMeta.UID)))))
@@ -541,9 +543,9 @@ var _ = Describe("Reconcile metal3machine", func() {
 				Objects: []client.Object{
 					newMetal3Machine(
 						metal3machineName, m3mMetaWithAnnotation(),
-						&infrav1alpha5.Metal3MachineSpec{
-							ProviderID: pointer.StringPtr("metal3://abcd"),
-							Image: infrav1alpha5.Image{
+						&capm3.Metal3MachineSpec{
+							ProviderID: pointer.StringPtr(providerID),
+							Image: capm3.Image{
 								Checksum: "abcd",
 								URL:      "abcd",
 							},
@@ -630,7 +632,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "bmh-0",
 							Labels: map[string]string{
-								"metal3.io/uuid": "54db7dd5-269a-4d94-a12a-c4eafcecb8e7",
+								baremetal.ProviderLabelPrefix: string(bmhuid),
 							},
 						},
 						Spec: v1.NodeSpec{},

--- a/controllers/metal3machine_controller_integration_test.go
+++ b/controllers/metal3machine_controller_integration_test.go
@@ -88,7 +88,7 @@ func m3mMetaWithAnnotation() *metav1.ObjectMeta {
 		Namespace:       namespaceName,
 		OwnerReferences: m3mOwnerRefs(),
 		Annotations: map[string]string{
-			baremetal.HostAnnotation: "testNameSpace/bmh-0",
+			baremetal.HostAnnotation: namespaceName + "/bmh-0",
 		},
 	}
 }
@@ -100,7 +100,7 @@ func m3mMetaWithAnnotationDeletion() *metav1.ObjectMeta {
 		DeletionTimestamp: &deletionTimestamp,
 		OwnerReferences:   m3mOwnerRefs(),
 		Annotations: map[string]string{
-			baremetal.HostAnnotation: "testNameSpace/bmh-0",
+			baremetal.HostAnnotation: namespaceName + "/bmh-0",
 		},
 	}
 }

--- a/controllers/metal3machine_controller_integration_test.go
+++ b/controllers/metal3machine_controller_integration_test.go
@@ -528,6 +528,16 @@ var _ = Describe("Reconcile metal3machine", func() {
 					newMetal3Cluster(metal3ClusterName, nil, nil, nil, false),
 					newBareMetalHost(nil, nil),
 				},
+				TargetObjects: []runtime.Object{
+					&corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-0",
+						},
+						Spec: corev1.NodeSpec{
+							ProviderID: providerID,
+						},
+					},
+				},
 				ErrorExpected:       false,
 				RequeueExpected:     false,
 				ClusterInfraReady:   true,
@@ -555,6 +565,25 @@ var _ = Describe("Reconcile metal3machine", func() {
 					newCluster(clusterName, nil, nil),
 					newMetal3Cluster(metal3ClusterName, nil, nil, nil, false),
 					newBareMetalHost(nil, nil),
+				},
+				TargetObjects: []runtime.Object{
+					&corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-0",
+						},
+						Spec: corev1.NodeSpec{
+							ProviderID: providerID,
+						},
+					},
+					&corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-1",
+							Labels: map[string]string{
+								baremetal.ProviderLabelPrefix: string(bmhuid),
+							},
+						},
+						Spec: corev1.NodeSpec{},
+					},
 				},
 				ErrorExpected:              false,
 				RequeueExpected:            false,
@@ -630,7 +659,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 				TargetObjects: []runtime.Object{
 					&v1.Node{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "bmh-0",
+							Name: "node-0",
 							Labels: map[string]string{
 								baremetal.ProviderLabelPrefix: "54db7dd5-269a-4d94-a12a-c4eafcecb8e7",
 							},

--- a/controllers/metal3machine_controller_integration_test.go
+++ b/controllers/metal3machine_controller_integration_test.go
@@ -420,8 +420,8 @@ var _ = Describe("Reconcile metal3machine", func() {
 					),
 					machineWithInfra(),
 					newCluster(clusterName, nil, nil),
-					newMetal3Cluster(metal3ClusterName, nil, nil, nil, false),
-					newBareMetalHost(nil, nil),
+					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
+					newBareMetalHost("bmh-0", nil, nil, nil, false),
 				},
 				ErrorExpected:       false,
 				RequeueExpected:     false,
@@ -455,10 +455,10 @@ var _ = Describe("Reconcile metal3machine", func() {
 					),
 					machineWithBootstrap(),
 					newCluster(clusterName, nil, nil),
-					newMetal3Cluster(metal3ClusterName, nil, nil, nil, false),
-					newBareMetalHost(nil, &bmh.BareMetalHostStatus{
-						Provisioning: bmh.ProvisionStatus{
-							State: bmh.StateAvailable,
+					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
+					newBareMetalHost("bmh-0", nil, &bmov1alpha1.BareMetalHostStatus{
+						Provisioning: bmov1alpha1.ProvisionStatus{
+							State: bmov1alpha1.StateAvailable,
 						},
 					}),
 				},
@@ -493,10 +493,10 @@ var _ = Describe("Reconcile metal3machine", func() {
 					),
 					machineWithBootstrap(),
 					newCluster(clusterName, nil, nil),
-					newMetal3Cluster(metal3ClusterName, nil, nil, nil, false),
-					newBareMetalHost(nil, &bmh.BareMetalHostStatus{
-						Provisioning: bmh.ProvisionStatus{
-							State: bmh.StateReady,
+					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
+					newBareMetalHost("bmh-0", nil, &bmov1alpha1.BareMetalHostStatus{
+						Provisioning: bmov1alpha1.ProvisionStatus{
+							State: bmov1alpha1.StateReady,
 						},
 					}),
 				},
@@ -525,8 +525,8 @@ var _ = Describe("Reconcile metal3machine", func() {
 					),
 					machineWithBootstrap(),
 					newCluster(clusterName, nil, nil),
-					newMetal3Cluster(metal3ClusterName, nil, nil, nil, false),
-					newBareMetalHost(nil, nil),
+					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
+					newBareMetalHost("bmh-0", nil, nil, nil, false),
 				},
 				TargetObjects: []runtime.Object{
 					&corev1.Node{
@@ -563,8 +563,8 @@ var _ = Describe("Reconcile metal3machine", func() {
 					),
 					machineWithBootstrap(),
 					newCluster(clusterName, nil, nil),
-					newMetal3Cluster(metal3ClusterName, nil, nil, nil, false),
-					newBareMetalHost(nil, nil),
+					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
+					newBareMetalHost("bmh-0", nil, nil, nil, false),
 				},
 				TargetObjects: []runtime.Object{
 					&corev1.Node{
@@ -608,10 +608,10 @@ var _ = Describe("Reconcile metal3machine", func() {
 					}, nil, false),
 					machineWithBootstrap(),
 					newCluster(clusterName, nil, nil),
-					newMetal3Cluster(metal3ClusterName, nil, nil, nil, false),
-					newBareMetalHost(nil, &bmh.BareMetalHostStatus{
-						Provisioning: bmh.ProvisionStatus{
-							State: bmh.StateProvisioning,
+					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
+					newBareMetalHost("bmh-0", nil, &bmov1alpha1.BareMetalHostStatus{
+						Provisioning: bmov1alpha1.ProvisionStatus{
+							State: bmov1alpha1.StateProvisioning,
 						},
 					}),
 				},
@@ -632,8 +632,8 @@ var _ = Describe("Reconcile metal3machine", func() {
 					newMetal3Machine(metal3machineName, m3mMetaWithAnnotation(), nil, nil, false),
 					machineWithBootstrap(),
 					newCluster(clusterName, nil, nil),
-					newMetal3Cluster(metal3ClusterName, bmcOwnerRef(), bmcSpec(), nil, false),
-					newBareMetalHost(nil, nil),
+					newMetal3Cluster(metal3ClusterName, bmcOwnerRef(), bmcSpec(), nil, nil, false),
+					newBareMetalHost("bmh-0", nil, nil, nil, false),
 				},
 				ErrorExpected:           false,
 				RequeueExpected:         true,
@@ -653,8 +653,8 @@ var _ = Describe("Reconcile metal3machine", func() {
 					newMetal3Machine(metal3machineName, m3mMetaWithAnnotation(), nil, nil, false),
 					machineWithBootstrap(),
 					newCluster(clusterName, nil, nil),
-					newMetal3Cluster(metal3ClusterName, bmcOwnerRef(), bmcSpec(), nil, false),
-					newBareMetalHost(nil, nil),
+					newMetal3Cluster(metal3ClusterName, bmcOwnerRef(), bmcSpec(), nil, nil, false),
+					newBareMetalHost("bmh-0", nil, nil, nil, false),
 				},
 				TargetObjects: []runtime.Object{
 					&v1.Node{
@@ -706,9 +706,9 @@ var _ = Describe("Reconcile metal3machine", func() {
 					),
 					machineWithInfra(),
 					newCluster(clusterName, nil, nil),
-					newMetal3Cluster(metal3ClusterName, nil, nil, nil, false),
-					newBareMetalHost(&bmh.BareMetalHostSpec{
-						ConsumerRef: &v1.ObjectReference{
+					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
+					newBareMetalHost("bmh-0", &bmov1alpha1.BareMetalHostSpec{
+						ConsumerRef: &corev1.ObjectReference{
 							Name:       metal3machineName,
 							Namespace:  namespaceName,
 							Kind:       "Metal3Machine",

--- a/controllers/metal3machine_controller_integration_test.go
+++ b/controllers/metal3machine_controller_integration_test.go
@@ -65,7 +65,7 @@ func m3mOwnerRefs() []metav1.OwnerReference {
 
 func m3mMetaWithOwnerRef() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
-		Name:            "abc",
+		Name:            metal3machineName,
 		Namespace:       namespaceName,
 		OwnerReferences: m3mOwnerRefs(),
 		Annotations:     map[string]string{},
@@ -74,7 +74,7 @@ func m3mMetaWithOwnerRef() *metav1.ObjectMeta {
 
 func m3mMetaWithDeletion() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
-		Name:              "abc",
+		Name:              metal3machineName,
 		Namespace:         namespaceName,
 		DeletionTimestamp: &deletionTimestamp,
 		OwnerReferences:   m3mOwnerRefs(),
@@ -84,23 +84,23 @@ func m3mMetaWithDeletion() *metav1.ObjectMeta {
 
 func m3mMetaWithAnnotation() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
-		Name:            "abc",
+		Name:            metal3machineName,
 		Namespace:       namespaceName,
 		OwnerReferences: m3mOwnerRefs(),
 		Annotations: map[string]string{
-			baremetal.HostAnnotation: namespaceName + "/bmh-0",
+			baremetal.HostAnnotation: namespaceName + "/" + baremetalhostName,
 		},
 	}
 }
 
 func m3mMetaWithAnnotationDeletion() *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
-		Name:              "abc",
+		Name:              metal3machineName,
 		Namespace:         namespaceName,
 		DeletionTimestamp: &deletionTimestamp,
 		OwnerReferences:   m3mOwnerRefs(),
 		Annotations: map[string]string{
-			baremetal.HostAnnotation: namespaceName + "/bmh-0",
+			baremetal.HostAnnotation: namespaceName + "/" + baremetalhostName,
 		},
 	}
 }
@@ -208,7 +208,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 			objMeta := testmachine.ObjectMeta
 			_ = c.Get(context.TODO(), *getKey(clusterName), testcluster)
 			_ = c.Get(context.TODO(), *getKey(metal3machineName), testBMmachine)
-			_ = c.Get(context.TODO(), *getKey("bmh-0"), testBMHost)
+			_ = c.Get(context.TODO(), *getKey(baremetalhostName), testBMHost)
 
 			if tc.ErrorExpected {
 				Expect(err).To(HaveOccurred())
@@ -421,7 +421,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 					machineWithInfra(),
 					newCluster(clusterName, nil, nil),
 					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
-					newBareMetalHost("bmh-0", nil, nil, nil, false),
+					newBareMetalHost(baremetalhostName, nil, nil, nil, false),
 				},
 				ErrorExpected:       false,
 				RequeueExpected:     false,
@@ -456,7 +456,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 					machineWithBootstrap(),
 					newCluster(clusterName, nil, nil),
 					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
-					newBareMetalHost("bmh-0", nil, &bmov1alpha1.BareMetalHostStatus{
+					newBareMetalHost(baremetalhostName, nil, &bmov1alpha1.BareMetalHostStatus{
 						Provisioning: bmov1alpha1.ProvisionStatus{
 							State: bmov1alpha1.StateAvailable,
 						},
@@ -494,7 +494,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 					machineWithBootstrap(),
 					newCluster(clusterName, nil, nil),
 					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
-					newBareMetalHost("bmh-0", nil, &bmov1alpha1.BareMetalHostStatus{
+					newBareMetalHost(baremetalhostName, nil, &bmov1alpha1.BareMetalHostStatus{
 						Provisioning: bmov1alpha1.ProvisionStatus{
 							State: bmov1alpha1.StateReady,
 						},
@@ -526,7 +526,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 					machineWithBootstrap(),
 					newCluster(clusterName, nil, nil),
 					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
-					newBareMetalHost("bmh-0", nil, nil, nil, false),
+					newBareMetalHost(baremetalhostName, nil, nil, nil, false),
 				},
 				TargetObjects: []runtime.Object{
 					&corev1.Node{
@@ -564,7 +564,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 					machineWithBootstrap(),
 					newCluster(clusterName, nil, nil),
 					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
-					newBareMetalHost("bmh-0", nil, nil, nil, false),
+					newBareMetalHost(baremetalhostName, nil, nil, nil, false),
 				},
 				TargetObjects: []runtime.Object{
 					&corev1.Node{
@@ -609,7 +609,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 					machineWithBootstrap(),
 					newCluster(clusterName, nil, nil),
 					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
-					newBareMetalHost("bmh-0", nil, &bmov1alpha1.BareMetalHostStatus{
+					newBareMetalHost(baremetalhostName, nil, &bmov1alpha1.BareMetalHostStatus{
 						Provisioning: bmov1alpha1.ProvisionStatus{
 							State: bmov1alpha1.StateProvisioning,
 						},
@@ -633,7 +633,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 					machineWithBootstrap(),
 					newCluster(clusterName, nil, nil),
 					newMetal3Cluster(metal3ClusterName, bmcOwnerRef(), bmcSpec(), nil, nil, false),
-					newBareMetalHost("bmh-0", nil, nil, nil, false),
+					newBareMetalHost(baremetalhostName, nil, nil, nil, false),
 				},
 				ErrorExpected:           false,
 				RequeueExpected:         true,
@@ -654,7 +654,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 					machineWithBootstrap(),
 					newCluster(clusterName, nil, nil),
 					newMetal3Cluster(metal3ClusterName, bmcOwnerRef(), bmcSpec(), nil, nil, false),
-					newBareMetalHost("bmh-0", nil, nil, nil, false),
+					newBareMetalHost(baremetalhostName, nil, nil, nil, false),
 				},
 				TargetObjects: []runtime.Object{
 					&v1.Node{
@@ -707,7 +707,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 					machineWithInfra(),
 					newCluster(clusterName, nil, nil),
 					newMetal3Cluster(metal3ClusterName, nil, nil, nil, nil, false),
-					newBareMetalHost("bmh-0", &bmov1alpha1.BareMetalHostSpec{
+					newBareMetalHost(baremetalhostName, &bmov1alpha1.BareMetalHostSpec{
 						ConsumerRef: &corev1.ObjectReference{
 							Name:       metal3machineName,
 							Namespace:  namespaceName,

--- a/controllers/metal3machine_controller_integration_test.go
+++ b/controllers/metal3machine_controller_integration_test.go
@@ -239,10 +239,10 @@ var _ = Describe("Reconcile metal3machine", func() {
 			}
 			if tc.CheckBMProviderID {
 				if tc.CheckBMProviderIDUnchanged {
-					Expect(testBMmachine.Spec.ProviderID).NotTo(Equal(fmt.Sprintf("%s%s", baremetal.ProviderIDPrefix,
-						string(testBMHost.ObjectMeta.UID))))
+					Expect(testBMmachine.Spec.ProviderID).NotTo(Equal(pointer.StringPtr(fmt.Sprintf("%s%s", baremetal.ProviderIDPrefix,
+						string(testBMHost.ObjectMeta.UID)))))
 				} else {
-					Expect(testBMmachine.Spec.ProviderID).To(Equal(pointer.StringPtr(fmt.Sprintf("metal3://%s",
+					Expect(testBMmachine.Spec.ProviderID).To(Equal(pointer.StringPtr(fmt.Sprintf("%s%s", baremetal.ProviderIDPrefix,
 						string(testBMHost.ObjectMeta.UID)))))
 				}
 			}
@@ -544,7 +544,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 					newMetal3Machine(
 						metal3machineName, m3mMetaWithAnnotation(),
 						&capm3.Metal3MachineSpec{
-							ProviderID: pointer.StringPtr(providerID),
+							ProviderID: pointer.StringPtr(fmt.Sprintf("%sabcd", baremetal.ProviderIDPrefix)),
 							Image: capm3.Image{
 								Checksum: "abcd",
 								URL:      "abcd",
@@ -632,7 +632,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "bmh-0",
 							Labels: map[string]string{
-								baremetal.ProviderLabelPrefix: string(bmhuid),
+								baremetal.ProviderLabelPrefix: "54db7dd5-269a-4d94-a12a-c4eafcecb8e7",
 							},
 						},
 						Spec: v1.NodeSpec{},

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -446,12 +446,12 @@ var _ = Describe("Metal3Machine manager", func() {
 				Host: &bmh.BareMetalHost{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "host1",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					Spec: bmh.BareMetalHostSpec{
 						ConsumerRef: &corev1.ObjectReference{
 							Name:       "someothermachine",
-							Namespace:  "myns",
+							Namespace:  namespaceName,
 							Kind:       "Metal3Machine",
 							APIVersion: infrav1alpha5.GroupVersion.String(),
 						},
@@ -466,7 +466,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Host: &bmh.BareMetalHost{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "host1",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 					Spec: bmh.BareMetalHostSpec{},
 				},
@@ -626,7 +626,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		func(tc testCaseMetal3DataToMetal3Machines) {
 			ipClaim := &infrav1alpha5.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:       "myns",
+					Namespace:       namespaceName,
 					OwnerReferences: tc.ownerRefs,
 				},
 			}
@@ -663,7 +663,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				{
 					NamespacedName: types.NamespacedName{
 						Name:      "abc",
-						Namespace: "myns",
+						Namespace: namespaceName,
 					},
 				},
 			},

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -132,7 +132,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		// if we fail to set it on the node, we do not go further
 		if tc.SetNodeProviderIDFails {
 			m.EXPECT().
-				SetNodeProviderID(context.TODO(), string(bmhuid), providerID, nil).
+				SetNodeProviderID(context.TODO(), string(bmhuid), &providerID, nil).
 				Return(errors.New("Failed"))
 			m.EXPECT().SetProviderID(string(bmhuid)).MaxTimes(0)
 			m.EXPECT().SetError(gomock.Any(), gomock.Any())
@@ -141,7 +141,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 
 		// we successfully set it on the node
 		m.EXPECT().
-			SetNodeProviderID(context.TODO(), string(bmhuid), providerID, nil).
+			SetNodeProviderID(context.TODO(), string(bmhuid), &providerID, nil).
 			Return(nil)
 		m.EXPECT().SetProviderID(providerID)
 
@@ -151,7 +151,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		m.EXPECT().GetBaremetalHostID(context.TODO()).Return(nil, nil)
 
 		m.EXPECT().
-			SetNodeProviderID(context.TODO(), bmhuid, providerID, nil).
+			SetNodeProviderID(context.TODO(), bmhuid, &providerID, nil).
 			MaxTimes(0)
 	}
 

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -110,7 +110,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		m.EXPECT().GetBaremetalHostID(context.TODO()).Return(nil,
 			errors.New("Failed"),
 		)
-		m.EXPECT().SetProviderID("abc").MaxTimes(0)
+		m.EXPECT().SetProviderID(bmhuid).MaxTimes(0)
 		m.EXPECT().SetError(gomock.Any(), gomock.Any())
 		return m
 	}
@@ -120,11 +120,11 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		if tc.GetProviderIDFails {
 			m.EXPECT().GetProviderIDAndBMHID().Return("", nil)
 			m.EXPECT().GetBaremetalHostID(context.TODO()).Return(
-				pointer.StringPtr("abc"), nil,
+				pointer.StringPtr(string(bmhuid)), nil,
 			)
 		} else {
 			m.EXPECT().GetProviderIDAndBMHID().Return(
-				"metal3://abc", pointer.StringPtr("abc"),
+				providerID, pointer.StringPtr(string(bmhuid)),
 			)
 			m.EXPECT().GetBaremetalHostID(context.TODO()).MaxTimes(0)
 		}
@@ -132,18 +132,18 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		// if we fail to set it on the node, we do not go further
 		if tc.SetNodeProviderIDFails {
 			m.EXPECT().
-				SetNodeProviderID(context.TODO(), "abc", "metal3://abc", nil).
+				SetNodeProviderID(context.TODO(), string(bmhuid), providerID, nil).
 				Return(errors.New("Failed"))
-			m.EXPECT().SetProviderID("abc").MaxTimes(0)
+			m.EXPECT().SetProviderID(string(bmhuid)).MaxTimes(0)
 			m.EXPECT().SetError(gomock.Any(), gomock.Any())
 			return m
 		}
 
 		// we successfully set it on the node
 		m.EXPECT().
-			SetNodeProviderID(context.TODO(), "abc", "metal3://abc", nil).
+			SetNodeProviderID(context.TODO(), string(bmhuid), providerID, nil).
 			Return(nil)
-		m.EXPECT().SetProviderID("metal3://abc")
+		m.EXPECT().SetProviderID(providerID)
 
 		// We did not get an id (got nil), so we'll requeue and not go further
 	} else {
@@ -151,7 +151,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		m.EXPECT().GetBaremetalHostID(context.TODO()).Return(nil, nil)
 
 		m.EXPECT().
-			SetNodeProviderID(context.TODO(), "abc", "metal3://abc", nil).
+			SetNodeProviderID(context.TODO(), bmhuid, providerID, nil).
 			MaxTimes(0)
 	}
 

--- a/controllers/metal3machinetemplate_controller_test.go
+++ b/controllers/metal3machinetemplate_controller_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 						Name:      "machine-1",
 						Namespace: "bar",
 						Annotations: map[string]string{
-							baremetal.HostAnnotation: "myns/myhost",
+							baremetal.HostAnnotation: namespaceName + "/myhost",
 						},
 					},
 					Spec: capm3.Metal3MachineSpec{

--- a/controllers/metal3machinetemplate_controller_test.go
+++ b/controllers/metal3machinetemplate_controller_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 	templateMgrErrorMsg := "failed to create helper for managing the templateMgr"
 	defaultTestRequest := ctrl.Request{
 		NamespacedName: types.NamespacedName{
-			Name:      metal3machineTemplateName,
+			Name:      metal3DataTemplateName,
 			Namespace: namespaceName,
 		},
 	}
@@ -103,7 +103,7 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 						Name:      "machine-1",
 						Namespace: "bar",
 						Annotations: map[string]string{
-							baremetal.HostAnnotation: namespaceName + "/myhost",
+							baremetal.HostAnnotation: namespaceName + "/" + baremetalhostName,
 						},
 					},
 					Spec: capm3.Metal3MachineSpec{
@@ -225,7 +225,7 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 					expectedResult: ctrl.Result{},
 					expectedError:  &templateMgrErrorMsg,
 					m3mTemplate: newMetal3MachineTemplate(
-						metal3machineTemplateName,
+						metal3DataTemplateName,
 						namespaceName,
 						map[string]string{}),
 				},
@@ -238,7 +238,7 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 					expectedResult: ctrl.Result{Requeue: true, RequeueAfter: requeueAfter},
 					expectedError:  nil,
 					m3mTemplate: newMetal3MachineTemplate(
-						metal3machineTemplateName,
+						metal3DataTemplateName,
 						namespaceName,
 						map[string]string{
 							capi.PausedAnnotation: "true",
@@ -253,7 +253,7 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 					expectedResult: ctrl.Result{},
 					expectedError:  nil,
 					m3mTemplate: newMetal3MachineTemplate(
-						metal3machineTemplateName,
+						metal3DataTemplateName,
 						namespaceName,
 						map[string]string{}),
 					shouldUpdateAutomatedCleaningMode: true,
@@ -297,7 +297,7 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 					testRequest:    defaultTestRequest,
 					expectedResult: ctrl.Result{},
 					expectedError:  new(string),
-					m3mTemplate: newMetal3MachineTemplate(metal3machineTemplateName,
+					m3mTemplate: newMetal3MachineTemplate(metal3DataTemplateName,
 						namespaceName,
 						map[string]string{}),
 				},
@@ -310,7 +310,7 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 					expectedResult: ctrl.Result{},
 					expectedError:  nil,
 					m3mTemplate: newMetal3MachineTemplate(
-						metal3machineTemplateName,
+						metal3DataTemplateName,
 						namespaceName,
 						map[string]string{}),
 					shouldUpdateAutomatedCleaningMode: true,

--- a/controllers/metal3machinetemplate_controller_test.go
+++ b/controllers/metal3machinetemplate_controller_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 	templateMgrErrorMsg := "failed to create helper for managing the templateMgr"
 	defaultTestRequest := ctrl.Request{
 		NamespacedName: types.NamespacedName{
-			Name:      metal3DataTemplateName,
+			Name:      metal3machineTemplateName,
 			Namespace: namespaceName,
 		},
 	}
@@ -225,7 +225,7 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 					expectedResult: ctrl.Result{},
 					expectedError:  &templateMgrErrorMsg,
 					m3mTemplate: newMetal3MachineTemplate(
-						metal3DataTemplateName,
+						metal3machineTemplateName,
 						namespaceName,
 						map[string]string{}),
 				},
@@ -238,7 +238,7 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 					expectedResult: ctrl.Result{Requeue: true, RequeueAfter: requeueAfter},
 					expectedError:  nil,
 					m3mTemplate: newMetal3MachineTemplate(
-						metal3DataTemplateName,
+						metal3machineTemplateName,
 						namespaceName,
 						map[string]string{
 							capi.PausedAnnotation: "true",
@@ -253,7 +253,7 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 					expectedResult: ctrl.Result{},
 					expectedError:  nil,
 					m3mTemplate: newMetal3MachineTemplate(
-						metal3DataTemplateName,
+						metal3machineTemplateName,
 						namespaceName,
 						map[string]string{}),
 					shouldUpdateAutomatedCleaningMode: true,
@@ -297,7 +297,7 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 					testRequest:    defaultTestRequest,
 					expectedResult: ctrl.Result{},
 					expectedError:  new(string),
-					m3mTemplate: newMetal3MachineTemplate(metal3DataTemplateName,
+					m3mTemplate: newMetal3MachineTemplate(metal3machineTemplateName,
 						namespaceName,
 						map[string]string{}),
 				},
@@ -310,7 +310,7 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 					expectedResult: ctrl.Result{},
 					expectedError:  nil,
 					m3mTemplate: newMetal3MachineTemplate(
-						metal3DataTemplateName,
+						metal3machineTemplateName,
 						namespaceName,
 						map[string]string{}),
 					shouldUpdateAutomatedCleaningMode: true,

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -382,7 +382,7 @@ func newBareMetalHost(spec *bmh.BareMetalHostSpec,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bmh-0",
 			Namespace: namespaceName,
-			UID:       "54db7dd5-269a-4d94-a12a-c4eafcecb8e7",
+			UID:       bmhuid,
 		},
 		Spec:   *spec,
 		Status: *status,

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -360,10 +360,9 @@ func newMetal3Machine(name string, meta *metav1.ObjectMeta,
 	}
 }
 
-func newBareMetalHost(spec *bmh.BareMetalHostSpec,
-	status *bmh.BareMetalHostStatus,
-) *bmh.BareMetalHost {
-
+func newBareMetalHost(bmhName string, spec *bmov1alpha1.BareMetalHostSpec,
+	status *bmov1alpha1.BareMetalHostStatus, labels map[string]string, paused bool,
+) *bmov1alpha1.BareMetalHost {
 	if spec == nil {
 		spec = &bmh.BareMetalHostSpec{}
 	}
@@ -380,7 +379,7 @@ func newBareMetalHost(spec *bmh.BareMetalHostSpec,
 			APIVersion: bmh.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bmh-0",
+			Name:      bmhName,
 			Namespace: namespaceName,
 			UID:       bmhuid,
 		},
@@ -388,4 +387,11 @@ func newBareMetalHost(spec *bmh.BareMetalHostSpec,
 		Status: *status,
 	}
 
+}
+
+func testObjectMeta(name string, namespace string, uid string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      name,
+		Namespace: namespace,
+	}
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -54,15 +54,16 @@ var testEnv *envtest.Environment
 var timestampNow = metav1.Now()
 
 const (
-	clusterName            = "controller-testcluster"
-	metal3ClusterName      = "controller-testmetal3cluster"
-	machineName            = "controller-testmachine"
-	metal3machineName      = "controller-testmetal3machine"
-	namespaceName          = "controller-testns"
-	metal3DataTemplateName = "controller-testmetal3datatemplate"
-	baremetalhostName      = "controller-testbaremetalhostname"
-	metal3DataName         = "controller-testmetal3dataname"
-	metal3DataClaimName    = "baremetal-testmetal3dataclaim"
+	clusterName               = "controller-testcluster"
+	metal3ClusterName         = "controller-testmetal3cluster"
+	machineName               = "controller-testmachine"
+	metal3machineName         = "controller-testmetal3machine"
+	namespaceName             = "controller-testns"
+	metal3DataTemplateName    = "controller-testmetal3datatemplate"
+	baremetalhostName         = "controller-testbaremetalhostname"
+	metal3DataName            = "controller-testmetal3dataname"
+	metal3DataClaimName       = "baremetal-testmetal3dataclaim"
+	metal3machineTemplateName = "controller-testmetal3machinetemplate"
 )
 
 func init() {
@@ -364,9 +365,9 @@ func newMetal3Machine(name string, meta *metav1.ObjectMeta,
 	}
 }
 
-func newBareMetalHost(bmhName string, spec *bmov1alpha1.BareMetalHostSpec,
-	status *bmov1alpha1.BareMetalHostStatus, labels map[string]string, paused bool,
-) *bmov1alpha1.BareMetalHost {
+func newBareMetalHost(bmhName string, spec *bmh.BareMetalHostSpec,
+	status *bmh.BareMetalHostStatus,
+) *bmh.BareMetalHost {
 	if spec == nil {
 		spec = &bmh.BareMetalHostSpec{}
 	}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -57,7 +57,7 @@ const (
 	metal3ClusterName         = "testmetal3Cluster"
 	machineName               = "testMachine"
 	metal3machineName         = "testmetal3machine"
-	namespaceName             = "testNameSpace"
+	namespaceName             = "controllerns"
 	metal3machineTemplateName = "testmetal3machinetemplate"
 )
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -393,5 +394,6 @@ func testObjectMeta(name string, namespace string, uid string) metav1.ObjectMeta
 	return metav1.ObjectMeta{
 		Name:      name,
 		Namespace: namespace,
+		UID:       types.UID(uid),
 	}
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -53,12 +53,12 @@ var testEnv *envtest.Environment
 var timestampNow = metav1.Now()
 
 const (
-	clusterName               = "testCluster"
-	metal3ClusterName         = "testmetal3Cluster"
-	machineName               = "testMachine"
-	metal3machineName         = "testmetal3machine"
+	clusterName               = "controllerns_testCluster"
+	metal3ClusterName         = "controllerns_testmetal3Cluster"
+	machineName               = "controllerns_testMachine"
+	metal3machineName         = "controllerns_testmetal3machine"
 	namespaceName             = "controllerns"
-	metal3machineTemplateName = "testmetal3machinetemplate"
+	metal3machineTemplateName = "controllerns_testmetal3machinetemplate"
 )
 
 func init() {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -54,12 +54,15 @@ var testEnv *envtest.Environment
 var timestampNow = metav1.Now()
 
 const (
-	clusterName               = "controllerns_testCluster"
-	metal3ClusterName         = "controllerns_testmetal3Cluster"
-	machineName               = "controllerns_testMachine"
-	metal3machineName         = "controllerns_testmetal3machine"
-	namespaceName             = "controllerns"
-	metal3machineTemplateName = "controllerns_testmetal3machinetemplate"
+	clusterName            = "controller-testcluster"
+	metal3ClusterName      = "controller-testmetal3cluster"
+	machineName            = "controller-testmachine"
+	metal3machineName      = "controller-testmetal3machine"
+	namespaceName          = "controller-testns"
+	metal3DataTemplateName = "controller-testmetal3datatemplate"
+	baremetalhostName      = "controller-testbaremetalhostname"
+	metal3DataName         = "controller-testmetal3dataname"
+	metal3DataClaimName    = "baremetal-testmetal3dataclaim"
 )
 
 func init() {

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -56,17 +56,17 @@ rm -rf "${M3PATH}/cluster-api-provider-metal3" # To avoid 'permission denied' er
 cp -R "${REPO_ROOT}" "${M3PATH}/cluster-api-provider-metal3/" 
 make launch_mgmt_cluster verify
 # Generate the cluster template from metal3-dev-env
-if [ -f "${PWD}/tests/scripts/generate-template.sh"  ]; then
-  ./tests/scripts/generate-template.sh
-  DEV_ENV_CLUSTER_TEMPLATE="${REPO_ROOT}/templates/test/cluster-template-prow-ha-m3-dev-env.yaml"
-  TEMPLATE_DIR_SRC="vm-setup/roles/run_tests/files/manifests/"
-  echo -n > "${DEV_ENV_CLUSTER_TEMPLATE}"
-  # shellcheck disable=SC2045
-  for file in $(ls -d ${TEMPLATE_DIR_SRC}*); do
-    echo "---" >> "${DEV_ENV_CLUSTER_TEMPLATE}"
-    cat "$file" >> "${DEV_ENV_CLUSTER_TEMPLATE}"
-  done
-fi
+# if [ -f "${PWD}/tests/scripts/generate-template.sh"  ]; then
+#   ./tests/scripts/generate-template.sh
+#   DEV_ENV_CLUSTER_TEMPLATE="${REPO_ROOT}/templates/test/cluster-template-prow-ha-m3-dev-env.yaml"
+#   TEMPLATE_DIR_SRC="vm-setup/roles/run_tests/files/manifests/"
+#   echo -n > "${DEV_ENV_CLUSTER_TEMPLATE}"
+#   # shellcheck disable=SC2045
+#   for file in $(ls -d ${TEMPLATE_DIR_SRC}*); do
+#     echo "---" >> "${DEV_ENV_CLUSTER_TEMPLATE}"
+#     cat "$file" >> "${DEV_ENV_CLUSTER_TEMPLATE}"
+#   done
+# fi
 popd
 
 SSH_PUB_KEY_CONTENT=$(cat "$HOME/.ssh/id_rsa.pub")

--- a/templates/test/cluster-template-prow-ha-centos.yaml
+++ b/templates/test/cluster-template-prow-ha-centos.yaml
@@ -79,7 +79,7 @@ spec:
           container-runtime-endpoint: unix:///var/run/crio/crio.sock
           feature-gates: AllAlpha=false
           node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
-          provider-id: metal3://{{ ds.meta_data.uuid }}
+          provider-id: metal3://{{ ds.meta_data.providerid }}
           runtime-request-timeout: 5m
         name: '{{ ds.meta_data.name }}'
     initConfiguration:
@@ -90,7 +90,7 @@ spec:
           container-runtime-endpoint: unix:///var/run/crio/crio.sock
           feature-gates: AllAlpha=false
           node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
-          provider-id: metal3://{{ ds.meta_data.uuid }}
+          provider-id: metal3://{{ ds.meta_data.providerid }}
           runtime-request-timeout: 5m
         name: '{{ ds.meta_data.name }}'
     files:
@@ -461,7 +461,7 @@ spec:
             container-runtime-endpoint: unix:///var/run/crio/crio.sock
             feature-gates: AllAlpha=false
             node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
-            provider-id: metal3://{{ ds.meta_data.uuid }}
+            provider-id: metal3://{{ ds.meta_data.providerid }}
             runtime-request-timeout: 5m
           name: '{{ ds.meta_data.name }}'
       preKubeadmCommands:

--- a/templates/test/cluster-template-prow-ha.yaml
+++ b/templates/test/cluster-template-prow-ha.yaml
@@ -154,7 +154,7 @@ spec:
           container-runtime-endpoint: unix:///var/run/crio/crio.sock
           feature-gates: AllAlpha=false
           node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
-          provider-id: metal3://{{ ds.meta_data.uuid }}
+          provider-id: metal3://{{ ds.meta_data.providerid }}
           runtime-request-timeout: 5m
         name: '{{ ds.meta_data.name }}'
     joinConfiguration:
@@ -166,7 +166,7 @@ spec:
           container-runtime-endpoint: unix:///var/run/crio/crio.sock
           feature-gates: AllAlpha=false
           node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
-          provider-id: metal3://{{ ds.meta_data.uuid }}
+          provider-id: metal3://{{ ds.meta_data.providerid }}
           runtime-request-timeout: 5m
         name: '{{ ds.meta_data.name }}'
     postKubeadmCommands:
@@ -386,7 +386,7 @@ spec:
             container-runtime-endpoint: unix:///var/run/crio/crio.sock
             feature-gates: AllAlpha=false
             node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
-            provider-id: metal3://{{ ds.meta_data.uuid }}
+            provider-id: metal3://{{ ds.meta_data.providerid }}
             runtime-request-timeout: 5m
           name: '{{ ds.meta_data.name }}'
       preKubeadmCommands:

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -68,12 +68,12 @@ providers:
       targetName: "metadata.yaml"
     # In the future, we can use the two commented templates below if we can find a way to make the e2e test less dependant on the dev-env.
     # If someone wants to run the e2e test with a custom template instead of the one from the dev-env, they can modify and use the two templates.
-    # - sourcePath: "${PWD}/test/e2e/_out/cluster-template-prow-ha.yaml"
-    #   targetName: "cluster-template-ha.yaml"
-    # - sourcePath: "${PWD}/test/e2e/_out/cluster-template-prow-ha-centos.yaml"
-    #   targetName: "cluster-template-ha-centos.yaml"
-    - sourcePath: "${PWD}/test/e2e/_out/cluster-template-prow-ha-m3-dev-env.yaml"
-      targetName: "cluster-template-ha-m3-dev-env.yaml"
+    - sourcePath: "${PWD}/test/e2e/_out/cluster-template-prow-ha.yaml"
+      targetName: "cluster-template-ha.yaml"
+    - sourcePath: "${PWD}/test/e2e/_out/cluster-template-prow-ha-centos.yaml"
+      targetName: "cluster-template-ha-centos.yaml"
+    # - sourcePath: "${PWD}/test/e2e/_out/cluster-template-prow-ha-m3-dev-env.yaml"
+    #   targetName: "cluster-template-ha-m3-dev-env.yaml"
 
 variables:
   KUBERNETES_VERSION: "${KUBERNETES_VERSION}"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -34,8 +34,11 @@ var _ = Describe("Workload cluster creation", func() {
 	BeforeEach(func() {
 		osType := strings.ToLower(os.Getenv("OS"))
 		Expect(osType).ToNot(Equal(""))
-		flavorSuffix = "-m3-dev-env"
-
+		if osType == "centos" {
+			flavorSuffix = "-centos"
+		} else {
+			flavorSuffix = ""
+		}
 		validateGlobals(specName)
 
 		// We need to override clusterctl apply log folder to avoid getting our credentials exposed.


### PR DESCRIPTION
On v1alpha5, we noticed some tests fail due to providerID related issues, which are usually visible on upgrade and node reuse tests. 

In the main branch, we already have a fix that solves such problems. The purpose of this PR is to back port the fix from main to v1alpha5. 

Co-authored-by: [furkatgofurov7](https://github.com/furkatgofurov7) | <furkat.gofurov@est.tech>