### PR TITLE
🐛 Fix overriding OS env var from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,9 @@ RBAC_ROOT ?= $(MANIFEST_ROOT)/rbac
 # Allow overriding the imagePullPolicy
 PULL_POLICY ?= IfNotPresent
 
-OS := linux
+ENVTEST_OS := linux
 ifeq ($(shell uname -s), Darwin)
-	OS := darwin
+	ENVTEST_OS := darwin
 endif
 ARCH ?= amd64
 
@@ -101,7 +101,7 @@ help:  ## Display this help
 
 .PHONY: unit
 unit: $(SETUP_ENVTEST) ## Run unit test
-	source <($(SETUP_ENVTEST) use -p env --os $(OS) --arch $(ARCH) $(ENVTEST_K8S_VERSION)); \
+	source <($(SETUP_ENVTEST) use -p env --os $(ENVTEST_OS) --arch $(ARCH) $(ENVTEST_K8S_VERSION)); \
 	go test ./controllers/... ./baremetal/... \
 		-ginkgo.noColor=$(GINKGO_NOCOLOR) \
 		$(GO_TEST_FLAGS) \


### PR DESCRIPTION
**What this PR does / why we need it**:
Seems like #758 has overridden the OS var exported for e2e test here https://github.com/metal3-io/cluster-api-provider-metal3/blob/9db40bfee4ea49ffba46c47235d51ef719a385ff/test/e2e/pivoting_based_feature_test.go#L35

Jenkins logs main e2e test : https://jenkins.nordix.org/view/Metal3%20Periodic/job/metal3_daily_main_e2e_test_centos/117/console