### PR TITLE
🌱 Use latest k8s version instead of previous minor version for e2e tests

### DIFF
--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -49,8 +49,8 @@ else
 fi
 
 export FROM_K8S_VERSION="v1.24.1"
-export KUBERNETES_VERSION=${FROM_K8S_VERSION}
-export UPGRADED_K8S_VERSION="v1.25.2"
+export KUBERNETES_VERSION="v1.25.2"
+
 # Can be overriden from jjbs
 export CAPI_VERSION=${CAPI_VERSION:-"v1beta1"}
 export CAPM3_VERSION=${CAPM3_VERSION:-"v1beta1"}
@@ -62,16 +62,7 @@ export PATH=$PATH:$HOME/.krew/bin
 # Upgrade test environment vars and config
 if [[ ${GINKGO_FOCUS:-} == "upgrade" ]]; then
   export NUM_NODES=${NUM_NODES:-"5"}
-  export FROM_K8S_VERSION="v1.23.8"
-  export KUBERNETES_VERSION=${FROM_K8S_VERSION}
-fi
-
-if [[ "${IMAGE_OS}" == "ubuntu" ]]; then
-  export UPGRADED_IMAGE_NAME="UBUNTU_22.04_NODE_IMAGE_K8S_${UPGRADED_K8S_VERSION}.qcow2"
-  export UPGRADED_RAW_IMAGE_NAME="UBUNTU_22.04_NODE_IMAGE_K8S_${UPGRADED_K8S_VERSION}-raw.img"
-else
-  export UPGRADED_IMAGE_NAME="CENTOS_9_NODE_IMAGE_K8S_${UPGRADED_K8S_VERSION}.qcow2"
-  export UPGRADED_RAW_IMAGE_NAME="CENTOS_9_NODE_IMAGE_K8S_${UPGRADED_K8S_VERSION}-raw.img"
+  export KUBERNETES_VERSION="v1.23.8"
 fi
 
 # Exported to the cluster templates

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -108,11 +108,10 @@ providers:
 
 variables:
   CNI: "/tmp/calico.yaml"
+  KUBERNETES_VERSION: "v1.25.2"
   # INIT_WITH_KUBERNETES_VERSION will be used here
   # https://github.com/kubernetes-sigs/cluster-api/blob/bb377163f141d69b7a61479756ee96891f6670bd/test/e2e/clusterctl_upgrade.go#L170
-  INIT_WITH_KUBERNETES_VERSION: "v1.23.8"
-  KUBERNETES_VERSION: "v1.25.2"
-  UPGRADED_K8S_VERSION: "v1.25.2"
+  INIT_WITH_KUBERNETES_VERSION: ${KUBERNETES_VERSION}
   CONTROL_PLANE_MACHINE_COUNT: 3
   WORKER_MACHINE_COUNT: 1
   APIVersion: "infrastructure.cluster.x-k8s.io/${CAPM3_VERSION}"

--- a/test/e2e/remediation_based_feature_test.go
+++ b/test/e2e/remediation_based_feature_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Testing nodes remediation [remediation]", func() {
 
 	It("Should create a cluster and and run remediation based tests", func() {
 		By("Creating target cluster")
-		targetCluster = createTargetCluster()
+		targetCluster = createTargetCluster(e2eConfig.GetVariable("KUBERNETES_VERSION"))
 
 		// Run Metal3Remediation test first, doesn't work after remediation...
 		By("Running Metal3Remediation tests")

--- a/test/e2e/upgrade_management_cluster_test.go
+++ b/test/e2e/upgrade_management_cluster_test.go
@@ -20,7 +20,9 @@ var _ = Describe("When testing cluster upgrade v1alpha5 > current [upgrade]", fu
 		osType := strings.ToLower(os.Getenv("OS"))
 		Expect(osType).ToNot(Equal(""))
 		validateGlobals(specName)
-
+		imageURL, imageChecksum := ensureImage(e2eConfig.GetVariable("INIT_WITH_KUBERNETES_VERSION"))
+		os.Setenv("IMAGE_RAW_CHECKSUM", imageChecksum)
+		os.Setenv("IMAGE_RAW_URL", imageURL)
 		// We need to override clusterctl apply log folder to avoid getting our credentials exposed.
 		clusterctlLogFolder = filepath.Join(os.TempDir(), "clusters", bootstrapClusterProxy.GetName())
 	})


### PR DESCRIPTION
Co-authored-by: Kashif Khan <kashif.khan@est.tech>

**What this PR does / why we need it**:
For now all e2e test use the previous minor version as default k8s version instead of the latest.

This PR refactor e2e to use the latest k8s version for all the test except tests that require an old version like `clusterctl upgrade` from `v1alpha5` that requires k8s `v1.23.8` or `nodeReuse` that does k8s upgrade from the previous minor version to the latest
