### PR TITLE
:bug: Modify kubeadm scripts to re-enable IPAM integration in e2e tests

### DIFF
--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -182,3 +182,4 @@ intervals:
   default/wait-bmh-provisioned: ["50m", "20s"]
   default/wait-pod-restart: ["6m", "10s"]
   default/wait-deprovision-cluster: ["30m", "10s"]
+  default/wait-all-pod-to-be-running-on-target-cluster: ["15m", "10s"]

--- a/test/e2e/data/infrastructure-metal3/bases/centos-kubeadm-config/centos-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/bases/centos-kubeadm-config/centos-kubeadm-config.yaml
@@ -25,38 +25,6 @@ spec:
       owner: root:root
       path: /usr/local/bin/retrieve.configuration.files.sh
       permissions: "0755"
-    - content: |
-        #!/bin/bash
-        while :; do
-          curl -sk https://127.0.0.1:6443/healthz 1>&2 > /dev/null
-          isOk=$?
-          isActive=$(systemctl show -p ActiveState keepalived.service | cut -d'=' -f2)
-          if [ $isOk == "0" ] &&  [ $isActive != "active" ]; then
-            logger 'API server is healthy, however keepalived is not running, starting keepalived'
-            echo 'API server is healthy, however keepalived is not running, starting keepalived'
-            sudo systemctl start keepalived.service
-          elif [ $isOk != "0" ] &&  [ $isActive == "active" ]; then
-            logger 'API server is not healthy, however keepalived running, stopping keepalived'
-            echo 'API server is not healthy, however keepalived running, stopping keepalived'
-            sudo systemctl stop keepalived.service
-          fi
-          sleep 5
-        done
-      owner: root:root
-      path: /usr/local/bin/monitor.keepalived.sh
-      permissions: "0755"
-    - path: /lib/systemd/system/monitor.keepalived.service
-      owner: root:root
-      content: |
-        [Unit]
-        Description=Monitors keepalived adjusts status with that of API server
-        After=syslog.target network-online.target
-        [Service]
-        Type=simple
-        Restart=always
-        ExecStart=/usr/local/bin/monitor.keepalived.sh
-        [Install]
-        WantedBy=multi-user.target
     - path: /etc/keepalived/keepalived.conf
       content: |
         ! Configuration File for keepalived
@@ -69,6 +37,15 @@ spec:
             smtp_server localhost
             smtp_connect_timeout 30
         }
+
+        vrrp_script k8s_api_check {
+            script "curl -sk https://127.0.0.1:6443/healthz"
+            interval 5
+            timeout 5
+            rise 3
+            fall 3
+        }
+
         vrrp_instance VI_1 {
             state MASTER
             interface eth1
@@ -77,6 +54,9 @@ spec:
             advert_int 1
             virtual_ipaddress {
                 ${CLUSTER_APIENDPOINT_HOST}
+            }
+            track_script {
+                k8s_api_check
             }
         }
     - path: /etc/NetworkManager/system-connections/eth0.nmconnection
@@ -89,16 +69,17 @@ spec:
         interface-name=eth0
         master=ironicendpoint
         slave-type=bridge
-        autoconnect=yes
-        autoconnect-priority=999
     - content: |
         [connection]
         id=ironicendpoint
         type=bridge
         interface-name=ironicendpoint
+        autoconnect=yes
+        autoconnect-priority=1
 
         [bridge]
         stp=false
+        interface-name=ironicendpoint
 
         [ipv4]
         address1={{ ds.meta_data.provisioningIP }}/{{ ds.meta_data.provisioningCIDR }}
@@ -149,19 +130,21 @@ spec:
           provider-id: ${PROVIDER_ID_FORMAT}
           runtime-request-timeout: 5m
         name: '{{ ds.meta_data.name }}'
-    postKubeadmCommands:
-    - mkdir -p /home/${IMAGE_USERNAME}/.kube
-    - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube
-    - cp /etc/kubernetes/admin.conf /home/${IMAGE_USERNAME}/.kube/config
-    - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube/config
     preKubeadmCommands:
-    - systemctl restart NetworkManager.service
-    - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
-    - nmcli connection up eth0
-    - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
-    - nmcli connection up ironicendpoint
-    - systemctl enable --now crio keepalived kubelet
-    - systemctl enable --now /lib/systemd/system/monitor.keepalived.service
+      - systemctl restart NetworkManager.service
+      - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
+      - nmcli connection up ironicendpoint
+      - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
+      - nmcli connection up eth0
+      - systemctl enable --now keepalived
+      - sleep 60
+      - systemctl enable --now crio kubelet
+    postKubeadmCommands:
+      - mkdir -p /home/${IMAGE_USERNAME}/.kube
+      - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube
+      - cp /etc/kubernetes/admin.conf /home/${IMAGE_USERNAME}/.kube/config
+      - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube/config
+
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/${CAPI_VERSION}
 kind: KubeadmConfigTemplate
