### PR TITLE
:bug: Remove bmhID arg from SetNodeProviderID call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ e2e-tests: e2e-substitutions cluster-templates ## This target should be called f
 	done
 	cd test; \
 	time go test -v -timeout 24h --tags=e2e ./e2e/... -args \
-		--ginkgo.timeout=6h --ginkgo.v --ginkgo.trace --ginkgo.show-node-events --ginkgo.no-color=$(GINKGO_NOCOLOR) \
+		--ginkgo.timeout=6h --ginkgo.v --ginkgo.trace --ginkgo.failFast --ginkgo.show-node-events --ginkgo.no-color=$(GINKGO_NOCOLOR) \
 		--ginkgo.junit-report="junit.e2e_suite.1.xml" \
 		--ginkgo.focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) \
 		-e2e.artifacts-folder="$(ARTIFACTS)" \

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -488,7 +488,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 		}
 
-		availableHost := newBareMetalHost("availableHost", &bmov1alpha1.BareMetalHostSpec{}, bmov1alpha1.StateReady, &bmov1alpha1.BareMetalHostStatus{}, true, "metadata", false)
+		availableHost := newBareMetalHost("availableHost", &bmov1alpha1.BareMetalHostSpec{}, bmov1alpha1.StateReady, &bmov1alpha1.BareMetalHostStatus{}, true, "metadata", false, "")
 
 		hostWithConRef := bmov1alpha1.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1098,7 +1098,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			UserDataNamespace:         "otherns",
 			ExpectedUserDataNamespace: "otherns",
 			Host: newBareMetalHost("host2", nil, bmov1alpha1.StateNone,
-				nil, false, "metadata", false,
+				nil, false, "metadata", false, "",
 			),
 			ExpectedImage:  expectedImg(),
 			ExpectUserData: true,
@@ -1107,7 +1107,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			UserDataNamespace:         "",
 			ExpectedUserDataNamespace: namespaceName,
 			Host: newBareMetalHost("host2", nil, bmov1alpha1.StateNone,
-				nil, false, "metadata", false,
+				nil, false, "metadata", false, "",
 			),
 			ExpectedImage:  expectedImg(),
 			ExpectUserData: true,
@@ -1116,7 +1116,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			UserDataNamespace:         "",
 			ExpectedUserDataNamespace: namespaceName,
 			Host: newBareMetalHost("host2", nil, bmov1alpha1.StateNone,
-				nil, false, "metadata", false,
+				nil, false, "metadata", false, "",
 			),
 			ExpectedImage:  expectedImg(),
 			ExpectUserData: true,
@@ -1126,7 +1126,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				UserDataNamespace:         "",
 				ExpectedUserDataNamespace: namespaceName,
 				Host: newBareMetalHost("host2", bmhSpecTestImg(),
-					bmov1alpha1.StateNone, nil, false, "metadata", false,
+					bmov1alpha1.StateNone, nil, false, "metadata", false, "",
 				),
 				ExpectedImage:  expectedImgTest(),
 				ExpectUserData: false,
@@ -1168,7 +1168,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			UserDataNamespace:         "otherns",
 			ExpectedUserDataNamespace: "otherns",
 			Host: newBareMetalHost("host2", nil, bmov1alpha1.StateNone,
-				nil, false, "metadata", false,
+				nil, false, "metadata", false, "",
 			),
 			ExpectedImage:  expectedImg(),
 			ExpectUserData: true,
@@ -1177,7 +1177,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			UserDataNamespace:         "",
 			ExpectedUserDataNamespace: namespaceName,
 			Host: newBareMetalHost("host2", nil, bmov1alpha1.StateNone,
-				nil, false, "metadata", false,
+				nil, false, "metadata", false, "",
 			),
 			ExpectedImage:  expectedImg(),
 			ExpectUserData: true,
@@ -1186,7 +1186,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			UserDataNamespace:         "",
 			ExpectedUserDataNamespace: namespaceName,
 			Host: newBareMetalHost("host2", nil, bmov1alpha1.StateNone,
-				nil, false, "metadata", false,
+				nil, false, "metadata", false, "",
 			),
 			ExpectedImage:  expectedImg(),
 			ExpectUserData: true,
