### PR TITLE
🐛 fix malformatted pipefail option in ci-e2e.sh

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eux pipefail
+set -euxo pipefail
 
 REPO_ROOT=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/..)
 cd "${REPO_ROOT}"


### PR DESCRIPTION
This set command fails, as its missing -o to read the pipefail option.
