### PR TITLE
🌱 Don't remove ownerRef from IPClaim when deleting

### DIFF
--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -537,20 +537,6 @@ func (m *DataManager) releaseAddressFromM3Pool(ctx context.Context, poolRef core
 
 	// Remove finalizer from Metal3IPClaim since we no longer need it
 	ipClaim.Finalizers = Filter(ipClaim.Finalizers, infrav1.DataFinalizer)
-	// Remove Metal3Data ownerRef
-	newOwnerRefs := []metav1.OwnerReference{}
-	for _, ownerRef := range ipClaim.OwnerReferences {
-		oGV, err := schema.ParseGroupVersion(ownerRef.APIVersion)
-		if err != nil {
-			return err
-		}
-		if ownerRef.Kind == "Metal3Data" && oGV.Group == infrav1.GroupVersion.Group {
-			continue
-		} else {
-			newOwnerRefs = append(newOwnerRefs, ownerRef)
-		}
-	}
-	ipClaim.OwnerReferences = newOwnerRefs
 	err = updateObject(ctx, m.client, ipClaim)
 	if err != nil {
 		return err

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -1329,8 +1329,8 @@ var _ = Describe("Metal3Data manager", func() {
 				if tc.injectDeleteErr {
 					// There was an error deleting the claim, so we expect it to still be there
 					Expect(err).To(BeNil())
-					// We expect the ownerRef to be gone
-					Expect(capm3IPClaim.OwnerReferences).To(BeEmpty())
+					// We expect the finalizer to be gone
+					Expect(capm3IPClaim.Finalizers).To(BeEmpty())
 				} else {
 					Expect(err).To(HaveOccurred())
 					Expect(apierrors.IsNotFound(err)).To(BeTrue())
@@ -1356,7 +1356,7 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			poolRef: corev1.TypedLocalObjectReference{Name: "abc"},
 		}),
-		Entry("Deletion error and ownerRef removal", testCaseReleaseAddressFromPool{
+		Entry("Deletion error and finalizer removal", testCaseReleaseAddressFromPool{
 			m3d: &infrav1.Metal3Data{
 				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
 				TypeMeta: metav1.TypeMeta{
@@ -1367,12 +1367,9 @@ var _ = Describe("Metal3Data manager", func() {
 			poolRef: corev1.TypedLocalObjectReference{Name: testPoolName},
 			ipClaim: &ipamv1.IPClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      metal3DataName + "-" + testPoolName,
-					Namespace: namespaceName,
-					OwnerReferences: []metav1.OwnerReference{{
-						Kind:       "Metal3Data",
-						APIVersion: infrav1.GroupVersion.Group + "/" + infrav1.GroupVersion.Version,
-					}},
+					Name:       metal3DataName + "-" + testPoolName,
+					Namespace:  namespaceName,
+					Finalizers: []string{infrav1.DataFinalizer},
 				},
 			},
 			injectDeleteErr: true,


### PR DESCRIPTION
**What this PR does / why we need it**:

The initial implementation for checking if an IPClaim was in use, checked the ownerRef to determine if CAPM3 was using it or not. Since this was an API change in IPAM and a bit now really what ownerRefs are for, we are reverting it and rely on finalizers instead.

Relevant PR in IPAM: https://github.com/metal3-io/ip-address-manager/pull/133