@@ -1196,7 +1196,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				UserDataNamespace:         "",
 				ExpectedUserDataNamespace: namespaceName,
 				Host: newBareMetalHost("host2", bmhSpecTestImg(),
-					bmov1alpha1.StateNone, nil, false, "metadata", false,
+					bmov1alpha1.StateNone, nil, false, "metadata", false, "",
 				),
 				ExpectedImage:  expectedImgTest(),
 				ExpectUserData: false,
@@ -1506,7 +1506,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil,
-				false, "metadata", false,
+				false, "metadata", false, "",
 			),
 			ExpectAnnotation: true,
 		}),
@@ -1516,7 +1516,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				m3mObjectMetaWithInvalidAnnotations(),
 			),
 			Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone,
-				nil, false, "metadata", false,
+				nil, false, "metadata", false, "",
 			),
 			ExpectAnnotation: true,
 		}),
@@ -1526,7 +1526,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				m3mObjectMetaEmptyAnnotations(),
 			),
 			Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone,
-				nil, false, "metadata", false,
+				nil, false, "metadata", false, "",
 			),
 			ExpectAnnotation: true,
 		}),
@@ -1536,7 +1536,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				m3mObjectMetaNoAnnotations(),
 			),
 			Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone,
-				nil, false, "metadata", false,
+				nil, false, "metadata", false, "",
 			),
 			ExpectAnnotation: true,
 		}),
@@ -1718,7 +1718,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		},
 		Entry("Deprovisioning needed", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpec(),
-				bmov1alpha1.StateProvisioned, bmhStatus(), false, "metadata", true,
+				bmov1alpha1.StateProvisioned, bmhStatus(), false, "metadata", true, "",
 			),
 			Machine: newMachine(machineName, "", nil),
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
@@ -1731,7 +1731,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("No Host status, deprovisioning needed", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpec(), bmov1alpha1.StateNone,
-				nil, false, "metadata", true,
+				nil, false, "metadata", true, "",
 			),
 			Machine: newMachine(machineName, "", nil),
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
@@ -1744,7 +1744,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("No Host status, no deprovisioning needed", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(), bmov1alpha1.StateNone, nil,
-				false, "metadata", true,
+				false, "metadata", true, "",
 			),
 			Machine: newMachine(machineName, "", nil),
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
@@ -1755,7 +1755,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Deprovisioning in progress", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(),
-				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "metadata", true,
+				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "metadata", true, "",
 			),
 			Machine: newMachine(machineName, "", nil),
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
@@ -1767,7 +1767,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Externally provisioned host should be powered down", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(),
-				bmov1alpha1.StateExternallyProvisioned, bmhPowerStatus(), true, "metadata", true,
+				bmov1alpha1.StateExternallyProvisioned, bmhPowerStatus(), true, "metadata", true, "",
 			),
 			Machine: newMachine(machineName, "", nil),
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
@@ -1780,7 +1780,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Consumer ref should be removed from externally provisioned host",
 			testCaseDelete{
 				Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(),
-					bmov1alpha1.StateExternallyProvisioned, bmhPowerStatus(), false, "metadata", true,
+					bmov1alpha1.StateExternallyProvisioned, bmhPowerStatus(), false, "metadata", true, "",
 				),
 				Machine: newMachine(machineName, "", nil),
 				M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
@@ -1793,7 +1793,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Consumer ref should be removed from unmanaged host",
 			testCaseDelete{
 				Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(),
-					bmov1alpha1.StateUnmanaged, bmhPowerStatus(), false, "metadata", true,
+					bmov1alpha1.StateUnmanaged, bmhPowerStatus(), false, "metadata", true, "",
 				),
 				Machine: newMachine(machineName, "", nil),
 				M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
