### PR TITLE
🌱 Add SkipCRDNamePreflightCheckAnnotation to Metal3Data CRD

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -44,6 +44,10 @@ patchesStrategicMerge:
 - patches/cainjection_in_metal3remediationtemplates.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
+# [ANNOTATION] To add CRD name check skip, uncomment the section with [ANNOTATION] prefix.
+# patch here is for adding an annotation for specific CRD (Metal3Data)
+- patches/skipcrdnamecheck_in_metal3datas.yaml
+
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml

--- a/config/crd/patches/skipcrdnamecheck_in_metal3datas.yaml
+++ b/config/crd/patches/skipcrdnamecheck_in_metal3datas.yaml
@@ -1,0 +1,10 @@
+# The following patch adds "clusterctl.cluster.x-k8s.io/skip-crd-name-preflight-check" 
+# CAPI annotation for clusterctl to inject annotation into the CRD. See more why this is needed
+# here: https://github.com/kubernetes-sigs/cluster-api/issues/5686#issuecomment-1238255937
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    clusterctl.cluster.x-k8s.io/skip-crd-name-preflight-check: ""
+  name: metal3datas.infrastructure.cluster.x-k8s.io


### PR DESCRIPTION
**What this PR does / why we need it**:

CAPI v1.3.X minor release is introducing a CRD name check and `clusterctl` will emit a warning for provider CRDs which don't comply with the CRD naming conventions. This warning can be skipped for resources not referenced by Cluster API core resources via the `clusterctl.cluster.x-k8s.io/skip-crd-name-preflight-check` annotation. The contracts specify:
```
 > The CRD name must have the format produced by sigs.k8s.io/cluster-api/util/contract.CalculateCRDName(Group, Kind)
 ```
 This PR makes sure that proper annotation is added to the metal3datas CRD using the kustomize patches, to avoid getting a warning when running `clusterctl init` with new v1.3.X CAPI minor releases.
  
xref: https://github.com/kubernetes-sigs/cluster-api/pull/7506#discussion_r1015544695

