### PR TITLE
🐛 Dump target cluster resources before repivoting

### DIFF
--- a/test/e2e/pivoting_based_feature_test.go
+++ b/test/e2e/pivoting_based_feature_test.go
@@ -52,13 +52,19 @@ var _ = Describe("Testing features in ephemeral or target cluster", func() {
 		certRotation(managementCluster.GetClientSet(), managementCluster.GetClient())
 		nodeReuse(managementCluster.GetClient())
 
-		if !ephemeralTest {
-			rePivoting()
-		}
-
 	})
 
 	AfterEach(func() {
+		if !ephemeralTest {
+			// Dump the target cluster resources before re-pivoting.
+			framework.DumpAllResources(ctx, framework.DumpAllResourcesInput{
+				Lister:    targetCluster.GetClient(),
+				Namespace: namespace,
+				LogPath:   filepath.Join(artifactFolder, "clusters", clusterName, "resources"),
+			})
+
+			rePivoting()
+		}
 		Logf("Logging state of bootstrap cluster")
 		listBareMetalHosts(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		listMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))


### PR DESCRIPTION
**What this PR does / why we need it**:
When tests fail after pivoting we are missing the resource from the target cluster in the tar ball this PR fix this issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