@@ -1805,7 +1805,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		),
 		Entry("Consumer ref should be removed, BMH state is available", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(), bmov1alpha1.StateAvailable,
-				bmhStatus(), false, "metadata", true,
+				bmhStatus(), false, "metadata", true, "",
 			),
 			Machine: newMachine(machineName, "", nil),
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
@@ -1816,7 +1816,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Consumer ref should be removed", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(), bmov1alpha1.StateReady,
-				bmhStatus(), false, "metadata", true,
+				bmhStatus(), false, "metadata", true, "",
 			),
 			Machine: newMachine(machineName, "", nil),
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
@@ -1827,7 +1827,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Consumer ref should be removed, secret not deleted", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(), bmov1alpha1.StateReady,
-				bmhStatus(), false, "metadata", true,
+				bmhStatus(), false, "metadata", true, "",
 			),
 			Machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1847,7 +1847,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Consumer ref does not match, so it should not be removed",
 			testCaseDelete{
 				Host: newBareMetalHost(baremetalhostName, bmhSpecSomeImg(),
-					bmov1alpha1.StateProvisioned, bmhStatus(), false, "metadata", true,
+					bmov1alpha1.StateProvisioned, bmhStatus(), false, "metadata", true, "",
 				),
 				Machine: newMachine("", "", nil),
 				M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
@@ -1859,7 +1859,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 		),
 		Entry("No consumer ref, so this is a no-op", testCaseDelete{
-			Host:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", true),
+			Host:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", true, ""),
 			Machine: newMachine("", "", nil),
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
@@ -1878,7 +1878,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("dataSecretName set, deleting secret", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(), bmov1alpha1.StateNone, nil,
-				false, "metadata", true,
+				false, "metadata", true, "",
 			),
 			Machine: &clusterv1.Machine{
 				ObjectMeta: testObjectMeta("", namespaceName, ""),
@@ -1897,7 +1897,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Clusterlabel should be removed", testCaseDelete{
 			Machine:                   newMachine(machineName, metal3machineName, nil),
 			M3Machine:                 newMetal3Machine(metal3machineName, nil, m3mSpecAll(), m3mSecretStatus(), m3mObjectMetaWithValidAnnotations()),
-			Host:                      newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", true),
+			Host:                      newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", true, ""),
 			BMCSecret:                 newBMCSecret("mycredentials", true),
 			ExpectSecretDeleted:       true,
 			ExpectClusterLabelDeleted: true,
@@ -1922,14 +1922,14 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("No clusterLabel in BMH or BMC Secret so this is a no-op ", testCaseDelete{
 			Machine:                   newMachine(machineName, metal3machineName, nil),
 			M3Machine:                 newMetal3Machine(metal3machineName, nil, m3mSpecAll(), m3mSecretStatus(), m3mObjectMetaWithValidAnnotations()),
-			Host:                      newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", false),
+			Host:                      newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 			BMCSecret:                 newBMCSecret("mycredentials", false),
 			ExpectSecretDeleted:       true,
 			ExpectClusterLabelDeleted: false,
 		}),
 		Entry("BMH MetaData, NetworkData and UserData should not be cleaned on deprovisioning", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpecSomeImg(),
-				bmov1alpha1.StateProvisioned, bmhStatus(), false, "metadata", true,
+				bmov1alpha1.StateProvisioned, bmhStatus(), false, "metadata", true, "",
 			),
 			Machine: newMachine(machineName, metal3machineName, nil),
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatusNil(),
@@ -1942,7 +1942,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Capm3FastTrack is set to false, AutomatedCleaning mode is set to metadata, set bmh online field to false", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpec(),
-				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "metadata", true),
+				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "metadata", true, ""),
 			Machine: newMachine(machineName, "", nil),
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
@@ -1955,7 +1955,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Capm3FastTrack is set to true, AutomatedCleaning mode is set to metadata, set bmh online field to true", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpec(),
-				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "metadata", true),
+				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "metadata", true, ""),
 			Machine: newMachine(machineName, "", nil),
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
@@ -1968,7 +1968,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Capm3FastTrack is set to false, AutomatedCleaning mode is set to disabled, set bmh online field to false", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpec(),
-				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "disabled", true),
+				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "disabled", true, ""),
 			Machine: newMachine(machineName, "", nil),
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
@@ -1981,7 +1981,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Capm3FastTrack is set to true, AutomatedCleaning mode is set to disabled, set bmh online field to false", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpec(),
-				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "disabled", true),
+				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "disabled", true, ""),
 			Machine: newMachine(machineName, "", nil),
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
@@ -1994,7 +1994,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Capm3FastTrack is empty, AutomatedCleaning mode is set to disabled, set bmh online field to false", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpec(),
-				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "disabled", true),
+				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "disabled", true, ""),
 			Machine: newMachine(machineName, "", nil),
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
@@ -2007,7 +2007,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Capm3FastTrack is empty, AutomatedCleaning mode is set to metadata, set bmh online field to false", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpec(),
-				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "metadata", true),
+				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "metadata", true, ""),
 			Machine: newMachine(machineName, "", nil),
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
@@ -2029,7 +2029,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					Provisioning: bmov1alpha1.ProvisionStatus{
 						State: bmov1alpha1.StateNone,
 					},
