### PR TITLE
🌱 Add integration test to e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,7 @@ _SKIP_ARGS := $(foreach arg,$(strip $(GINKGO_SKIP)),-ginkgo.skip="$(arg)")
 endif
 .PHONY: e2e-tests
 e2e-tests: CONTAINER_RUNTIME?=docker ## Env variable can override this default
+export CONTAINER_RUNTIME
 e2e-tests: e2e-substitutions cluster-templates ## This target should be called from scripts/ci-e2e.sh
 	for image in $(E2E_CONTAINERS); do \
 		$(CONTAINER_RUNTIME) pull $$image; \

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -64,6 +64,13 @@ if [[ ${GINKGO_FOCUS:-} == "upgrade" ]]; then
   export NUM_NODES=${NUM_NODES:-"5"}
 fi
 
+# Integration test environment vars and config
+if [[ ${GINKGO_FOCUS:-} == "integration" ]]; then
+  export NUM_NODES=${NUM_NODES:-"2"}
+  export CONTROL_PLANE_MACHINE_COUNT=${CONTROL_PLANE_MACHINE_COUNT:-"1"}
+  export WORKER_MACHINE_COUNT=${WORKER_MACHINE_COUNT:-"1"}
+fi
+
 # Exported to the cluster templates
 # Generate user ssh key
 if [ ! -f "${HOME}/.ssh/id_rsa" ]; then

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -38,6 +38,8 @@ const (
 	artifactoryURL         = "https://artifactory.nordix.org/artifactory/metal3/images/k8s"
 	imagesURL              = "http://172.22.0.1/images"
 	ironicImageDir         = "/opt/metal3-dev-env/ironic/html/images"
+	osTypeCentos           = "centos"
+	osTypeUbuntu           = "ubuntu"
 )
 
 func Byf(format string, a ...interface{}) {
@@ -106,9 +108,9 @@ func DumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterPr
 
 func EnsureImage(k8sVersion string) (imageURL string, imageChecksum string) {
 	osType := strings.ToLower(os.Getenv("OS"))
-	Expect(osType).To(BeElementOf([]string{"ubuntu", "centos"}))
+	Expect(osType).To(BeElementOf([]string{osTypeUbuntu, osTypeCentos}))
 	imageNamePrefix := "CENTOS_9_NODE_IMAGE_K8S"
-	if osType != "centos" {
+	if osType != osTypeCentos {
 		imageNamePrefix = "UBUNTU_22.04_NODE_IMAGE_K8S"
 	}
 	imageName := fmt.Sprintf("%s_%s.qcow2", imageNamePrefix, k8sVersion)

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -179,3 +179,4 @@ intervals:
   default/wait-machine-running: ["50m", "20s"]
   default/wait-bmh-provisioned: ["50m", "20s"]
   default/wait-pod-restart: ["6m", "10s"]
+  default/wait-deprovision-cluster: ["30m", "10s"]

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -101,6 +101,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	// Before all ParallelNodes.
 
 	Expect(configPath).To(BeAnExistingFile(), "Invalid test suite argument. e2e.config should be an existing file.")
+	Expect(os.RemoveAll(artifactFolder)).To(Succeed())
 	Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid test suite argument. Can't create e2e.artifacts-folder %q", artifactFolder)
 
 	By("Initializing a runtime.Scheme with all the GVK relevant for this test")

--- a/test/e2e/integration.go
+++ b/test/e2e/integration.go
@@ -1,0 +1,40 @@
+package e2e
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func createDirIfNotExist(dirPath string) {
+	err := os.MkdirAll(dirPath, 0750)
+	if err != nil && os.IsNotExist(err) {
+		log.Fatal(err)
+	}
+}
+
+func fetchContainerLogs(containerNames *[]string) {
+	By("Create directories and storing container logs")
+	for _, name := range *containerNames {
+		containerRuntime := e2eConfig.GetVariable("CONTAINER_RUNTIME")
+		logDir := filepath.Join(artifactFolder, containerRuntime, name)
+		By(fmt.Sprintf("Create log directory for container %s at %s", name, logDir))
+		createDirIfNotExist(logDir)
+		By(fmt.Sprintf("Fetch logs for container %s", name))
+		cmd := exec.Command("sudo", containerRuntime, "logs", name) // #nosec G204:gosec
+		out, err := cmd.Output()
+		if err != nil {
+			writeErr := os.WriteFile(filepath.Join(logDir, "stderr.log"), []byte(err.Error()), 0444)
+			Expect(writeErr).ToNot(HaveOccurred())
+			log.Fatal(err)
+		}
+		writeErr := os.WriteFile(filepath.Join(logDir, "stdout.log"), out, 0444)
+		Expect(writeErr).ToNot(HaveOccurred())
+	}
+}
+

--- a/test/e2e/integration_test.go
+++ b/test/e2e/integration_test.go
@@ -1,0 +1,71 @@
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/cluster-api/test/framework"
+)
+
+var _ = Describe("When testing integration [integration]", func() {
+	It("CI Test Provision", func() {
+		numberOfWorkers       = int(*e2eConfig.GetInt32PtrVariable("WORKER_MACHINE_COUNT"))
+		numberOfControlplane = int(*e2eConfig.GetInt32PtrVariable("CONTROL_PLANE_MACHINE_COUNT"))
+		k8sVersion := e2eConfig.GetVariable("KUBERNETES_VERSION")
+		By("Provision Workload cluster")
+		targetCluster, result := createTargetCluster(k8sVersion)
+		By("Pivot objects to target cluster")
+		pivoting(ctx, func() PivotingInput {
+			return PivotingInput{
+				E2EConfig:             e2eConfig,
+				BootstrapClusterProxy: bootstrapClusterProxy,
+				TargetCluster:         targetCluster,
+				SpecName:              specName,
+				ClusterName:           clusterName,
+				Namespace:             namespace,
+				ArtifactFolder:        artifactFolder,
+				ClusterctlConfigPath:  clusterctlConfigPath,
+			}
+		})
+		By("Repivot objects to the source cluster")
+		rePivoting(ctx, func() RePivotingInput {
+			return RePivotingInput{
+				E2EConfig:             e2eConfig,
+				BootstrapClusterProxy: bootstrapClusterProxy,
+				TargetCluster:         targetCluster,
+				SpecName:              specName,
+				ClusterName:           clusterName,
+				Namespace:             namespace,
+				ArtifactFolder:        artifactFolder,
+				ClusterctlConfigPath:  clusterctlConfigPath,
+			}
+		})
+		By("Deprovision target cluster")
+		bootstrapClient := bootstrapClusterProxy.GetClient()
+		intervals := e2eConfig.GetIntervals(specName, "wait-deprovision-cluster")
+		// In pivoting step we labeled the BMO CRDs (so that the objects are moved 
+		// by CAPI pivoting feature), which made CAPI DeleteClusterAndWait()
+		// fail as it has a check to make sure all resources managed by CAPI
+		// is gone after Cluster deletion. Therefore, we opted not to use
+		// DeleteClusterAndWait(), but only delete the cluster and then wait 
+		// for it to be deleted.
+		framework.DeleteCluster(ctx, framework.DeleteClusterInput{
+			Deleter: bootstrapClient,
+			Cluster: result.Cluster,
+		})
+		Logf("Waiting for the Cluster object to be deleted")
+		framework.WaitForClusterDeleted(ctx, framework.WaitForClusterDeletedInput{
+			Getter: bootstrapClient,
+			Cluster: result.Cluster,
+		}, intervals...)
+		numberOfAvailableBMHs := numberOfWorkers + numberOfControlplane
+		intervals = e2eConfig.GetIntervals(specName, "wait-bmh-deprovisioning-available")
+		WaitForNumBmhInState(ctx, bmov1alpha1.StateAvailable, WaitForNumInput{
+			Client:    bootstrapClient,
+			Options:   []client.ListOption{client.InNamespace(namespace)},
+			Replicas:  numberOfAvailableBMHs,
+			Intervals: intervals,
+		})
+	})
+})
+

--- a/test/e2e/pivoting.go
+++ b/test/e2e/pivoting.go
@@ -59,177 +59,196 @@ func pivoting(ctx context.Context, inputGetter func() PivotingInput) {
 	ListMachines(ctx, input.BootstrapClusterProxy.GetClient(), client.InNamespace(input.Namespace))
 	ListNodes(ctx, input.TargetCluster.GetClient())
 
-	By("Remove Ironic containers from the source cluster")
-	ephemeralCluster := os.Getenv("EPHEMERAL_CLUSTER")
-	isIronicDeployment := true
-	if ephemeralCluster == Kind {
-		isIronicDeployment = false
-	}
-	removeIronic(ctx, func() RemoveIronicInput {
-		return RemoveIronicInput{
-			ManagementCluster: input.BootstrapClusterProxy,
-			IsDeployment:      isIronicDeployment,
-			Namespace:         input.E2EConfig.GetVariable(ironicNamespace),
-			NamePrefix:        input.E2EConfig.GetVariable(NamePrefix),
-		}
-	})
+    ironicContainers = []string{
+        "ironic",
+        "ironic-inspector",
+        "ironic-endpoint-keepalived",
+        "ironic-log-watch",
+        "dnsmasq",
+    }
+    generalContainers = []string{
+        "httpd-infra",
+        "registry",
+        "sushy-tools",
+        "vbmc",
+    }
 
-	By("Create Ironic namespace")
-	targetClusterClientSet := input.TargetCluster.GetClientSet()
-	ironicNamespace := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: input.E2EConfig.GetVariable(ironicNamespace),
-		},
-	}
-	_, err := targetClusterClientSet.CoreV1().Namespaces().Create(ctx, ironicNamespace, metav1.CreateOptions{})
-	Expect(err).To(BeNil(), "Unable to create the Ironic namespace")
+    By("Fetch container logs")
+    ephemeralCluster := os.Getenv("EPHEMERAL_CLUSTER")
+    fetchContainerLogs(&generalContainers)
+    if ephemeralCluster == Kind {
+        fetchContainerLogs(&ironicContainers)
+    }
 
-	By("Initialize Provider component in target cluster")
-	clusterctl.Init(ctx, clusterctl.InitInput{
-		KubeconfigPath:          input.TargetCluster.GetKubeconfigPath(),
-		ClusterctlConfigPath:    input.E2EConfig.GetVariable("CONFIG_FILE_PATH"),
-		CoreProvider:            config.ClusterAPIProviderName + ":" + os.Getenv("CAPIRELEASE"),
-		BootstrapProviders:      []string{config.KubeadmBootstrapProviderName + ":" + os.Getenv("CAPIRELEASE")},
-		ControlPlaneProviders:   []string{config.KubeadmControlPlaneProviderName + ":" + os.Getenv("CAPIRELEASE")},
-		InfrastructureProviders: []string{config.Metal3ProviderName + ":" + os.Getenv("CAPM3RELEASE")},
-		LogFolder:               filepath.Join(input.ArtifactFolder, "clusters", input.ClusterName+"-pivoting"),
-	})
+    By("Remove Ironic containers from the source cluster")
+    isIronicDeployment := true
+    if ephemeralCluster == Kind {
+        isIronicDeployment = false
+    }
+    removeIronic(ctx, func() RemoveIronicInput {
+        return RemoveIronicInput{
+            ManagementCluster: input.BootstrapClusterProxy,
+            IsDeployment:      isIronicDeployment,
+            Namespace:         input.E2EConfig.GetVariable(ironicNamespace),
+            NamePrefix:        input.E2EConfig.GetVariable(NamePrefix),
+        }
+    })
 
-	LogFromFile(filepath.Join(input.ArtifactFolder, "clusters", input.ClusterName+"-pivoting", "clusterctl-init.log"))
+    By("Create Ironic namespace")
+    targetClusterClientSet := input.TargetCluster.GetClientSet()
+    ironicNamespace := &corev1.Namespace{
+        ObjectMeta: metav1.ObjectMeta{
+            Name: input.E2EConfig.GetVariable(ironicNamespace),
+        },
+    }
+    _, err := targetClusterClientSet.CoreV1().Namespaces().Create(ctx, ironicNamespace, metav1.CreateOptions{})
+    Expect(err).To(BeNil(), "Unable to create the Ironic namespace")
 
-	By("Add labels to BMO CRDs")
-	labelBMOCRDs(nil)
-	By("Add Labels to hardwareData CRDs")
-	labelHDCRDs(nil)
+    By("Initialize Provider component in target cluster")
+    clusterctl.Init(ctx, clusterctl.InitInput{
+        KubeconfigPath:          input.TargetCluster.GetKubeconfigPath(),
+        ClusterctlConfigPath:    input.E2EConfig.GetVariable("CONFIG_FILE_PATH"),
+        CoreProvider:            config.ClusterAPIProviderName + ":" + os.Getenv("CAPIRELEASE"),
+        BootstrapProviders:      []string{config.KubeadmBootstrapProviderName + ":" + os.Getenv("CAPIRELEASE")},
+        ControlPlaneProviders:   []string{config.KubeadmControlPlaneProviderName + ":" + os.Getenv("CAPIRELEASE")},
+        InfrastructureProviders: []string{config.Metal3ProviderName + ":" + os.Getenv("CAPM3RELEASE")},
+        LogFolder:               filepath.Join(input.ArtifactFolder, "clusters", input.ClusterName+"-pivoting"),
+    })
 
-	By("Install BMO")
-	installIronicBMO(func() installIronicBMOInput {
-		return installIronicBMOInput{
-			ManagementCluster:          input.TargetCluster,
-			BMOPath:                    input.E2EConfig.GetVariable(bmoPath),
-			deployIronic:               false,
-			deployBMO:                  true,
-			deployIronicTLSSetup:       getBool(input.E2EConfig.GetVariable(ironicTLSSetup)),
-			DeployIronicBasicAuth:      getBool(input.E2EConfig.GetVariable(ironicBasicAuth)),
-			NamePrefix:                 input.E2EConfig.GetVariable(NamePrefix),
-			RestartContainerCertUpdate: getBool(input.E2EConfig.GetVariable(restartContainerCertUpdate)),
-		}
-	})
+    LogFromFile(filepath.Join(input.ArtifactFolder, "clusters", input.ClusterName+"-pivoting", "clusterctl-init.log"))
 
-	By("Install Ironic in the target cluster")
-	installIronicBMO(func() installIronicBMOInput {
-		return installIronicBMOInput{
-			ManagementCluster:          input.TargetCluster,
-			BMOPath:                    input.E2EConfig.GetVariable(bmoPath),
-			deployIronic:               true,
-			deployBMO:                  false,
-			deployIronicTLSSetup:       getBool(input.E2EConfig.GetVariable(ironicTLSSetup)),
-			DeployIronicBasicAuth:      getBool(input.E2EConfig.GetVariable(ironicBasicAuth)),
-			NamePrefix:                 input.E2EConfig.GetVariable(NamePrefix),
-			RestartContainerCertUpdate: getBool(input.E2EConfig.GetVariable(restartContainerCertUpdate)),
-		}
-	})
+    By("Add labels to BMO CRDs")
+    labelBMOCRDs(nil)
+    By("Add Labels to hardwareData CRDs")
+    labelHDCRDs(nil)
 
-	By("Add labels to BMO CRDs in the target cluster")
-	labelBMOCRDs(input.TargetCluster)
-	By("Add Labels to hardwareData CRDs in the target cluster")
-	labelHDCRDs(input.TargetCluster)
+    By("Install BMO")
+    installIronicBMO(func() installIronicBMOInput {
+        return installIronicBMOInput{
+            ManagementCluster:          input.TargetCluster,
+            BMOPath:                    input.E2EConfig.GetVariable(bmoPath),
+            deployIronic:               false,
+            deployBMO:                  true,
+            deployIronicTLSSetup:       getBool(input.E2EConfig.GetVariable(ironicTLSSetup)),
+            DeployIronicBasicAuth:      getBool(input.E2EConfig.GetVariable(ironicBasicAuth)),
+            NamePrefix:                 input.E2EConfig.GetVariable(NamePrefix),
+            RestartContainerCertUpdate: getBool(input.E2EConfig.GetVariable(restartContainerCertUpdate)),
+        }
+    })
 
-	By("Ensure API servers are stable before doing move")
-	// Nb. This check was introduced to prevent doing move to self-hosted in an aggressive way and thus avoid flakes.
-	// More specifically, we were observing the test failing to get objects from the API server during move, so we
-	// are now testing the API servers are stable before starting move.
-	Consistently(func() error {
-		kubeSystem := &corev1.Namespace{}
-		return input.BootstrapClusterProxy.GetClient().Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
-	}, "5s", "100ms").Should(BeNil(), "Failed to assert bootstrap API server stability")
-	Consistently(func() error {
-		kubeSystem := &corev1.Namespace{}
-		return input.TargetCluster.GetClient().Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
-	}, "5s", "100ms").Should(BeNil(), "Failed to assert target API server stability")
+    By("Install Ironic in the target cluster")
+    installIronicBMO(func() installIronicBMOInput {
+        return installIronicBMOInput{
+            ManagementCluster:          input.TargetCluster,
+            BMOPath:                    input.E2EConfig.GetVariable(bmoPath),
+            deployIronic:               true,
+            deployBMO:                  false,
+            deployIronicTLSSetup:       getBool(input.E2EConfig.GetVariable(ironicTLSSetup)),
+            DeployIronicBasicAuth:      getBool(input.E2EConfig.GetVariable(ironicBasicAuth)),
+            NamePrefix:                 input.E2EConfig.GetVariable(NamePrefix),
+            RestartContainerCertUpdate: getBool(input.E2EConfig.GetVariable(restartContainerCertUpdate)),
+        }
+    })
 
-	By("Moving the cluster to self hosted")
-	clusterctl.Move(ctx, clusterctl.MoveInput{
-		LogFolder:            filepath.Join(input.ArtifactFolder, "clusters", input.ClusterName+"-bootstrap"),
-		ClusterctlConfigPath: input.ClusterctlConfigPath,
-		FromKubeconfigPath:   input.BootstrapClusterProxy.GetKubeconfigPath(),
-		ToKubeconfigPath:     input.TargetCluster.GetKubeconfigPath(),
-		Namespace:            input.Namespace,
-	})
-	LogFromFile(filepath.Join(input.ArtifactFolder, "clusters", input.ClusterName+"-bootstrap", "logs", input.Namespace, "clusterctl-move.log"))
+    By("Add labels to BMO CRDs in the target cluster")
+    labelBMOCRDs(input.TargetCluster)
+    By("Add Labels to hardwareData CRDs in the target cluster")
+    labelHDCRDs(input.TargetCluster)
+    By("Ensure API servers are stable before doing move")
+    // Nb. This check was introduced to prevent doing move to self-hosted in an aggressive way and thus avoid flakes.
+    // More specifically, we were observing the test failing to get objects from the API server during move, so we
+    // are now testing the API servers are stable before starting move.
+    Consistently(func() error {
+        kubeSystem := &corev1.Namespace{}
+        return input.BootstrapClusterProxy.GetClient().Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
+    }, "5s", "100ms").Should(BeNil(), "Failed to assert bootstrap API server stability")
+    Consistently(func() error {
+        kubeSystem := &corev1.Namespace{}
+        return input.TargetCluster.GetClient().Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
+    }, "5s", "100ms").Should(BeNil(), "Failed to assert target API server stability")
 
-	pivotingCluster := framework.DiscoveryAndWaitForCluster(ctx, framework.DiscoveryAndWaitForClusterInput{
-		Getter:    input.TargetCluster.GetClient(),
-		Namespace: input.Namespace,
-		Name:      input.ClusterName,
-	}, input.E2EConfig.GetIntervals(input.SpecName, "wait-cluster")...)
+    By("Moving the cluster to self hosted")
+    clusterctl.Move(ctx, clusterctl.MoveInput{
+        LogFolder:            filepath.Join(input.ArtifactFolder, "clusters", input.ClusterName+"-bootstrap"),
+        ClusterctlConfigPath: input.ClusterctlConfigPath,
+        FromKubeconfigPath:   input.BootstrapClusterProxy.GetKubeconfigPath(),
+        ToKubeconfigPath:     input.TargetCluster.GetKubeconfigPath(),
+        Namespace:            input.Namespace,
+    })
+    LogFromFile(filepath.Join(input.ArtifactFolder, "clusters", input.ClusterName+"-bootstrap", "logs", input.Namespace, "clusterctl-move.log"))
 
-	controlPlane := framework.GetKubeadmControlPlaneByCluster(ctx, framework.GetKubeadmControlPlaneByClusterInput{
-		Lister:      input.TargetCluster.GetClient(),
-		ClusterName: pivotingCluster.Name,
-		Namespace:   pivotingCluster.Namespace,
-	})
-	Expect(controlPlane).ToNot(BeNil())
+    pivotingCluster := framework.DiscoveryAndWaitForCluster(ctx, framework.DiscoveryAndWaitForClusterInput{
+        Getter:    input.TargetCluster.GetClient(),
+        Namespace: input.Namespace,
+        Name:      input.ClusterName,
+    }, input.E2EConfig.GetIntervals(input.SpecName, "wait-cluster")...)
 
-	By("Check that BMHs are in provisioned state")
-	WaitForNumBmhInState(ctx, bmov1alpha1.StateProvisioned, WaitForNumInput{
-		Client:    input.TargetCluster.GetClient(),
-		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
-		Replicas:  numberOfAllBmh,
-		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-object-provisioned"),
-	})
+    controlPlane := framework.GetKubeadmControlPlaneByCluster(ctx, framework.GetKubeadmControlPlaneByClusterInput{
+        Lister:      input.TargetCluster.GetClient(),
+        ClusterName: pivotingCluster.Name,
+        Namespace:   pivotingCluster.Namespace,
+    })
+    Expect(controlPlane).ToNot(BeNil())
 
-	By("Check if metal3machines become ready.")
-	WaitForNumMetal3MachinesReady(ctx, WaitForNumInput{
-		Client:    input.TargetCluster.GetClient(),
-		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
-		Replicas:  numberOfAllBmh,
-		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-object-provisioned"),
-	})
+    By("Check that BMHs are in provisioned state")
+    WaitForNumBmhInState(ctx, bmov1alpha1.StateProvisioned, WaitForNumInput{
+        Client:    input.TargetCluster.GetClient(),
+        Options:   []client.ListOption{client.InNamespace(input.Namespace)},
+        Replicas:  numberOfAllBmh,
+        Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-object-provisioned"),
+    })
 
-	By("Check that all machines become running.")
-	WaitForNumMachinesInState(ctx, clusterv1.MachinePhaseRunning, WaitForNumInput{
-		Client:    input.TargetCluster.GetClient(),
-		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
-		Replicas:  numberOfAllBmh,
-		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-machine-running"),
-	})
+    By("Check if metal3machines become ready.")
+    WaitForNumMetal3MachinesReady(ctx, WaitForNumInput{
+        Client:    input.TargetCluster.GetClient(),
+        Options:   []client.ListOption{client.InNamespace(input.Namespace)},
+        Replicas:  numberOfAllBmh,
+        Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-object-provisioned"),
+    })
 
-	By("PIVOTING TESTS PASSED!")
+    By("Check that all machines become running.")
+    WaitForNumMachinesInState(ctx, clusterv1.MachinePhaseRunning, WaitForNumInput{
+        Client:    input.TargetCluster.GetClient(),
+        Options:   []client.ListOption{client.InNamespace(input.Namespace)},
+        Replicas:  numberOfAllBmh,
+        Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-machine-running"),
+    })
+
+    By("PIVOTING TESTS PASSED!")
 }
 
 type installIronicBMOInput struct {
-	ManagementCluster          framework.ClusterProxy
-	BMOPath                    string
-	deployIronic               bool
-	deployBMO                  bool
-	deployIronicTLSSetup       bool
-	DeployIronicBasicAuth      bool
-	NamePrefix                 string
-	RestartContainerCertUpdate bool
+    ManagementCluster          framework.ClusterProxy
+    BMOPath                    string
+    deployIronic               bool
+    deployBMO                  bool
+    deployIronicTLSSetup       bool
+    DeployIronicBasicAuth      bool
+    NamePrefix                 string
+    RestartContainerCertUpdate bool
 }
 
 func installIronicBMO(inputGetter func() installIronicBMOInput) {
-	input := inputGetter()
+    input := inputGetter()
 
-	ironicHost := os.Getenv("CLUSTER_PROVISIONING_IP")
-	path := fmt.Sprintf("%s/tools/", input.BMOPath)
-	args := []string{
-		strconv.FormatBool(input.deployBMO),
-		strconv.FormatBool(input.deployIronic),
-		strconv.FormatBool(input.DeployIronicBasicAuth),
-		strconv.FormatBool(input.deployIronicTLSSetup),
-		"true",
-	}
-	env := []string{
-		fmt.Sprintf("IRONIC_HOST=%s", ironicHost),
-		fmt.Sprintf("IRONIC_HOST_IP=%s", ironicHost),
-		fmt.Sprintf("KUBECTL_ARGS=--kubeconfig=%s", input.ManagementCluster.GetKubeconfigPath()),
-		fmt.Sprintf("NAMEPREFIX=%s", input.NamePrefix),
-		fmt.Sprintf("RESTART_CONTAINER_CERTIFICATE_UPDATED=%s", strconv.FormatBool(input.RestartContainerCertUpdate)),
-		"USER=ubuntu",
-	}
-	cmd := exec.Command("./deploy.sh", args...) // #nosec G204:gosec
+    ironicHost := os.Getenv("CLUSTER_PROVISIONING_IP")
+    path := fmt.Sprintf("%s/tools/", input.BMOPath)
+    args := []string{
+        strconv.FormatBool(input.deployBMO),
+        strconv.FormatBool(input.deployIronic),
+        strconv.FormatBool(input.DeployIronicBasicAuth),
+        strconv.FormatBool(input.deployIronicTLSSetup),
+        "true",
+    }
+    env := []string{
+        fmt.Sprintf("IRONIC_HOST=%s", ironicHost),
+        fmt.Sprintf("IRONIC_HOST_IP=%s", ironicHost),
+        fmt.Sprintf("KUBECTL_ARGS=--kubeconfig=%s", input.ManagementCluster.GetKubeconfigPath()),
+        fmt.Sprintf("NAMEPREFIX=%s", input.NamePrefix),
+        fmt.Sprintf("RESTART_CONTAINER_CERTIFICATE_UPDATED=%s", strconv.FormatBool(input.RestartContainerCertUpdate)),
+        "USER=ubuntu",
+    }
+    cmd := exec.Command("./deploy.sh", args...) // #nosec G204:gosec
 	cmd.Dir = path
 	cmd.Env = append(env, os.Environ()...)
 
@@ -348,6 +367,9 @@ type RePivotingInput struct {
 func rePivoting(ctx context.Context, inputGetter func() RePivotingInput) {
 	Logf("Start the re-pivoting test")
 	input := inputGetter()
+	numberOfWorkers := int(*input.E2EConfig.GetInt32PtrVariable("WORKER_MACHINE_COUNT"))
+	numberOfControlplane := int(*input.E2EConfig.GetInt32PtrVariable("CONTROL_PLANE_MACHINE_COUNT"))
+	numberOfAllBmh := numberOfWorkers + numberOfControlplane
 	By("Remove Ironic deployment from target cluster")
 	removeIronic(ctx, func() RemoveIronicInput {
 		return RemoveIronicInput{
@@ -422,7 +444,7 @@ func rePivoting(ctx context.Context, inputGetter func() RePivotingInput) {
 	WaitForNumBmhInState(ctx, bmov1alpha1.StateProvisioned, WaitForNumInput{
 		Client:    input.BootstrapClusterProxy.GetClient(),
 		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
-		Replicas:  4,
+		Replicas:  numberOfAllBmh,
 		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-object-provisioned"),
 	})
 
@@ -430,7 +452,7 @@ func rePivoting(ctx context.Context, inputGetter func() RePivotingInput) {
 	WaitForNumMetal3MachinesReady(ctx, WaitForNumInput{
 		Client:    input.BootstrapClusterProxy.GetClient(),
 		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
-		Replicas:  4,
+		Replicas:  numberOfAllBmh,
 		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-object-provisioned"),
 	})
 
@@ -438,7 +460,7 @@ func rePivoting(ctx context.Context, inputGetter func() RePivotingInput) {
 	WaitForNumMachinesInState(ctx, clusterv1.MachinePhaseRunning, WaitForNumInput{
 		Client:    input.BootstrapClusterProxy.GetClient(),
 		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
-		Replicas:  4,
+		Replicas:  numberOfAllBmh,
 		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-machine-running"),
 	})
 

--- a/test/e2e/remediation_based_feature_test.go
+++ b/test/e2e/remediation_based_feature_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Testing nodes remediation [remediation]", func() {
 
 	It("Should create a cluster and and run remediation based tests", func() {
 		By("Creating target cluster")
-		targetCluster = createTargetCluster(e2eConfig.GetVariable("KUBERNETES_VERSION"))
+		targetCluster, _ = createTargetCluster(e2eConfig.GetVariable("KUBERNETES_VERSION"))
 
 		// Run Metal3Remediation test first, doesn't work after remediation...
 		By("Running Metal3Remediation tests")

--- a/test/e2e/upgrade_kubernetes_test.go
+++ b/test/e2e/upgrade_kubernetes_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Kubernetes version upgrade in target nodes [upgrade]", func() 
 
 	It("Should create a cluster and and run k8s_upgrade tests", func() {
 		By("Creating target cluster")
-		targetCluster = createTargetCluster(e2eConfig.GetVariable("FROM_K8S_VERSION"))
+		targetCluster, _ = createTargetCluster(e2eConfig.GetVariable("FROM_K8S_VERSION"))
 
 		By("Running Kubernetes Upgrade tests")
 		upgradeKubernetes(ctx, func() upgradeKubernetesInput {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds ci-provisioning and provisioning (which currently can be run only from dev-env using ansible) to e2e tests.

Also added logs collections for all containers before pivoting, which is the behavior in dev-env pivoting.