### PR TITLE
🐛 Fix e2e waiting for status

### DIFF
--- a/test/e2e/inspection_test.go
+++ b/test/e2e/inspection_test.go
@@ -4,7 +4,6 @@ import (
 	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -34,31 +33,19 @@ func inspection() {
 	}
 
 	Byf("Waiting for %d BMHs to be in Inspecting state", numberOfAvailableBMHs)
-	Eventually(func(g Gomega) error {
+	Eventually(func(g Gomega) {
 		bmhs, err := getAllBmhs(ctx, bootstrapClient, namespace, specName)
-		if err != nil {
-			Logf("Error: %v", err)
-			return err
-		}
+		g.Expect(err).NotTo(HaveOccurred())
 		inspectingBMHs := filterBmhsByProvisioningState(bmhs, bmov1alpha1.StateInspecting)
-		if len(inspectingBMHs) != numberOfAvailableBMHs {
-			return errors.Errorf("Waiting for %v BMHs to be in Inspecting state, but got %v", numberOfAvailableBMHs, len(inspectingBMHs))
-		}
-		return nil
+		g.Expect(inspectingBMHs).To(HaveLen(numberOfAvailableBMHs))
 	}, e2eConfig.GetIntervals(specName, "wait-bmh-inspecting")...).Should(Succeed())
 
 	Byf("Waiting for %d BMHs to be in Available state", numberOfAvailableBMHs)
-	Eventually(func(g Gomega) error {
+	Eventually(func(g Gomega) {
 		bmhs, err := getAllBmhs(ctx, bootstrapClient, namespace, specName)
-		if err != nil {
-			Logf("Error: %v", err)
-			return err
-		}
+		g.Expect(err).NotTo(HaveOccurred())
 		availableBMHs := filterBmhsByProvisioningState(bmhs, bmov1alpha1.StateAvailable)
-		if len(availableBMHs) != numberOfAvailableBMHs {
-			return errors.Errorf("Waiting for %v BMHs to be in Available state, but got %v", numberOfAvailableBMHs, len(availableBMHs))
-		}
-		return nil
+		g.Expect(availableBMHs).To(HaveLen(numberOfAvailableBMHs))
 	}, e2eConfig.GetIntervals(specName, "wait-bmh-available")...).Should(Succeed())
 
 	By("INSPECTION TESTS PASSED!")

--- a/test/e2e/pivoting_test.go
+++ b/test/e2e/pivoting_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -115,46 +114,31 @@ func pivoting() {
 	Expect(controlPlane).ToNot(BeNil())
 
 	By("Check if BMH is in provisioned state")
-	Eventually(func() error {
+	Eventually(func(g Gomega) {
 		bmhList := &bmov1alpha1.BareMetalHostList{}
-		if err := targetCluster.GetClient().List(ctx, bmhList, client.InNamespace(namespace)); err != nil {
-			return err
-		}
+		g.Expect(targetCluster.GetClient().List(ctx, bmhList, client.InNamespace(namespace))).To(Succeed())
 		for _, bmh := range bmhList.Items {
-			if !bmh.WasProvisioned() {
-				return errors.New("BMHs cannot be provisioned")
-			}
+			g.Expect(bmh.WasProvisioned()).To(BeTrue())
 		}
-		return nil
-	}, e2eConfig.GetIntervals(specName, "wait-object-provisioned")...).Should(BeNil())
+	}, e2eConfig.GetIntervals(specName, "wait-object-provisioned")...).Should(Succeed())
 
 	By("Check if metal3machines become ready.")
-	Eventually(func() error {
+	Eventually(func(g Gomega) {
 		m3Machines := &infrav1.Metal3MachineList{}
-		if err := targetCluster.GetClient().List(ctx, m3Machines, client.InNamespace(namespace)); err != nil {
-			return err
-		}
+		g.Expect(targetCluster.GetClient().List(ctx, m3Machines, client.InNamespace(namespace)))
 		for _, m3Machine := range m3Machines.Items {
-			if !m3Machine.Status.Ready {
-				return errors.New("Metal3Machines cannot be ready")
-			}
+			g.Expect(m3Machine.Status.Ready).To(BeTrue())
 		}
-		return nil
-	}, e2eConfig.GetIntervals(specName, "wait-object-provisioned")...).Should(BeNil())
+	}, e2eConfig.GetIntervals(specName, "wait-object-provisioned")...).Should(Succeed())
 
 	By("Check if machines become running.")
-	Eventually(func() error {
+	Eventually(func(g Gomega) {
 		machines := &clusterv1.MachineList{}
-		if err := targetCluster.GetClient().List(ctx, machines, client.InNamespace(namespace)); err != nil {
-			return err
-		}
+		g.Expect(targetCluster.GetClient().List(ctx, machines, client.InNamespace(namespace))).To(Succeed())
 		for _, machine := range machines.Items {
-			if !strings.EqualFold(machine.Status.Phase, "running") { // Case insensitive comparison
-				return errors.New("Machines cannot be in the Running state")
-			}
+			g.Expect(strings.EqualFold(machine.Status.Phase, "running")).To(BeTrue())
 		}
-		return nil
-	}, e2eConfig.GetIntervals(specName, "wait-machine-running")...).Should(BeNil())
+	}, e2eConfig.GetIntervals(specName, "wait-machine-running")...).Should(Succeed())
 
 	By("PIVOTING TESTS PASSED!")
 }
@@ -348,31 +332,21 @@ func rePivoting() {
 	}, e2eConfig.GetIntervals(specName, "wait-object-provisioned")...).Should(Succeed())
 
 	By("Check if metal3machines become ready.")
-	Eventually(func() error {
+	Eventually(func(g Gomega) {
 		m3Machines := &infrav1.Metal3MachineList{}
-		if err := bootstrapClusterProxy.GetClient().List(ctx, m3Machines, client.InNamespace(namespace)); err != nil {
-			return err
-		}
+		g.Expect(bootstrapClusterProxy.GetClient().List(ctx, m3Machines, client.InNamespace(namespace))).Should(Succeed())
 		for _, m3Machine := range m3Machines.Items {
-			if !m3Machine.Status.Ready {
-				return errors.New("Metal3Machines cannot be ready")
-			}
+			g.Expect(m3Machine.Status.Ready).To(BeTrue())
 		}
-		return nil
 	}, e2eConfig.GetIntervals(specName, "wait-object-provisioned")...).Should(Succeed())
 
 	By("Check if machines become running.")
-	Eventually(func() error {
+	Eventually(func(g Gomega) {
 		machines := &clusterv1.MachineList{}
-		if err := bootstrapClusterProxy.GetClient().List(ctx, machines, client.InNamespace(namespace)); err != nil {
-			return err
-		}
+		g.Expect(bootstrapClusterProxy.GetClient().List(ctx, machines, client.InNamespace(namespace))).Should(Succeed())
 		for _, machine := range machines.Items {
-			if !strings.EqualFold(machine.Status.Phase, "running") { // Case insensitive comparison
-				return errors.New("Machines cannot be in the Running state")
-			}
+			g.Expect(strings.EqualFold(machine.Status.Phase, "running")).To(BeTrue())
 		}
-		return nil
 	}, e2eConfig.GetIntervals(specName, "wait-machine-running")...).Should(Succeed())
 
 	By("RE-PIVOTING TEST PASSED!")


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes the flake we have been seeing in the e2e tests where it gets stuck scaling up the KCP in remediation.

In the e2e tests we often have to wait for BMHs/M3Ms/Machines to be in some specific state. In some places we had mistakenly not added any conditions to the Eventually call, or used it in a not supported way. This commit makes the use of Eventually more consistent and fixes the missing conditions.

I'm also working on a larger follow up PR for factoring out the common code and turn it into functions.