### PR TITLE
🌱 E2e: Don't print CRs in target cluster when running ephemeral test

### DIFF
--- a/test/e2e/pivoting_based_feature_test.go
+++ b/test/e2e/pivoting_based_feature_test.go
@@ -65,9 +65,11 @@ var _ = Describe("Testing features in ephemeral or target cluster", func() {
 		listMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		listNodes(ctx, bootstrapClusterProxy.GetClient())
 		Logf("Logging state of target cluster")
-		listBareMetalHosts(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
-		listMetal3Machines(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
-		listMachines(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
+		if !ephemeralTest {
+			listBareMetalHosts(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
+			listMetal3Machines(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
+			listMachines(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
+		}
 		listNodes(ctx, targetCluster.GetClient())
 		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue in the e2e ephemeral test. For the ephemeral test there are no Metal3 CRDs in the target cluster, so we should not try to print them.

