### PR TITLE
🐛 manifestlint: move from kubeval to kubeconform

### DIFF
--- a/hack/manifestlint.sh
+++ b/hack/manifestlint.sh
@@ -4,30 +4,36 @@ set -eux
 
 IS_CONTAINER=${IS_CONTAINER:-false}
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+K8S_VERSION="${K8S_VERSION:-master}"
 
 # --strict: Disallow additional properties not in schema.
-# --ignore-missing-schemas: Skip validation for resource 
+# --ignore-missing-schemas: Skip validation for resource
 # definitions without a schema. This will skip the checks
 # for the Custom Resource Definitions(CRDs).
-# -d, --directories strings: A comma-separated list of
-# directories to recursively search for YAML documents.
-# -i, --ignored-filename-patterns strings: A comma-separated
-# list of regular expressions specifying filenames to ignore.
-# -o, --output string: The format of the output of this script.
-# Options are: [stdout json tap].
-
+# --ignore-filename-pattern string: ignore pattern, can give multiple
 # We are skipping validation for the files that
-# matches our regexp pattern (i.e. kustom, patch, clusterctl). 
+# matches our regexp pattern (i.e. kustom, patch).
+# --output string: The format of the output of this script.
+# --kubernetes-version string: which k8s version schema to test against
+
+# KUBECONFORM_PATH is needed as kubeconform binary in the official image
+# is at the root /kubeconform, but it is not at default path, while
+# in non-container run, it is on go bin path and can't have leading /
 
 if [ "${IS_CONTAINER}" != "false" ]; then
-    kubeval --strict --ignore-missing-schemas \
-    -d config,examples  -i kustom,patch,clusterctl -o tap
+    "${KUBECONFORM_PATH:-}"kubeconform --strict --ignore-missing-schemas \
+    --kubernetes-version "${K8S_VERSION}" \
+    --ignore-filename-pattern kustom --ignore-filename-pattern patch \
+    --ignore-filename-pattern clusterctl \
+    --output tap \
+    config/ examples/
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/capm3:ro,z" \
+    --env KUBECONFORM_PATH="/" \
+    --volume "${PWD}:/workdir:ro,z" \
     --entrypoint sh \
-    --workdir /capm3 \
-    garethr/kubeval:latest \
-    /capm3/hack/manifestlint.sh "${@}"
-fi;
+    --workdir /workdir \
+    ghcr.io/yannh/kubeconform:v0.5.0-alpine@sha256:ae1583859c7c9683b2f044a9cc911d9427030cd48ec33eeff6c0f23396780da9 \
+    /workdir/hack/manifestlint.sh "$@"
+fi


### PR DESCRIPTION
kubeval is not maintained anymore, and suggest moving to kubeconform. Change manifestlint.sh to use kubeconform.

Pin kubeconform image with a version and a digest.

This is a manual cherry-pick of #824 