### PR TITLE
🐛 Fix cleanup for keep tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ E2E_CONF_FILE_ENVSUBST ?= $(E2E_OUT_DIR)/$(notdir $(E2E_CONF_FILE))
 E2E_CONTAINERS ?= quay.io/metal3-io/cluster-api-provider-metal3 quay.io/metal3-io/baremetal-operator quay.io/metal3-io/ip-address-manager
 
 SKIP_CLEANUP ?= false
+KEEP_TEST_ENV ?= false
 EPHEMERAL_TEST ?= false
 SKIP_CREATE_MGMT_CLUSTER ?= true
 
@@ -182,11 +183,13 @@ e2e-tests: $(GINKGO) e2e-substitutions cluster-templates ## This target should b
 
 	$(GINKGO) --timeout=$(GINKGO_TIMEOUT) -v --trace --tags=e2e  \
 		--show-node-events --no-color=$(GINKGO_NOCOLOR) \
+		--fail-fast="$(KEEP_TEST_ENV)" \
 		--junit-report="junit.e2e_suite.1.xml" \
 		--focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) "$(ROOT_DIR)/$(TEST_DIR)/e2e/" -- \
 		-e2e.artifacts-folder="$(ARTIFACTS)" \
 		-e2e.config="$(E2E_CONF_FILE_ENVSUBST)" \
 		-e2e.skip-resource-cleanup=$(SKIP_CLEANUP) \
+		-e2e.keep-test-environment=$(KEEP_TEST_ENV) \
 		-e2e.trigger-ephemeral-test=$(EPHEMERAL_TEST) \
 		-e2e.use-existing-cluster=$(SKIP_CREATE_MGMT_CLUSTER)
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -49,6 +49,9 @@ var (
 
 	// ephemeralTest triggers only e2e test in ephemeral cluster if true.
 	ephemeralTest bool
+
+	// keepTestEnv keeps the test environment by aborting the test suite when e2e test fails.
+	keepTestEnv bool
 )
 
 // Test suite global vars.
@@ -81,6 +84,7 @@ func init() {
 	flag.StringVar(&configPath, "e2e.config", "", "path to the e2e config file")
 	flag.StringVar(&artifactFolder, "e2e.artifacts-folder", "", "folder where e2e test artifact should be stored")
 	flag.BoolVar(&skipCleanup, "e2e.skip-resource-cleanup", false, "if true, the resource cleanup after tests will be skipped")
+	flag.BoolVar(&keepTestEnv, "e2e.keep-test-environment", false, "if true, the test aborts when failed, keeping all the environment")
 	flag.BoolVar(&upgradeTest, "e2e.trigger-upgrade-test", false, "if true, the e2e upgrade test will be triggered and other tests will be skipped")
 	flag.BoolVar(&ephemeralTest, "e2e.trigger-ephemeral-test", false, "if true, all e2e tests run in the ephemeral cluster without pivoting to the target cluster")
 	flag.BoolVar(&useExistingCluster, "e2e.use-existing-cluster", true, "if true, the test uses the current cluster instead of creating a new one (default discovery rules apply)")

--- a/test/e2e/live_iso_test.go
+++ b/test/e2e/live_iso_test.go
@@ -83,9 +83,9 @@ func liveIsoTest() {
 	})
 
 	AfterEach(func() {
-		// Abort the test in case of failure and skipCleanup is true during keep VM trigger
+		// Abort the test in case of failure and keepTestEnv is true during keep VM trigger
 		if CurrentSpecReport().Failed() {
-			if skipCleanup {
+			if keepTestEnv {
 				AbortSuite("e2e test aborted and skip cleaning the VM", 4)
 			}
 		}

--- a/test/e2e/pivoting_based_feature_test.go
+++ b/test/e2e/pivoting_based_feature_test.go
@@ -110,9 +110,9 @@ var _ = Describe("Testing features in ephemeral or target cluster", func() {
 			ListMachines(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
 		}
 		ListNodes(ctx, targetCluster.GetClient())
-		// // Abort the test in case of failure and skipCleanup is true during keep VM trigger
+		// Abort the test in case of failure and keepTestEnv is true during keep VM trigger
 		if CurrentSpecReport().Failed() {
-			if skipCleanup {
+			if keepTestEnv {
 				AbortSuite("e2e test aborted and skip cleaning the VM", 4)
 			}
 		}

--- a/test/e2e/remediation_based_feature_test.go
+++ b/test/e2e/remediation_based_feature_test.go
@@ -62,16 +62,16 @@ var _ = Describe("Testing nodes remediation [remediation]", func() {
 	})
 
 	AfterEach(func() {
-		// Abort the test in case of failure and skipCleanup is true during keep VM trigger
-		if CurrentSpecReport().Failed() {
-			if skipCleanup {
-				AbortSuite("e2e test aborted and skip cleaning the VM", 4)
-			}
-		}
 		ListBareMetalHosts(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		ListMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		ListMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		ListNodes(ctx, targetCluster.GetClient())
+		// Abort the test in case of failure and keepTestEnv is true during keep VM trigger
+		if CurrentSpecReport().Failed() {
+			if keepTestEnv {
+				AbortSuite("e2e test aborted and skip cleaning the VM", 4)
+			}
+		}
 		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 	})
 

--- a/test/e2e/upgrade_kubernetes_test.go
+++ b/test/e2e/upgrade_kubernetes_test.go
@@ -56,16 +56,16 @@ var _ = Describe("Kubernetes version upgrade in target nodes [upgrade]", func() 
 	})
 
 	AfterEach(func() {
-		// // Abort the test in case of failure and skipCleanup is true during keep VM trigger
-		if CurrentSpecReport().Failed() {
-			if skipCleanup {
-				AbortSuite("e2e test aborted and skip cleaning the VM", 4)
-			}
-		}
 		ListBareMetalHosts(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		ListMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		ListMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		ListNodes(ctx, targetCluster.GetClient())
+		// // Abort the test in case of failure and keepTestEnv is true during keep VM trigger
+		if CurrentSpecReport().Failed() {
+			if keepTestEnv {
+				AbortSuite("e2e test aborted and skip cleaning the VM", 4)
+			}
+		}
 		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 	})
 

--- a/test/e2e/upgrade_management_cluster_test.go
+++ b/test/e2e/upgrade_management_cluster_test.go
@@ -239,9 +239,9 @@ func preUpgrade(clusterProxy framework.ClusterProxy) {
 // preCleanupManagementCluster hook should be called from ClusterctlUpgradeSpec before cleaning the target management cluster
 // it moves back Ironic to the bootstrap cluster.
 func preCleanupManagementCluster(clusterProxy framework.ClusterProxy) {
-	// Abort the test in case of failure and skipCleanup is true during keep VM trigger
+	// Abort the test in case of failure and keepTestEnv is true during keep VM trigger
 	if CurrentSpecReport().Failed() {
-		if skipCleanup {
+		if keepTestEnv {
 			AbortSuite("e2e test aborted and skip cleaning the VM", 4)
 		}
 	}


### PR DESCRIPTION
Currently, during keep tests environment is not cleaned up after successful e2e test. The env should be kept only tests fails. This PR fixes this issue by introducing KEEP_TEST_ENV variable.
