### PR TITLE
✨ add explicit securitycontext to controllers

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -18,39 +18,50 @@ spec:
         controller-tools.k8s.io: "1.0"
     spec:
       containers:
-      - command:
-        - /manager
-        args:
-          - "--webhook-port=9443"
-          - "--enableBMHNameBasedPreallocation=${enableBMHNameBasedPreallocation:=false}"
-        image: controller:latest
-        imagePullPolicy: IfNotPresent
-        name: manager
-        env:
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-        envFrom:
-          - configMapRef:
-              name: capm3fasttrack-configmap
-        ports:
-        - containerPort: 9440
-          name: healthz
-          protocol: TCP
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: healthz
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: healthz
+        - command:
+            - /manager
+          args:
+            - "--webhook-port=9443"
+            - "--enableBMHNameBasedPreallocation=${enableBMHNameBasedPreallocation:=false}"
+          image: controller:latest
+          imagePullPolicy: IfNotPresent
+          name: manager
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - configMapRef:
+                name: capm3fasttrack-configmap
+          ports:
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: healthz
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            runAsUser: 65532
+            runAsGroup: 65532
       terminationGracePeriodSeconds: 10
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: manager
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
-

--- a/hack/tools/remove_sec_ctx.py
+++ b/hack/tools/remove_sec_ctx.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+#
+# remove security contexts from stdin-read yaml, and output yaml to stdout
+# this allows tilt's live update to work
+#
+
+import sys
+import yaml
+
+
+def main():
+    # remove security contexts
+    output = []
+    content = "\n".join(sys.stdin.readlines())
+    data = yaml.safe_load_all(content)
+
+    for d in data:
+        if d.get("kind", "") == "Deployment":
+            try:
+                spec = d["spec"]["template"]["spec"]
+                spec["securityContext"] = {}
+                for container in spec.get("containers", []):
+                    container["securityContext"] = {}
+            except (KeyError, TypeError):
+                pass
+        output.append(yaml.safe_dump(d))
+
+    print("---\n".join(output))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
It is always good to not rely on the defaults, but be explicit. Set explicit, secure securityContext for the capm3 controller manager deployment and containers.

Functionally, the only thing actually changing for runtime is setting the seccompProfile to RuntimeDefault. Without this, default setting is Unconfined.
