### PR TITLE
🌱 Add v1.2 CAPI release contract to e2e metadata file

### DIFF
--- a/hack/gen_tilt_settings.sh
+++ b/hack/gen_tilt_settings.sh
@@ -37,7 +37,7 @@ function get_latest_release() {
 }
 
 CAPIRELEASEPATH="${CAPIRELEASEPATH:-https://api.github.com/repos/${CAPI_BASE_URL:-kubernetes-sigs/cluster-api}/releases}"
-export CAPIRELEASE="${CAPIRELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v1.1.")}"
+export CAPIRELEASE="${CAPIRELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v1.2.")}"
 
 cat <<EOF > tilt-settings.json
 {

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -60,10 +60,10 @@ source "${M3_DEV_ENV_PATH}/lib/ironic_tls_setup.sh"
 
 if [[ ${GINKGO_FOCUS:-} == "upgrade" ]]; then
   export CAPI_FROM_RELEASE="${CAPIRELEASE}"
-  export CAPI_TO_RELEASE="${CAPI_TO_RELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v1.1.")}"
+  export CAPI_TO_RELEASE="${CAPI_TO_RELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v1.2.")}"
 
   export CAPM3_FROM_RELEASE="${CAPM3RELEASE}"
-  export CAPM3_TO_RELEASE="${CAPM3_TO_RELEASE:-$(get_latest_release "${CAPM3RELEASEPATH}" "v1.1.")}"
+  export CAPM3_TO_RELEASE="${CAPM3_TO_RELEASE:-$(get_latest_release "${CAPM3RELEASEPATH}" "v1.2.")}"
 else
   export CAPI_FROM_RELEASE="${CAPI_FROM_RELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v0.4.")}"
   export CAPI_TO_RELEASE="${CAPIRELEASE}"

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -48,10 +48,10 @@ else
   export EPHEMERAL_CLUSTER="minikube"
 fi
 
-# Until the upgrade process starts with CAPI 0.4.x
-# CAPM 0.5.x and K8s 1.23.x it is not possible to set
-# the starting version of the target cluster (FROM_K8S_VERSION)
-# higher than 1.23.x
+# Until the upgrade process starts with CAPI v0.4.x
+# CAPM3 v0.5.x and K8s v1.23.x it is not possible to set
+# the starting version of k8s in the target cluster (FROM_K8S_VERSION)
+# higher than v1.23.x
 export FROM_K8S_VERSION="v1.23.8"
 export KUBERNETES_VERSION=${FROM_K8S_VERSION}
 export UPGRADED_K8S_VERSION="v1.24.1"

--- a/test/e2e/data/shared/v1beta1/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1/metadata.yaml
@@ -2,6 +2,9 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
 - major: 1
+  minor: 2
+  contract: v1beta1
+- major: 1
   minor: 1
   contract: v1beta1
 - major: 1


### PR DESCRIPTION
**What this PR does / why we need it**:
Also, fetch correct CAPI release when running e2e upgrade tests `{GINKGO_FOCUS:-} == "upgrade"`

This is a follow-up to #674 