### PR TITLE
Change order for network-data

### DIFF
--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -613,20 +613,6 @@ func renderNetworkServices(services infrav1.NetworkDataService, poolAddresses ma
 func renderNetworkLinks(networkLinks infrav1.NetworkDataLink, bmh *bmov1alpha1.BareMetalHost) ([]interface{}, error) {
 	data := []interface{}{}
 
-	// Ethernet links
-	for _, link := range networkLinks.Ethernets {
-		macAddress, err := getLinkMacAddress(link.MACAddress, bmh)
-		if err != nil {
-			return nil, err
-		}
-		data = append(data, map[string]interface{}{
-			"type":                 link.Type,
-			"id":                   link.Id,
-			"mtu":                  link.MTU,
-			"ethernet_mac_address": macAddress,
-		})
-	}
-
 	// Bond links
 	for _, link := range networkLinks.Bonds {
 		macAddress, err := getLinkMacAddress(link.MACAddress, bmh)
@@ -640,6 +626,20 @@ func renderNetworkLinks(networkLinks infrav1.NetworkDataLink, bmh *bmov1alpha1.B
 			"ethernet_mac_address": macAddress,
 			"bond_mode":            link.BondMode,
 			"bond_links":           link.BondLinks,
+		})
+	}
+
+	// Ethernet links
+	for _, link := range networkLinks.Ethernets {
+		macAddress, err := getLinkMacAddress(link.MACAddress, bmh)
+		if err != nil {
+			return nil, err
+		}
+		data = append(data, map[string]interface{}{
+			"type":                 link.Type,
+			"id":                   link.Id,
+			"mtu":                  link.MTU,
+			"ethernet_mac_address": macAddress,
 		})
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
- https://github.com/canonical/cloud-init/blob/main/cloudinit/net/network_state.py#L309-L327
- https://github.com/canonical/cloud-init/blob/main/cloudinit/sources/helpers/openstack.py#L654-L684
- Used by cloud-init to sequentially render network data for bond interfaces.
- it is necessary to change the network-data render order.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
