### PR TITLE
🌱 Seperate k8s and clusterctl upgrade tests

### DIFF
--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -48,8 +48,8 @@ else
   export EPHEMERAL_CLUSTER="minikube"
 fi
 
-export FROM_K8S_VERSION="v1.26.4"
-export KUBERNETES_VERSION="v1.27.1"
+export FROM_K8S_VERSION=${FROM_K8S_VERSION:-"v1.26.4"}
+export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.27.1"}
 
 # Can be overriden from jjbs
 export CAPI_VERSION=${CAPI_VERSION:-"v1beta1"}
@@ -60,7 +60,7 @@ export CAPM3_LOCAL_IMAGE="${CAPM3PATH}"
 export PATH=$PATH:$HOME/.krew/bin
 
 # Upgrade test environment vars and config
-if [[ ${GINKGO_FOCUS:-} == "upgrade" ]]; then
+if [[ ${GINKGO_FOCUS:-} = .*-upgrade ]]; then
   export NUM_NODES=${NUM_NODES:-"5"}
 fi
 

--- a/test/e2e/upgrade_kubernetes_test.go
+++ b/test/e2e/upgrade_kubernetes_test.go
@@ -19,7 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Kubernetes version upgrade in target nodes [upgrade]", func() {
+var _ = Describe("Kubernetes version upgrade in target nodes [k8s-upgrade]", func() {
 
 	var (
 		ctx                 = context.TODO()

--- a/test/e2e/upgrade_management_cluster_test.go
+++ b/test/e2e/upgrade_management_cluster_test.go
@@ -17,7 +17,7 @@ import (
 
 const workDir = "/opt/metal3-dev-env/"
 
-var _ = Describe("When testing cluster upgrade v1alpha5/v1.1 > current [upgrade]", func() {
+var _ = Describe("When testing cluster upgrade v1alpha5 > current [clusterctl-upgrade]", func() {
 	BeforeEach(func() {
 		osType := strings.ToLower(os.Getenv("OS"))
 		Expect(osType).ToNot(Equal(""))


### PR DESCRIPTION
Adds labels to kubernetes and clusterctl upgrade tests to seperate the test using GINKGO_FOCUS
