### PR TITLE
 🌱 Improve target log collection for e2e

### DIFF
--- a/scripts/fetch_target_logs.sh
+++ b/scripts/fetch_target_logs.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -x
+
+DIR_NAME="/tmp/target_cluster_logs"
+NAMESPACES="$(kubectl --kubeconfig="${KUBE_CONFIG}" get namespace -o json | jq -r '.items[].metadata.name')"
+mkdir -p "${DIR_NAME}"
+for NAMESPACE in ${NAMESPACES}
+do
+  mkdir -p "${DIR_NAME}/${NAMESPACE}"
+# Fetch logs from target cluster according to the pods name
+  PODS="$(kubectl --kubeconfig="${KUBE_CONFIG}" get pods -n "${NAMESPACE}" -o json | jq -r '.items[].metadata.name')"
+  for POD in ${PODS}
+  do
+    mkdir -p "${DIR_NAME}/${NAMESPACE}/${POD}"
+    CONTAINERS="$(kubectl --kubeconfig="${KUBE_CONFIG}" get pods -n "${NAMESPACE}" "${POD}" -o json | jq -r '.spec.containers[].name')"
+    for CONTAINER in ${CONTAINERS}
+    do
+      LOG_DIR="${DIR_NAME}/${NAMESPACE}/${POD}/${CONTAINER}"
+      mkdir -p "${LOG_DIR}"
+      kubectl --kubeconfig="${KUBE_CONFIG}" logs -n "${NAMESPACE}" "${POD}" "${CONTAINER}" \
+        > "${LOG_DIR}/stdout.log" 2> "${LOG_DIR}/stderr.log"
+    done
+  done
+done

--- a/test/e2e/integration_test.go
+++ b/test/e2e/integration_test.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"path/filepath"
+
 	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	"sigs.k8s.io/cluster-api/test/framework"
@@ -26,6 +28,13 @@ var _ = Describe("When testing integration [integration]", func() {
 				ArtifactFolder:        artifactFolder,
 				ClusterctlConfigPath:  clusterctlConfigPath,
 			}
+		})
+		// Fetch the target cluster resources before re-pivoting.
+		By("Fetch the target cluster resources before re-pivoting")
+		framework.DumpAllResources(ctx, framework.DumpAllResourcesInput{
+			Lister:    targetCluster.GetClient(),
+			Namespace: namespace,
+			LogPath:   filepath.Join(artifactFolder, "clusters", clusterName, "resources"),
 		})
 		By("Repivot objects to the source cluster")
 		rePivoting(ctx, func() RePivotingInput {


### PR DESCRIPTION

This PR will help the log collection of target cluster during e2e tests. It has the following parts:

-  It will fetch target cluster kubeconfig and save it to tmp folder with kubeconfig-test1.yaml, which will help the project-infra log collection of target during failure in target cluster and also helps to collect logs of target cluster before re-pivoting in case of successful run.
- Fetch target clulster resources during integration test.
- Add script to collect target logs before re-pivot. 