### PR TITLE
🌱 Add m3d waiting condition to m3m object

### DIFF
--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -51,4 +51,9 @@ const (
 	MissingBMHReason = "MissingBMH"
 	// Could not set the ProviderID on the target cluster's Node object.
 	SettingProviderIDOnNodeFailedReason = "SettingProviderIDOnNodeFailed"
+	// Metal3DataReadyCondition reports a summary of Metal3Data status.
+	Metal3DataReadyCondition clusterv1.ConditionType = "Metal3DataReady"
+	// WaitingForMetal3DataReason used when waiting for Metal3Data
+	// to be ready before proceeding.
+	WaitingForMetal3DataReason = "WaitingForMetal3Data"
 )

--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -595,7 +595,7 @@ func (m *DataManager) addressFromM3Claim(ctx context.Context, poolRef corev1.Typ
 	}
 
 	if ipClaim.Status.ErrorMessage != nil {
-		m.Data.Status.ErrorMessage = pointer.StringPtr(fmt.Sprintf(
+		m.setError(ctx, fmt.Sprintf(
 			"IP Allocation for %v failed : %v", poolRef.Name, *ipClaim.Status.ErrorMessage,
 		))
 		return addressFromPool{}, false, errors.New(*m.Data.Status.ErrorMessage)

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -1633,9 +1633,15 @@ func (m *MachineManager) WaitForM3Metadata(ctx context.Context) error {
 
 	// If it is not ready yet, wait.
 	if !metal3Data.Status.Ready {
+		m.Log.Info("Waiting for Metal3Data to become ready")
+		m.SetConditionMetal3MachineToFalse(infrav1.Metal3DataReadyCondition, infrav1.WaitingForMetal3DataReason, clusterv1.ConditionSeverityInfo, "")
 		// Secret generation not ready
 		return &RequeueAfterError{RequeueAfter: requeueAfter}
 	}
+
+	// At this point, Metal3Data is ready
+	m.Log.Info("Metal3data is ready")
+	m.SetConditionMetal3MachineToTrue(infrav1.Metal3DataReadyCondition)
 
 	// Get the secrets if given in Metal3Data and not already set.
 	if m.Metal3Machine.Status.MetaData == nil &&

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -186,6 +186,7 @@ func patchMetal3Machine(ctx context.Context, patchHelper *patch.Helper, metal3Ma
 	conditions.SetSummary(metal3Machine,
 		conditions.WithConditions(
 			infrav1.AssociateBMHCondition,
+			infrav1.Metal3DataReadyCondition,
 			infrav1.KubernetesNodeReadyCondition,
 		),
 	)
@@ -195,6 +196,7 @@ func patchMetal3Machine(ctx context.Context, patchHelper *patch.Helper, metal3Ma
 		patch.WithOwnedConditions{Conditions: []clusterv1.ConditionType{
 			clusterv1.ReadyCondition,
 			infrav1.AssociateBMHCondition,
+			infrav1.Metal3DataReadyCondition,
 			infrav1.KubernetesNodeReadyCondition,
 		}},
 		patch.WithStatusObservedGeneration{},


### PR DESCRIPTION
Co-authored-by: Adil Ghaffar <muhammad.adil.ghaffar@est.tech>

When there is an issue on ip allocation on ipam `m3m` will be waiting without explicitly showing what the user should look for. This PR adds a waiting condition to `m3m` when `m3d` is not ready and the latter would show in the `ErrorMessage` any error in the ip allocation.