### PR TITLE
🐛 Fix BMOBRANCH fetching in e2e by sourcing lib/releases from dev env

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -48,6 +48,8 @@ pushd ${M3_DEV_ENV_PATH}
 make install_requirements configure_host 
 # shellcheck disable=SC1091
 source lib/common.sh
+# shellcheck disable=SC1091
+source lib/releases.sh
 clone_repos
 # The old path ends with '/..', making cp to copy the content of the directory instead of the whole one.  
 REPO_ROOT=$(realpath "$REPO_ROOT") 


### PR DESCRIPTION
After this PR https://github.com/metal3-io/metal3-dev-env/pull/1072 BMOBRANCH var is moved from lib/common.sh to lib/releases.sh. So we need to source both the files here.