-				}, false, "metadata", true),
+				}, false, "metadata", true, ""),
 			Machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      machineName,
@@ -2125,7 +2125,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					Provisioning: bmov1alpha1.ProvisionStatus{
 						State: bmov1alpha1.StateNone,
 					},
-				}, false, "metadata", false),
+				}, false, "metadata", false, ""),
 			Machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      machineName,
@@ -2550,7 +2550,8 @@ var _ = Describe("Metal3Machine manager", func() {
 
 		DescribeTable("Test SetNodeProviderID",
 			func(tc testCaseSetNodePoviderID) {
-				fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
+				BMHHost := newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false, tc.HostID)
+				fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(BMHHost).Build()
 				corev1Client := clientfake.NewSimpleClientset(tc.TargetObjects...).CoreV1()
 				m := func(ctx context.Context, client client.Client, cluster *clusterv1.Cluster) (
 					clientcorev1.CoreV1Interface, error,
@@ -2584,7 +2585,7 @@ var _ = Describe("Metal3Machine manager", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 
-				err = machineMgr.SetNodeProviderID(context.TODO(), &tc.HostID,
+				err = machineMgr.SetNodeProviderID(context.TODO(),
 					&tc.ExpectedProviderID, m,
 				)
 
@@ -2620,13 +2621,28 @@ var _ = Describe("Metal3Machine manager", func() {
 					&corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
-								ProviderLabelPrefix: string(bmhuid),
+								ProviderLabelPrefix: string(Bmhuid),
 							},
 						},
 					},
 				},
-				HostID:               string(bmhuid),
+				HostID:               string(Bmhuid),
 				ExpectedError:        false,
+				ExpectedProviderID:   fmt.Sprintf("metal3://%s/%s/%s", namespaceName, baremetalhostName, metal3machineName),
+				M3MHasHostAnnotation: true,
+			}),
+			Entry("Fails to set target ProviderID, if no matching node is found", testCaseSetNodePoviderID{
+				TargetObjects: []runtime.Object{
+					&corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								ProviderLabelPrefix: string(Bmhuid),
+							},
+						},
+					},
+				},
+				HostID:               "wrong-bmhuid",
+				ExpectedError:        true,
 				ExpectedProviderID:   fmt.Sprintf("metal3://%s/%s/%s", namespaceName, baremetalhostName, metal3machineName),
 				M3MHasHostAnnotation: true,
 			}),
@@ -2651,7 +2667,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		)
 		DescribeTable("Test SetNodeProviderID with noCloudProvider set to false",
 			func(tc testCaseSetNodePoviderID) {
-				fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
+				BMHHost := newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false, tc.HostID)
+				fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(BMHHost).Build()
 				corev1Client := clientfake.NewSimpleClientset(tc.TargetObjects...).CoreV1()
 				m := func(ctx context.Context, client client.Client, cluster *clusterv1.Cluster) (
 					clientcorev1.CoreV1Interface, error,
@@ -2677,7 +2694,7 @@ var _ = Describe("Metal3Machine manager", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 
-				err = machineMgr.SetNodeProviderID(context.TODO(), &tc.HostID,
+				err = machineMgr.SetNodeProviderID(context.TODO(),
 					&tc.ExpectedProviderID, m,
 				)
 
@@ -2848,7 +2865,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			},
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil, nil),
-			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
+			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 		}),
 		Entry("Secret set in Machine, different namespace", testCaseGetUserDataSecretName{
 			Secret: &corev1.Secret{
@@ -2876,7 +2893,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			},
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil, nil),
-			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
+			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 		}),
 		Entry("Secret in other namespace set in Machine", testCaseGetUserDataSecretName{
 			Secret: &corev1.Secret{
@@ -2908,7 +2925,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			},
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil, nil),
-			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
+			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 		}),
 		Entry("UserDataSecretName set in Machine, secret exists", testCaseGetUserDataSecretName{
 			Secret: newSecret(),
@@ -2921,7 +2938,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			},
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil, nil),
-			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
+			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 		}),
 		Entry("UserDataSecretName set in Machine, no secret", testCaseGetUserDataSecretName{
 			Machine: &clusterv1.Machine{
@@ -2933,7 +2950,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			},
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil, nil),
-			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
+			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 		}),
 	)
 
