### PR TITLE
🐛 Fix missing LACP bond mode

### DIFF
--- a/api/v1beta1/metal3datatemplate_types.go
+++ b/api/v1beta1/metal3datatemplate_types.go
@@ -219,9 +219,9 @@ type NetworkDataLinkEthernet struct {
 
 // NetworkDataLinkBond represents a bond link object
 type NetworkDataLinkBond struct {
-	// +kubebuilder:validation:Enum="balance-rr";"active-backup";"balance-xor";"broadcast";"balance-tlb";"balance-alb";"802.1ad"
+	// +kubebuilder:validation:Enum="balance-rr";"active-backup";"balance-xor";"broadcast";"balance-tlb";"balance-alb";"802.3ad"
 	// BondMode is the mode of bond used. It can be one of
-	// balance-rr, active-backup, balance-xor, broadcast, balance-tlb, balance-alb, 802.1ad
+	// balance-rr, active-backup, balance-xor, broadcast, balance-tlb, balance-alb, 802.3ad
 	BondMode string `json:"bondMode"`
 
 	// Id is the ID of the interface (used for naming)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3datatemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3datatemplates.yaml
@@ -1155,7 +1155,7 @@ spec:
                             bondMode:
                               description: BondMode is the mode of bond used. It can
                                 be one of balance-rr, active-backup, balance-xor,
-                                broadcast, balance-tlb, balance-alb, 802.1ad
+                                broadcast, balance-tlb, balance-alb, 802.3ad
                               enum:
                               - balance-rr
                               - active-backup
@@ -1163,7 +1163,7 @@ spec:
                               - broadcast
                               - balance-tlb
                               - balance-alb
-                              - 802.1ad
+                              - 802.3ad
                               type: string
                             id:
                               description: Id is the ID of the interface (used for


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

In #268 pr, v1alpha4 v1alpha5 has been fixed to 802.3ad (LACP) bond mode, but only v1beta1 is missing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # N/A
