### PR TITLE
:bug: Fixing sha256sum generation

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -152,7 +152,8 @@ func EnsureImage(k8sVersion string) (imageURL string, imageChecksum string) {
 		Expect(err).To(BeNil())
 		sha256sum, err := getSha256Hash(rawImagePath)
 		Expect(err).To(BeNil())
-		err = os.WriteFile(fmt.Sprintf("%s/%s.sha256sum", ironicImageDir, rawImageName), sha256sum, 0544)
+		formattedSha256sum := fmt.Sprintf("%x", sha256sum)
+		err = os.WriteFile(fmt.Sprintf("%s/%s.sha256sum", ironicImageDir, rawImageName), []byte(formattedSha256sum), 0544)
 		Expect(err).To(BeNil())
 		Logf("Image: %v downloaded", rawImagePath)
 	} else {


### PR DESCRIPTION
What this PR does / why we need it:
This is fixing generation of sha256sum, it was not being formatted properly before which was resulting in wrong hash.