@@ -3024,7 +3041,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					m3mObjectMetaWithValidAnnotations(),
 				),
 				Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil,
-					false, "metadata", false,
+					false, "metadata", false, "",
 				),
 				ExpectRequeue:  false,
 				ExpectOwnerRef: true,
@@ -3037,7 +3054,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					m3mObjectMetaWithValidAnnotations(),
 				),
 				Host: newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil,
-					false, "metadata", false,
+					false, "metadata", false, "",
 				),
 				BMCSecret:      newBMCSecret("mycredentials", false),
 				ExpectRequeue:  false,
@@ -3050,7 +3067,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpecAll(), nil,
 					m3mObjectMetaWithValidAnnotations(),
 				),
-				Host:           newBareMetalHost("", nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
+				Host:           newBareMetalHost("", nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 				ExpectRequeue:  true,
 				ExpectOwnerRef: false,
 			},
@@ -3069,7 +3086,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			testCaseAssociate{
 				Machine:            newMachine(machineName, metal3machineName, nil),
 				M3Machine:          newMetal3Machine(metal3machineName, nil, m3mSpecAll(), nil, nil),
-				Host:               newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", false),
+				Host:               newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 				BMCSecret:          newBMCSecret("mycredentials", false),
 				ExpectClusterLabel: true,
 				ExpectRequeue:      false,
@@ -3096,7 +3113,7 @@ var _ = Describe("Metal3Machine manager", func() {
 						},
 					}, nil, nil,
 				),
-				Host:               newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", false),
+				Host:               newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 				BMCSecret:          newBMCSecret("mycredentials", false),
 				ExpectClusterLabel: true,
 				ExpectRequeue:      true,
@@ -3125,7 +3142,7 @@ var _ = Describe("Metal3Machine manager", func() {
 						RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: namespaceName},
 					}, nil,
 				),
-				Host:      newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", false),
+				Host:      newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 				BMCSecret: newBMCSecret("mycredentials", false),
 				Data: &infrav1.Metal3Data{
 					ObjectMeta: metav1.ObjectMeta{
@@ -3185,7 +3202,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
+			Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 		}),
 		Entry("Update machine, DataTemplate missing", testCaseUpdate{
 			Machine: newMachine(machineName, "", nil),
@@ -3196,7 +3213,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			}, nil,
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			Host:        newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false),
+			Host:        newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 			ExpectError: true,
 		}),
 	)
