### PR TITLE
🌱 Bump Dockerfile golang image tag to v1.18.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Support FROM override
+ARG BUILD_IMAGE=docker.io/golang:1.18.10@sha256:50c889275d26f816b5314fc99f55425fa76b18fcaf16af255f5d57f09e1f48da
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
+
 # Build the manager binary on golang image
-FROM docker.io/golang:1.17 as builder
+FROM $BUILD_IMAGE as builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
@@ -42,7 +46,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
     -o manager .
 
 # Copy the controller-manager into a thin image
-FROM gcr.io/distroless/static:nonroot
+FROM $BASE_IMAGE
 WORKDIR /
 COPY --from=builder /workspace/manager .
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies


### PR DESCRIPTION
golang images less than v1.18.10 is vulnerable. Relates to https://github.com/kubernetes-sigs/cluster-api/issues/7974 