### PR TITLE
🐛hack: download latest CAPI for tilt

### DIFF
--- a/hack/gen_tilt_settings.sh
+++ b/hack/gen_tilt_settings.sh
@@ -25,7 +25,8 @@ function get_latest_release() {
     release="$(curl -H "Authorization: token ${GITHUB_TOKEN}" -sL "${1}")" || ( set -x && exit 1 )
   fi
   # This gets the latest release as vx.y.z or vx.y.z-rc.0, including any version with a suffix starting with - , for example -rc.0
-  release_tag="$(echo "$release" | jq -r "[.[].tag_name | select( startswith(\"${2:-""}\"))] | max ")"
+  # This relies on the order of the Github release page + select filter
+  release_tag="$(echo "$release" | jq -r "[.[].tag_name | select( startswith(\"${2:-}\"))] | .[0]")"
 
   if [[ "$release_tag" == "null" ]]; then
     set -x


### PR DESCRIPTION
This logic change matches metal3-dev-env PR#1118.

Rely on Github's release order + prefix filter, instead of jq's max() which sorts v1.3.0-rc1 as newer than v1.3.0, which is wrong for the versioning convention we use.

/assign furkatgofurov7