### PR TITLE
WIP: :bug: adding cleanup code for upgrade management cluster test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ e2e-tests: e2e-substitutions cluster-templates ## This target should be called f
 	cd test; \
 	time go test -v -timeout 24h --tags=e2e ./e2e/... -args \
 		--ginkgo.timeout=6h --ginkgo.v --ginkgo.trace --ginkgo.show-node-events --ginkgo.no-color=$(GINKGO_NOCOLOR) \
-		--ginkgo.junit-report="junit.e2e_suite.1.xml" \
+		--ginkgo.seed=1674507739 --ginkgo.junit-report="junit.e2e_suite.1.xml" \
 		--ginkgo.focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) \
 		-e2e.artifacts-folder="$(ARTIFACTS)" \
 		-e2e.config="$(E2E_CONF_FILE_ENVSUBST)" \

--- a/test/e2e/upgrade_management_cluster_test.go
+++ b/test/e2e/upgrade_management_cluster_test.go
@@ -70,6 +70,14 @@ var _ = Describe("When testing cluster upgrade v1alpha5 > current [upgrade]", fu
 			}
 		})
 	}
+
+	AfterEach(func() {
+		ListBareMetalHosts(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		ListMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		ListMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		ListNodes(ctx, targetCluster.GetClient())
+		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
+	})
 })
 
 // preWaitForCluster is a hook function that should be called from ClusterctlUpgradeSpec before waiting for the cluster to spin up

--- a/test/e2e/upgrade_management_cluster_test.go
+++ b/test/e2e/upgrade_management_cluster_test.go
@@ -72,9 +72,6 @@ var _ = Describe("When testing cluster upgrade v1alpha5 > current [upgrade]", fu
 	}
 
 	AfterEach(func() {
-		ListBareMetalHosts(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
-		ListMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
-		ListMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		ListNodes(ctx, targetCluster.GetClient())
 		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
We need this PR to fix the flake fail in our CI in upgrade tests. K8s upgrade test fails if it runs after upgrade management cluster test because of missing cleanup code.
