### PR TITLE
Add default Metal3DataTemplate to example

### DIFF
--- a/examples/clusterctl-templates/clusterctl-cluster.yaml
+++ b/examples/clusterctl-templates/clusterctl-cluster.yaml
@@ -150,3 +150,19 @@ spec:
           kubeletExtraArgs:
             node-labels: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
 ${WORKERS_KUBEADM_EXTRA_CONFIG}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3DataTemplate
+metadata:
+  name: ${CLUSTER_NAME}-controlplane-template
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3DataTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers-template
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}


### PR DESCRIPTION
**What this PR does / why we need it**

User would be confused when they want to try metal3 provider for the first time. Add naive default to create Machine correctly at least.

**Which issue(s) this PR fixes**

Fixes https://github.com/metal3-io/cluster-api-provider-metal3/issues/820
