### PR TITLE
🌱 shellcheck: pin to 0.9.0

### DIFF
--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -14,6 +14,6 @@ else
     --volume "${PWD}:/capm3:ro,z" \
     --entrypoint sh \
     --workdir /capm3 \
-    docker.io/koalaman/shellcheck-alpine:stable \
+    docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7 \
     /capm3/hack/shellcheck.sh "${@}"
 fi;


### PR DESCRIPTION
Pin shellcheck to 0.9.0 with digest.

Shellcheck 0.9.0 was released this morning. This way it is in line with other repositories, and pinned by digest.