### PR TITLE
🌱 Bump upgraded k8s version and add basic logging after e2e tests

### DIFF
--- a/controllers/metal3cluster_controller_integration_test.go
+++ b/controllers/metal3cluster_controller_integration_test.go
@@ -3,7 +3,9 @@ Copyright 2021 The Kubernetes Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/controllers/metal3cluster_controller_test.go
+++ b/controllers/metal3cluster_controller_test.go
@@ -3,7 +3,9 @@ Copyright 2021 The Kubernetes Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -54,7 +54,7 @@ fi
 # higher than v1.23.x
 export FROM_K8S_VERSION="v1.23.8"
 export KUBERNETES_VERSION=${FROM_K8S_VERSION}
-export UPGRADED_K8S_VERSION="v1.24.1"
+export UPGRADED_K8S_VERSION="v1.24.9"
 # Can be overriden from jjbs
 export CAPI_VERSION=${CAPI_VERSION:-"v1beta1"}
 export CAPM3_VERSION=${CAPM3_VERSION:-"v1beta1"}

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -109,7 +109,7 @@ providers:
 variables:
   CNI: "/tmp/calico.yaml"
   KUBERNETES_VERSION: "v1.24.0"
-  UPGRADED_K8S_VERSION: "v1.24.1"
+  UPGRADED_K8S_VERSION: "v1.24.9"
   CONTROL_PLANE_MACHINE_COUNT: 3
   WORKER_MACHINE_COUNT: 1
   APIVersion: "infrastructure.cluster.x-k8s.io/${CAPM3_VERSION}"

--- a/test/e2e/pivoting_based_feature_test.go
+++ b/test/e2e/pivoting_based_feature_test.go
@@ -13,6 +13,7 @@ import (
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -59,6 +60,18 @@ var _ = Describe("Testing features in ephemeral or target cluster", func() {
 	})
 
 	AfterEach(func() {
+		Logf("Logging state of bootstrap cluster")
+		listBareMetalHosts(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		listMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		listMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		listNodes(ctx, bootstrapClusterProxy.GetClient())
+		Logf("Logging state of target cluster")
+		if !ephemeralTest {
+			listBareMetalHosts(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
+			listMetal3Machines(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
+			listMachines(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
+		}
+		listNodes(ctx, targetCluster.GetClient())
 		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 	})
 

--- a/test/e2e/remediation_based_feature_test.go
+++ b/test/e2e/remediation_based_feature_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type vmState string
@@ -59,6 +60,10 @@ var _ = Describe("Testing nodes remediation [remediation]", func() {
 	})
 
 	AfterEach(func() {
+		listBareMetalHosts(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		listMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		listMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		listNodes(ctx, targetCluster.GetClient())
 		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Due to changes in kubeadm and cluster-api for the container registry, we need to bump the upgraded k8s version to pass the test.

It is currently hard to tell what state the cluster was in when it failed. This should hopefully make it a bit clearer.
Similar to https://github.com/metal3-io/cluster-api-provider-metal3/pull/714 (but this was hard to backport it seems).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
