### PR TITLE
🐛 Don't use IPClaims with deletion timestamp

### DIFF
--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -714,6 +714,12 @@ func (m *DataManager) getAddressFromPool(ctx context.Context, poolName string,
 		}
 	}
 
+	if !ipClaim.DeletionTimestamp.IsZero() {
+		// This IPClaim is about to be deleted so we cannot use it. Requeue.
+		m.Log.Info("Found IPClaim with deletion timestamp, requeuing.", "IPClaim", ipClaim)
+		return addresses, true, nil
+	}
+
 	if ipClaim.Status.ErrorMessage != nil {
 		m.Data.Status.ErrorMessage = pointer.StringPtr(fmt.Sprintf(
 			"IP Allocation for %v failed : %v", poolName, ipClaim.Status.ErrorMessage,


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes: #680 

This fixes an issue where old IPClaims could be reused by CAPM3 before IPAM had a chance to delete them. One easy way to reproduce it is to scale down IPAM to 0 (to make sure it never has time to delete old claims) and then do an upgrade of the KCP.
CAPM3 will then happily reuse the old IPClaims for the new machines even though they have deletion timestamps.
Once IPAM is scaled up again, it will proceed to clean up the IPClaims, resulting in missing IPClaims for all the new machines.

The fix I have implemented here is to make CAPM3 check for deletion timestamps before "accepting" the IPClaim. So CAPM3 will simply requeue and wait for a "proper" IPClaim.

I guess an alternative would be to use the claims with a deletion timestamp and prevent IPAM from deleting them instead. But I think that makes less sense. But please let me know if you have other suggestions/opinions. Perhaps we should combine the two and add a finalizer for extra safety so IPAM cannot delete it if CAPM3 is using it, but still avoid using them if there is a deletion timestamp?
