### PR TITLE
Revert "🐛 Remove bmhID arg from SetNodeProviderID call"

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -93,7 +93,7 @@ type MachineManagerInterface interface {
 	Update(context.Context) error
 	HasAnnotation() bool
 	GetProviderIDAndBMHID() (string, *string)
-	SetNodeProviderID(context.Context, *string, ClientGetter) error
+	SetNodeProviderID(context.Context, *string, *string, ClientGetter) error
 	SetProviderID(string)
 	SetPauseAnnotation(context.Context) error
 	RemovePauseAnnotation(context.Context) error
@@ -1332,7 +1332,8 @@ func (m *MachineManager) GetProviderIDAndBMHID() (string, *string) {
 type ClientGetter func(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) (clientcorev1.CoreV1Interface, error)
 
 // SetNodeProviderID sets the metal3 provider ID on the kubernetes node.
-func (m *MachineManager) SetNodeProviderID(ctx context.Context, providerIDOnM3M *string, clientFactory ClientGetter) error {
+func (m *MachineManager) SetNodeProviderID(ctx context.Context, bmhID *string, providerIDOnM3M *string, clientFactory ClientGetter) error {
+	// todo: bmhID should not be trusted and needs to removed from the signature.
 	corev1Remote, err := clientFactory(ctx, m.client, m.Cluster)
 	if err != nil {
 		return errors.Wrap(err, "Error creating a remote client")
@@ -1344,15 +1345,12 @@ func (m *MachineManager) SetNodeProviderID(ctx context.Context, providerIDOnM3M 
 		m.Log.Info("unable to retrieve BMH name from Metal3Machine")
 		return &RequeueAfterError{RequeueAfter: requeueAfter}
 	}
-	bmhUID, err := m.getBmhUIDFromM3Machine(ctx)
-	if err != nil {
-		m.Log.Info("unable to retrieve BMH UID from Metal3Machine")
-		return &RequeueAfterError{RequeueAfter: requeueAfter}
+	providerIDLegacy := "metal3://unknown"
+	nodeLabel := fmt.Sprintf("%s=unknown", ProviderLabelPrefix)
+	if bmhID != nil {
+		providerIDLegacy = fmt.Sprintf("metal3://%s", *bmhID)
+		nodeLabel = fmt.Sprintf("%s=%s", ProviderLabelPrefix, *bmhID)
 	}
-
-	providerIDLegacy := fmt.Sprintf("metal3://%s", bmhUID)
-	nodeLabel := fmt.Sprintf("%s=%s", ProviderLabelPrefix, bmhUID)
-
 	providerIDNew := fmt.Sprintf("metal3://%s/%s/%s", namespace, bmhName, m3mName)
 
 	matchingNodesCount, err := m.getMatchingNodesWithoutLabelCount(ctx, providerIDLegacy, providerIDNew, providerIDOnM3M, clientFactory)
@@ -1372,6 +1370,10 @@ func (m *MachineManager) SetNodeProviderID(ctx context.Context, providerIDOnM3M 
 	}
 	if matchingNodesCount == 1 {
 		return nil
+	}
+	if bmhID == nil {
+		m.Log.Info("requeuing, could not find the BMH ID yet.")
+		return &RequeueAfterError{RequeueAfter: requeueAfter}
 	}
 	nodes, countNodesWithLabel, err := m.getNodesWithLabel(ctx, nodeLabel, clientFactory)
 	if err != nil {
@@ -1799,19 +1801,6 @@ func (m *MachineManager) getBmhNameFromM3Machine() (string, error) {
 	}
 	bmhName := valueParts[1]
 	return bmhName, nil
-}
-
-// getBmhUIDFromM3Machine retrieves bmhUID from m3m.
-func (m *MachineManager) getBmhUIDFromM3Machine(ctx context.Context) (string, error) {
-	host, err := getHost(ctx, m.Metal3Machine, m.client, m.Log)
-	if err != nil || host == nil {
-		errMessage := fmt.Sprintf("Failed to get a BaremetalHost for the metal3machine: %s", m.Metal3Machine.GetName())
-		return "", errors.New(errMessage)
-	}
-	if host.UID == "" {
-		return "", errors.New("Missing BaremetalHost UID")
-	}
-	return string(host.UID), nil
 }
 
 // getNodesWithLabel gets kubernetes nodes with a given label.

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -2584,7 +2584,7 @@ var _ = Describe("Metal3Machine manager", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 
-				err = machineMgr.SetNodeProviderID(context.TODO(),
+				err = machineMgr.SetNodeProviderID(context.TODO(), &tc.HostID,
 					&tc.ExpectedProviderID, m,
 				)
 
@@ -2677,7 +2677,7 @@ var _ = Describe("Metal3Machine manager", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 
-				err = machineMgr.SetNodeProviderID(context.TODO(),
+				err = machineMgr.SetNodeProviderID(context.TODO(), &tc.HostID,
 					&tc.ExpectedProviderID, m,
 				)
 

--- a/baremetal/mocks/zz_generated.metal3machine_manager.go
+++ b/baremetal/mocks/zz_generated.metal3machine_manager.go
@@ -251,17 +251,17 @@ func (mr *MockMachineManagerInterfaceMockRecorder) SetFinalizer() *gomock.Call {
 }
 
 // SetNodeProviderID mocks base method.
-func (m *MockMachineManagerInterface) SetNodeProviderID(arg0 context.Context, arg1 *string, arg2 baremetal.ClientGetter) error {
+func (m *MockMachineManagerInterface) SetNodeProviderID(arg0 context.Context, arg1, arg2 *string, arg3 baremetal.ClientGetter) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetNodeProviderID", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetNodeProviderID", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetNodeProviderID indicates an expected call of SetNodeProviderID.
-func (mr *MockMachineManagerInterfaceMockRecorder) SetNodeProviderID(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMachineManagerInterfaceMockRecorder) SetNodeProviderID(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNodeProviderID", reflect.TypeOf((*MockMachineManagerInterface)(nil).SetNodeProviderID), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNodeProviderID", reflect.TypeOf((*MockMachineManagerInterface)(nil).SetNodeProviderID), arg0, arg1, arg2, arg3)
 }
 
 // SetPauseAnnotation mocks base method.

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -265,7 +265,7 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 	}
 	if providerID != "" || bmhID != nil {
 		// Set the providerID on the node if no Cloud provider
-		err = machineMgr.SetNodeProviderID(ctx, &providerID, r.CapiClientGetter)
+		err = machineMgr.SetNodeProviderID(ctx, bmhID, &providerID, r.CapiClientGetter)
 		if err != nil {
 			machineMgr.SetConditionMetal3MachineToFalse(infrav1.KubernetesNodeReadyCondition, infrav1.SettingProviderIDOnNodeFailedReason, clusterv1.ConditionSeverityError, err.Error())
 			return checkMachineError(machineMgr, err,

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -137,7 +137,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		// if we fail to set it on the node, we do not go further
 		if tc.SetNodeProviderIDFails {
 			m.EXPECT().
-				SetNodeProviderID(context.TODO(), gomock.Eq(&provID), nil).
+				SetNodeProviderID(context.TODO(), gomock.Eq(pointer.StringPtr(string(bmhuid))), gomock.Eq(&provID), nil).
 				Return(errors.New("Failed"))
 			m.EXPECT().SetProviderID(string(bmhuid)).MaxTimes(0)
 			m.EXPECT().SetError(gomock.Any(), gomock.Any())
@@ -148,7 +148,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 
 		// we successfully set it on the node
 		m.EXPECT().
-			SetNodeProviderID(context.TODO(), gomock.Eq(&provID), nil).
+			SetNodeProviderID(context.TODO(), gomock.Eq(pointer.StringPtr(string(bmhuid))), gomock.Eq(&provID), nil).
 			Return(nil)
 		m.EXPECT().SetProviderID(provID)
 
@@ -158,7 +158,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		m.EXPECT().GetBaremetalHostID(context.TODO()).Return(nil, nil)
 
 		m.EXPECT().
-			SetNodeProviderID(context.TODO(), gomock.Eq(&providerID), nil).
+			SetNodeProviderID(context.TODO(), gomock.Eq(pointer.StringPtr(string(bmhuid))), gomock.Eq(&providerID), nil).
 			MaxTimes(0)
 	}
 


### PR DESCRIPTION
Running the unit test on latest main branch fails with:

```

• [FAILED] [0.000 seconds]
Metal3Machine manager Test SetNodeProviderID Test SetNodeProviderID [It] Set target ProviderID, matching node
/Users/fgofurov/workspace/cluster-api-provider-metal3/baremetal/metal3machine_manager_test.go:2618

  [FAILED] Unexpected error:
      <*baremetal.RequeueAfterError | 0x14000be7a48>: {
          RequeueAfter: 30000000000,
      }
      requeue in: 30s
  occurred
  In [It] at: /Users/fgofurov/workspace/cluster-api-provider-metal3/baremetal/metal3machine_manager_test.go:2595 @ 03/01/23 09:31:45.073
------------------------------
• [FAILED] [0.000 seconds]
Metal3Machine manager Test SetNodeProviderID Test SetNodeProviderID [It] Set target ProviderID, providerID set
/Users/fgofurov/workspace/cluster-api-provider-metal3/baremetal/metal3machine_manager_test.go:2633

  [FAILED] Unexpected error:
      <*baremetal.RequeueAfterError | 0x14000402fe0>: {
          RequeueAfter: 30000000000,
      }
      requeue in: 30s
  occurred
  In [It] at: /Users/fgofurov/workspace/cluster-api-provider-metal3/baremetal/metal3machine_manager_test.go:2595 @ 03/01/23 09:31:45.074
------------------------------
• [FAILED] [0.000 seconds]
Metal3Machine manager Test SetNodeProviderID Test SetNodeProviderID with noCloudProvider set to false [It] Accept providerID when set on a node
/Users/fgofurov/workspace/cluster-api-provider-metal3/baremetal/metal3machine_manager_test.go:2702

  [FAILED] Unexpected error:
      <*baremetal.RequeueAfterError | 0x14000403d78>: {
          RequeueAfter: 30000000000,
      }
      requeue in: 30s
  occurred
  In [It] at: /Users/fgofurov/workspace/cluster-api-provider-metal3/baremetal/metal3machine_manager_test.go:2688 @ 03/01/23 09:31:45.074
------------------------------
•••••••••requeue in: 30s
```

For now this reverts metal3-io/cluster-api-provider-metal3#868 and unit tests should pass locally but we still have to investigate how it passed initially in #868 