### PR TITLE
🌱 Uplift CAPI to v1.3.2 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ provider:
   when running the clusterctl and set the level of the logging verbose with a positive integer number, ie. -v5.
 
     ```shell
-    clusterctl init --core cluster-api:v1.3.1 --bootstrap kubeadm:v1.3.1 \
-        --control-plane kubeadm:v1.3.1 -v5
+    clusterctl init --core cluster-api:v1.3.2 --bootstrap kubeadm:v1.3.2 \
+        --control-plane kubeadm:v1.3.2 -v5
     ```
 
 1. Install Metal3 provider. This will install the latest version of Cluster API Provider Metal3 CRDs and controllers.

--- a/api/go.mod
+++ b/api/go.mod
@@ -12,7 +12,7 @@ require (
 	k8s.io/apimachinery v0.25.0
 	k8s.io/client-go v0.25.0
 	k8s.io/utils v0.0.0-20220823124924-e9cbc92d1a73
-	sigs.k8s.io/cluster-api v1.3.1
+	sigs.k8s.io/cluster-api v1.3.2
 	sigs.k8s.io/controller-runtime v0.13.1
 
 )
@@ -69,7 +69,7 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.3.1
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.3.2
 
 replace github.com/docker/distribution => github.com/docker/distribution v2.8.1+incompatible
 

--- a/api/go.sum
+++ b/api/go.sum
@@ -632,8 +632,8 @@ k8s.io/utils v0.0.0-20220823124924-e9cbc92d1a73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/cluster-api v1.3.1 h1:sFd/ayOhQxd4YZX1qw8HC2xO7eKRBNRL+mlCKwdVhvY=
-sigs.k8s.io/cluster-api v1.3.1/go.mod h1:ef5vvtp2PyhEHTYCw8niaVPlOX5Ntvrh+8oBZt0PJ08=
+sigs.k8s.io/cluster-api v1.3.2 h1:DkkaVASrxgOP4hT24ndGwfge8+YjHKuAyZBSGJwAlq4=
+sigs.k8s.io/cluster-api v1.3.2/go.mod h1:nnXmR51rHshpMEXmB4LZIwdiXWKXV6yaooB1KzrL0Qs=
 sigs.k8s.io/controller-runtime v0.13.1 h1:tUsRCSJVM1QQOOeViGeX3GMT3dQF1eePPw6sEE3xSlg=
 sigs.k8s.io/controller-runtime v0.13.1/go.mod h1:Zbz+el8Yg31jubvAEyglRZGdLAjplZl+PgtYNI6WNTI=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=

--- a/go.mod
+++ b/go.mod
@@ -20,14 +20,14 @@ require (
 	k8s.io/component-base v0.25.0
 	k8s.io/klog/v2 v2.80.1
 	k8s.io/utils v0.0.0-20220823124924-e9cbc92d1a73
-	sigs.k8s.io/cluster-api v1.3.1
+	sigs.k8s.io/cluster-api v1.3.2
 	sigs.k8s.io/controller-runtime v0.13.1
 	sigs.k8s.io/yaml v1.3.0
 )
 
 replace github.com/metal3-io/cluster-api-provider-metal3/api => ./api
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.3.1
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.3.2
 
 replace github.com/docker/distribution => github.com/docker/distribution v2.8.1+incompatible
 

--- a/go.sum
+++ b/go.sum
@@ -1019,8 +1019,8 @@ k8s.io/utils v0.0.0-20220823124924-e9cbc92d1a73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/cluster-api v1.3.1 h1:sFd/ayOhQxd4YZX1qw8HC2xO7eKRBNRL+mlCKwdVhvY=
-sigs.k8s.io/cluster-api v1.3.1/go.mod h1:ef5vvtp2PyhEHTYCw8niaVPlOX5Ntvrh+8oBZt0PJ08=
+sigs.k8s.io/cluster-api v1.3.2 h1:DkkaVASrxgOP4hT24ndGwfge8+YjHKuAyZBSGJwAlq4=
+sigs.k8s.io/cluster-api v1.3.2/go.mod h1:nnXmR51rHshpMEXmB4LZIwdiXWKXV6yaooB1KzrL0Qs=
 sigs.k8s.io/controller-runtime v0.13.1 h1:tUsRCSJVM1QQOOeViGeX3GMT3dQF1eePPw6sEE3xSlg=
 sigs.k8s.io/controller-runtime v0.13.1/go.mod h1:Zbz+el8Yg31jubvAEyglRZGdLAjplZl+PgtYNI6WNTI=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=

--- a/test/go.mod
+++ b/test/go.mod
@@ -14,12 +14,14 @@ require (
 	k8s.io/apimachinery v0.25.4
 	k8s.io/client-go v0.25.4
 	k8s.io/utils v0.0.0-20220823124924-e9cbc92d1a73
-	sigs.k8s.io/cluster-api v1.3.1
-	sigs.k8s.io/cluster-api/test v1.3.1
+	sigs.k8s.io/cluster-api v1.3.2
+	sigs.k8s.io/cluster-api/test v1.3.2
 	sigs.k8s.io/controller-runtime v0.13.1
 )
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.3.1
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.3.2
+
+replace sigs.k8s.io/cluster-api/test => sigs.k8s.io/cluster-api/test v1.3.2
 
 replace github.com/metal3-io/cluster-api-provider-metal3/api => ./../api
 
@@ -129,5 +131,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace sigs.k8s.io/cluster-api/test => sigs.k8s.io/cluster-api/test v1.3.1

--- a/test/go.sum
+++ b/test/go.sum
@@ -941,10 +941,10 @@ k8s.io/utils v0.0.0-20220823124924-e9cbc92d1a73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/cluster-api v1.3.1 h1:sFd/ayOhQxd4YZX1qw8HC2xO7eKRBNRL+mlCKwdVhvY=
-sigs.k8s.io/cluster-api v1.3.1/go.mod h1:ef5vvtp2PyhEHTYCw8niaVPlOX5Ntvrh+8oBZt0PJ08=
-sigs.k8s.io/cluster-api/test v1.3.1 h1:5j0EJi58qgP6Ga9W0fI/T0rW+CeKPq1BoOg30Yx9zfI=
-sigs.k8s.io/cluster-api/test v1.3.1/go.mod h1:aK8zSbF7gQyoM2FaPVFcE0o125feyRXVKlw03Ok+feA=
+sigs.k8s.io/cluster-api v1.3.2 h1:DkkaVASrxgOP4hT24ndGwfge8+YjHKuAyZBSGJwAlq4=
+sigs.k8s.io/cluster-api v1.3.2/go.mod h1:nnXmR51rHshpMEXmB4LZIwdiXWKXV6yaooB1KzrL0Qs=
+sigs.k8s.io/cluster-api/test v1.3.2 h1:+EH9OwoIJ/UpGntRRhNxwIZkW3hx2pEn6aQrm7pRuJE=
+sigs.k8s.io/cluster-api/test v1.3.2/go.mod h1:HKkh1O4lALo51GsXVIJ1rQNyLRE+CbEVcA+f/1gU5Rw=
 sigs.k8s.io/controller-runtime v0.13.1 h1:tUsRCSJVM1QQOOeViGeX3GMT3dQF1eePPw6sEE3xSlg=
 sigs.k8s.io/controller-runtime v0.13.1/go.mod h1:Zbz+el8Yg31jubvAEyglRZGdLAjplZl+PgtYNI6WNTI=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.3.2

