### PR TITLE
🌱 Disable scheduled workflows from running in forks

### DIFF
--- a/.github/workflows/kubesec.yml
+++ b/.github/workflows/kubesec.yml
@@ -10,6 +10,9 @@ permissions:
 
 jobs:
   setup:
+    # This workflow is only of value to the metal3-io/cluster-api-provider-metal3 repository and
+    # would always fail in forks
+    if: github.repository == 'metal3-io/cluster-api-provider-metal3'
     runs-on: ubuntu-20.04
     permissions:
       actions: read

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   markdown-link-check:
     name: Broken Links
+    # This workflow is only of value to the metal3-io/cluster-api-provider-metal3 repository and
+    # would always fail in forks
+    if: github.repository == 'metal3-io/cluster-api-provider-metal3'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,9 @@ jobs:
     permissions:
       contents: write
     name: tag release
+    # This workflow is only of value to the metal3-io/cluster-api-provider-metal3 repository and
+    # would always fail in forks
+    if: github.repository == 'metal3-io/cluster-api-provider-metal3'
     runs-on: ubuntu-latest
     steps:
       - name: Export RELEASE_TAG var


### PR DESCRIPTION
Workflows use resources that are only available when run in the [metal3-io/cluster-api-provider-metal3](https://github.com/metal3-io/cluster-api-provider-metal3) repository, so workflow run would always fail when they run in a forked repository. They are of no value to fork repositories. They are triggered by the schedule event, so they cause regular annoying and confusing workflow failure notifications for every fork owner. Rather checking these workflows only in upstream repo is enough. This PR is inspired by https://github.com/arduino/arduino-cli/pull/888