### PR TITLE
🌱 Add labels in e2e feature tests for GINKGO FOCUS 

### DIFF
--- a/test/e2e/live_iso_test.go
+++ b/test/e2e/live_iso_test.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("When testing live iso [live-iso]", func() {
+var _ = Describe("When testing live iso [live-iso] [features]", func() {
 	liveIsoTest()
 })
 

--- a/test/e2e/pivoting_based_feature_test.go
+++ b/test/e2e/pivoting_based_feature_test.go
@@ -24,7 +24,7 @@ var (
 	workerMachineCount       int64
 )
 
-var _ = Describe("Testing features in ephemeral or target cluster", func() {
+var _ = Describe("Testing features in ephemeral or target cluster [pivoting] [features]", func() {
 
 	BeforeEach(func() {
 		osType := strings.ToLower(os.Getenv("OS"))

--- a/test/e2e/remediation_based_feature_test.go
+++ b/test/e2e/remediation_based_feature_test.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Testing nodes remediation [remediation]", func() {
+var _ = Describe("Testing nodes remediation [remediation] [features]", func() {
 
 	var (
 		ctx                 = context.TODO()


### PR DESCRIPTION
PR adds GINKGO_FOCUS label for e2e feature tests,  GINKGO_SKIP variable is being removed from CI. We will keep GINKGO_SKIP in CAPM3 for development purposes. 
Related changes done [here](https://gerrit.nordix.org/c/infra/cicd/+/18193) in jjb, and  [here](https://github.com/metal3-io/project-infra/pull/523) in project infra