@@ -4761,22 +4778,30 @@ func newBareMetalHost(name string,
 	status *bmov1alpha1.BareMetalHostStatus,
 	powerOn bool,
 	autoCleanMode string,
-	clusterlabel bool) *bmov1alpha1.BareMetalHost {
+	clusterlabel bool,
+	bmhUID string) *bmov1alpha1.BareMetalHost {
 	if name == "" {
 		return &bmov1alpha1.BareMetalHost{
 			ObjectMeta: testObjectMeta("", namespaceName, ""),
 		}
 	}
 
+	uid := Bmhuid
+	if bmhUID != "" {
+		uid = types.UID(bmhUID)
+	}
+
 	objMeta := &metav1.ObjectMeta{
 		Name:      name,
 		Namespace: namespaceName,
+		UID:       uid,
 	}
 
 	if clusterlabel == true {
 		objMeta = &metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespaceName,
+			UID:       uid,
 			Labels: map[string]string{
 				clusterv1.ClusterLabelName: clusterName,
 				"foo":                      "bar",

--- a/baremetal/mocks/zz_generated.metal3machine_manager.go
+++ b/baremetal/mocks/zz_generated.metal3machine_manager.go
@@ -251,17 +251,17 @@ func (mr *MockMachineManagerInterfaceMockRecorder) SetFinalizer() *gomock.Call {
 }
 
 // SetNodeProviderID mocks base method.
-func (m *MockMachineManagerInterface) SetNodeProviderID(arg0 context.Context, arg1, arg2 *string, arg3 baremetal.ClientGetter) error {
+func (m *MockMachineManagerInterface) SetNodeProviderID(arg0 context.Context, arg1 *string, arg2 baremetal.ClientGetter) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetNodeProviderID", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "SetNodeProviderID", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetNodeProviderID indicates an expected call of SetNodeProviderID.
-func (mr *MockMachineManagerInterfaceMockRecorder) SetNodeProviderID(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockMachineManagerInterfaceMockRecorder) SetNodeProviderID(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNodeProviderID", reflect.TypeOf((*MockMachineManagerInterface)(nil).SetNodeProviderID), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNodeProviderID", reflect.TypeOf((*MockMachineManagerInterface)(nil).SetNodeProviderID), arg0, arg1, arg2)
 }
 
 // SetPauseAnnotation mocks base method.

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -265,7 +265,7 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 	}
 	if providerID != "" || bmhID != nil {
 		// Set the providerID on the node if no Cloud provider
-		err = machineMgr.SetNodeProviderID(ctx, bmhID, &providerID, r.CapiClientGetter)
+		err = machineMgr.SetNodeProviderID(ctx, &providerID, r.CapiClientGetter)
 		if err != nil {
 			machineMgr.SetConditionMetal3MachineToFalse(infrav1.KubernetesNodeReadyCondition, infrav1.SettingProviderIDOnNodeFailedReason, clusterv1.ConditionSeverityError, err.Error())
 			return checkMachineError(machineMgr, err,

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -137,7 +137,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		// if we fail to set it on the node, we do not go further
 		if tc.SetNodeProviderIDFails {
 			m.EXPECT().
-				SetNodeProviderID(context.TODO(), gomock.Eq(pointer.StringPtr(string(bmhuid))), gomock.Eq(&provID), nil).
+				SetNodeProviderID(context.TODO(), gomock.Eq(&provID), nil).
 				Return(errors.New("Failed"))
 			m.EXPECT().SetProviderID(string(bmhuid)).MaxTimes(0)
 			m.EXPECT().SetError(gomock.Any(), gomock.Any())
@@ -148,7 +148,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 
 		// we successfully set it on the node
 		m.EXPECT().
-			SetNodeProviderID(context.TODO(), gomock.Eq(pointer.StringPtr(string(bmhuid))), gomock.Eq(&provID), nil).
+			SetNodeProviderID(context.TODO(), gomock.Eq(&provID), nil).
 			Return(nil)
 		m.EXPECT().SetProviderID(provID)
 
@@ -158,7 +158,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		m.EXPECT().GetBaremetalHostID(context.TODO()).Return(nil, nil)
 
 		m.EXPECT().
-			SetNodeProviderID(context.TODO(), gomock.Eq(pointer.StringPtr(string(bmhuid))), gomock.Eq(&providerID), nil).
+			SetNodeProviderID(context.TODO(), gomock.Eq(&providerID), nil).
 			MaxTimes(0)
 	}
 

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -48,7 +48,7 @@ else
   export EPHEMERAL_CLUSTER="minikube"
 fi
 
-export FROM_K8S_VERSION="v1.24.1"
+export FROM_K8S_VERSION="v1.24.9"
 export KUBERNETES_VERSION="v1.25.2"
 
 # Can be overriden from jjbs

--- a/test/e2e/data/infrastructure-metal3/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
@@ -112,6 +112,7 @@ spec:
     - systemctl enable --now keepalived
     - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube/config
     preKubeadmCommands:
+    - sed -i "s/MACAddressPolicy=persistent/MACAddressPolicy=none/g" /usr/lib/systemd/network/99-default.link
     - netplan apply
     - systemctl enable --now crio kubelet
     - if (curl -sk --max-time 10 https://${CLUSTER_APIENDPOINT_HOST}:${CLUSTER_APIENDPOINT_PORT}/healthz); then echo "keepalived already running";else systemctl start keepalived; fi
@@ -146,5 +147,6 @@ spec:
           registries = ['${REGISTRY}']
         path: /etc/containers/registries.conf
       preKubeadmCommands:
+      - sed -i "s/MACAddressPolicy=persistent/MACAddressPolicy=none/g" /usr/lib/systemd/network/99-default.link
       - netplan apply
       - systemctl enable --now crio kubelet

--- a/test/e2e/pivoting_based_feature_test.go
+++ b/test/e2e/pivoting_based_feature_test.go
@@ -11,7 +11,6 @@ import (
 
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -77,42 +76,45 @@ var _ = Describe("Testing features in ephemeral or target cluster", func() {
 	})
 
 	AfterEach(func() {
-		if !ephemeralTest {
-			// Dump the target cluster resources before re-pivoting.
-			Logf("Dump the target cluster resources before re-pivoting")
-			framework.DumpAllResources(ctx, framework.DumpAllResourcesInput{
-				Lister:    targetCluster.GetClient(),
-				Namespace: namespace,
-				LogPath:   filepath.Join(artifactFolder, "clusters", clusterName, "resources"),
-			})
 
-			rePivoting(ctx, func() RePivotingInput {
-				return RePivotingInput{
-					E2EConfig:             e2eConfig,
-					BootstrapClusterProxy: bootstrapClusterProxy,
-					TargetCluster:         targetCluster,
-					SpecName:              specName,
-					ClusterName:           clusterName,
-					Namespace:             namespace,
-					ArtifactFolder:        artifactFolder,
-					ClusterctlConfigPath:  clusterctlConfigPath,
-				}
-			})
-		}
-		Logf("Logging state of bootstrap cluster")
-		ListBareMetalHosts(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
-		ListMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
-		ListMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
-		ListNodes(ctx, bootstrapClusterProxy.GetClient())
-		Logf("Logging state of target cluster")
-		if !ephemeralTest {
-			ListBareMetalHosts(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
-			ListMetal3Machines(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
-			ListMachines(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
-		}
-		ListNodes(ctx, targetCluster.GetClient())
-		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 	})
+	// AfterEach(func() {
+	// 	if !ephemeralTest {
+	// 		// Dump the target cluster resources before re-pivoting.
+	// 		Logf("Dump the target cluster resources before re-pivoting")
+	// 		framework.DumpAllResources(ctx, framework.DumpAllResourcesInput{
+	// 			Lister:    targetCluster.GetClient(),
+	// 			Namespace: namespace,
+	// 			LogPath:   filepath.Join(artifactFolder, "clusters", clusterName, "resources"),
+	// 		})
+
+	// 		rePivoting(ctx, func() RePivotingInput {
+	// 			return RePivotingInput{
+	// 				E2EConfig:             e2eConfig,
+	// 				BootstrapClusterProxy: bootstrapClusterProxy,
+	// 				TargetCluster:         targetCluster,
+	// 				SpecName:              specName,
+	// 				ClusterName:           clusterName,
+	// 				Namespace:             namespace,
+	// 				ArtifactFolder:        artifactFolder,
+	// 				ClusterctlConfigPath:  clusterctlConfigPath,
+	// 			}
+	// 		})
+	// 	}
+	// 	Logf("Logging state of bootstrap cluster")
+	// 	ListBareMetalHosts(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+	// 	ListMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+	// 	ListMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+	// 	ListNodes(ctx, bootstrapClusterProxy.GetClient())
+	// 	Logf("Logging state of target cluster")
+	// 	if !ephemeralTest {
+	// 		ListBareMetalHosts(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
+	// 		ListMetal3Machines(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
+	// 		ListMachines(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
+	// 	}
+	// 	ListNodes(ctx, targetCluster.GetClient())
+	// 	DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
+	// })
 
 })
 


### PR DESCRIPTION
Backport PR for #877
Creating a manual PR because the ubuntu e2e feature test is failing on automated cherry-pick PR, for debugging its better to have manual PR