### PR TITLE
🌱 E2e: Support running Ironic with MariaDB

### DIFF
--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -122,10 +122,11 @@ variables:
   BMOPATH: "${M3PATH}/baremetal-operator"
   IRONIC_TLS_SETUP: "true"
   IRONIC_BASIC_AUTH: "true"
+  IRONIC_KEEPALIVED: "true"
+  IRONIC_USE_MARIADB: "false"
   RESTART_CONTAINER_CERTIFICATE_UPDATED: "true"
   CONTAINER_REGISTRY: "${CONTAINER_REGISTRY:-quay.io}"
   IRONIC_IMAGE_TAG: "${IRONIC_IMAGE_TAG:-main}"
-  MARIADB_IMAGE_TAG: "${MARIADB_IMAGE_TAG:-main}"
   UPGRADED_BMO_IMAGE_TAG: "${UPGRADED_BMO_IMAGE_TAG:-main}"
 
   INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPI_FROM_RELEASE}/clusterctl-{OS}-{ARCH}"

--- a/test/e2e/pivoting.go
+++ b/test/e2e/pivoting.go
@@ -31,6 +31,8 @@ const (
 	bmoPath                    = "BMOPATH"
 	ironicTLSSetup             = "IRONIC_TLS_SETUP"
 	ironicBasicAuth            = "IRONIC_BASIC_AUTH"
+	ironicKeepalived           = "IRONIC_KEEPALIVED"
+	ironicMariadb              = "IRONIC_USE_MARIADB"
 	Kind                       = "kind"
 	NamePrefix                 = "NAMEPREFIX"
 	restartContainerCertUpdate = "RESTART_CONTAINER_CERTIFICATE_UPDATED"
@@ -131,7 +133,9 @@ func pivoting(ctx context.Context, inputGetter func() PivotingInput) {
 			deployIronic:               false,
 			deployBMO:                  true,
 			deployIronicTLSSetup:       getBool(input.E2EConfig.GetVariable(ironicTLSSetup)),
-			DeployIronicBasicAuth:      getBool(input.E2EConfig.GetVariable(ironicBasicAuth)),
+			deployIronicBasicAuth:      getBool(input.E2EConfig.GetVariable(ironicBasicAuth)),
+			deployIronicKeepalived:     getBool(input.E2EConfig.GetVariable(ironicKeepalived)),
+			deployIronicMariadb:        getBool(input.E2EConfig.GetVariable(ironicMariadb)),
 			NamePrefix:                 input.E2EConfig.GetVariable(NamePrefix),
 			RestartContainerCertUpdate: getBool(input.E2EConfig.GetVariable(restartContainerCertUpdate)),
 		}
@@ -145,7 +149,9 @@ func pivoting(ctx context.Context, inputGetter func() PivotingInput) {
 			deployIronic:               true,
 			deployBMO:                  false,
 			deployIronicTLSSetup:       getBool(input.E2EConfig.GetVariable(ironicTLSSetup)),
-			DeployIronicBasicAuth:      getBool(input.E2EConfig.GetVariable(ironicBasicAuth)),
+			deployIronicBasicAuth:      getBool(input.E2EConfig.GetVariable(ironicBasicAuth)),
+			deployIronicKeepalived:     getBool(input.E2EConfig.GetVariable(ironicKeepalived)),
+			deployIronicMariadb:        getBool(input.E2EConfig.GetVariable(ironicMariadb)),
 			NamePrefix:                 input.E2EConfig.GetVariable(NamePrefix),
 			RestartContainerCertUpdate: getBool(input.E2EConfig.GetVariable(restartContainerCertUpdate)),
 		}
@@ -224,7 +230,9 @@ type installIronicBMOInput struct {
 	deployIronic               bool
 	deployBMO                  bool
 	deployIronicTLSSetup       bool
-	DeployIronicBasicAuth      bool
+	deployIronicBasicAuth      bool
+	deployIronicKeepalived     bool
+	deployIronicMariadb        bool
 	NamePrefix                 string
 	RestartContainerCertUpdate bool
 }
@@ -234,13 +242,27 @@ func installIronicBMO(inputGetter func() installIronicBMOInput) {
 
 	ironicHost := os.Getenv("CLUSTER_PROVISIONING_IP")
 	path := fmt.Sprintf("%s/tools/", input.BMOPath)
-	args := []string{
-		strconv.FormatBool(input.deployBMO),
-		strconv.FormatBool(input.deployIronic),
-		strconv.FormatBool(input.DeployIronicBasicAuth),
-		strconv.FormatBool(input.deployIronicTLSSetup),
-		"true",
+
+	args := []string{}
+	if input.deployBMO {
+		args = append(args, "-b")
 	}
+	if input.deployIronic {
+		args = append(args, "-i")
+	}
+	if input.deployIronicTLSSetup {
+		args = append(args, "-t")
+	}
+	if !input.deployIronicBasicAuth {
+		args = append(args, "-n")
+	}
+	if input.deployIronicKeepalived {
+		args = append(args, "-k")
+	}
+	if input.deployIronicMariadb {
+		args = append(args, "-m")
+	}
+
 	env := []string{
 		fmt.Sprintf("IRONIC_HOST=%s", ironicHost),
 		fmt.Sprintf("IRONIC_HOST_IP=%s", ironicHost),
@@ -399,7 +421,9 @@ func rePivoting(ctx context.Context, inputGetter func() RePivotingInput) {
 				deployIronic:               true,
 				deployBMO:                  false,
 				deployIronicTLSSetup:       getBool(input.E2EConfig.GetVariable(ironicTLSSetup)),
-				DeployIronicBasicAuth:      getBool(input.E2EConfig.GetVariable(ironicBasicAuth)),
+				deployIronicBasicAuth:      getBool(input.E2EConfig.GetVariable(ironicBasicAuth)),
+				deployIronicKeepalived:     getBool(input.E2EConfig.GetVariable(ironicKeepalived)),
+				deployIronicMariadb:        getBool(input.E2EConfig.GetVariable(ironicMariadb)),
 				NamePrefix:                 input.E2EConfig.GetVariable(NamePrefix),
 				RestartContainerCertUpdate: getBool(input.E2EConfig.GetVariable(restartContainerCertUpdate)),
 			}

--- a/test/e2e/upgrade_ironic.go
+++ b/test/e2e/upgrade_ironic.go
@@ -27,7 +27,6 @@ func upgradeIronic(ctx context.Context, inputGetter func() upgradeIronicInput) {
 		ironicDeployName  = namePrefix + "-ironic"
 		containerRegistry = input.E2EConfig.GetVariable("CONTAINER_REGISTRY")
 		ironicImageTag    = input.E2EConfig.GetVariable("IRONIC_IMAGE_TAG")
-		mariadbImageTag   = input.E2EConfig.GetVariable("MARIADB_IMAGE_TAG")
 	)
 
 	Logf("namePrefix %v", namePrefix)
@@ -35,7 +34,6 @@ func upgradeIronic(ctx context.Context, inputGetter func() upgradeIronicInput) {
 	Logf("ironicDeployName %v", ironicDeployName)
 	Logf("containerRegistry %v", containerRegistry)
 	Logf("ironicImageTag %v", ironicImageTag)
-	Logf("mariadbImageTag %v", mariadbImageTag)
 
 	By("Upgrading ironic image based containers")
 	deploy, err := clientSet.AppsV1().Deployments(ironicNamespace).Get(ctx, ironicDeployName, metav1.GetOptions{})
@@ -48,9 +46,6 @@ func upgradeIronic(ctx context.Context, inputGetter func() upgradeIronicInput) {
 			"ironic-log-watch",
 			"ironic-inspector":
 			deploy.Spec.Template.Spec.Containers[i].Image = containerRegistry + "/metal3-io/ironic:" + ironicImageTag
-		case
-			"mariadb":
-			deploy.Spec.Template.Spec.Containers[i].Image = containerRegistry + "/metal3-io/mariadb:" + mariadbImageTag
 		}
 	}
 

--- a/test/e2e/upgrade_management_cluster_test.go
+++ b/test/e2e/upgrade_management_cluster_test.go
@@ -169,7 +169,9 @@ func preInitFunc(clusterProxy framework.ClusterProxy) {
 			deployIronic:               false,
 			deployBMO:                  true,
 			deployIronicTLSSetup:       getBool(e2eConfig.GetVariable(ironicTLSSetup)),
-			DeployIronicBasicAuth:      getBool(e2eConfig.GetVariable(ironicBasicAuth)),
+			deployIronicBasicAuth:      getBool(e2eConfig.GetVariable(ironicBasicAuth)),
+			deployIronicKeepalived:     getBool(e2eConfig.GetVariable(ironicKeepalived)),
+			deployIronicMariadb:        getBool(e2eConfig.GetVariable(ironicMariadb)),
 			NamePrefix:                 e2eConfig.GetVariable(NamePrefix),
 			RestartContainerCertUpdate: getBool(e2eConfig.GetVariable(restartContainerCertUpdate)),
 		}
@@ -184,7 +186,9 @@ func preInitFunc(clusterProxy framework.ClusterProxy) {
 			deployIronic:               true,
 			deployBMO:                  false,
 			deployIronicTLSSetup:       getBool(e2eConfig.GetVariable(ironicTLSSetup)),
-			DeployIronicBasicAuth:      getBool(e2eConfig.GetVariable(ironicBasicAuth)),
+			deployIronicBasicAuth:      getBool(e2eConfig.GetVariable(ironicBasicAuth)),
+			deployIronicKeepalived:     getBool(e2eConfig.GetVariable(ironicKeepalived)),
+			deployIronicMariadb:        getBool(e2eConfig.GetVariable(ironicMariadb)),
 			NamePrefix:                 e2eConfig.GetVariable(NamePrefix),
 			RestartContainerCertUpdate: getBool(e2eConfig.GetVariable(restartContainerCertUpdate)),
 		}
@@ -250,7 +254,9 @@ func preCleanupManagementCluster(clusterProxy framework.ClusterProxy) {
 					deployIronic:               true,
 					deployBMO:                  false,
 					deployIronicTLSSetup:       getBool(e2eConfig.GetVariable(ironicTLSSetup)),
-					DeployIronicBasicAuth:      getBool(e2eConfig.GetVariable(ironicBasicAuth)),
+					deployIronicBasicAuth:      getBool(e2eConfig.GetVariable(ironicBasicAuth)),
+					deployIronicKeepalived:     getBool(e2eConfig.GetVariable(ironicKeepalived)),
+					deployIronicMariadb:        getBool(e2eConfig.GetVariable(ironicMariadb)),
 					NamePrefix:                 e2eConfig.GetVariable(NamePrefix),
 					RestartContainerCertUpdate: getBool(e2eConfig.GetVariable(restartContainerCertUpdate)),
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Support running Ironic with MariaDB
- Use new deploy script args instead of positional booleans
- Add keepalived variable to e2e config for consistency

Related:
- https://github.com/metal3-io/baremetal-operator/pull/1196
- https://github.com/metal3-io/metal3-dev-env/pull/1127
