### PR TITLE
🌱 hack: update ensure-kind.sh

### DIFF
--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 The Kubernetes Authors.
+# Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,20 +18,26 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-GOPATH_BIN="$(go env GOPATH)/bin/"
-MINIMUM_KIND_VERSION=v0.11.1
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
+GOPATH_BIN="$(go env GOPATH)/bin"
+MINIMUM_KIND_VERSION=v0.17.0
+goarch="$(go env GOARCH)"
+goos="$(go env GOOS)"
 
 # Ensure the kind tool exists and is a viable version, or installs it
 verify_kind_version() {
 
   # If kind is not available on the path, get it
   if ! [ -x "$(command -v kind)" ]; then
-    if [[ "${OSTYPE}" == "linux-gnu" ]]; then
+    if [ "$goos" == "linux" ] || [ "$goos" == "darwin" ]; then
       echo 'kind not found, installing'
       if ! [ -d "${GOPATH_BIN}" ]; then
         mkdir -p "${GOPATH_BIN}"
       fi
-      curl -sLo "${GOPATH_BIN}/kind" https://github.com/kubernetes-sigs/kind/releases/download/${MINIMUM_KIND_VERSION}/kind-linux-amd64
+      curl -sLo "${GOPATH_BIN}/kind" "https://github.com/kubernetes-sigs/kind/releases/download/${MINIMUM_KIND_VERSION}/kind-${goos}-${goarch}"
       chmod +x "${GOPATH_BIN}/kind"
     else
       echo "Missing required binary in path: kind"
@@ -40,8 +46,14 @@ verify_kind_version() {
   fi
 
   local kind_version
-  kind_version="v$(kind version -q)"
-  if [[ "${MINIMUM_KIND_VERSION}" != $(echo -e "${MINIMUM_KIND_VERSION}\n${kind_version}" | sort -V | head -n1) ]]; then
+  if [ -x "$(command -v kind)" ]; then
+    kind_version="v$(kind version -q)"
+  else
+    echo "warning: GOPATH_BIN=${GOPATH_BIN} not in your path"
+    kind_version="v$("${GOPATH_BIN}"/kind version -q)"
+  fi
+
+  if [[ "${MINIMUM_KIND_VERSION}" != $(echo -e "${MINIMUM_KIND_VERSION}\n${kind_version}" | sort -s -t. -k 1,1n -k 2,2n -k 3,3n | head -n1) ]]; then
     cat <<EOF
 Detected kind version: ${kind_version}.
 Requires ${MINIMUM_KIND_VERSION} or greater.


### PR DESCRIPTION
Take ensure-kind.sh from CAPI, that has added support for Mac (Darwin), raised minimum kind version to 0.17.0 and added support for `set -x` via `TRACE` env.

Also, fix the script not to fail if GOPATH_BIN in not in user's path before running the script, but print a warning and then use full path for the kind so we can do version check properly, and also warn user that he needs to fix their PATH.
