### PR TITLE
🐛 Fix remediation cleanup

### DIFF
--- a/baremetal/metal3remediation_manager.go
+++ b/baremetal/metal3remediation_manager.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -107,25 +108,17 @@ func NewRemediationManager(client client.Client, capiClientGetter ClientGetter,
 
 // SetFinalizer sets finalizer. Return if it was set.
 func (r *RemediationManager) SetFinalizer() {
-	// If the Metal3Remediation doesn't have finalizer, add it.
-	if !r.HasFinalizer() {
-		r.Metal3Remediation.Finalizers = append(r.Metal3Remediation.Finalizers,
-			infrav1.RemediationFinalizer,
-		)
-	}
+	controllerutil.AddFinalizer(r.Metal3Remediation, infrav1.RemediationFinalizer)
 }
 
 // UnsetFinalizer unsets finalizer.
 func (r *RemediationManager) UnsetFinalizer() {
-	// Cluster is deleted so remove the finalizer.
-	r.Metal3Remediation.Finalizers = Filter(r.Metal3Remediation.Finalizers,
-		infrav1.RemediationFinalizer,
-	)
+	controllerutil.RemoveFinalizer(r.Metal3Remediation, infrav1.RemediationFinalizer)
 }
 
 // HasFinalizer returns if finalizer is set.
 func (r *RemediationManager) HasFinalizer() bool {
-	return Contains(r.Metal3Remediation.Finalizers, infrav1.RemediationFinalizer)
+	return controllerutil.ContainsFinalizer(r.Metal3Remediation, infrav1.RemediationFinalizer)
 }
 
 // TimeToRemediate checks if it is time to execute a next remediation step

--- a/test/e2e/metal3remediation_test.go
+++ b/test/e2e/metal3remediation_test.go
@@ -82,6 +82,12 @@ func metal3remediation() {
 	By("Deleting Metal3Remediation CR")
 	Expect(bootstrapClient.Delete(ctx, m3Remediation)).To(Succeed(), "should delete Metal3Remediation CR")
 
+	By("Make sure Metal3Remediation CR was actually deleted (finalizer is removed)")
+	Eventually(func() bool {
+		err = bootstrapClient.Get(ctx, client.ObjectKeyFromObject(m3Remediation), m3Remediation)
+		return apierrors.IsNotFound(err)
+	}, 2*time.Minute, 10*time.Second).Should(BeTrue(), "Metal3Remediation should have been deleted")
+
 	By("METAL3REMEDIATION TESTS PASSED!")
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The updated remediation flow introduced by https://github.com/metal3-io/cluster-api-provider-metal3/pull/668 has an issue, the remediations CRs can't be deleted because the finalizer isn't removed.

The fix is: Initialize patch helper after getting current CR!!! Otherwise nothing will deleted by patch, only added.

Some more improvements done along the way deugging this:

- Requeue CR when patch fails
- CRs with deletion timestamp are handled in normal CR flow (finalizer needs to be removed)
- add CR deleted check to e2e test
- slightly better logging
- use controller utils for finalizer handling