### PR TITLE
Change bmo deployment in e2e to using getopts

### DIFF
--- a/test/e2e/pivoting.go
+++ b/test/e2e/pivoting.go
@@ -214,12 +214,18 @@ func installIronicBMO(inputGetter func() installIronicBMOInput) {
 
 	ironicHost := os.Getenv("CLUSTER_PROVISIONING_IP")
 	path := fmt.Sprintf("%s/tools/", input.BMOPath)
-	args := []string{
-		strconv.FormatBool(input.deployBMO),
-		strconv.FormatBool(input.deployIronic),
-		strconv.FormatBool(input.DeployIronicBasicAuth),
-		strconv.FormatBool(input.deployIronicTLSSetup),
-		"true",
+	args := []string{}
+	if input.deployBMO {
+		args = append(args, "-b")
+	}
+	if input.deployIronic {
+		args = append(args, "-i")
+	}
+	if !input.deployBasicAuth {
+		args = append(args, "-n")
+	}
+	if input.deployIronicTLSSetup {
+		args = append(args, "-t")
 	}
 	env := []string{
 		fmt.Sprintf("IRONIC_HOST=%s", ironicHost),


### PR DESCRIPTION
**What this PR does / why we need it**:

[BMO is no longer using positional arguments](https://github.com/metal3-io/baremetal-operator/blob/main/tools/deploy.sh#L58), hence we need to change this in e2e