### PR TITLE
🌱 Improve handling of IPClaims with deletion timestamp

### DIFF
--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -153,6 +154,7 @@ func testObjectMeta(name string, namespace string, uid string) metav1.ObjectMeta
 	return metav1.ObjectMeta{
 		Name:      name,
 		Namespace: namespace,
+		UID:       types.UID(uid),
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- If the IPClaim is old (=not matching current Metal3Data), attempt to clean it up
- If the IPClaim is in use, accept it even if it has a deletion timestamp. This could happen e.g. if the user tried to delete it but the Metal3Data/Metal3Machine still exists.
