### PR TITLE
🐛  Fix body_path in the release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ name: release
 
 jobs:
   build:
+    name: tag release
     runs-on: ubuntu-latest
     steps:
       - name: Export RELEASE_TAG var
@@ -28,4 +29,4 @@ jobs:
         with:
           draft: true
           files: out/*
-          body_path: releasenotes/releasenotes.md
+          body_path: releasenotes/${{ env.RELEASE_TAG }}.md


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/metal3-io/cluster-api-provider-metal3/pull/781/commits/834790ada9d15291ca8e447f2c3464ffc3173acd changed the path to put release notes under releasenotes folder from  `$(RELEASE_NOTES_DIR)/releasenotes.md` to `$(RELEASE_NOTES_DIR)/$(RELEASE_TAG).md`  thus leaving release.yaml file with old path. This should fix that path issue.
