### PR TITLE
🌱 Ginkgo v2: Use --show-node-events parameter instead of --progress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ e2e-tests: e2e-substitutions cluster-templates ## This target should be called f
 		$(CONTAINER_RUNTIME) pull $$image; \
 	done
 	time go test -v -timeout 24h --tags=e2e ./test/e2e/... -args \
-		--ginkgo.timeout=6h --ginkgo.v --ginkgo.trace --ginkgo.progress --ginkgo.no-color=$(GINKGO_NOCOLOR) \
+		--ginkgo.timeout=6h --ginkgo.v --ginkgo.trace --ginkgo.show-node-events --ginkgo.no-color=$(GINKGO_NOCOLOR) \
 		--ginkgo.junit-report="junit.e2e_suite.1.xml" \
 		--ginkgo.focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) \
 		-e2e.artifacts-folder="$(ARTIFACTS)" \


### PR DESCRIPTION
**What this PR does / why we need it**:
`--progress ` was deprecated in Ginkgo v2 (https://github.com/onsi/ginkgo/blob/master/CHANGELOG.md#ginkgo-output-now-includes-a-timeline-view-of-the-spec) and we need to move to `--show-node-events` parameter, see the deprecation warning below:
 ```
Test Suite Failed
You're using deprecated Ginkgo functionality:
=============================================
  --progress is deprecated .  The functionality provided by --progress was confusing and is no longer needed.  Use --show-node-events instead to see node entry and exit events included in the timeline of failed and verbose specs.  Or you can run with -vv to always see all node events.  Lastly, --poll-progress-after and the PollProgressAfter decorator now provide a better mechanism for debugging specs that tend to get stuck. 
```

