### PR TITLE
🌱 remove ginkgo failFast when running e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ e2e-tests: e2e-substitutions cluster-templates ## This target should be called f
 		$(CONTAINER_RUNTIME) pull $$image; \
 	done
 	time go test -v -timeout 24h -tags=e2e ./test/e2e/... -args \
-		-ginkgo.timeout=6h -ginkgo.v -ginkgo.trace -ginkgo.progress -ginkgo.failFast -ginkgo.noColor=$(GINKGO_NOCOLOR) \
+		-ginkgo.timeout=6h -ginkgo.v -ginkgo.trace -ginkgo.progress -ginkgo.noColor=$(GINKGO_NOCOLOR) \
 		-ginkgo.focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) \
 		-e2e.artifacts-folder="$(ARTIFACTS)" \
 		-e2e.config="$(E2E_CONF_FILE_ENVSUBST)" \


### PR DESCRIPTION
This PR removes `failfast` so we will run all the tests even when a spec fails in the middle. `failfast` was introduced because when the test fail in pivoting all the next tests were get failed which should be fixed by https://github.com/metal3-io/cluster-api-provider-metal3/pull/759