### PR TITLE
:bug: Remove kubeconfig from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ envfile
 # kubeconfigs
 kind.kubeconfig
 minikube.kubeconfig
-kubeconfig
+/kubeconfig
 
 # ssh keys
 .ssh*

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-coverage.*
 
 # Ansible
 *.retry


### PR DESCRIPTION
In `baremetal/remote/remote.go`, we import `"sigs.k8s.io/cluster-api/util/kubeconfig"`, and the "kubeconfig" line in the `.gitignore` file causes this directory to be omitted from the vendor directory.  In vendorized scenarios, this causes builds to fail.