### PR TITLE
🌱 Use finalizer on IPClaim to avoid premature deletion

### DIFF
--- a/controllers/metal3data_controller.go
+++ b/controllers/metal3data_controller.go
@@ -55,7 +55,7 @@ type Metal3DataReconciler struct {
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
-// Reconcile handles Metal3Machine events.
+// Reconcile handles Metal3Data events.
 func (r *Metal3DataReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
 	metadataLog := r.Log.WithName(dataControllerName).WithValues("metal3-data", req.NamespacedName)
 
@@ -72,7 +72,7 @@ func (r *Metal3DataReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to init patch helper")
 	}
-	// Always patch capm3Machine exiting this function so we can persist any Metal3Machine changes.
+	// Always patch capm3Data exiting this function so we can persist any Metal3Data changes.
 	defer func() {
 		err := helper.Patch(ctx, capm3Metadata)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add a finalizer on IPClaims to protect them from accidental deletion while still in use.
- Also remove the owner reference on the IPClaim before marking for deletion so that IPAM can use it to determine if the IPClaim is still in use or not.
- Edited some confusing comments

I'm a bit unsure if this should be considered a "feature" or something else. Put 🌱 "other" for now.