### PR TITLE
🌱 Uplift capi to v1.2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ provider:
   when running the clusterctl and set the level of the logging verbose with a positive integer number, ie. -v5.
 
     ```shell
-    clusterctl init --core cluster-api:v1.2.8 --bootstrap kubeadm:v1.2.8 \
-        --control-plane kubeadm:v1.2.8 -v5
+    clusterctl init --core cluster-api:v1.2.9 --bootstrap kubeadm:v1.2.9 \
+        --control-plane kubeadm:v1.2.9 -v5
     ```
 
 1. Install Metal3 provider. This will install the latest version of Cluster API Provider Metal3 CRDs and controllers.

--- a/api/go.mod
+++ b/api/go.mod
@@ -12,7 +12,7 @@ require (
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
-	sigs.k8s.io/cluster-api v1.2.8
+	sigs.k8s.io/cluster-api v1.2.9
 	sigs.k8s.io/controller-runtime v0.12.3
 
 )
@@ -71,7 +71,7 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.2.8
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.2.9
 
 replace github.com/docker/distribution => github.com/docker/distribution v2.8.1+incompatible
 

--- a/api/go.sum
+++ b/api/go.sum
@@ -1307,8 +1307,8 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30/go.mod h1:fEO7lRTdivWO2qYVCVG7dEADOMo/MLDCVr8So2g88Uw=
-sigs.k8s.io/cluster-api v1.2.8 h1:O0ZGyxGBeJaSWVptM7U0vTArAVlxCE5OtQItZ4OS2Y4=
-sigs.k8s.io/cluster-api v1.2.8/go.mod h1:HmxYwjLGHia5yjFoMY8I03Ha4kXAB+VTJnHFhAmPVig=
+sigs.k8s.io/cluster-api v1.2.9 h1:8Q+gVLJUsuPixfgjKInNnA7xbgESLWGq26STfRkBqdc=
+sigs.k8s.io/cluster-api v1.2.9/go.mod h1:ZuiH8az7bIv0D6AzkbOrPUtiRAnKH9U1YnFC6nrk72I=
 sigs.k8s.io/controller-runtime v0.12.3 h1:FCM8xeY/FI8hoAfh/V4XbbYMY20gElh9yh+A98usMio=
 sigs.k8s.io/controller-runtime v0.12.3/go.mod h1:qKsk4WE6zW2Hfj0G4v10EnNB2jMG1C+NTb8h+DwCoU0=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 h1:kDi4JBNAsJWfz1aEXhO8Jg87JJaPNLh5tIzYHgStQ9Y=

--- a/go.mod
+++ b/go.mod
@@ -23,15 +23,15 @@ require (
 	k8s.io/component-base v0.24.2
 	k8s.io/klog/v2 v2.60.1
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
-	sigs.k8s.io/cluster-api v1.2.8
-	sigs.k8s.io/cluster-api/test v1.2.8
+	sigs.k8s.io/cluster-api v1.2.9
+	sigs.k8s.io/cluster-api/test v1.2.9
 	sigs.k8s.io/controller-runtime v0.12.3
 	sigs.k8s.io/yaml v1.3.0
 )
 
 replace github.com/metal3-io/cluster-api-provider-metal3/api => ./api
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.2.8
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.2.9
 
 replace github.com/docker/distribution => github.com/docker/distribution v2.8.1+incompatible
 

--- a/go.sum
+++ b/go.sum
@@ -1393,10 +1393,10 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30/go.mod h1:fEO7lRTdivWO2qYVCVG7dEADOMo/MLDCVr8So2g88Uw=
-sigs.k8s.io/cluster-api v1.2.8 h1:O0ZGyxGBeJaSWVptM7U0vTArAVlxCE5OtQItZ4OS2Y4=
-sigs.k8s.io/cluster-api v1.2.8/go.mod h1:HmxYwjLGHia5yjFoMY8I03Ha4kXAB+VTJnHFhAmPVig=
-sigs.k8s.io/cluster-api/test v1.2.8 h1:kYziHLSV+KqBoQXg7STGU4ZQpClayqIyw+BTYGx71uE=
-sigs.k8s.io/cluster-api/test v1.2.8/go.mod h1:55r564Dm7/eO7LH76SRE8whfg4yUnsLz5akqqej4Q+8=
+sigs.k8s.io/cluster-api v1.2.9 h1:8Q+gVLJUsuPixfgjKInNnA7xbgESLWGq26STfRkBqdc=
+sigs.k8s.io/cluster-api v1.2.9/go.mod h1:ZuiH8az7bIv0D6AzkbOrPUtiRAnKH9U1YnFC6nrk72I=
+sigs.k8s.io/cluster-api/test v1.2.9 h1:URMCZ4GHPmgIvH7vIVSItne0iEK0SBiHiyFZa9O1oXU=
+sigs.k8s.io/cluster-api/test v1.2.9/go.mod h1:/bOh2uQ+sbK8Iy0GM6wYq52z867klX95NHgtOG29PEU=
 sigs.k8s.io/controller-runtime v0.12.3 h1:FCM8xeY/FI8hoAfh/V4XbbYMY20gElh9yh+A98usMio=
 sigs.k8s.io/controller-runtime v0.12.3/go.mod h1:qKsk4WE6zW2Hfj0G4v10EnNB2jMG1C+NTb8h+DwCoU0=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 h1:kDi4JBNAsJWfz1aEXhO8Jg87JJaPNLh5tIzYHgStQ9Y=


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.2.9
