### PR TITLE
🌱 Bump Calico to v3.25.1

### DIFF
--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -132,7 +132,7 @@ variables:
   INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPI_FROM_RELEASE}/clusterctl-{OS}-{ARCH}"
   PROVIDER_ID_FORMAT: "metal3://{{ ds.meta_data.providerid }}"
   # Pin Calico version
-  CALICO_PATCH_RELEASE: "v3.24.1"
+  CALICO_PATCH_RELEASE: "v3.25.1"
   # Pin CertManager for upgrade tests
   CERT_MANAGER_RELEASE: v1.11.1
   # Default vars for the template, those values could be overridden by the env-vars.


### PR DESCRIPTION
The PR https://github.com/metal3-io/cluster-api-provider-metal3/pull/968/ should have bumped the calico to v3.25.1 but the commit seems to be missing. Bumping it here then. 