### PR TITLE
🌱 Update owners file to move inactive approvers/reviewers to emeritus and add Lennart as a reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,18 +3,20 @@
 approvers:
  - kashifest
  - furkatgofurov7
- - Xenwar
 
 reviewers:
- - namnx228
  - smoshiur1237
  - mboukhalfa
  - zhouhao3
  - adilGhaffarDev
+ - lentzi90
 
 emeritus_approvers:
  - maelk
  - fmuyassarov
+ - Xenwar
 
 emeritus_reviewers:
  - jan-est
+ - namnx228
+


### PR DESCRIPTION
This PR updates the OWNERS file to move inactive approvers/reviewers to emeritus. Also add Lennart Jern as a reviewer as he has reached the number of commits to be eligible for reviewer.