### PR TITLE
:bug: Clean varenv after mngmt upgrade

### DIFF
--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -129,6 +129,7 @@ variables:
   UPGRADED_BMO_IMAGE_TAG: "${UPGRADED_BMO_IMAGE_TAG:-main}"
 
   INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPI_FROM_RELEASE}/clusterctl-{OS}-{ARCH}"
+  PROVIDER_ID_FORMAT: "metal3://{{ ds.meta_data.providerid }}"
   # Pin Calico version
   CALICO_PATCH_RELEASE: "v3.24.1"
   # Pin CertManager for upgrade tests

--- a/test/e2e/upgrade_management_cluster_test.go
+++ b/test/e2e/upgrade_management_cluster_test.go
@@ -266,4 +266,24 @@ func preCleanupManagementCluster(clusterProxy framework.ClusterProxy) {
 		}
 	})
 	reInstallIronic()
+
+	//#nosec G204 -- We need to pass in the file name here.
+	cmd := exec.Command("bash", "-c", "kubectl apply -f bmhosts_crs.yaml  -n metal3")
+	cmd.Dir = workDir
+	output, err := cmd.CombinedOutput()
+	Logf("Applying bmh to meta3 namespace : \n %v", string(output))
+	Expect(err).To(BeNil())
+
+	// Clean env variables set for management upgrade, defaults are set in e2e config file
+	// Capi/capm3 versions
+	os.Unsetenv("CAPI_VERSION")
+	os.Unsetenv("CAPM3_VERSION")
+	// The provider id format
+	os.Unsetenv("PROVIDER_ID_FORMAT")
+	// IPs
+	os.Unsetenv("CLUSTER_APIENDPOINT_HOST")
+	os.Unsetenv("BAREMETALV4_POOL_RANGE_START")
+	os.Unsetenv("BAREMETALV4_POOL_RANGE_END")
+	os.Unsetenv("PROVISIONING_POOL_RANGE_START")
+	os.Unsetenv("PROVISIONING_POOL_RANGE_END")
 }


### PR DESCRIPTION
Fix upgrade test issue:
Unset custom var env after management upgrade
Apply bmh to metal3 namespace after removing management ns 