### PR TITLE
🐛 cherry-pick gomod.sh changes from main

### DIFF
--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -5,44 +5,40 @@
 #
 # NOTE: This won't work unless the build environment has internet access
 
-set -ux
+set -eux
 
 IS_CONTAINER=${IS_CONTAINER:-false}
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
-  export XDG_CACHE_HOME="/tmp/.cache"
+    export XDG_CACHE_HOME=/tmp/.cache
 
-  STATUS=$(git status --porcelain)
-  if [ -n "$STATUS" ]; then
-      echo "Dirty tree: refusing to continue out of caution"
-      exit 1
-  fi
+    mkdir /tmp/gomod
+    cp -r . /tmp/gomod
+    cd /tmp/gomod
 
-  go mod tidy
-  rc=$?
+    STATUS="$(git status --porcelain)"
+    if [ -n "${STATUS}" ]; then
+        echo "Dirty tree: refusing to continue out of caution"
+        exit 1
+    fi
 
-  if [ $rc -ne 0 ]; then
-      echo "'go mod tidy' failed"
-      exit 1;
-  fi
+    make modules
 
-  STATUS=$(git status --porcelain go.mod go.sum)
-  if [ -n "$STATUS" ]; then
-      echo "go.mod and go.sum changed"
-      echo "Please run 'go mod tidy' and commit the changes to go.mod & go.sum."
-      echo "Abort"
-      exit 1
-  fi
-
-  exit 0;
+    STATUS="$(git status --porcelain)"
+    if [ -n "${STATUS}" ]; then
+        echo "one of the go.mod and/or go.sum files changed"
+        echo "${STATUS}"
+        echo "Please run 'go mod tidy' and commit the changes"
+        exit 1
+    fi
 
 else
-  "${CONTAINER_RUNTIME}" run --rm \
-    --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/capm3:ro,z"  \
-    --entrypoint sh \
-    --workdir /capm3 \
-    registry.hub.docker.com/library/golang:1.17 \
-    /capm3/hack/gomod.sh "${@}"
-fi;
+    "${CONTAINER_RUNTIME}" run --rm \
+        --env IS_CONTAINER=TRUE \
+        --volume "${PWD}:/workdir:ro,z" \
+        --entrypoint sh \
+        --workdir /workdir \
+        docker.io/golang:1.17 \
+        /workdir/hack/gomod.sh "$@"
+fi


### PR DESCRIPTION
gomod.sh was cleaned up in main, cherry-pick for release-1.1. This makes running gomod.sh locally possible as intended.

Manual cherry-pick of #857.
