### PR TITLE
✨ Support namespace in Metal3Machine's HostSelector

### DIFF
--- a/api/v1alpha5/common_types.go
+++ b/api/v1alpha5/common_types.go
@@ -43,6 +43,11 @@ type HostSelector struct {
 
 	// Label match expressions that must be true on a chosen BareMetalHost
 	MatchExpressions []HostSelectorRequirement `json:"matchExpressions,omitempty"`
+
+	// Namespace where to look for BareMetalHosts. If empty, look for
+	// BareMetalHosts in the namespace of Metal3Machine
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
 }
 
 type HostSelectorRequirement struct {

--- a/api/v1alpha5/metal3machine_types.go
+++ b/api/v1alpha5/metal3machine_types.go
@@ -45,9 +45,9 @@ type Metal3MachineSpec struct {
 	// namespace if not specified.
 	UserData *corev1.SecretReference `json:"userData,omitempty"`
 
-	// HostSelector specifies matching criteria for labels on BareMetalHosts.
-	// This is used to limit the set of BareMetalHost objects considered for
-	// claiming for a metal3machine.
+	// HostSelector specifies matching criteria for labels and namespace on
+	// BareMetalHosts. This is used to limit the set of BareMetalHost objects
+	// considered for claiming for a metal3machine.
 	HostSelector HostSelector `json:"hostSelector,omitempty"`
 
 	// MetadataTemplate is a reference to a Metal3DataTemplate object containing

--- a/api/v1alpha5/zz_generated.conversion.go
+++ b/api/v1alpha5/zz_generated.conversion.go
@@ -753,6 +753,7 @@ func Convert_v1beta1_FromPool_To_v1alpha5_FromPool(in *v1beta1.FromPool, out *Fr
 func autoConvert_v1alpha5_HostSelector_To_v1beta1_HostSelector(in *HostSelector, out *v1beta1.HostSelector, s conversion.Scope) error {
 	out.MatchLabels = *(*map[string]string)(unsafe.Pointer(&in.MatchLabels))
 	out.MatchExpressions = *(*[]v1beta1.HostSelectorRequirement)(unsafe.Pointer(&in.MatchExpressions))
+	out.Namespace = in.Namespace
 	return nil
 }
 
@@ -764,6 +765,7 @@ func Convert_v1alpha5_HostSelector_To_v1beta1_HostSelector(in *HostSelector, out
 func autoConvert_v1beta1_HostSelector_To_v1alpha5_HostSelector(in *v1beta1.HostSelector, out *HostSelector, s conversion.Scope) error {
 	out.MatchLabels = *(*map[string]string)(unsafe.Pointer(&in.MatchLabels))
 	out.MatchExpressions = *(*[]HostSelectorRequirement)(unsafe.Pointer(&in.MatchExpressions))
+	out.Namespace = in.Namespace
 	return nil
 }
 

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -51,6 +51,11 @@ type HostSelector struct {
 	// Label match expressions that must be true on a chosen BareMetalHost
 	// +optional
 	MatchExpressions []HostSelectorRequirement `json:"matchExpressions,omitempty"`
+
+	// Namespace where to look for BareMetalHosts. If empty, look for
+	// BareMetalHosts in the namespace of Metal3Machine
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
 }
 
 type HostSelectorRequirement struct {

--- a/api/v1beta1/metal3machine_types.go
+++ b/api/v1beta1/metal3machine_types.go
@@ -49,9 +49,9 @@ type Metal3MachineSpec struct {
 	// +optional
 	UserData *corev1.SecretReference `json:"userData,omitempty"`
 
-	// HostSelector specifies matching criteria for labels on BareMetalHosts.
-	// This is used to limit the set of BareMetalHost objects considered for
-	// claiming for a metal3machine.
+	// HostSelector specifies matching criteria for labels and namespace on
+	// BareMetalHosts. This is used to limit the set of BareMetalHost objects
+	// considered for claiming for a metal3machine.
 	// +optional
 	HostSelector HostSelector `json:"hostSelector,omitempty"`
 

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -850,9 +850,13 @@ func getHost(ctx context.Context, m3Machine *infrav1.Metal3Machine, cl client.Cl
 func (m *MachineManager) chooseHost(ctx context.Context) (*bmov1alpha1.BareMetalHost, *patch.Helper, error) {
 	// get list of BMH.
 	hosts := bmov1alpha1.BareMetalHostList{}
+
 	// without this ListOption, all namespaces would be including in the listing.
 	opts := &client.ListOptions{
 		Namespace: m.Metal3Machine.Namespace,
+	}
+	if m.Metal3Machine.Spec.HostSelector.Namespace != "" {
+		opts.Namespace = m.Metal3Machine.Spec.HostSelector.Namespace
 	}
 
 	err := m.client.List(ctx, &hosts, opts)
@@ -934,11 +938,11 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmov1alpha1.BareMetal
 				default:
 					continue
 				}
-				m.Log.Info("Host matched hostSelector for Metal3Machine, adding it to availableHosts list", "host", host.Name)
+				m.Log.Info("Host matched hostSelector for Metal3Machine, adding it to availableHosts list", "host", host.Name, "namespace", host.Namespace)
 				availableHosts = append(availableHosts, &hosts.Items[i])
 			}
 		} else {
-			m.Log.Info("Host did not match hostSelector for Metal3Machine", "host", host.Name)
+			m.Log.Info("Host did not match hostSelector for Metal3Machine", "host", host.Name, "namespace", host.Namespace)
 		}
 	}
 

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -615,6 +615,9 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			}, "",
 		)
+		m3mconfig6, infrastructureRef6 := newConfig("",
+			map[string]string{"key1": "value1"}, []infrav1.HostSelectorRequirement{}, namespaceName,
+		)
 
 		type testCaseChooseHost struct {
 			Machine          *clusterv1.Machine
@@ -815,6 +818,12 @@ var _ = Describe("Metal3Machine manager", func() {
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*availableHost, hostWithLabel, hostWithOtherConsRef}},
 				M3Machine:        m3mconfig5,
 				ExpectedHostName: "",
+			}),
+			Entry("Pick host with non-empty namespace selector", testCaseChooseHost{
+				Machine:          newMachine(machineName, "", infrastructureRef6),
+				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithLabel, *availableHost}},
+				M3Machine:        m3mconfig6,
+				ExpectedHostName: hostWithLabel.Name,
 			}),
 		)
 	})

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -589,13 +589,13 @@ var _ = Describe("Metal3Machine manager", func() {
 		}
 
 		m3mconfig, infrastructureRef := newConfig("", map[string]string{},
-			[]infrav1.HostSelectorRequirement{},
+			[]infrav1.HostSelectorRequirement{}, "",
 		)
 		m3mconfig2, infrastructureRef2 := newConfig("",
-			map[string]string{"key1": "value1"}, []infrav1.HostSelectorRequirement{},
+			map[string]string{"key1": "value1"}, []infrav1.HostSelectorRequirement{}, "",
 		)
 		m3mconfig3, infrastructureRef3 := newConfig("",
-			map[string]string{"boguskey": "value"}, []infrav1.HostSelectorRequirement{},
+			map[string]string{"boguskey": "value"}, []infrav1.HostSelectorRequirement{}, "",
 		)
 		m3mconfig4, infrastructureRef4 := newConfig("", map[string]string{},
 			[]infrav1.HostSelectorRequirement{
@@ -604,7 +604,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					Operator: "in",
 					Values:   []string{"abc", "value1", "123"},
 				},
-			},
+			}, "",
 		)
 		m3mconfig5, infrastructureRef5 := newConfig("", map[string]string{},
 			[]infrav1.HostSelectorRequirement{
@@ -613,7 +613,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					Operator: "pancakes",
 					Values:   []string{"abc", "value1", "123"},
 				},
-			},
+			}, "",
 		)
 
 		type testCaseChooseHost struct {
@@ -1050,7 +1050,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			fakeClient := fake.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(tc.Host).Build()
 
 			m3mconfig, infrastructureRef := newConfig(tc.UserDataNamespace,
-				map[string]string{}, []infrav1.HostSelectorRequirement{},
+				map[string]string{}, []infrav1.HostSelectorRequirement{}, "",
 			)
 			machine := newMachine(machineName, "", infrastructureRef)
 
@@ -1139,7 +1139,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			fakeClient := fake.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(tc.Host).Build()
 
 			m3mconfig, infrastructureRef := newConfig(tc.UserDataNamespace,
-				map[string]string{}, []infrav1.HostSelectorRequirement{},
+				map[string]string{}, []infrav1.HostSelectorRequirement{}, "",
 			)
 			machine := newMachine(machineName, "", infrastructureRef)
 
@@ -4643,7 +4643,7 @@ func setupSchemeMm() *runtime.Scheme {
 
 func newConfig(userDataNamespace string,
 	labels map[string]string, reqs []infrav1.HostSelectorRequirement,
-) (*infrav1.Metal3Machine, *corev1.ObjectReference) {
+	namespaceSelector string) (*infrav1.Metal3Machine, *corev1.ObjectReference) {
 	config := infrav1.Metal3Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespaceName,
@@ -4661,6 +4661,7 @@ func newConfig(userDataNamespace string,
 			HostSelector: infrav1.HostSelector{
 				MatchLabels:      labels,
 				MatchExpressions: reqs,
+				Namespace:        namespaceSelector,
 			},
 		},
 		Status: infrav1.Metal3MachineStatus{

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -819,7 +819,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				M3Machine:        m3mconfig5,
 				ExpectedHostName: "",
 			}),
-			Entry("Pick host with non-empty namespace selector", testCaseChooseHost{
+			Entry("Pick host using non-empty namespace selector", testCaseChooseHost{
 				Machine:          newMachine(machineName, "", infrastructureRef6),
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithLabel, *availableHost}},
 				M3Machine:        m3mconfig6,

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machines.yaml
@@ -469,9 +469,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               hostSelector:
-                description: HostSelector specifies matching criteria for labels on
-                  BareMetalHosts. This is used to limit the set of BareMetalHost objects
-                  considered for claiming for a metal3machine.
+                description: HostSelector specifies matching criteria for labels and
+                  namespace on BareMetalHosts. This is used to limit the set of BareMetalHost
+                  objects considered for claiming for a metal3machine.
                 properties:
                   matchExpressions:
                     description: Label match expressions that must be true on a chosen
@@ -501,6 +501,10 @@ spec:
                     description: Key/value pairs of labels that must exist on a chosen
                       BareMetalHost
                     type: object
+                  namespace:
+                    description: Namespace where to look for BareMetalHosts. If empty,
+                      look for BareMetalHosts in the namespace of Metal3Machine
+                    type: string
                 type: object
               image:
                 description: Image is the image to be provisioned.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machines.yaml
@@ -112,9 +112,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               hostSelector:
-                description: HostSelector specifies matching criteria for labels on
-                  BareMetalHosts. This is used to limit the set of BareMetalHost objects
-                  considered for claiming for a metal3machine.
+                description: HostSelector specifies matching criteria for labels and
+                  namespace on BareMetalHosts. This is used to limit the set of BareMetalHost
+                  objects considered for claiming for a metal3machine.
                 properties:
                   matchExpressions:
                     description: Label match expressions that must be true on a chosen
@@ -144,6 +144,10 @@ spec:
                     description: Key/value pairs of labels that must exist on a chosen
                       BareMetalHost
                     type: object
+                  namespace:
+                    description: Namespace where to look for BareMetalHosts. If empty,
+                      look for BareMetalHosts in the namespace of Metal3Machine
+                    type: string
                 type: object
               image:
                 description: Image is the image to be provisioned.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machinetemplates.yaml
@@ -325,8 +325,9 @@ spec:
                         x-kubernetes-map-type: atomic
                       hostSelector:
                         description: HostSelector specifies matching criteria for
-                          labels on BareMetalHosts. This is used to limit the set
-                          of BareMetalHost objects considered for claiming for a metal3machine.
+                          labels and namespace on BareMetalHosts. This is used to
+                          limit the set of BareMetalHost objects considered for claiming
+                          for a metal3machine.
                         properties:
                           matchExpressions:
                             description: Label match expressions that must be true
@@ -356,6 +357,11 @@ spec:
                             description: Key/value pairs of labels that must exist
                               on a chosen BareMetalHost
                             type: object
+                          namespace:
+                            description: Namespace where to look for BareMetalHosts.
+                              If empty, look for BareMetalHosts in the namespace of
+                              Metal3Machine
+                            type: string
                         type: object
                       image:
                         description: Image is the image to be provisioned.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machinetemplates.yaml
@@ -112,8 +112,9 @@ spec:
                         x-kubernetes-map-type: atomic
                       hostSelector:
                         description: HostSelector specifies matching criteria for
-                          labels on BareMetalHosts. This is used to limit the set
-                          of BareMetalHost objects considered for claiming for a metal3machine.
+                          labels and namespace on BareMetalHosts. This is used to
+                          limit the set of BareMetalHost objects considered for claiming
+                          for a metal3machine.
                         properties:
                           matchExpressions:
                             description: Label match expressions that must be true
@@ -143,6 +144,11 @@ spec:
                             description: Key/value pairs of labels that must exist
                               on a chosen BareMetalHost
                             type: object
+                          namespace:
+                            description: Namespace where to look for BareMetalHosts.
+                              If empty, look for BareMetalHosts in the namespace of
+                              Metal3Machine
+                            type: string
                         type: object
                       image:
                         description: Image is the image to be provisioned.

--- a/docs/api.md
+++ b/docs/api.md
@@ -287,9 +287,9 @@ The fields are:
   follows the format definition that can be found
   [here](https://docs.openstack.org/nova/latest/_downloads/9119ca7ac90aa2990e762c08baea3a36/network_data.json).
 
-* **hostSelector** -- Specify criteria for matching labels on `BareMetalHost`
-  objects. This can be used to limit the set of available `BareMetalHost`
-  objects chosen for this `Machine`.
+* **hostSelector** -- Specify criteria for matching labels and namespace on
+  `BareMetalHost` objects. This can be used to limit the set of available
+  `BareMetalHost` objects chosen for this `Machine`.
 
 * **automatedCleaningMode** -- An interface to enable or disable Ironic automated cleaning during provisioning
   or deprovisioning of a host. When set to `disabled`, automated cleaning will be skipped, where
@@ -327,12 +327,15 @@ the generated Metal3Data object and the secrets generated for this machine.
 
 ### hostSelector Examples
 
-The `hostSelector field has two possible optional sub-fields:
+The `hostSelector field has three possible optional sub-fields:
 
 * **matchLabels** -- Key/value pairs of labels that must match exactly.
 
 * **matchExpressions** -- A set of expressions that must evaluate to true for
   the labels on a `BareMetalHost`.
+
+* **namespace** -- Namespace where to look for BareMetalHosts. If empty, look
+  for BareMetalHosts in the namespace of Metal3Machine
 
 Valid operators include:
 
@@ -389,7 +392,7 @@ spec:
             values: [‘a’, ‘b’, ‘c’]
 ```
 
-Example 3: Only consider `BareMetalHost` with `key1` set to `value1` AND `key2`
+Example 4: Only consider `BareMetalHost` with `key1` set to `value1` AND `key2`
 set to `value2` AND `key3` set to either `a`, `b`, or `c`.
 
 ```yaml
@@ -404,6 +407,19 @@ spec:
           - key: key3
             operator: in
             values: [‘a’, ‘b’, ‘c’]
+```
+
+Example 5: Only consider `BareMetalHost` with label `key1` set to `value1`
+located in namespace `my-bmh-ns`
+
+```yaml
+spec:
+  providerSpec:
+    value:
+      hostSelector:
+        matchLabels:
+          key1: value1
+        namespace: my-bmh-ns
 ```
 
 ### Metal3Machine example


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds support for `namespace` field in a `HostSelector` of `Metal3Machine` and `Metal3MachineTemplate` CRDs.

Short discussion about this feature was in [this Slack thread](https://kubernetes.slack.com/archives/CHD49TLE7/p1669736106751629).

cc. @jsen- and @schrej 

## Motivation

In case each `CAPI`/`Metal3` cluster (or tenant) is located in a dedicated namespace - it is not possible to have a shared pool of BMHs among those clusters.

This feature will allow to pick `BareMetalHosts` (BMHs) from different namespace than namespace of a `Metal3Machine` (or `Cluster` namespace). With namespace selection feature each cluster (or tenant) can be isolated in a dedicated namespace and reference BMHs from different namespace in which they can be pre-provisioned. 

Signed-off-by: Ondrej Vasko <ondrej.vaskoo@gmail.com>