### PR TITLE
:seedling: Added pod security standards manifest file for CAPM3

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -356,6 +356,11 @@ def strip_sec_ctx(yaml):
             spec["securityContext"] = {}
             for container in spec.get("containers", []):
                 container["securityContext"] = {}
+        if data.get("kind") == "Namespace":
+            spec = data["metadata"]["labels"]
+            pod_security_standard_label = "pod-security.kubernetes.io/enforce" 
+            spec.pop(pod_security_standard_label, None)
+                
         output.append(str(encode_yaml(data)))
 
     return "---\n".join(output)

--- a/config/default/capm3/namespace.yaml
+++ b/config/default/capm3/namespace.yaml
@@ -2,3 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: capm3-system
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+


### PR DESCRIPTION
Added manifest file to enforce restricted pod security standards for capm3 repository.
