### PR TITLE
🐛 Use keyfile format for CentOS network config

### DIFF
--- a/test/e2e/data/infrastructure-metal3/bases/centos-kubeadm-config/centos-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/bases/centos-kubeadm-config/centos-kubeadm-config.yaml
@@ -163,9 +163,7 @@ spec:
     - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
     - nmcli connection up ironicendpoint
     - systemctl enable --now crio keepalived kubelet
-    - systemctl link /lib/systemd/system/monitor.keepalived.service
-    - systemctl enable monitor.keepalived.service
-    - systemctl start monitor.keepalived.service
+    - systemctl enable --now /lib/systemd/system/monitor.keepalived.service
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/${CAPI_VERSION}
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-metal3/bases/centos-kubeadm-config/centos-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/bases/centos-kubeadm-config/centos-kubeadm-config.yaml
@@ -79,27 +79,37 @@ spec:
                 ${CLUSTER_APIENDPOINT_HOST}
             }
         }
-    - path: /etc/sysconfig/network-scripts/ifcfg-eth0
+    - path: /etc/NetworkManager/system-connections/eth0.nmconnection
       owner: root:root
-      permissions: '0644'
+      permissions: '0600'
       content: |
-        BOOTPROTO=none
-        DEVICE=eth0
-        ONBOOT=yes
-        TYPE=Ethernet
-        USERCTL=no
-        BRIDGE=${CLUSTER_PROVISIONING_INTERFACE}
+        [connection]
+        id=eth0
+        type=ethernet
+        interface-name=eth0
+        master=ironicendpoint
+        slave-type=bridge
+        autoconnect=yes
+        autoconnect-priority=999
     - content: |
-        TYPE=Bridge
-        DEVICE=${CLUSTER_PROVISIONING_INTERFACE}
-        ONBOOT=yes
-        USERCTL=no
-        BOOTPROTO="static"
-        IPADDR={{ ds.meta_data.provisioningIP }}
-        PREFIX={{ ds.meta_data.provisioningCIDR }}
-      path: /etc/sysconfig/network-scripts/ifcfg-ironicendpoint
+        [connection]
+        id=ironicendpoint
+        type=bridge
+        interface-name=ironicendpoint
+
+        [bridge]
+        stp=false
+
+        [ipv4]
+        address1={{ ds.meta_data.provisioningIP }}/{{ ds.meta_data.provisioningCIDR }}
+        method=manual
+
+        [ipv6]
+        addr-gen-mode=eui64
+        method=ignore
+      path: /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
       owner: root:root
-      permissions: '0644'
+      permissions: '0600'
     - content: |
         [kubernetes]
         name=Kubernetes
@@ -148,8 +158,10 @@ spec:
     - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube/config
     preKubeadmCommands:
     - systemctl restart NetworkManager.service
-    - nmcli connection load /etc/sysconfig/network-scripts/ifcfg-eth0
-    - nmcli connection up filename /etc/sysconfig/network-scripts/ifcfg-eth0
+    - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
+    - nmcli connection up eth0
+    - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
+    - nmcli connection up ironicendpoint
     - systemctl enable --now crio keepalived kubelet
     - systemctl link /lib/systemd/system/monitor.keepalived.service
     - systemctl enable monitor.keepalived.service
@@ -183,26 +195,36 @@ spec:
         path: /usr/local/bin/retrieve.configuration.files.sh
         permissions: "0755"
       - content: |
-          BOOTPROTO=none
-          DEVICE=eth0
-          ONBOOT=yes
-          TYPE=Ethernet
-          USERCTL=no
-          BRIDGE=${CLUSTER_PROVISIONING_INTERFACE}
-        path: /etc/sysconfig/network-scripts/ifcfg-eth0
+          [connection]
+          id=eth0
+          type=ethernet
+          interface-name=eth0
+          master=ironicendpoint
+          slave-type=bridge
+          autoconnect=yes
+          autoconnect-priority=999
+        path: /etc/NetworkManager/system-connections/eth0.nmconnection
         owner: root:root
-        permissions: '0644'
-      - path: /etc/sysconfig/network-scripts/ifcfg-ironicendpoint
+        permissions: '0600'
+      - path: /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
         owner: root:root
-        permissions: '0644'
+        permissions: '0600'
         content: |
-          TYPE=Bridge
-          DEVICE=${CLUSTER_PROVISIONING_INTERFACE}
-          ONBOOT=yes
-          USERCTL=no
-          BOOTPROTO="static"
-          IPADDR={{ ds.meta_data.provisioningIP }}
-          PREFIX={{ ds.meta_data.provisioningCIDR }}
+          [connection]
+          id=ironicendpoint
+          type=bridge
+          interface-name=ironicendpoint
+
+          [bridge]
+          stp=false
+
+          [ipv4]
+          address1={{ ds.meta_data.provisioningIP }}/{{ ds.meta_data.provisioningCIDR }}
+          method=manual
+
+          [ipv6]
+          addr-gen-mode=eui64
+          method=ignore
       - path: /etc/yum.repos.d/kubernetes.repo
         owner: root:root
         permissions: '0644'
@@ -225,6 +247,8 @@ spec:
           registries = ['${REGISTRY}']
       preKubeadmCommands:
       - systemctl restart NetworkManager.service
-      - nmcli connection load /etc/sysconfig/network-scripts/ifcfg-eth0
-      - nmcli connection up filename /etc/sysconfig/network-scripts/ifcfg-eth0
+      - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
+      - nmcli connection up eth0
+      - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
+      - nmcli connection up ironicendpoint
       - systemctl enable --now crio kubelet

--- a/test/e2e/data/infrastructure-metal3/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
@@ -115,9 +115,7 @@ spec:
     - netplan apply
     - systemctl enable --now crio kubelet
     - if (curl -sk --max-time 10 https://${CLUSTER_APIENDPOINT_HOST}:${CLUSTER_APIENDPOINT_PORT}/healthz); then echo "keepalived already running";else systemctl start keepalived; fi
-    - systemctl link /lib/systemd/system/monitor.keepalived.service
-    - systemctl enable monitor.keepalived.service
-    - systemctl start monitor.keepalived.service
+    - systemctl enable --now /lib/systemd/system/monitor.keepalived.service
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/${CAPI_VERSION}
 kind: KubeadmConfigTemplate


### PR DESCRIPTION
**What this PR does / why we need it**:

The network config format was already changed in metal3-dev-env. We need to use the same here or it will be ignored and break the tests.

Also fixes the systemctl commands for enabling the monitor.keepalived unit. It looks like there has been some changes in systemd which make `systemctl enable monitor.keepalived.service` fail because it is operating on a symlink.

```
Failed to enable unit: Refusing to operate on alias name or linked unit file: monitor.keepalived.service
```

My understanding is, that instead of first linking and then enabling the link, we should just enable the unit using the absolute path. This also creates a symlink.
This issue is not *yet* seen on Ubuntu because it has an older systemd version.

See:
- https://github.com/metal3-io/metal3-dev-env/pull/1009
- https://github.com/metal3-io/metal3-dev-env/pull/1062
