### PR TITLE
 🌱 Refactor e2e tests and add more logs

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -72,6 +72,10 @@ var (
 
 	kubeconfigPath string
 	e2eTestsPath   string
+
+	numberOfControlplane int
+	numberOfWorkers      int
+	numberOfAllBmh       int
 )
 
 func init() {
@@ -105,6 +109,9 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	By(fmt.Sprintf("Loading the e2e test configuration from %q", configPath))
 	e2eConfig = loadE2EConfig(configPath)
+	numberOfControlplane = int(*e2eConfig.GetInt32PtrVariable("CONTROL_PLANE_MACHINE_COUNT"))
+	numberOfWorkers = int(*e2eConfig.GetInt32PtrVariable("WORKER_MACHINE_COUNT"))
+	numberOfAllBmh = numberOfControlplane + numberOfWorkers
 
 	By(fmt.Sprintf("Creating a clusterctl local repository into %q", artifactFolder))
 	clusterctlConfigPath = createClusterctlLocalRepository(e2eConfig, filepath.Join(artifactFolder, "repository"))

--- a/test/e2e/live_iso_test.go
+++ b/test/e2e/live_iso_test.go
@@ -28,6 +28,7 @@ func liveIsoTest() {
 		liveISOImageURL := e2eConfig.GetVariable("LIVE_ISO_IMAGE")
 		Logf("Starting live ISO test")
 		bootstrapClient := bootstrapClusterProxy.GetClient()
+		listBareMetalHosts(ctx, bootstrapClient, client.InNamespace(namespace))
 
 		waitForNumBmhInState(ctx, bmov1alpha1.StateAvailable, waitForNumInput{
 			Client:    bootstrapClient,
@@ -66,6 +67,7 @@ func liveIsoTest() {
 			g.Expect(isoBmh.Status.Provisioning.State).To(Equal(bmov1alpha1.StateProvisioned), fmt.Sprintf("BMH %s is not in provisioned state", isoBmh.Name))
 			Logf("BMH %s is in %s state", isoBmh.Name, isoBmh.Status.Provisioning.State)
 		}, e2eConfig.GetIntervals(specName, "wait-bmh-provisioned")...).Should(Succeed())
+		listBareMetalHosts(ctx, bootstrapClient, client.InNamespace(namespace))
 
 		vmName := bmhToVMName(isoBmh)
 		serialLogFile := fmt.Sprintf("/var/log/libvirt/qemu/%s-serial0.log", vmName)

--- a/test/e2e/node_reuse_test.go
+++ b/test/e2e/node_reuse_test.go
@@ -49,6 +49,11 @@ func nodeReuse(clusterClient client.Client) {
 	Logf("NUMBER OF CONTROLPLANE BMH: %v", numberOfControlplane)
 	Logf("NUMBER OF WORKER BMH: %v", numberOfWorkers)
 
+	listBareMetalHosts(ctx, clusterClient, client.InNamespace(namespace))
+	listMetal3Machines(ctx, clusterClient, client.InNamespace(namespace))
+	listMachines(ctx, clusterClient, client.InNamespace(namespace))
+	listNodes(ctx, targetClusterClient)
+
 	By("Untaint all CP nodes before scaling down machinedeployment")
 	controlplaneNodes := getControlplaneNodes(clientSet)
 	untaintNodes(targetClusterClient, controlplaneNodes, controlplaneTaints)
@@ -188,6 +193,11 @@ func nodeReuse(clusterClient client.Client) {
 		Intervals: e2eConfig.GetIntervals(specName, "wait-machine-running"),
 	})
 
+	listBareMetalHosts(ctx, clusterClient, client.InNamespace(namespace))
+	listMetal3Machines(ctx, clusterClient, client.InNamespace(namespace))
+	listMachines(ctx, clusterClient, client.InNamespace(namespace))
+	listNodes(ctx, targetClusterClient)
+
 	By("Untaint CP nodes after upgrade of two controlplane nodes")
 	controlplaneNodes = getControlplaneNodes(clientSet)
 	untaintNodes(targetClusterClient, controlplaneNodes, controlplaneTaints)
@@ -247,6 +257,11 @@ func nodeReuse(clusterClient client.Client) {
 		Replicas:  numberOfControlplane,
 		Intervals: e2eConfig.GetIntervals(specName, "wait-cp-available"),
 	})
+
+	listBareMetalHosts(ctx, clusterClient, client.InNamespace(namespace))
+	listMetal3Machines(ctx, clusterClient, client.InNamespace(namespace))
+	listMachines(ctx, clusterClient, client.InNamespace(namespace))
+	listNodes(ctx, targetClusterClient)
 
 	By("Get MachineDeployment")
 	machineDeployments := framework.GetMachineDeploymentsByCluster(ctx, framework.GetMachineDeploymentsByClusterInput{
@@ -372,6 +387,11 @@ func nodeReuse(clusterClient client.Client) {
 	By("Check difference between before and after upgrade mappings in MachineDeployment")
 	equal = reflect.DeepEqual(mdBmhBeforeUpgrade, mdBmhAfterUpgrade)
 	Expect(equal).To(BeTrue(), "The same BMHs were not reused in MachineDeployment")
+
+	listBareMetalHosts(ctx, clusterClient, client.InNamespace(namespace))
+	listMetal3Machines(ctx, clusterClient, client.InNamespace(namespace))
+	listMachines(ctx, clusterClient, client.InNamespace(namespace))
+	listNodes(ctx, targetClusterClient)
 
 	By("Scale controlplane up to 3")
 	scaleKubeadmControlPlane(ctx, clusterClient, client.ObjectKey{Namespace: namespace, Name: clusterName}, 3)

--- a/test/e2e/pivoting_based_feature_test.go
+++ b/test/e2e/pivoting_based_feature_test.go
@@ -13,6 +13,7 @@ import (
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -59,6 +60,16 @@ var _ = Describe("Testing features in ephemeral or target cluster", func() {
 	})
 
 	AfterEach(func() {
+		Logf("Logging state of bootstrap cluster")
+		listBareMetalHosts(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		listMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		listMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		listNodes(ctx, bootstrapClusterProxy.GetClient())
+		Logf("Logging state of target cluster")
+		listBareMetalHosts(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
+		listMetal3Machines(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
+		listMachines(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
+		listNodes(ctx, targetCluster.GetClient())
 		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 	})
 

--- a/test/e2e/pivoting_based_feature_test.go
+++ b/test/e2e/pivoting_based_feature_test.go
@@ -67,8 +67,8 @@ var _ = Describe("Testing features in ephemeral or target cluster", func() {
 func createTargetCluster() (targetCluster framework.ClusterProxy) {
 	By("Creating a high available cluster")
 
-	controlPlaneMachineCount = int64(*e2eConfig.GetInt32PtrVariable("CONTROL_PLANE_MACHINE_COUNT"))
-	workerMachineCount = int64(*e2eConfig.GetInt32PtrVariable("WORKER_MACHINE_COUNT"))
+	controlPlaneMachineCount = int64(numberOfControlplane)
+	workerMachineCount = int64(numberOfWorkers)
 	result := &clusterctl.ApplyClusterTemplateAndWaitResult{}
 
 	clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{

--- a/test/e2e/pivoting_test.go
+++ b/test/e2e/pivoting_test.go
@@ -28,6 +28,11 @@ const bmoPath = "BMOPATH"
 
 func pivoting() {
 	Logf("Starting pivoting tests")
+	listBareMetalHosts(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+	listMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+	listMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+	listNodes(ctx, targetCluster.GetClient())
+
 	By("Remove Ironic containers from the source cluster")
 	ephemeralCluster := os.Getenv("EPHEMERAL_CLUSTER")
 	if ephemeralCluster == KIND {

--- a/test/e2e/remediation_based_feature_test.go
+++ b/test/e2e/remediation_based_feature_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type vmState string
@@ -59,6 +60,10 @@ var _ = Describe("Testing nodes remediation [remediation]", func() {
 	})
 
 	AfterEach(func() {
+		listBareMetalHosts(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		listMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		listMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		listNodes(ctx, targetCluster.GetClient())
 		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 	})
 

--- a/test/e2e/remediation_test.go
+++ b/test/e2e/remediation_test.go
@@ -53,6 +53,11 @@ func remediation() {
 	workerNodeName := workerMachineName
 	vmName := bmhToVMName(workerBmh)
 
+	listBareMetalHosts(ctx, bootstrapClient, client.InNamespace(namespace))
+	listMetal3Machines(ctx, bootstrapClient, client.InNamespace(namespace))
+	listMachines(ctx, bootstrapClient, client.InNamespace(namespace))
+	listNodes(ctx, targetClient)
+
 	By("Checking that rebooted node becomes Ready")
 	Logf("Marking a BMH '%s' for reboot", workerBmh.GetName())
 	annotateBmh(ctx, bootstrapClient, workerBmh, rebootAnnotation, pointer.String(""))
@@ -70,6 +75,10 @@ func remediation() {
 	By("Power cycling 2 control plane nodes")
 	powerCycle(ctx, bootstrapClient, targetClient, bmhsAndMachines[1:3], specName)
 
+	listMetal3Machines(ctx, bootstrapClient, client.InNamespace(namespace))
+	listMachines(ctx, bootstrapClient, client.InNamespace(namespace))
+	listNodes(ctx, targetClient)
+
 	By("Testing unhealthy and inspection annotations")
 	By("Scaling down KCP to 1 replica")
 	newReplicaCount := 1
@@ -81,8 +90,16 @@ func remediation() {
 		Intervals: e2eConfig.GetIntervals(specName, "wait-machine-remediation"),
 	})
 
+	listMetal3Machines(ctx, bootstrapClient, client.InNamespace(namespace))
+	listMachines(ctx, bootstrapClient, client.InNamespace(namespace))
+	listNodes(ctx, targetClient)
+
 	// Calling an inspection tests here for now until we have a parallelism enabled in e2e framework.
 	inspection()
+
+	listMetal3Machines(ctx, bootstrapClient, client.InNamespace(namespace))
+	listMachines(ctx, bootstrapClient, client.InNamespace(namespace))
+	listNodes(ctx, targetClient)
 
 	Logf("Start checking unhealthy annotation")
 	Logf("Annotating BMH as unhealthy")
@@ -104,6 +121,10 @@ func remediation() {
 		Replicas:  2,
 		Intervals: e2eConfig.GetIntervals(specName, "wait-machine-remediation"),
 	})
+
+	listMetal3Machines(ctx, bootstrapClient, client.InNamespace(namespace))
+	listMachines(ctx, bootstrapClient, client.InNamespace(namespace))
+	listNodes(ctx, targetClient)
 
 	By("Scaling up machine deployment to 3 replicas")
 	scaleMachineDeployment(ctx, bootstrapClient, clusterName, namespace, 3)
@@ -149,6 +170,10 @@ func remediation() {
 
 	By("UNHEALTHY ANNOTATION CHECK PASSED!")
 
+	listMetal3Machines(ctx, bootstrapClient, client.InNamespace(namespace))
+	listMachines(ctx, bootstrapClient, client.InNamespace(namespace))
+	listNodes(ctx, targetClient)
+
 	By("Scaling machine deployment down to 1")
 	scaleMachineDeployment(ctx, bootstrapClient, clusterName, namespace, 1)
 	By("Waiting for 2 old workers to deprovision")
@@ -158,6 +183,10 @@ func remediation() {
 		Replicas:  2,
 		Intervals: e2eConfig.GetIntervals(specName, "wait-machine-remediation"),
 	})
+
+	listMetal3Machines(ctx, bootstrapClient, client.InNamespace(namespace))
+	listMachines(ctx, bootstrapClient, client.InNamespace(namespace))
+	listNodes(ctx, targetClient)
 
 	By("Testing Metal3DataTemplate reference")
 	Logf("Creating a new Metal3DataTemplate")
@@ -225,6 +254,10 @@ func remediation() {
 		filtered := filterM3DataByReference(datas.Items, m3dataTemplateName)
 		g.Expect(filtered).To(HaveLen(1))
 	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(Succeed())
+
+	listMetal3Machines(ctx, bootstrapClient, client.InNamespace(namespace))
+	listMachines(ctx, bootstrapClient, client.InNamespace(namespace))
+	listNodes(ctx, targetClient)
 
 	By("Scaling up KCP to 3 replicas")
 	scaleKubeadmControlPlane(ctx, bootstrapClient, client.ObjectKey{Namespace: "metal3", Name: "test1"}, 3)

--- a/test/e2e/upgrade_management_cluster_test.go
+++ b/test/e2e/upgrade_management_cluster_test.go
@@ -131,6 +131,9 @@ func upgradeManagementCluster() {
 		| Pivot to run ironic/BMO and resources on target |
 		*--------------------------------------------------*/
 		By("Start pivoting")
+		listBareMetalHosts(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		listNodes(ctx, upgradeClusterClient)
+
 		By("Remove Ironic containers from the source cluster")
 		ephemeralCluster := os.Getenv("EPHEMERAL_CLUSTER")
 		if ephemeralCluster == KIND {
@@ -185,6 +188,9 @@ func upgradeManagementCluster() {
 			Intervals: e2eConfig.GetIntervals(specName, "wait-bmh-provisioned"),
 		})
 
+		listBareMetalHosts(ctx, upgradeClusterClient, client.InNamespace(namespace))
+		listNodes(ctx, upgradeClusterClient)
+
 		Logf("Apply the available BMHs CRs")
 		cmd = exec.Command("kubectl", "apply", "-f", "/opt/metal3-dev-env/bmhosts_crs.yaml", "-n", namespace, "--kubeconfig", upgradeClusterProxy.GetKubeconfigPath())
 		output, err = cmd.CombinedOutput()
@@ -198,6 +204,9 @@ func upgradeManagementCluster() {
 			Replicas:  2,
 			Intervals: e2eConfig.GetIntervals(specName, "wait-bmh-available"),
 		})
+
+		listBareMetalHosts(ctx, upgradeClusterClient, client.InNamespace(namespace))
+		listNodes(ctx, upgradeClusterClient)
 
 		/*-------------------------------*
 		| Create a test workload cluster |
@@ -255,6 +264,8 @@ func upgradeManagementCluster() {
 			}
 			g.Expect(n).To(Equal(2))
 		}, e2eConfig.GetIntervals(specName, "wait-machine-running")...).Should(Succeed())
+
+		listBareMetalHosts(ctx, upgradeClusterClient, client.InNamespace(namespace))
 
 		By("THE MANAGEMENT CLUSTER WITH OLDER VERSION OF PROVIDERS WORKS!")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extracts some of the code we are using in many places to wait for BMHs/M3Ms/Machines/Nodes into separate functions. Some other functions are also moved to common.go since they are used from multiple tests.
To make it easier to see what is going on and what the state is, it also adds some functions to print the status similar to `kubectl get nodes,machines,m3m,bmh` and adds calls to them throughout the tests.

Please note that there are 2 commits. One is for the actual refactorization and one is for adding logs. For easier review, it may make sense to look at them one at a time. If you would rather want separate PRs let me know. I can split it up.