@@ -243,8 +226,9 @@ spec:
           registries = ['${REGISTRY}']
       preKubeadmCommands:
       - systemctl restart NetworkManager.service
-      - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
-      - nmcli connection up eth0
       - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
       - nmcli connection up ironicendpoint
+      - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
+      - nmcli connection up eth0
       - systemctl enable --now crio kubelet
+      - sleep 120

--- a/test/e2e/pivoting_based_feature_test.go
+++ b/test/e2e/pivoting_based_feature_test.go
@@ -8,6 +8,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -76,6 +78,24 @@ var _ = Describe("Testing features in ephemeral or target cluster [pivoting] [fe
 	})
 
 	AfterEach(func() {
+		Logf("Logging state of bootstrap cluster")
+		ListBareMetalHosts(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		ListMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		ListMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		ListNodes(ctx, bootstrapClusterProxy.GetClient())
+		Logf("Logging state of target cluster")
+		if !ephemeralTest {
+			ListBareMetalHosts(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
+			ListMetal3Machines(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
+			ListMachines(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
+		}
+		ListNodes(ctx, targetCluster.GetClient())
+		// Abort the test in case of failure and keepTestEnv is true during keep VM trigger
+		if CurrentSpecReport().Failed() {
+			if keepTestEnv {
+				AbortSuite("e2e test aborted and skip cleaning the VM", 4)
+			}
+		}
 		if !ephemeralTest {
 			// Dump the target cluster resources before re-pivoting.
 			Logf("Dump the target cluster resources before re-pivoting")
@@ -97,24 +117,6 @@ var _ = Describe("Testing features in ephemeral or target cluster [pivoting] [fe
 					ClusterctlConfigPath:  clusterctlConfigPath,
 				}
 			})
-		}
-		Logf("Logging state of bootstrap cluster")
-		ListBareMetalHosts(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
-		ListMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
-		ListMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
-		ListNodes(ctx, bootstrapClusterProxy.GetClient())
-		Logf("Logging state of target cluster")
-		if !ephemeralTest {
-			ListBareMetalHosts(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
-			ListMetal3Machines(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
-			ListMachines(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
-		}
-		ListNodes(ctx, targetCluster.GetClient())
-		// Abort the test in case of failure and keepTestEnv is true during keep VM trigger
-		if CurrentSpecReport().Failed() {
-			if keepTestEnv {
-				AbortSuite("e2e test aborted and skip cleaning the VM", 4)
-			}
 		}
 		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 	})
@@ -148,5 +150,10 @@ func createTargetCluster(k8sVersion string) (framework.ClusterProxy, *clusterctl
 		WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
 	}, &result)
 	targetCluster := bootstrapClusterProxy.GetWorkloadCluster(ctx, namespace, clusterName)
+	framework.WaitForPodListCondition(ctx, framework.WaitForPodListConditionInput{
+		Lister:      targetCluster.GetClient(),
+		ListOptions: &client.ListOptions{LabelSelector: labels.Everything(), Namespace: "kube-system"},
+		Condition:   framework.PhasePodCondition(corev1.PodRunning),
+	}, e2eConfig.GetIntervals(specName, "wait-all-pod-to-be-running-on-target-cluster")...)
 	return targetCluster, &result
 }


### PR DESCRIPTION
From the centos node image I have removed the code that blocekd cloud-init
network configuration features that also blocked the IPAM integration.

As the result of the node image change, some processes have to be modified in the centos kubeadm
scripts. Kubeadm script changes include:
  - Moving keepalived's K8s api monitoring from custom daemon to vrrp script in keeaplived
  - Adding a delay after the kubelet and crio are started to avoid flakes with kubeadm
    (this will be improved in a follow-up from a delay to an actual status check)
  - Fixing the startup order of eth0 and ironicendpoint interfaces

A polling check was added to delay the certmanager deployment during target cluster bootstrapping
until all pods are running, this helps to avoid accidentally assigning IPs from crio default cni
IP range that can happen if not all of the calico nodes are up.

Moved up the test aborting logic in e2e after-each sequence to actually make it work in a keep vm
as intended.