### PR TITLE
🌱 Update metadata to include capi 1.2.X releases

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,6 +2,9 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
 - major: 1
+  minor: 2
+  contract: v1beta1
+- major: 1
   minor: 1
   contract: v1beta1
 - major: 1


### PR DESCRIPTION
Update metadata to include capi 1.2.X releases
Otherwise we get, 
```
est:~ $ clusterctl init --infrastructure=metal3:v1.2.0-rc.0
Fetching providers
Error: invalid provider metadata: version v1.2.0-rc.0 for the provider capm3-system/infrastructure-metal3 does not match any release series

```