### PR TITLE
🌱 Remove skipping e2e upgrade test workaround

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,13 +162,6 @@ cluster-templates: $(KUSTOMIZE) ## Generate cluster templates
 GINKGO_FOCUS  ?=
 GINKGO_SKIP ?=
 
-# TODO (Mohammed) select the test in JJB
-ifeq ($(GINKGO_FOCUS),upgrade)
-GINKGO_FOCUS := upgrade
-else
-GINKGO_SKIP := upgrade
-endif
-
 ifneq ($(strip $(GINKGO_SKIP)),)
 _SKIP_ARGS := $(foreach arg,$(strip $(GINKGO_SKIP)),-ginkgo.skip="$(arg)")
 endif


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR remove the implicit logic to skip upgrade e2e when running other feature e2e (pivoting, remediation ..). After this we will explicitly skip tests from the JJB.
This PR depends on https://github.com/metal3-io/project-infra/pull/454

Fixes #
