### PR TITLE
🌱 bump golang image from 1.19.6 to 1.19.9, pin distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.19.6@sha256:7ce31d15a3a4dbf20446cccffa4020d3a2974ad2287d96123f55caf22c7adb71
-ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
+ARG BUILD_IMAGE=docker.io/golang:1.19.9@sha256:86af5649fa1d9265d3fe7caf633231340b93e4164b96e14bc4e1131a191c1ddd
+ARG BASE_IMAGE=gcr.io/distroless/static@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f  # nonroot
 
 # Build the manager binary on golang image
 FROM $BUILD_IMAGE as builder


### PR DESCRIPTION
Bump golang for controller image to 1.19.9
Pin distroless.

Manual cherry picks of https://github.com/metal3-io/cluster-api-provider-metal3/pull/969 and https://github.com/metal3-io/cluster-api-provider-metal3/pull/958