### PR TITLE
remove unsupported OSes

### DIFF
--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -24,10 +24,10 @@ function os_check() {
     export DISTRO="${ID}${VERSION_ID%.*}"
     export OS="${ID}"
     export OS_VERSION_ID=$VERSION_ID
-    export SUPPORTED_DISTROS=(centos8 centos9 rhel8 ubuntu20 ubuntu22)
+    export SUPPORTED_DISTROS=(centos9 ubuntu20 ubuntu22)
 
     if [[ ! "${SUPPORTED_DISTROS[*]}" =~ $DISTRO ]]; then
-        echo "Supported OS distros for the host are: CentOS Stream 8/9 or RHEL8/9 or Ubuntu20.04 or Ubuntu22.04"
+        echo "Supported OS distros for the host are: CentOS Stream 9, and Ubuntu 20.04/22.04"
         exit 1
     fi
 }


### PR DESCRIPTION
Remove unsupported OSes. We only support and test with Centos9 and Ubuntu 20.04 and 22.04.

Main PR: https://github.com/metal3-io/metal3-dev-env/pull/1164

/hold 
