### PR TITLE
Bump mdl to 0.12.0 and pin it to sha:digest

### DIFF
--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -14,6 +14,6 @@ else
     --volume "${PWD}:/capm3:ro,z" \
     --entrypoint sh \
     --workdir /capm3 \
-    docker.io/pipelinecomponents/markdownlint:latest \
+    registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2 \
     /capm3/hack/markdownlint.sh "${@}"
 fi;


### PR DESCRIPTION
Pin markdownlint image to 0.12.0 with SHA to guard against changes without explicit acknowledgement.

Makes OpenSSF scorecard happier as well by pinning down another dependency.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
