### PR TITLE
🐛 Only use redfish for live-iso test

### DIFF
--- a/test/e2e/live_iso_test.go
+++ b/test/e2e/live_iso_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo"
@@ -45,7 +46,9 @@ func liveIsoTest() {
 		var isoBmh bmov1alpha1.BareMetalHost
 		for _, bmh := range bmhs {
 			Logf("Checking BMH %s", bmh.Name)
-			if bmh.Status.Provisioning.State == bmov1alpha1.StateAvailable {
+			// Pick the first BMH that is available and uses redfish (ipmi does not support live-iso)
+			if bmh.Status.Provisioning.State == bmov1alpha1.StateAvailable &&
+				strings.HasPrefix(bmh.Spec.BMC.Address, "redfish") {
 				isoBmh = bmh
 				Logf("BMH %s is in %s state", bmh.Name, bmh.Status.Provisioning.State)
 				break


### PR DESCRIPTION
**What this PR does / why we need it**:

The live-iso e2e test is failing because it is trying to use a BMH with ipmi, which does not support live-iso. This PR filters the BMHs so that we only select those that use redfish instead.

