### PR TITLE
🌱 pin golang to 1.19.4 with digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.19
+ARG BUILD_IMAGE=docker.io/golang:1.19.4@sha256:660f138b4477001d65324a51fa158c1b868651b44e43f0953bf062e9f38b72f3
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 # Build the manager binary on golang image


### PR DESCRIPTION
Pin golang:1.19.4 with a digest.
