### PR TITLE
:book: remove .mdlrc and fix complaints

### DIFF
--- a/.mdlrc
+++ b/.mdlrc
@@ -1,2 +1,0 @@
-#Disable line-length for some code examples in getting-started
-rules "~MD013", "~MD005"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,17 +30,17 @@ GitHub pull requests. Those guidelines are the same as the
 
 ## Certificate of Origin
 
-By contributing to this project you agree to the Developer Certificate of
-Origin (DCO). This document was created by the Linux Kernel community and is a
-simple statement that you, as a contributor, have the legal right to make the
+By contributing to this project you agree to the Developer Certificate of Origin
+(DCO). This document was created by the Linux Kernel community and is a simple
+statement that you, as a contributor, have the legal right to make the
 contribution. See the [DCO](DCO) file for details.
 
 ## Finding Things That Need Help
 
 If you're new to the project and want to help, but don't know where to start, we
-have a semi-curated list of issues that
-should not need deep knowledge of the system. [Have a look and see if anything
-sounds interesting](https://github.com/metal3-io/cluster-api-provider-metal3/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
+have a semi-curated list of issues that should not need deep knowledge of the
+system.
+[Have a look and see if anything sounds interesting](https://github.com/metal3-io/cluster-api-provider-metal3/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
 Alternatively, read some of the docs on other controllers and try to write your
 own, file and fix any/all issues that come up, including gaps in documentation!
 
@@ -48,60 +48,80 @@ own, file and fix any/all issues that come up, including gaps in documentation!
 
 ### Codebase and Go Modules
 
-> :warning: The project does not follow Go Modules guidelines for compatibility requirements for 1.x semver releases.
-Cluster API Provider Metal3 follows Cluster API release cadence and versioning which follows upstream Kubernetes semantic versioning. With the v1 release of our codebase, we guarantee the following:
+> :warning: The project does not follow Go Modules guidelines for compatibility
+> requirements for 1.x semver releases. Cluster API Provider Metal3 follows
+> Cluster API release cadence and versioning which follows upstream Kubernetes
+> semantic versioning. With the v1 release of our codebase, we guarantee the
+> following:
 
-- A (*minor*) release CAN include:
+- A (_minor_) release CAN include:
+
    - Introduction of new API versions, or new Kinds.
    - Compatible API changes like field additions, deprecation notices, etc.
    - Breaking API changes for deprecated APIs, fields, or code.
    - Features, promotion or removal of feature gates.
    - And more!
 
-- A (*patch*) release SHOULD only include backwards compatible set of bugfixes.
+- A (_patch_) release SHOULD only include backwards compatible set of bugfixes.
 
-These guarantees extend to all code exposed in our Go Module, including
-*types from dependencies in public APIs*.
-Types and functions not in public APIs are not considered part of the guarantee.
-The test module, and experiments do not provide any backward compatible guarantees.
+These guarantees extend to all code exposed in our Go Module, including _types
+from dependencies in public APIs_. Types and functions not in public APIs are
+not considered part of the guarantee. The test module, and experiments do not
+provide any backward compatible guarantees.
 
 #### Backporting
 
-We only accept backports of critical bugs, security issues, or bugs without easy workarounds, any
-backport MUST not be breaking for either API or behavioral changes.
-We generally do not accept PRs against older release branches.
+We only accept backports of critical bugs, security issues, or bugs without easy
+workarounds, any backport MUST not be breaking for either API or behavioral
+changes. We generally do not accept PRs against older release branches.
 
 ## Branches
 
-Cluster API Provider Metal3 has two types of branches: the *main* branch and
-*release-X* branches.
+Cluster API Provider Metal3 has two types of branches: the _main_ branch and
+_release-X_ branches.
 
-The *main* branch is where development happens. All the latest and
-greatest code, including breaking changes, happens on main.
+The _main_ branch is where development happens. All the latest and greatest
+code, including breaking changes, happens on main.
 
-The *release-X* branches contain stable, backwards compatible code. On every
-major or minor release, a new branch is created. It is from these
-branches that minor and patch releases are tagged. In some cases, it may
-be necessary to open PRs for bugfixes directly against stable branches, but
-this should generally not be the case.
+The _release-X_ branches contain stable, backwards compatible code. On every
+major or minor release, a new branch is created. It is from these branches that
+minor and patch releases are tagged. In some cases, it may be necessary to open
+PRs for bugfixes directly against stable branches, but this should generally not
+be the case.
 
 ### Support and guarantees
 
-Cluster API Provider Metal3 maintains the most recent release/releases for all supported API and contract versions. Support for this section refers to the ability to backport and release patch versions;
-[backport policy](#backporting) is defined above.
+Cluster API Provider Metal3 maintains the most recent release/releases for all
+supported API and contract versions. Support for this section refers to the
+ability to backport and release patch versions; [backport policy](#backporting)
+is defined above.
 
-- The API version is determined from the GroupVersion defined in the top-level `api/` package.
-- The EOL date of each API Version is determined from the last release available once a new API version is published.
+- The API version is determined from the GroupVersion defined in the top-level
+  `api/` package.
+- The EOL date of each API Version is determined from the last release available
+  once a new API version is published.
+
+<!-- markdownlint-disable MD013 -->
 
 | API Version  | Supported Until                                                              |
 | ------------ | ---------------------------------------------------------------------------- |
 | **v1beta1**  | TBD (current latest)                                                         |
 | **v1alpha5** | EOL since 2022-09-30 ([apiVersion removal](#removal-of-v1alpha5-apiversion)) |
 
-- For the current stable API version (v1beta1) we support the two most recent minor releases; older minor releases are immediately unsupported when a new major/minor release is available.
-- For older API versions we only support the most recent minor release until the API version reaches EOL.
-- We will maintain test coverage for all supported minor releases and for one additional release for the current stable API version in case we have to do an emergency patch release.
-  For example, if v1.5 and v1.4 are currently supported, we will also maintain test coverage for v1.3 for one additional release cycle. When v1.6 is released, tests for v1.3 will be removed.
+<!-- markdownlint-enable MD013 -->
+
+- For the current stable API version (v1beta1) we support the two most recent
+  minor releases; older minor releases are immediately unsupported when a new
+  major/minor release is available.
+- For older API versions we only support the most recent minor release until the
+  API version reaches EOL.
+- We will maintain test coverage for all supported minor releases and for one
+  additional release for the current stable API version in case we have to do an
+  emergency patch release. For example, if v1.5 and v1.4 are currently
+  supported, we will also maintain test coverage for v1.3 for one additional
+  release cycle. When v1.6 is released, tests for v1.3 will be removed.
+
+<!-- markdownlint-disable MD013 -->
 
 | Minor Release | API Version  | Supported Until                                     |
 | ------------- | ------------ | --------------------------------------------------- |
@@ -112,9 +132,13 @@ Cluster API Provider Metal3 maintains the most recent release/releases for all s
 | v0.5.x        | **v1alpha4** | EOL since 2022-09-30 - API version EOL              |
 | v0.4.x        | **v1alpha3** | EOL since 2022-02-23 - API version EOL              |
 
-(*) Previous support policy applies, older minor releases were immediately unsupported when a new major/minor release was available
+<!-- markdownlint-enable MD013 -->
 
-- Exceptions can be filed with maintainers and taken into consideration on a case-by-case basis.
+(\*) Previous support policy applies, older minor releases were immediately
+unsupported when a new major/minor release was available
+
+- Exceptions can be filed with maintainers and taken into consideration on a
+  case-by-case basis.
 
 ### Removal of v1alpha5 apiVersion
 
@@ -123,7 +147,8 @@ We are going to remove the v1alpha5 apiVersion in upcoming releases:
 - v1.7
    - v1alpha5 apiVersion will be removed from the CRDs
 
-For more details and latest information please see the following issue: [Removing v1alpha5 apiVersion](https://github.com/metal3-io/cluster-api-provider-metal3/issues/971).
+For more details and latest information please see the following issue:
+[Removing v1alpha5 apiVersion](https://github.com/metal3-io/cluster-api-provider-metal3/issues/971).
 
 ## Contributing a Patch
 
@@ -141,40 +166,38 @@ All code PR must be labeled with one of
 - 🌱 (`:seedling:`, minor or other)
 
 Individual commits should not be tagged separately, but will generally be
-assumed to match the PR. For instance, if you have a bugfix in with
-a breaking change, it's generally encouraged to submit the bugfix
-separately, but if you must put them in one PR, mark the commit
-separately.
+assumed to match the PR. For instance, if you have a bugfix in with a breaking
+change, it's generally encouraged to submit the bugfix separately, but if you
+must put them in one PR, mark the commit separately.
 
 All changes must be code reviewed. Coding conventions and standards are
-explained in the official [developer
-docs](https://github.com/kubernetes/community/tree/master/contributors/devel).
-Expect reviewers to request that you
-avoid common [go style
-mistakes](https://github.com/golang/go/wiki/CodeReviewComments) in your PRs.
+explained in the official
+[developer docs](https://github.com/kubernetes/community/tree/master/contributors/devel).
+Expect reviewers to request that you avoid common
+[go style mistakes](https://github.com/golang/go/wiki/CodeReviewComments) in
+your PRs.
 
 ## Backporting a Patch
 
-Cluster API Provider Metal3 maintains older versions through `release-X.Y` branches. We accept
-backports of bug fixes to the most recent
-release branch. For example, if the most recent branch is `release-0.2`, and the
-`main` branch is under active
-development for v0.3.0, a bug fix that merged to `main` that also affects
-`v0.2.x` may be considered for backporting
-to `release-0.2`. We generally do not accept PRs against older release branches.
+Cluster API Provider Metal3 maintains older versions through `release-X.Y`
+branches. We accept backports of bug fixes to the most recent release branch.
+For example, if the most recent branch is `release-0.2`, and the `main` branch
+is under active development for v0.3.0, a bug fix that merged to `main` that
+also affects `v0.2.x` may be considered for backporting to `release-0.2`. We
+generally do not accept PRs against older release branches.
 
 ## Breaking Changes
 
 Breaking changes are generally allowed in the `main` branch, as this is the
 branch used to develop the next minor release of Cluster API.
 
-There may be times, however, when `main` is closed for breaking changes. This
-is likely to happen as we near the release of a new minor version.
+There may be times, however, when `main` is closed for breaking changes. This is
+likely to happen as we near the release of a new minor version.
 
 Breaking changes are not allowed in release branches, as these represent minor
-versions that have already been released.
-These versions have consumers who expect the APIs, behaviors, etc. to remain
-stable during the life time of the patch stream for the minor release.
+versions that have already been released. These versions have consumers who
+expect the APIs, behaviors, etc. to remain stable during the life time of the
+patch stream for the minor release.
 
 Examples of breaking changes include:
 
@@ -188,21 +211,20 @@ Examples of breaking changes include:
 
 There may, at times, need to be exceptions where breaking changes are allowed in
 release branches. These are at the discretion of the project's maintainers, and
-must be carefully considered before merging. An example of an allowed
-breaking change might be a fix for a behavioral bug that was released in an
-initial minor version (such as `v0.3.0`).
+must be carefully considered before merging. An example of an allowed breaking
+change might be a fix for a behavioral bug that was released in an initial minor
+version (such as `v0.3.0`).
 
 ### Merge Approval
 
-Please see the [Kubernetes community document on pull
-requests](https://git.k8s.io/community/contributors/guide/pull-requests.md) for
-more information about the merge process.
+Please see the
+[Kubernetes community document on pull requests](https://git.k8s.io/community/contributors/guide/pull-requests.md)
+for more information about the merge process.
 
 ### Google Doc Viewing Permissions
 
 To gain viewing permissions to google docs in this project, please join the
-[metal3-dev](https://groups.google.com/forum/#!forum/metal3-dev) google
-group.
+[metal3-dev](https://groups.google.com/forum/#!forum/metal3-dev) google group.
 
 ### Issue and Pull Request Management
 
@@ -216,29 +238,31 @@ Metal3 maintainers can assign you an issue or pull request by leaving a
 ### Commands and Workflow
 
 Cluster API Provider Metal3 follows the standard Kubernetes workflow: any PR
-needs `lgtm` and `approved` labels, and PRs must pass the tests before being merged.
-See [the contributor docs](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-testing-and-merge-workflow) for more info.
+needs `lgtm` and `approved` labels, and PRs must pass the tests before being
+merged. See
+[the contributor docs](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-testing-and-merge-workflow)
+for more info.
 
-We use the same priority and kind labels as Kubernetes. See the labels
-tab in GitHub for the full list.
+We use the same priority and kind labels as Kubernetes. See the labels tab in
+GitHub for the full list.
 
-The standard Kubernetes comment commands should work in
-Cluster API Provider Metal3. See [Prow](https://prow.apps.test.metal3.io/command-help)
-for a command reference.
+The standard Kubernetes comment commands should work in Cluster API Provider
+Metal3. See [Prow](https://prow.apps.test.metal3.io/command-help) for a command
+reference.
 
 ## Release Process
 
 Minor and patch releases are generally done immediately after a feature or
 bugfix is landed, or sometimes a series of features tied together.
 
-Minor releases will only be tagged on the *most recent* major release
-branch, except in exceptional circumstances. Patches will be backported
-to maintained stable versions, as needed.
+Minor releases will only be tagged on the _most recent_ major release branch,
+except in exceptional circumstances. Patches will be backported to maintained
+stable versions, as needed.
 
-Major releases are done shortly after a breaking change is merged -- once
-a breaking change is merged, the next release *must* be a major revision.
-We don't intend to have a lot of these, so we may put off merging breaking
-PRs until a later date.
+Major releases are done shortly after a breaking change is merged -- once a
+breaking change is merged, the next release _must_ be a major revision. We don't
+intend to have a lot of these, so we may put off merging breaking PRs until a
+later date.
 
 ### Exact Steps
 

--- a/README.md
+++ b/README.md
@@ -9,87 +9,99 @@ Kubernetes-native declarative infrastructure for Metal3.
 
 ## What is the Cluster API Provider Metal3
 
-The [Cluster API](https://github.com/kubernetes-sigs/cluster-api/) brings declarative,
-Kubernetes-style APIs to cluster creation, configuration and management. The API
-itself is shared across multiple cloud providers. Cluster API Provider Metal3 is
-one of the providers for Cluster API and enables users to deploy a Cluster API based
-cluster on top of bare metal infrastructure using Metal3.
+The [Cluster API](https://github.com/kubernetes-sigs/cluster-api/) brings
+declarative, Kubernetes-style APIs to cluster creation, configuration and
+management. The API itself is shared across multiple cloud providers. Cluster
+API Provider Metal3 is one of the providers for Cluster API and enables users to
+deploy a Cluster API based cluster on top of bare metal infrastructure using
+Metal3.
 
 ## Compatibility with Cluster API
 
-| CAPM3 version | Cluster API version | CAPM3 Release | CAPI Release |
-|---------------|---------------------|---------------|--------------|
-| v1alpha5      | v1alpha4            | v0.5.X        | v0.4.X       |
-| v1beta1       | v1beta1             | v1.1.X        | v1.1.X       |
-| v1beta1       | v1beta1             | v1.2.X        | v1.2.X       |
-| v1beta1       | v1beta1             | v1.3.X        | v1.3.X       |
-| v1beta1       | v1beta1             | v1.4.X        | v1.4.X       |
+| CAPM3 version | Cluster API version | CAPM3 Release |  CAPI Release  |
+| ------------- | ------------------- | ------------- | -------------- |
+| v1alpha5      | v1alpha4            | v0.5.X        |  v0.4.X        |
+| v1beta1       | v1beta1             | v1.1.X        |  v1.1.X        |
+| v1beta1       | v1beta1             | v1.2.X        |  v1.2.X        |
+| v1beta1       | v1beta1             | v1.3.X        |  v1.3.X        |
+| v1beta1       | v1beta1             | v1.4.X        |  v1.4.X        |
 
 ## Deploying the metal3 provider
 
 The recommended method is using
 [Clusterctl](https://main.cluster-api.sigs.k8s.io/clusterctl/overview.html).
 
-Starting from `v0.5.0` release of Cluster API Provider Metal3, Baremetal Operator is decoupled
-from Cluster API Provider Metal3 deployments when deployed via `clusterctl`. For this reason,
-Baremetal Operator will not be installed when initializing the Metal3 provider with clusterctl,
-and its CRDs and controller need to be manually installed. Example flow of installing Metal3
-provider:
+Starting from `v0.5.0` release of Cluster API Provider Metal3, Baremetal
+Operator is decoupled from Cluster API Provider Metal3 deployments when deployed
+via `clusterctl`. For this reason, Baremetal Operator will not be installed when
+initializing the Metal3 provider with clusterctl, and its CRDs and controller
+need to be manually installed. Example flow of installing Metal3 provider:
 
-1. Install Cluster API core, bootstrap and control-plane providers. This will also install
-  cert-manager if it is not already installed. To have more verbose logs you can use the -v flag
-  when running the clusterctl and set the level of the logging verbose with a positive integer number, ie. -v5.
+1. Install Cluster API core, bootstrap and control-plane providers. This will
+   also install cert-manager if it is not already installed. To have more
+   verbose logs you can use the -v flag when running the clusterctl and set the
+   level of the logging verbose with a positive integer number, ie. -v5.
 
-    ```shell
-    clusterctl init --core cluster-api:v1.4.2 --bootstrap kubeadm:v1.4.2 \
-        --control-plane kubeadm:v1.4.2 -v5
-    ```
+   ```shell
+   clusterctl init --core cluster-api:v1.4.2 --bootstrap kubeadm:v1.4.2 \
+       --control-plane kubeadm:v1.4.2 -v5
+   ```
 
-1. Install Metal3 provider. This will install the latest version of Cluster API Provider Metal3 CRDs and controllers.
+1. Install Metal3 provider. This will install the latest version of Cluster API
+   Provider Metal3 CRDs and controllers.
 
-    ```shell
-    clusterctl init --infrastructure metal3
-    ```
+   ```shell
+   clusterctl init --infrastructure metal3
+   ```
 
-    You can also specify the provider version by appending a version tag to the provider name as follows:
+   You can also specify the provider version by appending a version tag to the
+   provider name as follows:
 
-    ```shell
-    clusterctl init --infrastructure metal3:v1.4.0
-    ```
+   ```shell
+   clusterctl init --infrastructure metal3:v1.4.0
+   ```
 
-1. Deploy Baremetal Operator manifests and CRDs. You need to install cert-manager for Baremetal Operator,
-  but since step 1 already does it, we can skip it and only install the operator. Depending on
-  whether you want TLS, or basic-auth enabled, kustomize paths may differ. Check operator [dev-setup doc](https://github.com/metal3-io/baremetal-operator/blob/main/docs/dev-setup.md)
-  for more info.
+1. Deploy Baremetal Operator manifests and CRDs. You need to install
+   cert-manager for Baremetal Operator, but since step 1 already does it, we can
+   skip it and only install the operator. Depending on whether you want TLS, or
+   basic-auth enabled, kustomize paths may differ. Check operator
+   [dev-setup doc](https://github.com/metal3-io/baremetal-operator/blob/main/docs/dev-setup.md)
+   for more info.
 
-    ```shell
-    git clone https://github.com/metal3-io/baremetal-operator.git
-    kubectl create namespace baremetal-operator-system
-    cd baremetal-operator
-    kustomize build config/default | kubectl apply -f -
-    ```
+   ```shell
+   git clone https://github.com/metal3-io/baremetal-operator.git
+   kubectl create namespace baremetal-operator-system
+   cd baremetal-operator
+   kustomize build config/default | kubectl apply -f -
+   ```
 
 1. Install Ironic. There are a couple of ways to do it.
-    - Run within a Kubernetes cluster as a pod, refer to the [deploy.sh](https://github.com/metal3-io/baremetal-operator/blob/main/tools/deploy.sh)
-      script.
-    - Outside of a Kubernetes cluster as a container. Please refer to the [run_local_ironic.sh](https://github.com/metal3-io/baremetal-operator/blob/main/tools/run_local_ironic.sh) script.
+   - Run within a Kubernetes cluster as a pod, refer to the
+     [deploy.sh](https://github.com/metal3-io/baremetal-operator/blob/main/tools/deploy.sh)
+     script.
+   - Outside of a Kubernetes cluster as a container. Please refer to the
+     [run_local_ironic.sh](https://github.com/metal3-io/baremetal-operator/blob/main/tools/run_local_ironic.sh)
+     script.
 
 Please refer to the [getting-started](docs/getting-started.md) for more info.
 
 ## Pivoting ⚠️
 
-Starting from `v0.5.0` release of Cluster API Provider Metal3, Baremetal Operator is decoupled
-from Cluster API Provider Metal3 deployments when deployed via `clusterctl`. For that reason,
-when performing `clusterctl move`, custom objects outside of the Cluster API chain or not part
-of CAPM3 will not be pivoted to a target cluster. An example of those objects is BareMetalHost, or
-user created ConfigMaps and Secrets which are reconciled by Baremetal Operator. To ensure that those objects are
-also pivoted as part of `clusterctl move`, `clusterctl.cluster.x-k8s.io` label needs to be set
-on the BareMetalHost CRD before pivoting. If there are other CRDs also need to be pivoted to the
-target cluster, the same label needs to be set on them.
+Starting from `v0.5.0` release of Cluster API Provider Metal3, Baremetal
+Operator is decoupled from Cluster API Provider Metal3 deployments when deployed
+via `clusterctl`. For that reason, when performing `clusterctl move`, custom
+objects outside of the Cluster API chain or not part of CAPM3 will not be
+pivoted to a target cluster. An example of those objects is BareMetalHost, or
+user created ConfigMaps and Secrets which are reconciled by Baremetal Operator.
+To ensure that those objects are also pivoted as part of `clusterctl move`,
+`clusterctl.cluster.x-k8s.io` label needs to be set on the BareMetalHost CRD
+before pivoting. If there are other CRDs also need to be pivoted to the target
+cluster, the same label needs to be set on them.
 
-All the other objects owned by BareMetalHost, such as Secret and ConfigMap don't require this
-label to be set, because they hold ownerReferences to BareMetalHost, and that is good enough
-for clusterctl to move all the hierarchy of BareMetalHost object.
+All the other objects owned by BareMetalHost, such as Secret and ConfigMap don't
+require this label to be set, because they hold ownerReferences to
+BareMetalHost, and that is good enough for clusterctl to move all the hierarchy
+of BareMetalHost object.
 
 ## Development Environment
 
@@ -98,20 +110,20 @@ There are multiple ways to setup a development environment:
 - [Using Tilt](docs/dev-setup.md#tilt-development-environment)
 - [Other management cluster](docs/dev-setup.md#development-using-Kind-or-Minikube)
 - See [metal3-dev-env](https://github.com/metal3-io/metal3-dev-env) for an
-  end-to-end development and test environment for
-  `cluster-api-provider-metal3` and
-  [baremetal-operator](https://github.com/metal3-io/baremetal-operator).
+  end-to-end development and test environment for `cluster-api-provider-metal3`
+  and [baremetal-operator](https://github.com/metal3-io/baremetal-operator).
 
 ## API
 
 See the [API Documentation](docs/api.md) for details about the objects used with
-this Cluster API provider. You can also see the [cluster deployment
-workflow](docs/deployment_workflow.md) for the outline of the
-deployment process.
+this Cluster API provider. You can also see the
+[cluster deployment workflow](docs/deployment_workflow.md) for the outline of
+the deployment process.
 
 ## Architecture
 
-The architecture with the components involved is documented [here](docs/architecture.md)
+The architecture with the components involved is documented
+[here](docs/architecture.md)
 
 ## E2E test
 
@@ -119,59 +131,85 @@ To trigger e2e test on a PR, use the following phrases:
 
 ### integration tests
 
-- **/test-ubuntu-e2e-integration-main** runs integration e2e tests with CAPM3 API version v1beta1 and branch main on Ubuntu
-- **/test-centos-e2e-integration-main** runs integration e2e tests with CAPM3 API version v1beta1 and branch main on CentOS
+- **/test-ubuntu-e2e-integration-main** runs integration e2e tests with CAPM3
+  API version v1beta1 and branch main on Ubuntu
+- **/test-centos-e2e-integration-main** runs integration e2e tests with CAPM3
+  API version v1beta1 and branch main on CentOS
 
 ### Feature tests
 
 On main branch:
 
-- **/test-ubuntu-e2e-feature-main** runs e2e feature tests with CAPM3 API version v1beta1 and branch main on Ubuntu
-- **/test-centos-e2e-feature-main** runs e2e feature tests with CAPM3 API version v1beta1 and branch main on CentOS
+- **/test-ubuntu-e2e-feature-main** runs e2e feature tests with CAPM3 API
+  version v1beta1 and branch main on Ubuntu
+- **/test-centos-e2e-feature-main** runs e2e feature tests with CAPM3 API
+  version v1beta1 and branch main on CentOS
 
-Or use parallel prefix `parallel-` for faster tests. Note that these tests run in multiple VMs by creating an independent VM for each test spec:
+Or use parallel prefix `parallel-` for faster tests. Note that these tests run
+in multiple VMs by creating an independent VM for each test spec:
 
-- **/parallel-test-ubuntu-e2e-feature-main** runs e2e feature tests in parallel with CAPM3 API version v1beta1 and branch main on Ubuntu
-- **/parallel-test-centos-e2e-feature-main** runs e2e feature tests in parallel with CAPM3 API version v1beta1 and branch main on CentOS
+- **/parallel-test-ubuntu-e2e-feature-main** runs e2e feature tests in parallel
+  with CAPM3 API version v1beta1 and branch main on Ubuntu
+- **/parallel-test-centos-e2e-feature-main** runs e2e feature tests in parallel
+  with CAPM3 API version v1beta1 and branch main on CentOS
 
 Release-1.4 branch:
 
-- **/test-ubuntu-e2e-feature-release-1-4** runs e2e feature tests with CAPM3 API version v1beta1 and branch release-1.4 on Ubuntu
-- **/test-centos-e2e-feature-release-1-4** runs e2e feature tests with CAPM3 API version v1beta1 and branch release-1.4 on CentOS
+- **/test-ubuntu-e2e-feature-release-1-4** runs e2e feature tests with CAPM3 API
+  version v1beta1 and branch release-1.4 on Ubuntu
+- **/test-centos-e2e-feature-release-1-4** runs e2e feature tests with CAPM3 API
+  version v1beta1 and branch release-1.4 on CentOS
 
 Release-1.3 branch:
 
-- **/test-ubuntu-e2e-feature-release-1-3** runs e2e feature tests with CAPM3 API version v1beta1 and branch release-1.3 on Ubuntu
-- **/test-centos-e2e-feature-release-1-3** runs e2e feature tests with CAPM3 API version v1beta1 and branch release-1.3 on CentOS
+- **/test-ubuntu-e2e-feature-release-1-3** runs e2e feature tests with CAPM3 API
+  version v1beta1 and branch release-1.3 on Ubuntu
+- **/test-centos-e2e-feature-release-1-3** runs e2e feature tests with CAPM3 API
+  version v1beta1 and branch release-1.3 on CentOS
 
 Release-1.2 branch:
 
-- **/test-ubuntu-e2e-feature-release-1-2** runs e2e feature tests with CAPM3 API version v1beta1 and branch release-1.2 on Ubuntu
-- **/test-centos-e2e-feature-release-1-2** runs e2e feature tests with CAPM3 API version v1beta1 and branch release-1.2 on CentOS
+- **/test-ubuntu-e2e-feature-release-1-2** runs e2e feature tests with CAPM3 API
+  version v1beta1 and branch release-1.2 on Ubuntu
+- **/test-centos-e2e-feature-release-1-2** runs e2e feature tests with CAPM3 API
+  version v1beta1 and branch release-1.2 on CentOS
 
 ### Upgrade tests
 
-CAPM3 tests upgrade from all supported release to the current one, while also maintaining a test for the previous API version release v1alpha5.
+CAPM3 tests upgrade from all supported release to the current one, while also
+maintaining a test for the previous API version release v1alpha5.
 We run upgrade test on main branch from different releases:
 
-- **/test-e2e-upgrade-main-from-release-0-5** runs e2e upgrade tests from CAPM3 API version v1alpha5/branch release-0.5 to CAPM3 API version v1beta1/branch main on Ubuntu
+- **/test-e2e-upgrade-main-from-release-0-5** runs e2e upgrade tests from CAPM3
+  API version v1alpha5/branch release-0.5 to CAPM3 API version v1beta1/branch
+  main on Ubuntu
 
-- **/test-e2e-upgrade-main-from-release-1-2** runs e2e upgrade tests from CAPM3 API version v1beta1/branch release-1.2 to CAPM3 API version v1beta1/branch main on Ubuntu
+- **/test-e2e-upgrade-main-from-release-1-2** runs e2e upgrade tests from CAPM3
+  API version v1beta1/branch release-1.2 to CAPM3 API version v1beta1/branch
+  main on Ubuntu
 
-- **/test-e2e-upgrade-main-from-release-1-3** runs e2e upgrade tests from CAPM3 API version v1beta1/branch release-1.3 to CAPM3 API version v1beta1/branch main on Ubuntu
+- **/test-e2e-upgrade-main-from-release-1-3** runs e2e upgrade tests from CAPM3
+  API version v1beta1/branch release-1.3 to CAPM3 API version v1beta1/branch
+  main on Ubuntu
 
-- **/test-e2e-upgrade-main-from-release-1-4** runs e2e upgrade tests from CAPM3 API version v1beta1/branch release-1.4 to CAPM3 API version v1beta1/branch main on Ubuntu
+- **/test-e2e-upgrade-main-from-release-1-4** runs e2e upgrade tests from CAPM3
+  API version v1beta1/branch release-1.4 to CAPM3 API version v1beta1/branch
+  main on Ubuntu
 
 ### Keep VM
 
-After the e2e test is completed, Jenkins executes another script to clean up the environment first and then deletes the VM. However, sometimes it may be desirable to keep the VM for debugging purposes. To avoid clean up
-and deletion operations, use `keep-` prefix e.g:
+After the e2e test is completed, Jenkins executes another script to clean up the
+environment first and then deletes the VM. However, sometimes it may be
+desirable to keep the VM for debugging purposes. To avoid clean up and deletion
+operations, use `keep-` prefix e.g:
 
-- **/keep-test-ubuntu-e2e-integration-main** run keep e2e tests with CAPM3 API version v1beta1 and branch main on Ubuntu
+- **/keep-test-ubuntu-e2e-integration-main** run keep e2e tests with CAPM3 API
+  version v1beta1 and branch main on Ubuntu
 
 Note:
 
 - Triggers follow the pattern: `/[keep-|parallel-]test-<os>-e2e-<type>-<branch>`
-- Test VM created with `keep-` prefix will not be kept forever but deleted after 24 hours.
+- Test VM created with `keep-` prefix will not be kept forever but deleted after
+  24 hours.
 
 More info about e2e test can be found [here](docs/e2e-test.md)

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,42 +3,42 @@
 This describes a setup where the following Cluster API core components and
 Metal3-io components are deployed :
 
-* Cluster API manager
-* Cluster API Bootstrap Provider Kubeadm (CABPK) manager
-* Cluster API Kubeadm Control Plane manager
-* Baremetal Operator (including the Ironic setup)
-* Cluster API Provider Metal3 (CAPM3)
+- Cluster API manager
+- Cluster API Bootstrap Provider Kubeadm (CABPK) manager
+- Cluster API Kubeadm Control Plane manager
+- Baremetal Operator (including the Ironic setup)
+- Cluster API Provider Metal3 (CAPM3)
 
 ## BareMetalHost
 
 The BareMetalHost is an object from
-[baremetal-operator](https://github.com/metal3-io/baremetal-operator). Each
-CR represents a physical host with BMC credentials, hardware status etc.
+[baremetal-operator](https://github.com/metal3-io/baremetal-operator). Each CR
+represents a physical host with BMC credentials, hardware status etc.
 
 BareMetalHost exposes those different fields that are secret references:
 
-* **userData** : for a cloud-init user-data in a secret with the key `userData`
-* **metaData** : for a cloud-init metadata in a secret with the key `metaData`
-* **networkData** : for a cloud-init network data in a secret with the key
+- **userData** : for a cloud-init user-data in a secret with the key `userData`
+- **metaData** : for a cloud-init metadata in a secret with the key `metaData`
+- **networkData** : for a cloud-init network data in a secret with the key
   `networkData`
 
 For the metaData, some values are set by default to maintain compatibility:
 
-* **uuid**: This is the BareMetalHost UID
-* **metal3-namespace**: the name of the BareMetalHost
-* **metal3-name**: The name of the BareMetalHost
-* **local-hostname**: The name of the BareMetalHost
-* **local_hostname**: The namespace of the BareMetalHost
+- **uuid**: This is the BareMetalHost UID
+- **metal3-namespace**: the name of the BareMetalHost
+- **metal3-name**: The name of the BareMetalHost
+- **local-hostname**: The name of the BareMetalHost
+- **local_hostname**: The namespace of the BareMetalHost
 
 However, setting any of those values in the metaData secret will override those
 default values.
 
 ### Unhealthy annotation
 
-In CAPM3 API version v1alpha4 (which is removed from main branch but exist in previous
-release branches) and onwards, it is possible to mark
-BareMetalHost object as unhealthy by adding an annotation `capi.metal3.io/unhealthy`.
-This annotation prevents CAPM3 to select unhealthy BareMetalHost for newly created
+In CAPM3 API version v1alpha4 (which is removed from main branch but exist in
+previous release branches) and onwards, it is possible to mark BareMetalHost
+object as unhealthy by adding an annotation `capi.metal3.io/unhealthy`. This
+annotation prevents CAPM3 to select unhealthy BareMetalHost for newly created
 metal3machine. Removing the annotation will enable the normal operations.
 
 ## Cluster
@@ -75,12 +75,12 @@ spec:
 
 ## Metal3Cluster
 
-The metal3Cluster object contains information related to the deployment of
-the cluster on Baremetal. It currently has two specification fields :
+The metal3Cluster object contains information related to the deployment of the
+cluster on Baremetal. It currently has two specification fields :
 
-* **controlPlaneEndpoint**: contains the target cluster API server address and
+- **controlPlaneEndpoint**: contains the target cluster API server address and
   port
-* **noCloudProvider**: (true/false) Whether the cluster will not be deployed
+- **noCloudProvider**: (true/false) Whether the cluster will not be deployed
   with an external cloud provider. If set to true, CAPM3 will patch the target
   cluster node objects to add a providerID. This will allow the CAPI process to
   continue even if the cluster is deployed without cloud provider.
@@ -94,17 +94,17 @@ metadata:
   name: m3cluster
   namespace: metal3
 spec:
- controlPlaneEndpoint:
-   host: 192.168.111.249
-   port: 6443
- noCloudProvider: true
+  controlPlaneEndpoint:
+    host: 192.168.111.249
+    port: 6443
+  noCloudProvider: true
 ```
 
 ## KubeadmControlPlane
 
 This object contains all information related to the control plane configuration.
 It references an **infrastructureTemplate** that must be a
-*Metal3MachineTemplate* in this case.
+_Metal3MachineTemplate_ in this case.
 
 For example:
 
@@ -132,14 +132,14 @@ spec:
     joinConfiguration:
       controlPlane: {}
       nodeRegistration:
-        name: '{{ ds.meta_data.name }}'
+        name: "{{ ds.meta_data.name }}"
         kubeletExtraArgs:
-          node-labels: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+          node-labels: "metal3.io/uuid={{ ds.meta_data.uuid }}"
     initConfiguration:
       nodeRegistration:
-        name: '{{ ds.meta_data.name }}'
+        name: "{{ ds.meta_data.name }}"
         kubeletExtraArgs:
-          node-labels: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+          node-labels: "metal3.io/uuid={{ ds.meta_data.uuid }}"
 ```
 
 ## KubeadmConfig
@@ -151,15 +151,14 @@ In order to deploy Kubernetes successfully, you need to know the cluster API
 address before deployment. However, if you are deploying an HA cluster or if you
 are deploying without using static ip addresses, the cluster API server address
 is unknown. A solution to go around the problem is to deploy Keepalived.
-Keepalived allows you to set up a virtual IP, defined beforehand, and shared
-by the nodes. Hence the commands to set up Keepalived have to run before
-kubeadm.
+Keepalived allows you to set up a virtual IP, defined beforehand, and shared by
+the nodes. Hence the commands to set up Keepalived have to run before kubeadm.
 
 The content of a KubeadmConfig can contain Jinja2 template elements, since the
-cloud-init renders the cloud-config as a Jinja2 template. It is possible to
-use metadata from cloud-init, using the following: `{{ ds.meta_data.<key>}}`.
-The keys and values are passed to cloud-init through a `Metal3DataTemplate`
-object (see below).
+cloud-init renders the cloud-config as a Jinja2 template. It is possible to use
+metadata from cloud-init, using the following: `{{ ds.meta_data.<key>}}`. The
+keys and values are passed to cloud-init through a `Metal3DataTemplate` object
+(see below).
 
 Example KubeadmConfig:
 
@@ -172,14 +171,14 @@ metadata:
 spec:
   initConfiguration:
     nodeRegistration:
-      name: '{{ ds.meta_data.name }}'
+      name: "{{ ds.meta_data.name }}"
       kubeletExtraArgs:
-        node-labels: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+        node-labels: "metal3.io/uuid={{ ds.meta_data.uuid }}"
   preKubeadmCommands:
     - netplan apply
     - systemctl enable --now crio kubelet
-    - if (curl -sk --max-time 10 https://192.168.111.249:6443/healthz); then echo "keepalived
-      already running";else systemctl start keepalived; fi
+    - if (curl -sk --max-time 10 https://192.168.111.249:6443/healthz); then
+      echo "keepalived already running";else systemctl start keepalived; fi
     - systemctl link /lib/systemd/system/monitor.keepalived.service
     - systemctl enable monitor.keepalived.service
     - systemctl start monitor.keepalived.service
@@ -190,28 +189,28 @@ spec:
     - systemctl enable --now keepalived
     - chown metal3:metal3 /home/metal3/.kube/config
   files:
-      - path: /etc/keepalived/keepalived.conf
-        content: |
-          ! Configuration File for keepalived
-          global_defs {
-              notification_email {
-              sysadmin@example.com
-              support@example.com
-              }
-              notification_email_from lb@example.com
-              smtp_server localhost
-              smtp_connect_timeout 30
-          }
-          vrrp_instance VI_2 {
-              state MASTER
-              interface enp2s0
-              virtual_router_id 2
-              priority 101
-              advert_int 1
-              virtual_ipaddress {
-                  192.168.111.249
-              }
-          }
+    - path: /etc/keepalived/keepalived.conf
+      content: |
+        ! Configuration File for keepalived
+        global_defs {
+            notification_email {
+            sysadmin@example.com
+            support@example.com
+            }
+            notification_email_from lb@example.com
+            smtp_server localhost
+            smtp_connect_timeout 30
+        }
+        vrrp_instance VI_2 {
+            state MASTER
+            interface enp2s0
+            virtual_router_id 2
+            priority 101
+            advert_int 1
+            virtual_ipaddress {
+                192.168.111.249
+            }
+        }
 ```
 
 ## Machine
@@ -255,29 +254,29 @@ must be a Metal3Machine.
 
 The fields are:
 
-* **image** -- This includes two sub-fields, `url` and `checksum`, which
-  include the URL to the image and the URL to a checksum for that image. These
-  fields are required. The image will be used for provisioning of the
-  `BareMetalHost` chosen by the `Machine` actuator.
+- **image** -- This includes two sub-fields, `url` and `checksum`, which include
+  the URL to the image and the URL to a checksum for that image. These fields
+  are required. The image will be used for provisioning of the `BareMetalHost`
+  chosen by the `Machine` actuator.
 
-* **userData** -- This includes two sub-fields, `name` and `namespace`, which
-  reference a `Secret` that contains base64 encoded user-data to be written to
-  a config drive on the provisioned `BareMetalHost`. This field is optional and
-  is automatically set by CAPM3 with the userData from the machine object. If
-  you want to overwrite the userData, this should be done in the CAPI machine.
+- **userData** -- This includes two sub-fields, `name` and `namespace`, which
+  reference a `Secret` that contains base64 encoded user-data to be written to a
+  config drive on the provisioned `BareMetalHost`. This field is optional and is
+  automatically set by CAPM3 with the userData from the machine object. If you
+  want to overwrite the userData, this should be done in the CAPI machine.
 
-* **dataTemplate** -- This includes a reference to a Metal3DataTemplate object
+- **dataTemplate** -- This includes a reference to a Metal3DataTemplate object
   containing the metadata and network data templates, and includes two fields,
   `name` and `namespace`.
 
-* **metaData** is a reference to a secret containing the metadata rendered from
+- **metaData** is a reference to a secret containing the metadata rendered from
   the Metal3DataTemplate metadata template object automatically. In case this
   would not be managed by the Metal3DataTemplate controller, if provided by the
   user for example, the ownerreference should be set properly to ensure that the
   secret belongs to the cluster ownerReference tree (see
   [doc](https://cluster-api.sigs.k8s.io/clusterctl/provider-contract.html#ownerreferences-chain)).
 
-* **networkData** is a reference to a secret containing the network data
+- **networkData** is a reference to a secret containing the network data
   rendered from the Metal3DataTemplate metadata template object automatically.
   In case this would not be managed by the Metal3DataTemplate controller, if
   provided by the user for example, the ownerreference should be set properly to
@@ -287,39 +286,40 @@ The fields are:
   follows the format definition that can be found
   [here](https://docs.openstack.org/nova/latest/_downloads/9119ca7ac90aa2990e762c08baea3a36/network_data.json).
 
-* **hostSelector** -- Specify criteria for matching labels on `BareMetalHost`
+- **hostSelector** -- Specify criteria for matching labels on `BareMetalHost`
   objects. This can be used to limit the set of available `BareMetalHost`
   objects chosen for this `Machine`.
 
-* **automatedCleaningMode** -- An interface to enable or disable Ironic automated cleaning during provisioning
-  or deprovisioning of a host. When set to `disabled`, automated cleaning will be skipped, where
-  `metadata` value enables it. It is recommended to tune the cleaning via metal3MachineTemplate rather than
-  metal3Machine. When `spec.template.spec.automatedCleaningMode` field of metal3MachineTemplate
-  is updated, metal3MachineTemplate controller will update all the metal3Machines (generated from the metal3MachineTemplate)
+- **automatedCleaningMode** -- An interface to enable or disable Ironic
+  automated cleaning during provisioning or deprovisioning of a host. When set
+  to `disabled`, automated cleaning will be skipped, where `metadata` value
+  enables it. It is recommended to tune the cleaning via metal3MachineTemplate
+  rather than metal3Machine. When `spec.template.spec.automatedCleaningMode`
+  field of metal3MachineTemplate is updated, metal3MachineTemplate controller
+  will update all the metal3Machines (generated from the metal3MachineTemplate)
   and eventually BareMetalHosts with the same value.
 
-The `metaData` and `networkData` field in the `spec` section are for the user
-to give directly a secret to use as metaData or networkData. The `userData`,
+The `metaData` and `networkData` field in the `spec` section are for the user to
+give directly a secret to use as metaData or networkData. The `userData`,
 `metaData` and `networkData` fields in the `status` section are for the
 controller to store the reference to the secret that is actually being used,
 whether it is from one of the spec fields, or somehow generated. This is aimed
-at making a clear difference between the desired state from the user (whether
-it is with a DataTemplate reference, or direct `metaData` or `userData` secrets)
+at making a clear difference between the desired state from the user (whether it
+is with a DataTemplate reference, or direct `metaData` or `userData` secrets)
 and what the controller is actually using.
 
-The `dataTemplate` field consists of an object reference to a
-Metal3DataTemplate object containing the templates for the metadata and
-network data generation for this Metal3Machine. The `renderedData` field is a
-reference to the Metal3Data object created for this machine. If the
-dataTemplate field is set but either the `renderedData`, `metaData` or
-`networkData` fields in the status are unset, then the Metal3Machine
-controller will wait until it can find the Metal3Data object and the rendered
-secrets. It will then populate those fields.
+The `dataTemplate` field consists of an object reference to a Metal3DataTemplate
+object containing the templates for the metadata and network data generation for
+this Metal3Machine. The `renderedData` field is a reference to the Metal3Data
+object created for this machine. If the dataTemplate field is set but either the
+`renderedData`, `metaData` or `networkData` fields in the status are unset, then
+the Metal3Machine controller will wait until it can find the Metal3Data object
+and the rendered secrets. It will then populate those fields.
 
-When CAPM3 controller will set the different fields in the BareMetalHost,
-it will reference the metadata secret and the network data secret
-in the BareMetalHost. If any of the `metaData` or `networkData` status fields
-are unset, that field will also remain unset on the BareMetalHost.
+When CAPM3 controller will set the different fields in the BareMetalHost, it
+will reference the metadata secret and the network data secret in the
+BareMetalHost. If any of the `metaData` or `networkData` status fields are
+unset, that field will also remain unset on the BareMetalHost.
 
 When the Metal3Machine gets deleted, the CAPM3 controller will remove its
 ownerreference from the data template object. This will trigger the deletion of
@@ -329,27 +329,23 @@ the generated Metal3Data object and the secrets generated for this machine.
 
 The `hostSelector field has two possible optional sub-fields:
 
-* **matchLabels** -- Key/value pairs of labels that must match exactly.
+- **matchLabels** -- Key/value pairs of labels that must match exactly.
 
-* **matchExpressions** -- A set of expressions that must evaluate to true for
+- **matchExpressions** -- A set of expressions that must evaluate to true for
   the labels on a `BareMetalHost`.
 
 Valid operators include:
 
-* **!** -- Key does not exist. Values ignored.
-* **=** -- Key equals specified value. There must only be one
-  value specified.
-* **==** -- Key equals specified value. There must only be one
-  value specified.
-* **in** -- Value is a member of a set of possible values
-* **!=** -- Key does not equal the specified value. There must
-  only be one value specified.
-* **notin** -- Value not a member of the specified set of values.
-* **exists** -- Key exists. Values ignored.
-* **gt** -- Value is greater than the one specified. Value must be
-  an integer.
-* **lt** -- Value is less than the one specified. Value must be
-  an integer.
+- **!** -- Key does not exist. Values ignored.
+- **=** -- Key equals specified value. There must only be one value specified.
+- **==** -- Key equals specified value. There must only be one value specified.
+- **in** -- Value is a member of a set of possible values
+- **!=** -- Key does not equal the specified value. There must only be one value
+  specified.
+- **notin** -- Value not a member of the specified set of values.
+- **exists** -- Key exists. Values ignored.
+- **gt** -- Value is greater than the one specified. Value must be an integer.
+- **lt** -- Value is less than the one specified. Value must be an integer.
 
 Example 1: Only consider a `BareMetalHost` with label `key1` set to `value1`.
 
@@ -384,9 +380,9 @@ spec:
     value:
       hostSelector:
         matchExpressions:
-          - key: key3
-            operator: in
-            values: [‘a’, ‘b’, ‘c’]
+        - key: key3
+          operator: in
+          values: [‘a’, ‘b’, ‘c’]
 ```
 
 Example 3: Only consider `BareMetalHost` with `key1` set to `value1` AND `key2`
@@ -401,9 +397,9 @@ spec:
           key1: value1
           key2: value2
         matchExpressions:
-          - key: key3
-            operator: in
-            values: [‘a’, ‘b’, ‘c’]
+        - key: key3
+          operator: in
+          values: [‘a’, ‘b’, ‘c’]
 ```
 
 ### Metal3Machine example
@@ -427,7 +423,7 @@ spec:
     matchExpressions:
       key: key2
       operator: in
-      values: {‘abc’, ‘123’, ‘value2’}
+      values: { ‘abc’, ‘123’, ‘value2’ }
   dataTemplate:
     Name: controlplane-metadata
   metaData:
@@ -436,9 +432,8 @@ spec:
 
 ## MachineDeployment
 
-MachineDeployment is a core Cluster API object that is similar to
-deployment for pods. It refers to a KubeadmConfigTemplate and to a
-Metal3MachineTemplate.
+MachineDeployment is a core Cluster API object that is similar to deployment for
+pods. It refers to a KubeadmConfigTemplate and to a Metal3MachineTemplate.
 
 Example MachineDeployment:
 
@@ -498,43 +493,53 @@ spec:
     spec:
       joinConfiguration:
         nodeRegistration:
-          name: '{{ ds.meta_data.name }}'
+          name: "{{ ds.meta_data.name }}"
           kubeletExtraArgs:
-            node-labels: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+            node-labels: "metal3.io/uuid={{ ds.meta_data.uuid }}"
       preKubeadmCommands:
-        - netplan apply
-        - systemctl enable --now crio kubelet
+      - netplan apply
+      - systemctl enable --now crio kubelet
 ```
 
 ## Metal3MachineTemplate
 
 The Metal3MachineTemplate contains following two specification fields:
 
-* **nodeReuse**: (true/false) Whether the same pool of BareMetalHosts will be re-used during the
-  upgrade/remediation operations. By default set to false, if set to true, CAPM3 Machine controller
-  will pick the same pool of BareMetalHosts that were released while upgrading/remediation - for the
-  next provisioning phase.
-* **template**: is a template containing the data needed to create a Metal3Machine.
+- **nodeReuse**: (true/false) Whether the same pool of BareMetalHosts will be
+  re-used during the upgrade/remediation operations. By default set to false, if
+  set to true, CAPM3 Machine controller will pick the same pool of
+  BareMetalHosts that were released while upgrading/remediation - for the next
+  provisioning phase.
+- **template**: is a template containing the data needed to create a
+  Metal3Machine.
 
 ### Enabling nodeReuse feature
 
-This feature can be desirable and enabled in scenarios such as upgrade or node remediation. For example, the same pool of hosts need to be used after cluster upgrade and no data of secondary storage should be lost.
-To achieve that:
+This feature can be desirable and enabled in scenarios such as upgrade or node
+remediation. For example, the same pool of hosts need to be used after cluster
+upgrade and no data of secondary storage should be lost. To achieve that:
 
-1. `spec.nodeReuse` field of metal3MachineTemplate must be set to `True`. This tells that we want to reuse the same hosts
-  after the upgrade, or to be exact same BareMetalHosts should be provisioned.
+1. `spec.nodeReuse` field of metal3MachineTemplate must be set to `True`. This
+   tells that we want to reuse the same hosts after the upgrade, or to be exact
+   same BareMetalHosts should be provisioned.
 
-1. `spec.template.spec.automatedCleaningMode` field of metal3MachineTemplate must be set to `disabled`. This tells that we
-  want secondary/hosted storage data to persist even after upgrade.
+1. `spec.template.spec.automatedCleaningMode` field of metal3MachineTemplate
+   must be set to `disabled`. This tells that we want secondary/hosted storage
+   data to persist even after upgrade.
 
 Above field changes need to be made before you start upgrading your cluster.
 
 #### Node Reuse flow
 
-When `spec.nodeReuse` field of metal3MachineTemplate is set to `True`, CAPM3 Machine controller:
+When `spec.nodeReuse` field of metal3MachineTemplate is set to `True`, CAPM3
+Machine controller:
 
-* Sets `infrastructure.cluster.x-k8s.io/node-reuse` label to the corresponding CAPI object name (`KubeadmControlPlane` or `MachineDeployment`) on the BareMetalHost during deprovisioning;
-* Selects the BareMetalHost that contains `infrastructure.cluster.x-k8s.io/node-reuse` label and matches exact same CAPI object name set in the previous step during next provisioning.
+- Sets `infrastructure.cluster.x-k8s.io/node-reuse` label to the corresponding
+  CAPI object name (`KubeadmControlPlane` or `MachineDeployment`) on the
+  BareMetalHost during deprovisioning;
+- Selects the BareMetalHost that contains
+  `infrastructure.cluster.x-k8s.io/node-reuse` label and matches exact same CAPI
+  object name set in the previous step during next provisioning.
 
 Example Metal3MachineTemplate :
 
@@ -560,7 +565,7 @@ spec:
         matchExpressions:
           key: key2
           operator: in
-          values: {‘abc’, ‘123’, ‘value2’}
+          values: { ‘abc’, ‘123’, ‘value2’ }
       dataTemplate:
         Name: m3mt-0-metadata
 ```
@@ -582,112 +587,112 @@ spec:
   templateReference: old-template
   metaData:
     strings:
-      - key: abc
-        value: def
+    - key: abc
+      value: def
     objectNames:
-      - key: name_m3m
-        object: metal3machine
-      - key: name_machine
-        object: machine
-      - key: name_bmh
-        object: baremetalhost
+    - key: name_m3m
+      object: metal3machine
+    - key: name_machine
+      object: machine
+    - key: name_bmh
+      object: baremetalhost
     indexes:
-      - key: index
-        offset: 0
-        step: 1
+    - key: index
+      offset: 0
+      step: 1
     ipAddressesFromIPPool:
-      - key: ip
-        Name: pool-1
+    - key: ip
+      Name: pool-1
     prefixesFromIPPool:
-      - key: ip
-        Name: pool-1
+    - key: ip
+      Name: pool-1
     gatewaysFromIPPool:
-      - key: gateway
-        Name: pool-1
+    - key: gateway
+      Name: pool-1
     dnsServersFromIPPool:
-      - key: dns
-        Name: pool-1
+    - key: dns
+      Name: pool-1
     fromHostInterfaces:
-      - key: mac
-        interface: "eth0"
+    - key: mac
+      interface: "eth0"
     fromLabels:
-      - key: label-1
-        object: machine
-        label: mylabelkey
+    - key: label-1
+      object: machine
+      label: mylabelkey
     fromAnnotations:
-      - key: annotation-1
-        object: machine
-        annotation: myannotationkey
+    - key: annotation-1
+      object: machine
+      annotation: myannotationkey
   networkData:
     links:
       ethernets:
-        - type: "phy"
-          id: "enp1s0"
-          mtu: 1500
-          macAddress:
-            fromHostInterface: "eth0"
-        - type: "phy"
-          id: "enp2s0"
-          mtu: 1500
-          macAddress:
-            fromHostInterface: "eth1"
+      - type: "phy"
+        id: "enp1s0"
+        mtu: 1500
+        macAddress:
+          fromHostInterface: "eth0"
+      - type: "phy"
+        id: "enp2s0"
+        mtu: 1500
+        macAddress:
+          fromHostInterface: "eth1"
       bonds:
-        - id: "bond0"
-          mtu: 1500
-          macAddress:
-            string: "XX:XX:XX:XX:XX:XX"
-          bondMode: "802.3ad"
-          bondLinks:
-            - enp1s0
-            - enp2s0
+      - id: "bond0"
+        mtu: 1500
+        macAddress:
+          string: "XX:XX:XX:XX:XX:XX"
+        bondMode: "802.3ad"
+        bondLinks:
+          - enp1s0
+          - enp2s0
       vlans:
-        - id: "vlan1"
-          mtu: 1500
-          macAddress:
-            string: "YY:YY:YY:YY:YY:YY"
-          vlanID: 1
-          vlanLink: bond0
+      - id: "vlan1"
+        mtu: 1500
+        macAddress:
+          string: "YY:YY:YY:YY:YY:YY"
+        vlanID: 1
+        vlanLink: bond0
     networks:
       ipv4DHCP:
-        - id: "provisioning"
-          link: "bond0"
+      - id: "provisioning"
+        link: "bond0"
 
       ipv4:
-        - id: "Baremetal"
-          link: "vlan1"
-          IPAddressFromIPPool: pool-1
-          routes:
-            - network: "0.0.0.0"
-              netmask: 0
-              gateway:
-                fromIPPool: pool-1
-              services:
-                dns:
-                  - "8.8.4.4"
-                dnsFromIPPool: pool-1
+      - id: "Baremetal"
+        link: "vlan1"
+        IPAddressFromIPPool: pool-1
+        routes:
+        - network: "0.0.0.0"
+          netmask: 0
+          gateway:
+            fromIPPool: pool-1
+          services:
+            dns:
+            - "8.8.4.4"
+            dnsFromIPPool: pool-1
       ipv6DHCP:
-        - id: "provisioning6"
-          link: "bond0"
+      - id: "provisioning6"
+        link: "bond0"
       ipv6SLAAC:
-        - id: "provisioning6slaac"
-          link: "bond0"
+      - id: "provisioning6slaac"
+        link: "bond0"
       ipv6:
-        - id: "Baremetal6"
-          link: "vlan1"
-          IPAddressFromIPPool: pool6-1
-          routes:
-            - network: "0::0"
-              netmask: 0
-              gateway:
-                string: "2001:0db8:85a3::8a2e:0370:1"
-              services:
-                dns:
-                  - "2001:4860:4860::8844"
-                dnsFromIPPool: pool6-1
+      - id: "Baremetal6"
+        link: "vlan1"
+        IPAddressFromIPPool: pool6-1
+        routes:
+        - network: "0::0"
+          netmask: 0
+          gateway:
+            string: "2001:0db8:85a3::8a2e:0370:1"
+          services:
+            dns:
+            - "2001:4860:4860::8844"
+            dnsFromIPPool: pool6-1
     services:
       dns:
-        - "8.8.8.8"
-        - "2001:4860:4860::8888"
+      - "8.8.8.8"
+      - "2001:4860:4860::8888"
 status:
   indexes:
     "0": "machine-1"
@@ -696,10 +701,10 @@ status:
   lastUpdated: "2020-04-02T06:36:09Z"
 ```
 
-This object will be reconciled by its own controller. When reconciled,
-the controller will add a label pointing to the Metal3Cluster that has nodes
-linking to this object. The spec contains a `metaData` and a `networkData` field
-that contain a template of the values that will be rendered for all nodes.
+This object will be reconciled by its own controller. When reconciled, the
+controller will add a label pointing to the Metal3Cluster that has nodes linking
+to this object. The spec contains a `metaData` and a `networkData` field that
+contain a template of the values that will be rendered for all nodes.
 
 The `metaData` field will be rendered into a map of strings in yaml format,
 while `networkData` will be rendered into a map equivalent of
@@ -713,35 +718,35 @@ follows the format definition that can be found
 The `metaData` field contains a list of items that will render data in different
 ways. The following types of objects are available and accept lists:
 
-* **strings**: renders the given string as value in the metadata. It takes a
+- **strings**: renders the given string as value in the metadata. It takes a
   `value` attribute.
-* **objectNames** : renders the name of the object that matches the type given.
+- **objectNames** : renders the name of the object that matches the type given.
   It takes an `object` attribute, containing the type of the object.
-* **indexes**: renders the index of the current object, with the offset from the
+- **indexes**: renders the index of the current object, with the offset from the
   `offset` field and using the step from the `step` field. The following
-  conditions must be matched : `offset` >= 0 and `step` >= 1
-  if the step is unspecified (default value being 0), the controller will
-  automatically change it for 1. The `prefix` and `suffix` attributes are to
-  provide a prefix and a suffix for the rendered index.
-* **ipAddressesFromIPPool**: renders an ip address from an *IPPool*
-  object. The *IPPool* objects are defined in the
+  conditions must be matched : `offset` >= 0 and `step` >= 1 if the step is
+  unspecified (default value being 0), the controller will automatically change
+  it for 1. The `prefix` and `suffix` attributes are to provide a prefix and a
+  suffix for the rendered index.
+- **ipAddressesFromIPPool**: renders an ip address from an _IPPool_ object. The
+  _IPPool_ objects are defined in the
   [IP Address manager repo](https://github.com/metal3-io/ip-address-manager)
-* **prefixesFromIPPool**: renders a network prefix from an *IPPool*
-  object. The *IPPool* objects are defined in the
+- **prefixesFromIPPool**: renders a network prefix from an _IPPool_ object. The
+  _IPPool_ objects are defined in the
   [IP Address manager repo](https://github.com/metal3-io/ip-address-manager)
-* **gatewaysFromIPPool**: renders a network gateway from an *IPPool*
-  object. The *IPPool* objects are defined in the
+- **gatewaysFromIPPool**: renders a network gateway from an _IPPool_ object. The
+  _IPPool_ objects are defined in the
   [IP Address manager repo](https://github.com/metal3-io/ip-address-manager)
-* **dnsServersFromIPPool**: renders a dns servers list from an *IPPool*
-  object. The *IPPool* objects are defined in the
+- **dnsServersFromIPPool**: renders a dns servers list from an _IPPool_ object.
+  The _IPPool_ objects are defined in the
   [IP Address manager repo](https://github.com/metal3-io/ip-address-manager)
-* **fromHostInterfaces**: renders the MAC address of the BareMetalHost that
+- **fromHostInterfaces**: renders the MAC address of the BareMetalHost that
   matches the name given as value.
-* **fromLabels**: renders the content of a label on an object or an empty string
+- **fromLabels**: renders the content of a label on an object or an empty string
   if the label is absent. It takes an `object` attribute to specify the type of
   the object where to fetch the label, and a `label` attribute that contains the
   label key.
-* **fromAnnotations**: renders the content of a annotation on an object or an
+- **fromAnnotations**: renders the content of a annotation on an object or an
   empty string if the annotation is absent. It takes an `object` attribute to
   specify the type of the object where to fetch the annotation, and an
   `annotation` attribute that contains the annotation key.
@@ -752,159 +757,160 @@ For each object, the attribute **key** is required.
 
 The `networkData` field will contain three items :
 
-* **links**: a list of layer 2 interface
-* **networks**: a list of layer 3 networks
-* **services** : a list of services (DNS)
+- **links**: a list of layer 2 interface
+- **networks**: a list of layer 3 networks
+- **services** : a list of services (DNS)
 
 #### Links specifications
 
 The object for the **links** section list can be:
 
-* **ethernets**: a list of ethernet interfaces
-* **bonds**: a list of bond interfaces
-* **vlans**: a list of vlan interfaces
+- **ethernets**: a list of ethernet interfaces
+- **bonds**: a list of bond interfaces
+- **vlans**: a list of vlan interfaces
 
 The **links/ethernets** objects contain the following:
 
-* **type**: Type of the ethernet interface
-* **id**: Interface name
-* **mtu**: Interface MTU
-* **macAddress**: an object to render the MAC Address
+- **type**: Type of the ethernet interface
+- **id**: Interface name
+- **mtu**: Interface MTU
+- **macAddress**: an object to render the MAC Address
 
 The **links/ethernets/type** can be one of :
 
-* bridge
-* dvs
-* hw_veb
-* hyperv
-* ovs
-* tap
-* vhostuser
-* vif
-* phy
+- bridge
+- dvs
+- hw_veb
+- hyperv
+- ovs
+- tap
+- vhostuser
+- vif
+- phy
 
 The **links/ethernets/macAddress** object can be one of:
 
-* **string**: with the desired Mac given as a string
-* **fromHostInterface**: with the interface name from BareMetalHost
-  hardware details.
+- **string**: with the desired Mac given as a string
+- **fromHostInterface**: with the interface name from BareMetalHost hardware
+  details.
 
 The **links/bonds** object contains the following:
 
-* **id**: Interface name
-* **mtu**: Interface MTU
-* **macAddress**: an object to render the MAC Address
-* **bondMode**: The bond mode
-* **bondLinks** : a list of links to use for the bond
+- **id**: Interface name
+- **mtu**: Interface MTU
+- **macAddress**: an object to render the MAC Address
+- **bondMode**: The bond mode
+- **bondLinks** : a list of links to use for the bond
 
 The **links/bonds/bondMode** can be one of :
 
-* 802.3ad
-* balance-rr
-* active-backup
-* balance-xor
-* broadcast
-* balance-tlb
-* balance-alb
+- 802.3ad
+- balance-rr
+- active-backup
+- balance-xor
+- broadcast
+- balance-tlb
+- balance-alb
 
 The **links/vlans** object contains the following:
 
-* **id**: Interface name
-* **mtu**: Interface MTU
-* **macAddress**: an object to render the MAC Address
-* **vlanID**: The vlan ID
-* **vlanLink** : The link on which to create the vlan
+- **id**: Interface name
+- **mtu**: Interface MTU
+- **macAddress**: an object to render the MAC Address
+- **vlanID**: The vlan ID
+- **vlanLink** : The link on which to create the vlan
 
 #### The networks specifications
 
 The object for the **networks** section can be:
 
-* **ipv4**: a list of ipv4 static allocations
-* **ipv4DHCP**: a list of ipv4 DHCP based allocations
-* **ipv6**: a list of ipv6 static allocations
-* **ipv6DHCP**: a list of ipv6 DHCP based allocations
-* **ipv6SLAAC**: a list of ipv6 SLAAC based allocations
+- **ipv4**: a list of ipv4 static allocations
+- **ipv4DHCP**: a list of ipv4 DHCP based allocations
+- **ipv6**: a list of ipv6 static allocations
+- **ipv6DHCP**: a list of ipv6 DHCP based allocations
+- **ipv6SLAAC**: a list of ipv6 SLAAC based allocations
 
 The **networks/ipv4** object contains the following:
 
-* **id**: the network name
-* **link**: The name of the link to configure this network for
-* **ipAddressFromIPPool**: renders an ip address from an *IPPool*
-  object. The *IPPool* objects are defined in the
+- **id**: the network name
+- **link**: The name of the link to configure this network for
+- **ipAddressFromIPPool**: renders an ip address from an _IPPool_ object. The
+  _IPPool_ objects are defined in the
   [IP Address manager repo](https://github.com/metal3-io/ip-address-manager)
-* **routes**: the list of route objects
+- **routes**: the list of route objects
 
-The **networks/ipv*/routes** is a route object containing:
+The **networks/ipv\*/routes** is a route object containing:
 
-* **network**: the subnet to reach
-* **netmask**: the mask of the subnet as integer
-* **gateway**: the gateway to use, it can either be given as a string in
-  *string* or as an IPPool name in *fromIPPool*
-* **services**: a list of services object as defined later
+- **network**: the subnet to reach
+- **netmask**: the mask of the subnet as integer
+- **gateway**: the gateway to use, it can either be given as a string in
+  _string_ or as an IPPool name in _fromIPPool_
+- **services**: a list of services object as defined later
 
 The **networks/ipv4Dhcp** object contains the following:
 
-* **id**: the network name
-* **link**: The name of the link to configure this network for
-* **routes**: the list of route objects
+- **id**: the network name
+- **link**: The name of the link to configure this network for
+- **routes**: the list of route objects
 
 The **networks/ipv6** object contains the following:
 
-* **id**: the network name
-* **link**: The name of the link to configure this network for
-* **ipAddressFromIPPool**: renders an ip address from an *IPPool*
-  object. The *IPPool* objects are defined in the
+- **id**: the network name
+- **link**: The name of the link to configure this network for
+- **ipAddressFromIPPool**: renders an ip address from an _IPPool_ object. The
+  _IPPool_ objects are defined in the
   [IP Address manager repo](https://github.com/metal3-io/ip-address-manager)
-* **routes**: the list of route objects
+- **routes**: the list of route objects
 
 The **networks/ipv6Dhcp** object contains the following:
 
-* **id**: the network name
-* **link**: The name of the link to configure this network for
-* **routes**: the list of route objects
+- **id**: the network name
+- **link**: The name of the link to configure this network for
+- **routes**: the list of route objects
 
 The **networks/ipv6Slaac** object contains the following:
 
-* **id**: the network name
-* **link**: The name of the link to configure this network for
-* **routes**: the list of route objects
+- **id**: the network name
+- **link**: The name of the link to configure this network for
+- **routes**: the list of route objects
 
 #### the services specifications
 
 The object for the **services** section can be:
 
-* **dns**: a list of dns service with the ip address of a dns server
-* **dnsFromIPPool**: the IPPool from which to fetch the dns servers list
+- **dns**: a list of dns service with the ip address of a dns server
+- **dnsFromIPPool**: the IPPool from which to fetch the dns servers list
 
 #### Updating metaData and networkData
 
 The data template parts containing the metadata and networkData must be
-immutable since the BareMetalHost references the secrets and they are used
-at provisioning time, the secrets cannot be updated to be able to reprovision
-the node in the exact same state. This means that updates have to be done by
+immutable since the BareMetalHost references the secrets and they are used at
+provisioning time, the secrets cannot be updated to be able to reprovision the
+node in the exact same state. This means that updates have to be done by
 creating a new template and referencing it in the new/updated
 Metal3MachineTemplate.
 
 The process to allow updating the metaData and networkData is then to create a
 new Metal3DataTemplate and reference the new one in the Metal3MachineTemplate.
 This requires the Metal3Data to be linked to both Metal3DataTemplates. This is
-achieved using the `templateReference` field of the Metal3DataTemplate. When
-a Metal3Data corresponding to the Metal3DataTemplate is created, the reconciler
+achieved using the `templateReference` field of the Metal3DataTemplate. When a
+Metal3Data corresponding to the Metal3DataTemplate is created, the reconciler
 will set the `templateReference` to the value of the Metal3DataTemplate, if set.
 
 The Metal3Data objects are linked to a Metal3DataTemplate by three ways:
 
-* Directly reference the template in the `template` field of the Metal3Data `spec`
-* They have the same `templateReference` key as the template
-* The template's `templateReference` matches the `name` of the `template` field
+- Directly reference the template in the `template` field of the Metal3Data
+  `spec`
+- They have the same `templateReference` key as the template
+- The template's `templateReference` matches the `name` of the `template` field
   of the `spec` of the Metal3Data.
 
 The third way ensures backward compatibility with previous version of
 implementation when there was no `templateReference` in Metal3Data objects.
 Since the `templateReference` field is an addition to the existing API, the
 default behaviour of the controller will be to list the Metal3Data objects by
-matching their template field if the `templateReference` is left empty on
-the template object. However, if the `templateReference` is set on the
+matching their template field if the `templateReference` is left empty on the
+template object. However, if the `templateReference` is set on the
 Metal3DataTemplate object, but not on the Metal3Data object, then the controller
 will match the `templateReference` field with the `name` of the `template` field
 of the Metal3Data object. This is performed by setting the `templateReference`
@@ -938,15 +944,15 @@ status:
   errorMessage: ""
 ```
 
-The *Metal3DataClaim* object will reference its target *Metal3DataTemplate*
-object. In its status, the *renderedData* would reference the *Metal3Data*
-object when it would be generated. In case of error, the *errorMessage* would
+The _Metal3DataClaim_ object will reference its target _Metal3DataTemplate_
+object. In its status, the _renderedData_ would reference the _Metal3Data_
+object when it would be generated. In case of error, the _errorMessage_ would
 contain a description of the error.
 
 ## The Metal3Data object
 
-The output of the controller would be a Metal3Data object,one per node linking to the
-Metal3DataTemplate object and the associated secrets
+The output of the controller would be a Metal3Data object,one per node linking
+to the Metal3DataTemplate object and the associated secrets
 
 The Metal3Data object would be:
 
@@ -987,22 +993,22 @@ generated and to the Metal3Machine using this Metal3Data object.
 
 If the Metal3DataTemplate object is updated, the generated secrets will not be
 updated, to allow for reprovisioning of the nodes in the exact same state as
-they were initially provisioned. Hence, to do an update, it is necessary to do
-a rolling upgrade of all nodes.
+they were initially provisioned. Hence, to do an update, it is necessary to do a
+rolling upgrade of all nodes.
 
 The reconciliation of the Metal3DataTemplate object will also be triggered by
 changes on Metal3Machines. In the case that a Metal3Machine gets modified, if
-the `dataTemplate` references a Metal3DataTemplate, that *Metal3DataClaim*
+the `dataTemplate` references a Metal3DataTemplate, that _Metal3DataClaim_
 object will be reconciled. There will be two cases:
 
-* An already generated Metal3Data object exists for that *Metal3DataClaim*. If
-  the reference is not in the *Metal3DataClaim* object, the reconciler will add
+- An already generated Metal3Data object exists for that _Metal3DataClaim_. If
+  the reference is not in the _Metal3DataClaim_ object, the reconciler will add
   it. The reconciler will also verify that the required secrets exist. If they
   do not, they will be created.
-* if no Metal3Data exists for that *Metal3DataClaim*, then the
-  reconciler will create one and fill the respective field with the secret name.
+- if no Metal3Data exists for that _Metal3DataClaim_, then the reconciler will
+  create one and fill the respective field with the secret name.
 
-To create a Metal3Data object, the *Metal3DataClaim* controller will select an
+To create a Metal3Data object, the _Metal3DataClaim_ controller will select an
 index for that Metal3Machine. The selection happens by selecting the lowest
 available index that is not in use. To do that, the controller will list all
 existing Metal3Data object linked to this Metal3DataTemplate and to get the
@@ -1018,7 +1024,7 @@ Metal3Data and try to create the new object with the new index, this will happen
 until the new object is created successfully. Upon success, it will render the
 content values, and create the secrets containing the rendered data. The
 controller will generate the content based on the `metaData` or `networkData`
-field of the Metal3DataTemplate Specs. The *ready* field in *renderedData* will
+field of the Metal3DataTemplate Specs. The _ready_ field in _renderedData_ will
 then be set accordingly. If any error happens during the rendering, an error
 message will be added.
 
@@ -1042,20 +1048,20 @@ provisioning of the BareMetalHost until it exists.
 ### Dynamic secret creation
 
 In the case where the Metal3Machine is created with a `dataTemplate` value, the
-Metal3Machine reconciler will create a *Metal3DataClaim* for that object.
+Metal3Machine reconciler will create a _Metal3DataClaim_ for that object.
 
-The *Metal3DataClaim* would then be reconciled, and its controller will create
-an index for this *Metal3DataClaim* if it does not exist yet, and create a
-Metal3Data object with the index. Upon success, it will set the *ready* field
-to true, and the *renderedData* field to reference the *Metal3Data* object.
+The _Metal3DataClaim_ would then be reconciled, and its controller will create
+an index for this _Metal3DataClaim_ if it does not exist yet, and create a
+Metal3Data object with the index. Upon success, it will set the _ready_ field to
+true, and the _renderedData_ field to reference the _Metal3Data_ object.
 
 The Metal3Data reconciler will then generate the secrets, based on the index,
 the Metal3DataTemplate and the machine. Once created, it will set the status
 field `ready` to True.
 
-Once the Metal3Data object is ready, the Metal3Machine controller will fetch
-the secrets that have been created (one or both) and use them to start
-provisioning the BareMetalHost.
+Once the Metal3Data object is ready, the Metal3Machine controller will fetch the
+secrets that have been created (one or both) and use them to start provisioning
+the BareMetalHost.
 
 ### Hybrid configuration
 
@@ -1071,6 +1077,5 @@ secret through the Metal3DataTemplate object.
 ## Metal3 dev env examples
 
 You can find CR examples in the
-[Metal3-io dev env project](https://github.com/metal3-io/metal3-dev-env),
-in the [template
-folder](https://github.com/metal3-io/metal3-dev-env/tree/main/tests/roles/run_tests/templates).
+[Metal3-io dev env project](https://github.com/metal3-io/metal3-dev-env), in the
+[template folder](https://github.com/metal3-io/metal3-dev-env/tree/main/tests/roles/run_tests/templates).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,28 +2,28 @@
 
 ## Introduction
 
-The ```cluster-api-provider-metal3 (CAPM3)``` is one of the controllers
-involved in managing the life cycle of kubernetes clusters on Metal3
-Machines. This document describes the components involved and their roles. It
-also discusses the flow of information from one CR to another with the help of
-the controllers. As to avoid ambiguity, we will refer to the physical or virtual
-machines managed by the controllers as Bare Metal Servers. And, the kubernetes
-resources (CRs) representing them as Metal3 Machines (M3M).
+The `cluster-api-provider-metal3 (CAPM3)` is one of the controllers involved in
+managing the life cycle of kubernetes clusters on Metal3 Machines. This document
+describes the components involved and their roles. It also discusses the flow of
+information from one CR to another with the help of the controllers. As to avoid
+ambiguity, we will refer to the physical or virtual machines managed by the
+controllers as Bare Metal Servers. And, the kubernetes resources (CRs)
+representing them as Metal3 Machines (M3M).
 
 ## Components
 
-The ```cluster-api-provider-metal3 (CAPM3)``` controller is responsible for
-watching and reconciling multiple resources. However, it is important to see
-other controllers and custom resources (CRs) involved in the process. The
-ultimate goal of the interaction between the controllers and CRs is to provision
-a kubernetes cluster on Bare Metal Servers. To that end, the controllers
-perform different actions on one or more relevant CRs.
+The `cluster-api-provider-metal3 (CAPM3)` controller is responsible for watching
+and reconciling multiple resources. However, it is important to see other
+controllers and custom resources (CRs) involved in the process. The ultimate
+goal of the interaction between the controllers and CRs is to provision a
+kubernetes cluster on Bare Metal Servers. To that end, the controllers perform
+different actions on one or more relevant CRs.
 
 The following diagram shows the different controllers and CRs involved. The
-CAPI, CABPK and CAPM3 controllers are beyond the scope of this document.
-With respect to CAPM3, we focus on what CRS it `watches` and `reconciles`. The
-arrows in black show which CRs the controller `reconciles` while the one in red
-show that a related controller is `watching` another CR.
+CAPI, CABPK and CAPM3 controllers are beyond the scope of this document. With
+respect to CAPM3, we focus on what CRS it `watches` and `reconciles`. The arrows
+in black show which CRs the controller `reconciles` while the one in red show
+that a related controller is `watching` another CR.
 
 ![components](images/components.png)
 
@@ -34,22 +34,21 @@ Similarly, it watches `Cluster` CR and makes changes on a related
 
 The left most components, BMO controller and BareMetalHost(BMH) CR, are the
 closest to the Bare Metal Server. If one wants to changes the state of a Metal3
-Machine, they modify the BMH CR. Upon change to the BMH, BMO interacts
-with Ironic to make changes on the Bare Metal Server.
+Machine, they modify the BMH CR. Upon change to the BMH, BMO interacts with
+Ironic to make changes on the Bare Metal Server.
 
 During the initial introspection and state changes, the above logic works in the
- opposite direction as well. Information gathered during introspection or any
- state changes on the Bare Metal Server, results in BMO learning about the
- change(s) via Ironic and a chain of events starts. Once BMO learns about the
- changes, it makes the required
-changes on the BMH.
+opposite direction as well. Information gathered during introspection or any
+state changes on the Bare Metal Server, results in BMO learning about the
+change(s) via Ironic and a chain of events starts. Once BMO learns about the
+changes, it makes the required changes on the BMH.
 
 As discussed above, the management of Bare Metal Servers requires the
 interaction of multiple controllers via multiple CRs. However, the interaction
 is performed on a specified number of fields on each CR. i.e. A controller
 `watches` a specified number of fields in each CR and makes changes on a set of
- fields. Before seeing the relationship, we need to see the CRs at two
-  stages, before and after provisioning a control plane machine.
+fields. Before seeing the relationship, we need to see the CRs at two stages,
+before and after provisioning a control plane machine.
 
 ---
 
@@ -229,6 +228,7 @@ status:
 ```
 
 ---
+
 ### Metal3Machine
 
 Metal3Machine, User provided Configuration
@@ -303,6 +303,8 @@ spec:
 
 BareMetalHost, after reconciliation
 
+<!-- markdownlint-disable MD013 -->
+
 ```yaml
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
@@ -355,6 +357,8 @@ status:
     credentialsVersion: "1435"
 ```
 
+<!-- markdownlint-enable MD013 -->
+
 ### KubeadmConfig
 
 KubeadmConfig, user provided Configuration
@@ -367,9 +371,9 @@ metadata:
 spec:
   initConfiguration:
     nodeRegistration:
-      name: '{{ ds.meta_data.name }}'
+      name: "{{ ds.meta_data.name }}"
       kubeletExtraArgs:
-        node-labels: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+        node-labels: "metal3.io/uuid={{ ds.meta_data.uuid }}"
   preKubeadmCommands: <list of commands>
   postKubeadmCommands: <list of commands>
   files: <list of files>
@@ -421,14 +425,15 @@ status:
 ```
 
 ---
+
 #### Flow of information
 
 As was shown on the above CRs, some of the fields are introduced in one CR and
 they travel through multiple CRs to reach the BMH, which is the closest to the
 Bare Metal Server. There is also a movement of information from the
 virtual/physical machines towards the CRs, but this is beyond the scope of this
- document. Some of the fields are added by users, while the others are by the
- relevant controllers.
+document. Some of the fields are added by users, while the others are by the
+relevant controllers.
 
 We have added the source of relevant fields as comments in the above yaml files.
 The following sequence diagram shows the flow of information (fields) across
@@ -438,9 +443,9 @@ multiple CRs with the help of controllers.
 
 #### Some relevant fields
 
-```apiEndpoint:``` IP:Port of a load balancer (keepalived VIP)
+`apiEndpoint:` IP:Port of a load balancer (keepalived VIP)
 
-```image:``` OS image for the Metal3 Machine
+`image:` OS image for the Metal3 Machine
 
 The following fields are used to make a relationship between CRs.
 

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -2,8 +2,7 @@
 
 ## Pre-requisites
 
-CAPM3 requires two external tools for running the tests
-during development.
+CAPM3 requires two external tools for running the tests during development.
 
 ### Install kustomize
 
@@ -21,9 +20,8 @@ during development.
 
 Both of the [Tilt](https://tilt.dev) setups below will get you started
 developing CAPM3 in a local kind cluster. The main difference is the number of
-components you will build from source and the scope of the changes you'd like
-to make.
-If you only want to make changes in CAPM3, then follow
+components you will build from source and the scope of the changes you'd like to
+make. If you only want to make changes in CAPM3, then follow
 [CAPM3 instructions](#tilt-for-dev-in-capm3). This will save you from having to
 build all of the images for CAPI, which can take a while. If the scope of your
 development will span both CAPM3 and CAPI, then follow the
@@ -31,12 +29,13 @@ development will span both CAPM3 and CAPI, then follow the
 
 ### Tilt for dev in CAPM3
 
-In order to develop CAPM3 using Tilt, there is a requirement to have kind
-and Tilt installed.
+In order to develop CAPM3 using Tilt, there is a requirement to have kind and
+Tilt installed.
 
 ```sh
 hack/ensure-kind.sh
-curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
+curl -fsSL \
+https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
 ```
 
 Once installed, you will need a tilt-settings.json. You can generate one using
@@ -54,7 +53,9 @@ Then start Tilt:
 make tilt-up
 ```
 
-The Tilt dashboard can be accessed at <http://localhost:10350>. If tilt is running remotely, it can be accessed using ssh tunneling. An example of ```~/.ssh/config```  is show below.
+The Tilt dashboard can be accessed at <http://localhost:10350>. If tilt is
+running remotely, it can be accessed using ssh tunneling. An example of
+`~/.ssh/config` is show below.
 
 ```bash
 Host tiltvm
@@ -66,9 +67,9 @@ Host tiltvm
 Changes in the go code will trigger an update of the images running to run the
 latest code of CAPM3.
 
-Tilt can be used in Metal3-dev-env, as long as the
-03_launch_mgmt_cluster.sh script is **NOT** run. In that case Ironic needs to
-be deployed locally first, following the
+Tilt can be used in Metal3-dev-env, as long as the 03_launch_mgmt_cluster.sh
+script is **NOT** run. In that case Ironic needs to be deployed locally first,
+following the
 [local Ironic setup](https://github.com/metal3-io/baremetal-operator/blob/main/docs/dev-setup.md#running-a-local-instance-of-ironic)
 
 By default, the Cluster API components deployed by Tilt have experimental
@@ -80,7 +81,7 @@ Once your kind management cluster is up and running, you can
 [deploy an example cluster](#deploy-an-example-cluster).
 
 You can also
-[deploy a flavor cluster as a local tilt resource](#Running-flavor-clusters-as-a-tilt-resource).
+[deploy a flavor cluster as a local tilt resource](#running-flavor-clusters-as-a-tilt-resource).
 
 To tear down the kind cluster built by the command above, just run:
 
@@ -90,8 +91,8 @@ make kind-reset
 
 ### Tilt for dev in both CAPM3 and CAPI
 
-If you want to develop in both CAPI and CAPM3 at the same time, then this is
-the path for you.
+If you want to develop in both CAPI and CAPM3 at the same time, then this is the
+path for you.
 
 First, you will need a kind setup with a registry. You can use the following
 command
@@ -102,16 +103,16 @@ command
 
 To use [Tilt](https://tilt.dev/) for a simplified development workflow, follow
 the [instructions](https://cluster-api.sigs.k8s.io/developer/tilt.html) in the
-cluster API repo.  The instructions will walk you through cloning the Cluster
-API (CAPI) repository and configuring Tilt to use `kind` to deploy the cluster
-api management components.
+cluster API repo. The instructions will walk you through cloning the Cluster API
+(CAPI) repository and configuring Tilt to use `kind` to deploy the cluster api
+management components.
 
 > you may wish to checkout out the correct version of CAPI to match the
-[version used in CAPM3](../go.mod)
+> [version used in CAPM3](../go.mod)
 
 Note that `tilt up` will be run from the `cluster-api repository` directory and
 the `tilt-settings.json` file will point back to the
-`cluster-api-provider-metal3` repository directory.  Any changes you make to the
+`cluster-api-provider-metal3` repository directory. Any changes you make to the
 source code in `cluster-api` or `cluster-api-provider-metal3` repositories will
 automatically redeployed to the `kind` cluster.
 
@@ -137,7 +138,9 @@ make kustomize
 ./hack/tools/bin/kustomize version
 ```
 
-If the above installation does not work, install kustomize using a package manager and move the binary to ```hack/tools/bin/kustomize``` in the cluster-api repo.
+If the above installation does not work, install kustomize using a package
+manager and move the binary to `hack/tools/bin/kustomize` in the cluster-api
+repo.
 
 After configuring the environment variables, run the following to generate your
 `tilt-settings.json` file in the cluster API repository:
@@ -164,10 +167,10 @@ EOF
 
 This requires the following environment variables to be exported :
 
-* `DEPLOY_KERNEL_URL`
-* `DEPLOY_RAMDISK_URL`
-* `IRONIC_INSPECTOR_URL`
-* `IRONIC_URL`
+- `DEPLOY_KERNEL_URL`
+- `DEPLOY_RAMDISK_URL`
+- `IRONIC_INSPECTOR_URL`
+- `IRONIC_URL`
 
 Those need to be set up accordingly with the
 [local Ironic setup](https://github.com/metal3-io/baremetal-operator/blob/main/docs/dev-setup.md#running-a-local-instance-of-ironic)
@@ -192,8 +195,8 @@ repositories. In case you have a tree like:
 ```
 
 and you create your `tilt-settings.json` in the ./cluster-api or in the
-./cluster-api-provider-metal3 folder. Then your tilt-settings.json file would
-be :
+./cluster-api-provider-metal3 folder. Then your tilt-settings.json file would be
+:
 
 ```json
 {
@@ -206,13 +209,13 @@ The provider name for Baremetal Operator is `metal3-bmo` and for IP Address
 Manager `metal3-ipam`. Those names are defined in their respective repository.
 
 > In case you are modifying the manifests for BMO or IPAM, then you should also
-modify the `kustomization.yaml` files in `./config/bmo` and `./config/ipam` to
-refer to the modified manifests locally instead of downloading released ones.
+> modify the `kustomization.yaml` files in `./config/bmo` and `./config/ipam` to
+> refer to the modified manifests locally instead of downloading released ones.
 
 ### Running flavor clusters as a tilt resource
 
-For a successful deployment, you need to have exported the proper variables.
-You can use the following command:
+For a successful deployment, you need to have exported the proper variables. You
+can use the following command:
 
 ```sh
     source ./examples/clusterctl-templates/example_variables.rc
@@ -224,8 +227,8 @@ Metal3-dev-env deployment scripts that are tailored for it.
 
 #### From CLI
 
-run `tilt up ${flavors}` to spin up worker clusters represented by
-a Tilt local resource.  You can also modify flavors while Tilt is up by running
+run `tilt up ${flavors}` to spin up worker clusters represented by a Tilt local
+resource. You can also modify flavors while Tilt is up by running
 `tilt args ${flavors}`
 
 #### From Tilt Config
@@ -234,14 +237,14 @@ Add your desired flavors to tilt_config.json:
 
 ```json
 {
-    "worker-flavors": ["default"]
+  "worker-flavors": ["default"]
 }
 ```
 
 #### Requirements
 
-Please note your tilt-settings.json must contain at minimum the following
-fields when using tilt resources to deploy cluster flavors:
+Please note your tilt-settings.json must contain at minimum the following fields
+when using tilt resources to deploy cluster flavors:
 
 ```json
 {
@@ -257,15 +260,15 @@ fields when using tilt resources to deploy cluster flavors:
 #### Defining Variable Overrides
 
 If you wish to override the default variables for flavor workers, you can
-specify them as part of your tilt-settings.json as seen in the example
-below.  Please note, the precedence of variables is as follows:
+specify them as part of your tilt-settings.json as seen in the example below.
+Please note, the precedence of variables is as follows:
 
 1. explicitly defined vars for each flavor i.e.
    `worker-templates.flavors[0].WORKER_MACHINE_COUNT`
 1. vars defined at 'metadata' level-- spans workers i.e.
    `metadata.WORKER_MACHINE_COUNT`
-1. programmatically defined default vars i.e. everything except Ironic
-   related URL variables "DEPLOY_KERNEL_URL", "DEPLOY_RAMDISK_URL",
+1. programmatically defined default vars i.e. everything except Ironic related
+   URL variables "DEPLOY_KERNEL_URL", "DEPLOY_RAMDISK_URL",
    "IRONIC_INSPECTOR_URL" and "IRONIC_URL"
 
 ```json
@@ -295,8 +298,8 @@ below.  Please note, the precedence of variables is as follows:
 
 See the [Kind docs](https://kind.sigs.k8s.io/docs/user/quick-start) for
 instructions on launching a Kind cluster and the
-[Minikube docs](https://kubernetes.io/docs/setup/minikube/) for
-instructions on launching a Minikube cluster.
+[Minikube docs](https://kubernetes.io/docs/setup/minikube/) for instructions on
+launching a Minikube cluster.
 
 ### Deploy CAPI and CAPM3
 
@@ -309,12 +312,12 @@ make deploy
 ```
 
 When a `Metal3Machine` is created, the provider looks for an available
-`BareMetalHost` object to claim and then sets it to be provisioned to fulfill the
-request expressed by the `Metal3Machine`. There’s no requirement to actually run
-the `baremetal-operator` to test the reconciliation logic of the provider.
+`BareMetalHost` object to claim and then sets it to be provisioned to fulfill
+the request expressed by the `Metal3Machine`. There’s no requirement to actually
+run the `baremetal-operator` to test the reconciliation logic of the provider.
 
-Refer to the [baremetal-operator developer
-documentation](https://github.com/metal3-io/baremetal-operator/blob/main/docs/dev-setup.md)
+Refer to the
+[baremetal-operator developer documentation](https://github.com/metal3-io/baremetal-operator/blob/main/docs/dev-setup.md)
 for instructions and tools for creating BareMetalHost objects.
 
 ### Run the Controller locally
@@ -322,7 +325,8 @@ for instructions and tools for creating BareMetalHost objects.
 You will first need to scale down the controller deployment:
 
 ```sh
-kubectl scale -n capm3-system deployment.v1.apps/capm3-controller-manager --replicas 0
+kubectl scale -n capm3-system deployment.v1.apps/capm3-controller-manager \
+  --replicas 0
 ```
 
 You can manually run the controller from outside of the cluster for development

--- a/docs/disk_cleaning.md
+++ b/docs/disk_cleaning.md
@@ -24,11 +24,12 @@ How we refer to these objects later on:
 ## What is automated cleaning
 
 Ironic offers two modes for node cleaning, automated and manual where automated
-cleaning is recommended for ironic deployments. Automated cleaning gets triggered
-automatically during the first provisioning and on every deprovisioning of a node.
-If automated cleaning is enabled, Ironic runs various cleaning steps by priority
-and meanwhile the node stays in `cleaning` state (m3m/host in `provisioning`/`deprovisioning`).
-To get more info, check Ironic's [documentation](https://docs.openstack.org/ironic/latest/admin/cleaning.html#automated-cleaning).
+cleaning is recommended for ironic deployments. Automated cleaning gets
+triggered automatically during the first provisioning and on every
+deprovisioning of a node. If automated cleaning is enabled, Ironic runs various
+cleaning steps by priority and meanwhile the node stays in `cleaning` state
+(m3m/host in `provisioning`/`deprovisioning`). To get more info, check Ironic's
+[documentation](https://docs.openstack.org/ironic/latest/admin/cleaning.html#automated-cleaning).
 
 ## How to enable/disabled automated cleaning via Metal3
 
@@ -36,8 +37,9 @@ Let's start with disabling. There are two ways to disable it.
 
 ### Via ironic.conf
 
-You can simply set `automated_clean` to false in your ironic.conf. See an [example](https://github.com/metal3-io/ironic-image/blob/a6c4bdce7345c6f85193454b650ac0c59e738247/ironic-config/ironic.conf.j2#L62). This will disable cleaning for all the nodes
-in a cluster.
+You can simply set `automated_clean` to false in your ironic.conf. See an
+[example](https://github.com/metal3-io/ironic-image/blob/a6c4bdce7345c6f85193454b650ac0c59e738247/ironic-config/ironic.conf.j2#L62).
+This will disable cleaning for all the nodes in a cluster.
 
 ```sh
 [conductor]
@@ -46,95 +48,103 @@ automated_clean=false
 
 Disadvantages:
 
-- once Ironic is deployed, changing the value of `automated_clean` requires rebuilding of
-    new Ironic containers images. Thus Ironic containers will need to be down until the new
-    ones are ready to serve the requests
+- once Ironic is deployed, changing the value of `automated_clean` requires
+  rebuilding of new Ironic containers images. Thus Ironic containers will need
+  to be down until the new ones are ready to serve the requests
 - same setting applies to all nodes
 
 ### Via CAPM3 APIs
 
-Automated cleaning was exposed to Metal3 as an additional interface so that it is possible
-to switch on/off the automated cleaning simply by editing YAMLs in Kubernetes cluster.
-m3mt, m3m and host CRs have `automatedCleaningMode`
-field in their Spec, which accepts either `disabled` or `metadata` values. By default,
-if a user doesn't set the value in a m3mt or m3m object, the field
-will be unset and omitted, while for a host the default value is `metadata`. We
-explain below why it is so. When set to `disabled`, cleaning will be skipped as the name
+Automated cleaning was exposed to Metal3 as an additional interface so that it
+is possible to switch on/off the automated cleaning simply by editing YAMLs in
+Kubernetes cluster. m3mt, m3m and host CRs have `automatedCleaningMode` field in
+their Spec, which accepts either `disabled` or `metadata` values. By default, if
+a user doesn't set the value in a m3mt or m3m object, the field will be unset
+and omitted, while for a host the default value is `metadata`. We explain below
+why it is so. When set to `disabled`, cleaning will be skipped as the name
 suggests, while `metadata` enables it.
 
 Advantages:
 
-- no need to rebuild a new Ironic container image to switch on/off automated cleaning mode
+- no need to rebuild a new Ironic container image to switch on/off automated
+  cleaning mode
 - simply edit K8S CR to switch on/off automated cleaning
 - possibility to switch on/off automated cleaning selectively per node
 
 Disadvantages:
 
-- accidental editing of a m3mt/m3m/host might introduce high risks with data corruption
+- accidental editing of a m3mt/m3m/host might introduce high risks with data
+  corruption
 
 #### Which resources do I need to edit
 
-As mentioned above, `automatedCleaningMode` exists in m3mt, m3m
-and host CRs. If you are using only Baremetal Operator (i.e. no CAPI & CAPM3), you
-will not have m3mt & m3m objects installed in your Kubernetes
-cluster and instead only host CR. As such, you should edit host CR
-`automatedCleaningMode` field to switch on/off the cleaning for your desired hosts.
+As mentioned above, `automatedCleaningMode` exists in m3mt, m3m and host CRs. If
+you are using only Baremetal Operator (i.e. no CAPI & CAPM3), you will not have
+m3mt & m3m objects installed in your Kubernetes cluster and instead only host
+CR. As such, you should edit host CR `automatedCleaningMode` field to switch
+on/off the cleaning for your desired hosts.
 
-If apart from Baremetal Operator, you are also using CAPI and CAPM3, then you can and
-should control the cleaning from CAPM3 CR, specifically m3mt.
+If apart from Baremetal Operator, you are also using CAPI and CAPM3, then you
+can and should control the cleaning from CAPM3 CR, specifically m3mt.
 
 Although, you can edit `automatedCleaningMode` value from m3m or host, we
-recommend doing it from m3mt, because m3mt controller always
-tries to replicate the value of `automatedCleaningMode` from the m3mt to the m3m. In
-other words, m3mt takes precedence over m3m, and m3m's value for
-`automatedCleaningMode` will be overridden by the value in m3mt.
+recommend doing it from m3mt, because m3mt controller always tries to replicate
+the value of `automatedCleaningMode` from the m3mt to the m3m. In other words,
+m3mt takes precedence over m3m, and m3m's value for `automatedCleaningMode` will
+be overridden by the value in m3mt.
 
-If you are wondering why `automatedCleaningMode` exists in m3m too, that's because
-CAPM3 m3m controller copies `automatedCleaningMode` field value from a m3m to its
-corresponding host. Note that m3m takes precedence over host, so if
-the value of `automatedCleaningMode` doesn't match between host and m3m, CAPM3 m3m
-controller will edit the host. However, this is not always the case, see below for more info.
+If you are wondering why `automatedCleaningMode` exists in m3m too, that's
+because CAPM3 m3m controller copies `automatedCleaningMode` field value from a
+m3m to its corresponding host. Note that m3m takes precedence over host, so if
+the value of `automatedCleaningMode` doesn't match between host and m3m, CAPM3
+m3m controller will edit the host. However, this is not always the case, see
+below for more info.
 
 #### When should I edit my CRs to disable cleaning
 
-Automated cleaning takes place when its first provisioning or during each deprovisioning of a
-host. You can disable cleaning before provisioning or deprovisioning. Disabling before
-deprovisioning means any data on the host will not be wiped out and kept as it is. Note that
-this may introduce security vulnerabilities if you have sensitive data which must be wiped out
-when the host is being recycled.
+Automated cleaning takes place when its first provisioning or during each
+deprovisioning of a host. You can disable cleaning before provisioning or
+deprovisioning. Disabling before deprovisioning means any data on the host will
+not be wiped out and kept as it is. Note that this may introduce security
+vulnerabilities if you have sensitive data which must be wiped out when the host
+is being recycled.
 
 #### What happens if I unset automatedCleaningMode in m3mt
 
-`automatedCleaningMode` accepts `metadata` and `disabled` or it can be unset. Please note that,
-there is no default value in CAPM3 m3mt and m3m objects for `automatedCleaningMode`. So,
-if you don't set either metadata or disabled in the m3mt, it will be unset both in the
-m3mt and m3m objects.
+`automatedCleaningMode` accepts `metadata` and `disabled` or it can be unset.
+Please note that, there is no default value in CAPM3 m3mt and m3m objects for
+`automatedCleaningMode`. So, if you don't set either metadata or disabled in the
+m3mt, it will be unset both in the m3mt and m3m objects.
 
-**Note:** There is a default value, `metadata`, in the host CR. For that reason, even if it is
-unset in the m3mt and m3m objects, Ironic node will still face automated cleaning because
-the host has enabled it by its default value.
+**Note:** There is a default value, `metadata`, in the host CR. For that reason,
+even if it is unset in the m3mt and m3m objects, Ironic node will still face
+automated cleaning because the host has enabled it by its default value.
 
 #### Selective configuration
 
-If you have more than one m3m referencing to the same m3mt, then the `automatedCleaningMode`
-value set on the m3mt will be copied to all those m3ms and eventually to corresponding hosts.
-As such, by default you can not have different configurations for two nodes if they are under the same
-pool. They both will have the same value, either `metadata` or `disabled`.
+If you have more than one m3m referencing to the same m3mt, then the
+`automatedCleaningMode` value set on the m3mt will be copied to all those m3ms
+and eventually to corresponding hosts. As such, by default you can not have
+different configurations for two nodes if they are under the same pool. They
+both will have the same value, either `metadata` or `disabled`.
 
-However, it is possible to have cleaning disabled for one of the m3m, while enabled for the other,
-even though they are in the same pool (i.e. referencing the same m3mt). To achieve that:
+However, it is possible to have cleaning disabled for one of the m3m, while
+enabled for the other, even though they are in the same pool (i.e. referencing
+the same m3mt). To achieve that:
 
-1. Don't set `automatedCleaningMode` in the m3mt. If unset in the m3mt, it will be unset in
-    m3ms too.
+1. Don't set `automatedCleaningMode` in the m3mt. If unset in the m3mt, it will
+   be unset in m3ms too.
 
 1. Since unset in the m3ms, hosts will get its default value `metadata`.
 
-1. Now we have two hosts, both cleaning enabled. Since `automatedCleaningMode` is unset in the m3mt,
-    you can set different cleaning modes for m3ms in the same pool. In other words, replicating the
-    value of `automatedCleaningMode` from m3mt to m3ms is blocked because it is unset in the m3mt.
-    This gives freedom to users to configure cleaning differently and selectively for each node regardless
-    of the fact that they belong to the same m3mt.
+1. Now we have two hosts, both cleaning enabled. Since `automatedCleaningMode`
+   is unset in the m3mt, you can set different cleaning modes for m3ms in the
+   same pool. In other words, replicating the value of `automatedCleaningMode`
+   from m3mt to m3ms is blocked because it is unset in the m3mt. This gives
+   freedom to users to configure cleaning differently and selectively for each
+   node regardless of the fact that they belong to the same m3mt.
 
-1. You can edit one of the m3m to set `automatedCleaningMode` to `disabled`. Once edited,
-    m3m controller replicates the value from the m3m to its owning host. As such, you end up
-    with two m3m, one cleaning enabled and the other disabled, but still in the same pool.
+1. You can edit one of the m3m to set `automatedCleaningMode` to `disabled`.
+   Once edited, m3m controller replicates the value from the m3m to its owning
+   host. As such, you end up with two m3m, one cleaning enabled and the other
+   disabled, but still in the same pool.

--- a/docs/e2e-test.md
+++ b/docs/e2e-test.md
@@ -1,12 +1,15 @@
 # E2E testing
 
-This doc gives short instructions how to run e2e tests. For the developing e2e tests, please refer to [Developing E2E tests](https://cluster-api.sigs.k8s.io/developer/e2e.html).
+This doc gives short instructions how to run e2e tests. For the developing e2e
+tests, please refer to
+[Developing E2E tests](https://cluster-api.sigs.k8s.io/developer/e2e.html).
 
 ## Prerequisites
 
 1. Make sure that `make` is available
 
    To install make:
+
    - Ubuntu
 
    ```sh
@@ -41,10 +44,12 @@ make test-e2e
 
 ## Cleanup
 
-After a finished test, cleanup is performed automatically. If the test setup failed or the test was interrupted, you can perform cleanup manually:
+After a finished test, cleanup is performed automatically. If the test setup
+failed or the test was interrupted, you can perform cleanup manually:
 
 ```sh
-make clean -C /opt/metal3-dev-env/metal3-dev-env/ && sudo rm -rf /opt/metal3-dev-env/
+make clean -C /opt/metal3-dev-env/metal3-dev-env/
+sudo rm -rf /opt/metal3-dev-env/
 ```
 
 ## Included tests
@@ -56,25 +61,33 @@ The e2e tests currently include three different sets:
 1. upgrade_tests
 1. live_iso_tests
 
-`pivoting_based_feature_tests`: Because these tests run mainly in the target cluster, they are dependent on the pivoting test and need to run in the following order:
+`pivoting_based_feature_tests`: Because these tests run mainly in the target
+cluster, they are dependent on the pivoting test and need to run in the
+following order:
 
 - Pivoting
 - Certificate rotation
 - Node reuse
 - Re-pivoting
 
-However, in case we need to run them in the ephemeral cluster pivoting and re-pivoting should be ignored.
+However, in case we need to run them in the ephemeral cluster pivoting and
+re-pivoting should be ignored.
 
-`remediation_feature_tests`: independent from the previous tests and can run independently includes:
+`remediation_feature_tests`: independent from the previous tests and can run
+independently includes:
 
 - Remediation
 - Inspection¹
 - Metal3Remediation
 
-¹ Inspection is actually run [in the middle of the remediation test](https://github.com/metal3-io/cluster-api-provider-metal3/blob/8d08f375de93a793f839b42b5ec40e6bebf98664/test/e2e/remediation_test.go#L108) for practical reasons at the moment.
+¹ Inspection is actually run
+[in the middle of the remediation test](https://github.com/metal3-io/cluster-api-provider-metal3/blob/8d08f375de93a793f839b42b5ec40e6bebf98664/test/e2e/remediation_test.go#L108)
+for practical reasons at the moment.
 
-The ephemeral cluster is first launched using [metal3-dev-env](https://github.com/metal3-io/metal3-dev-env).
-The remediation, inspection and Metal3Remediation tests are then run with the controllers still in the ephemeral cluster either before pivoting or after re-pivoting.
+The ephemeral cluster is first launched using
+[metal3-dev-env](https://github.com/metal3-io/metal3-dev-env). The remediation,
+inspection and Metal3Remediation tests are then run with the controllers still
+in the ephemeral cluster either before pivoting or after re-pivoting.
 
 `upgrade_management_cluster_test`:
 
@@ -82,34 +95,49 @@ The remediation, inspection and Metal3Remediation tests are then run with the co
 - Upgrade Ironic
 - Upgrade CAPI/CAPM3
 
-`live_iso_test`: independent from the previous tests and can run independently. This is testing the booting of target cluster's nodes with the live ISO.
+`live_iso_test`: independent from the previous tests and can run independently.
+This is testing the booting of target cluster's nodes with the live ISO.
 
 Guidelines to follow when adding new E2E tests:
 
-- Tests should be defined in a new file and separate test spec, unless the new test depends on existing tests.
-- Tests are categorized with a custom label that can be used to filter a set of E2E tests to be run. To run a subset of tests, a combination of either one or both of the `GINKGO_FOCUS` and `GINKGO_SKIP` env variables can be set. The labels are defined in the description of the `Describe` container between `[]`, for example:
+- Tests should be defined in a new file and separate test spec, unless the new
+  test depends on existing tests.
+- Tests are categorized with a custom label that can be used to filter a set of
+  E2E tests to be run. To run a subset of tests, a combination of either one or
+  both of the `GINKGO_FOCUS` and `GINKGO_SKIP` env variables can be set. The
+  labels are defined in the description of the `Describe` container between
+  `[]`, for example:
 
-`[upgrade]` => runs only existing upgrade tests including CAPI, CAPM3, Ironic and Baremetal Operator.
-`[remediation]` => runs only remediation and inspection tests.
-`[live-iso]` => runs only live ISO test.
+`[upgrade]` => runs only existing upgrade tests including CAPI, CAPM3, Ironic
+and Baremetal Operator. `[remediation]` => runs only remediation and inspection
+tests. `[live-iso]` => runs only live ISO test.
 
 For instance, to skip the upgrade E2E tests set `GINKGO_SKIP="[upgrade]"`
 
-`GINKGO_FOCUS` and `GINKGO_SKIP` are defined in the Makefile, and should be initialized in the CI JJBs to select the target e2e tests.
+`GINKGO_FOCUS` and `GINKGO_SKIP` are defined in the Makefile, and should be
+initialized in the CI JJBs to select the target e2e tests.
 
 ### Note on BMO and Ironic upgrade
 
-Both Ironic and BMO upgrade tests currently only check that a new version can be rolled out (by going from `latest` to `main`).
-However, they do not actually upgrade from some older release to a newer since they are not yet integrated with the e2e upgrade test.
-The idea is to move them to the e2e upgrade test and then upgrade Ironic and BMO together with CAPM3 from the previous minor release to the latest.
+Both Ironic and BMO upgrade tests currently only check that a new version can be
+rolled out (by going from `latest` to `main`). However, they do not actually
+upgrade from some older release to a newer since they are not yet integrated
+with the e2e upgrade test. The idea is to move them to the e2e upgrade test and
+then upgrade Ironic and BMO together with CAPM3 from the previous minor release
+to the latest.
 
 ### Test matrix for k8s version
 
-Current e2e tests use the following Kubernetes versions for source and target clusters:
+Current e2e tests use the following Kubernetes versions for source and target
+clusters:
 
-| tests | bootstrap cluster | metal3 cluster init  | metal3 cluster final  |
-| ----------- | ------------ | ----------- | ------------- |
-| integration | v1.27.1 | v1.27.1 | x |
-| remediation | v1.27.1 | v1.27.1 | x |
-| pivot based feature | v1.27.1 | v1.26.4 | v1.27.1 |
-| upgrade | v1.27.1 | v1.26.4 | v1.27.1 |
+<!-- markdownlint-disable MD013 -->
+
+| tests               | bootstrap cluster | metal3 cluster init | metal3 cluster final |
+| ------------------- | ----------------- | ------------------- | -------------------- |
+| integration         | v1.27.1           | v1.27.1             | x                    |
+| remediation         | v1.27.1           | v1.27.1             | x                    |
+| pivot based feature | v1.27.1           | v1.26.4             | v1.27.1              |
+| upgrade             | v1.27.1           | v1.26.4             | v1.27.1              |
+
+<!-- markdownlint-enable MD013 -->

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,8 +12,8 @@ The pre-requisite for the deployment of CAPM3 are the following:
 - Ironic up and running (inside or outside of the cluster)
 - BareMetalHost resources created for all hardware nodes and in "ready" or
   "available" state
-- all cluster-related CRs (inc. BareMetalHosts and related) must be in the
-  same namespace. This is due to the use of owner references.
+- all cluster-related CRs (inc. BareMetalHosts and related) must be in the same
+  namespace. This is due to the use of owner references.
 
 ### Using clusterctl
 
@@ -21,8 +21,8 @@ Please refer to
 [Clusterctl documentation](https://main.cluster-api.sigs.k8s.io/clusterctl/overview.html).
 Once the [Pre-requisites](#pre-requisites) are fulfilled, you can follow the
 normal clusterctl flow for the `init`, `config`, `upgrade`, `move` and `delete`
-workflow. Please refer to the [Pivoting Ironic](#pivoting-or-updating-ironic) section for
-additional information on the `move` process.
+workflow. Please refer to the [Pivoting Ironic](#pivoting-or-updating-ironic)
+section for additional information on the `move` process.
 
 #### Cluster templates variables
 
@@ -68,13 +68,17 @@ This is the URL of the image to deploy. It should be a qcow2 image. For example:
 
 #### IMAGE_CHECKSUM
 
-This is the URL of the md5sum, sha256sum or sha512sum of the image to deploy. For example:
+This is the URL of the md5sum, sha256sum or sha512sum of the image to deploy.
+For example:
 
 `IMAGE_CHECKSUM="http://192.168.0.1/ubuntu.qcow2.sha256sum"`
 
 #### NODE_DRAIN_TIMEOUT
 
-This variable sets the nodeDrainTimout for cluster, controlplane and machinedeployment template. Users can set desired value in seconds ("300s") or minutes ("5m"). If it is not set, default value will be "0s" which will not make any change in the current deployment. For example:
+This variable sets the nodeDrainTimout for cluster, controlplane and
+machinedeployment template. Users can set desired value in seconds ("300s") or
+minutes ("5m"). If it is not set, default value will be "0s" which will not make
+any change in the current deployment. For example:
 
 `NODE_DRAIN_TIMEOUT="300s"`
 
@@ -91,6 +95,8 @@ critical to maintain the indentation. The allowed keys are :
 - format
 
 Here is an example for Ubuntu:
+
+<!-- markdownlint-disable MD013 -->
 
 ```bash
 CTLPLANE_KUBEADM_EXTRA_CONFIG="
@@ -165,6 +171,8 @@ CTLPLANE_KUBEADM_EXTRA_CONFIG="
 "
 ```
 
+<!-- markdownlint-enable MD013 -->
+
 #### WORKERS_KUBEADM_EXTRA_CONFIG
 
 This contains the extra configuration to pass in KubeadmConfig for workers. It
@@ -178,6 +186,8 @@ is critical to maintain the indentation. The allowed keys are :
 - format
 
 Here is an example for Ubuntu:
+
+<!-- markdownlint-disable MD013 -->
 
 ```bash
 WORKERS_KUBEADM_EXTRA_CONFIG="
@@ -212,45 +222,47 @@ WORKERS_KUBEADM_EXTRA_CONFIG="
 "
 ```
 
+<!-- markdownlint-enable MD013 -->
+
 ## Pivoting or updating Ironic
 
 Before running the `move` command of Clusterctl, elements such as Ironic if
-applicable, need to be moved to the target cluster. It is recommended to
-scale down the Ironic pod in the origin cluster before deploying it on the
-target cluster to prevent issues with a duplicated DHCP server.
+applicable, need to be moved to the target cluster. It is recommended to scale
+down the Ironic pod in the origin cluster before deploying it on the target
+cluster to prevent issues with a duplicated DHCP server.
 
-Both for pivoting or updating Ironic, it is critical that the cluster is in
-a stable situation. No operations on BareMetal hosts shall be on-going,
-otherwise they might fail. Similarly, in order to prevent conflict during
-the pivoting of the DHCP server, we recommend to have no BareMetalHosts
-running IPA (in `ready` state with `fasttrack` option enabled) during the
-the pivoting. It could otherwise result in IP address conflicts or changes
-of the IP address of a running host that would not be supported by Ironic.
+Both for pivoting or updating Ironic, it is critical that the cluster is in a
+stable situation. No operations on BareMetal hosts shall be on-going, otherwise
+they might fail. Similarly, in order to prevent conflict during the pivoting of
+the DHCP server, we recommend to have no BareMetalHosts running IPA (in `ready`
+state with `fasttrack` option enabled) during the the pivoting. It could
+otherwise result in IP address conflicts or changes of the IP address of a
+running host that would not be supported by Ironic.
 
-In the case of a self-hosted cluster, special care must be paid to Ironic.
-Since Ironic runs on the target cluster, updating the target cluster means
-that Ironic will need to be moved between nodes of the cluster. This results
-in similar issues as pivoting. The following points should be ensured to run
-a target cluster upgrade:
+In the case of a self-hosted cluster, special care must be paid to Ironic. Since
+Ironic runs on the target cluster, updating the target cluster means that Ironic
+will need to be moved between nodes of the cluster. This results in similar
+issues as pivoting. The following points should be ensured to run a target
+cluster upgrade:
 
-- no unnecessary hosts are running IPA during the upgrade to limit the amount
-  of conflicts
+- no unnecessary hosts are running IPA during the upgrade to limit the amount of
+  conflicts
 - When upgrading the K8S node or group of nodes that run Ironic currently, only
   one node at a time should be upgraded, and no other parallel upgrade
   operations should be happening.
 - All nodes that are hosting Ironic or have connectivity to the provisioning
-  network must be using a static IP address. If not, Ironic might not come
-  up since Keepalived will not be starting. In addition, if using DHCP,
-  conflicts could happen. We highly recommend that ALL nodes with connectivity
-  to the provisioning network are using static IP addresses, using
-  Metal3DataTemplates for example.
+  network must be using a static IP address. If not, Ironic might not come up
+  since Keepalived will not be starting. In addition, if using DHCP, conflicts
+  could happen. We highly recommend that ALL nodes with connectivity to the
+  provisioning network are using static IP addresses, using Metal3DataTemplates
+  for example.
 - Ironic should always be the first component upgraded, before a CAPM3 / BMO
   upgrade using clusterctl for example, or before nodes upgrades. This is to
   ensure that the cluster is in a stable condition while upgrading Ironic.
 
-**Important Note:**
-Currently, when target cluster is up and node appears, CAPM3 will fetch the node
-and set the providerID value to BMH UUID, meaning that it is not advisable to
-directly map the K.Node <---> BMH after pivoting. However, if needed, we can
-still find the providerID value in Metal3Machine Spec. which enables us to do
-the mapping with an intermediary step, i.e K.Node <--> M3Machine <--> BMH.
+**Important Note:** Currently, when target cluster is up and node appears, CAPM3
+will fetch the node and set the providerID value to BMH UUID, meaning that it is
+not advisable to directly map the K.Node <---> BMH after pivoting. However, if
+needed, we can still find the providerID value in Metal3Machine Spec. which
+enables us to do the mapping with an intermediary step, i.e K.Node <-->
+M3Machine <--> BMH.

--- a/docs/ip_reuse.md
+++ b/docs/ip_reuse.md
@@ -2,35 +2,55 @@
 
 ## What is IP reuse
 
-As a developer or user there could be a need to make IPAddresses that will be attached to the Kubernetes nodes in the chain of: **BareMetalHost <=> Metal3Machine <=> CAPI Machine <=> Node** objects predictable, for example during the upgrade process and the main goal of this feature is to make that possible.
+As a developer or user there could be a need to make IPAddresses that will be
+attached to the Kubernetes nodes in the chain of: **BareMetalHost <=>
+Metal3Machine <=> CAPI Machine <=> Node** objects predictable, for example
+during the upgrade process and the main goal of this feature is to make that
+possible.
 
 ## Logic behind
 
-As is now, IPPool is an object representing a set of IPAddress pools to be used for IPAddress allocations. An IPClaim is an object representing a request for an IPAddress allocation. Consequently, the IPClaim object name is structured as following:
+As is now, IPPool is an object representing a set of IPAddress pools to be used
+for IPAddress allocations. An IPClaim is an object representing a request for an
+IPAddress allocation. Consequently, the IPClaim object name is structured as
+following:
 
 **IPClaimName** = **Metal3DataName** + **(-)** + **IPPoolName**
 
 Example: metal3datatemplate-0-pool0
 
-The `Metal3DataName` is derived from the `Metal3DataTemplateName` with an added index (`Metal3DataTemplateName-index`), and the `IPPoolName` comes from the IPPool object directly. (See the [IP Address manager repo](https://github.com/metal3-io/ip-address-manager) for more details on these objects).
-In the CAPM3 workflow, when a Metal3Machine is created and a Metal3Data object is requested, the
-process of choosing an `index` to be appended to the name of the `Metal3DataTemplateName`, is random.
-For example, let's imagine we have two Metal3Machines: `metal3machine-0` and `metal3machine-1`
-which creates the following `metal3datatemplate-0` and `metal3datatemplate-1` Metal3Data objects respectively. However, if two nodes are being upgraded at a time, there is no guarantee that same indices will be appended to the respective objects and in fact it can be in completely reverse order (i.e. `metal3machine-0` will get `m3datatemplate-1` and `metal3machine-1` will get `m3datatemplate-0`).
-In order to make it predictable, we structure IPClaim object name using the BareMetalHost name, as following:
+The `Metal3DataName` is derived from the `Metal3DataTemplateName` with an added
+index (`Metal3DataTemplateName-index`), and the `IPPoolName` comes from the
+IPPool object directly. (See the
+[IP Address manager repo](https://github.com/metal3-io/ip-address-manager) for
+more details on these objects). In the CAPM3 workflow, when a Metal3Machine is
+created and a Metal3Data object is requested, the process of choosing an `index`
+to be appended to the name of the `Metal3DataTemplateName`, is random. For
+example, let's imagine we have two Metal3Machines: `metal3machine-0` and
+`metal3machine-1` which creates the following `metal3datatemplate-0` and
+`metal3datatemplate-1` Metal3Data objects respectively. However, if two nodes
+are being upgraded at a time, there is no guarantee that same indices will be
+appended to the respective objects and in fact it can be in completely reverse
+order (i.e. `metal3machine-0` will get `m3datatemplate-1` and `metal3machine-1`
+will get `m3datatemplate-0`). In order to make it predictable, we structure
+IPClaim object name using the BareMetalHost name, as following:
 
 **IPClaimName** = **BareMetalHostName** + **(-)** + **IPPoolName**
 
 Example: node-0-pool0
 
-Now, the first part consists of `BareMetalHostName` which is the name of the BareMetalHost object, and should always stay the same once created (predictable). The second part of it is kept unchanged.
+Now, the first part consists of `BareMetalHostName` which is the name of the
+BareMetalHost object, and should always stay the same once created
+(predictable). The second part of it is kept unchanged.
 
 ## What is the use of PreAllocations field
 
 Once we have a predictable `IPClaimName`, we can make use of a
-`PreAllocations map[string]IPAddressStr` field in the IPPool object to achieve our goal.
+`PreAllocations map[string]IPAddressStr` field in the IPPool object to achieve
+our goal.
 
-We simply add the claim name(s) using the new format (BareMetalHost name included) to the `preAllocations` field in the `IPPool`, i.e:
+We simply add the claim name(s) using the new format (BareMetalHost name
+included) to the `preAllocations` field in the `IPPool`, i.e:
 
 ```yaml
 apiVersion: ipam.metal3.io/v1alpha1
@@ -47,22 +67,23 @@ spec:
     start: 192.168.111.100
   prefix: 24
   preAllocations:
-    node-0-pool0 : 192.168.111.101
+    node-0-pool0: 192.168.111.101
     node-1-pool0: 192.168.111.102
 status:
   indexes:
-    node-0-pool0 : 192.168.111.101
+    node-0-pool0: 192.168.111.101
     node-1-pool0: 192.168.111.102
 ```
 
-Since claim names include BareMetalHost names on them, we are able to predict an IPAddress assigned to the specific node.
+Since claim names include BareMetalHost names on them, we are able to predict an
+IPAddress assigned to the specific node.
 
 ## How to enable IP reuse
 
-To enable the feature, a boolean flag called `enableBMHNameBasedPreallocation` was added. It is configurable via clusterctl and it can be passed to the clusterctl configuration file by the user, i.e:
+To enable the feature, a boolean flag called `enableBMHNameBasedPreallocation`
+was added. It is configurable via clusterctl and it can be passed to the
+clusterctl configuration file by the user, i.e:
 
 ```yaml
-
 enableBMHNameBasedPreallocation: true
-
 ```

--- a/docs/remediation-controller.md
+++ b/docs/remediation-controller.md
@@ -2,61 +2,93 @@
 
 ## Introduction
 
-The ```Cluster API``` includes an optional [MachineHealthCheck (MHC)](https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/healthchecking.html) component that implements automated health checking capability. With ```CAPM3 Remediation Controller``` it is possible to plug in Metal3 specific remediation strategies to remediate an unhealthy nodes while relying on Cluster API MHC to determine those nodes as unhealthy.
+The `Cluster API` includes an optional
+[MachineHealthCheck (MHC)](https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/healthchecking.html)
+component that implements automated health checking capability. With
+`CAPM3 Remediation Controller` it is possible to plug in Metal3 specific
+remediation strategies to remediate an unhealthy nodes while relying on Cluster
+API MHC to determine those nodes as unhealthy.
 
 ## CAPI MachineHealthCheck
 
-A MachineHealthCheck is a Cluster API resource, which allows users to define conditions under which Machines within a Cluster should be considered unhealthy. Users can also specify a timeout for each of the conditions that they define to check on the Machine’s Node. If any of these conditions are met for the duration of the timeout, the Machine will be remediated. Within CAPM3 we use MHC to create remediation requests based on ```Metal3RemediationTemplate``` and ```Metal3Remediation``` CRDs to plug in our own remediation solution.
+A MachineHealthCheck is a Cluster API resource, which allows users to define
+conditions under which Machines within a Cluster should be considered unhealthy.
+Users can also specify a timeout for each of the conditions that they define to
+check on the Machine’s Node. If any of these conditions are met for the duration
+of the timeout, the Machine will be remediated. Within CAPM3 we use MHC to
+create remediation requests based on `Metal3RemediationTemplate` and
+`Metal3Remediation` CRDs to plug in our own remediation solution.
 
 ## Remediation Controller
 
-```CAPM3 Remediation Controller (RC)``` reconciles ```Metal3Remediation``` objects created by CAPI MachineHealthCheck. The RC locates a Machine with the same name as the Metal3Remediation CR and uses existing BMO and CAPM3 APIs to remediate associated unhealthy baremetal nodes. Our remediation controller supports ```reboot strategy``` specified in Metal3Remediation CRD and uses the same object to store state of the current remediation cycle.
+`CAPM3 Remediation Controller (RC)` reconciles `Metal3Remediation` objects
+created by CAPI MachineHealthCheck. The RC locates a Machine with the same name
+as the Metal3Remediation CR and uses existing BMO and CAPM3 APIs to remediate
+associated unhealthy baremetal nodes. Our remediation controller supports
+`reboot strategy` specified in Metal3Remediation CRD and uses the same object to
+store state of the current remediation cycle.
 
 ### Basic Remediation workflow
 
-* RC watches for the presence of Metal3Remediation CR.
-* Based on the remediation strategy defined in ```.spec.strategy.type``` in Metal3Remediation, RC uses BMO APIs to get hosts back into a healthy or manageable state.
-* RC uses ```.status.phase``` to save the states of the remediation. Available states are ```running```, ```waiting```, ```deleting machine```.
-* After RC have finished its remediation, it will wait for the Metal3Remediation CR to be removed. (When using CAPI MachineHealthCheck controller, MHC will noticed the Node becomes healthy and deletes the instantiated MachineRemediation CR.).
+- RC watches for the presence of Metal3Remediation CR.
+- Based on the remediation strategy defined in `.spec.strategy.type` in
+  Metal3Remediation, RC uses BMO APIs to get hosts back into a healthy or
+  manageable state.
+- RC uses `.status.phase` to save the states of the remediation. Available
+  states are `running`, `waiting`, `deleting machine`.
+- After RC have finished its remediation, it will wait for the Metal3Remediation
+  CR to be removed. (When using CAPI MachineHealthCheck controller, MHC will
+  noticed the Node becomes healthy and deletes the instantiated
+  MachineRemediation CR.).
 
 ### Workflow during retry and after remediation failure
 
-* ```.spec.strategy.retryLimit``` and  ```.spec.strategy.timeout``` defined in Metal3Remediation are used to set limit for reboot retries and time to wait between retries.
-* If RCs last ```.spec.strategy.timeout``` for Node to become healthy expires, it sets ```capi.MachineOwnerRemediatedCondition``` to False on Machine object to start deletion of the unhealthy Machine and the corresponding Metal3Remediation.
-* If RCs last ```.spec.strategy.timeout``` for Node to become healthy expires, it annotates BareMetalHost with ```capi.metal3.io/unhealthyannotation```.
+- `.spec.strategy.retryLimit` and `.spec.strategy.timeout` defined in
+  Metal3Remediation are used to set limit for reboot retries and time to wait
+  between retries.
+- If RCs last `.spec.strategy.timeout` for Node to become healthy expires, it
+  sets `capi.MachineOwnerRemediatedCondition` to False on Machine object to
+  start deletion of the unhealthy Machine and the corresponding
+  Metal3Remediation.
+- If RCs last `.spec.strategy.timeout` for Node to become healthy expires, it
+  annotates BareMetalHost with `capi.metal3.io/unhealthyannotation`.
 
 ---
 
 ### Configuration
 
-Use the following examples as a basis for creating a MachineHealthCheck and Metal3Remediation for worker nodes:
+Use the following examples as a basis for creating a MachineHealthCheck and
+Metal3Remediation for worker nodes:
 
 ```yaml
-
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
   name: worker-healthcheck
   namespace: metal3
 spec:
-  # clusterName is required to associate this MachineHealthCheck with a particular cluster
+  # clusterName is required to associate this MachineHealthCheck
+  # with a particular cluster
   clusterName: test1
-  # (Optional) maxUnhealthy prevents further remediation if the cluster is already partially unhealthy
+  # (Optional) maxUnhealthy prevents further remediation if the cluster is
+  # already partially unhealthy
   maxUnhealthy: 100%
-  # (Optional) nodeStartupTimeout determines how long a MachineHealthCheck should wait for
+  # (Optional) nodeStartupTimeout determines how long a MachineHealthCheck
+  # should wait for
   # a Node to join the cluster, before considering a Machine unhealthy.
   # Defaults to 10 minutes if not specified.
   # Set to 0 to disable the node startup timeout.
-  # Disabling this timeout will prevent a Machine from being considered unhealthy when
-  # the Node it created has not yet registered with the cluster. This can be useful when
-  # Nodes take a long time to start up or when you only want condition based checks for
-  # Machine health.
+  # Disabling this timeout will prevent a Machine from being considered
+  # unhealthy when the Node it created has not yet registered with the cluster.
+  # This can be useful when Nodes take a long time to start up or when you only
+  # want condition based checks for Machine health.
   nodeStartupTimeout: 0m
   # selector is used to determine which Machines should be health checked
   selector:
     matchLabels:
       nodepool: nodepool-0
-  # Conditions to check on Nodes for matched Machines, if any condition is matched for the duration of its timeout, the Machine is considered unhealthy
+  # Conditions to check on Nodes for matched Machines, if any condition is
+  # matched for the duration of its timeout, the Machine is considered unhealthy
   unhealthyConditions:
   - type: Ready
     status: Unknown
@@ -68,16 +100,14 @@ spec:
     kind: Metal3RemediationTemplate
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     name: worker-remediation-request
-
 ```
 
 ```yaml
-
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3RemediationTemplate
 metadata:
-    name: worker-remediation-request
-    namespace: metal3
+  name: worker-remediation-request
+  namespace: metal3
 spec:
   template:
     spec:
@@ -85,13 +115,12 @@ spec:
         type: "Reboot"
         retryLimit: 2
         timeout: 300s
-
 ```
 
-Use the following examples as a basis for creating a MachineHealthCheck and Metal3Remediation for controlplane nodes:
+Use the following examples as a basis for creating a MachineHealthCheck and
+Metal3Remediation for controlplane nodes:
 
 ```yaml
-
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
@@ -105,26 +134,24 @@ spec:
     matchLabels:
       cluster.x-k8s.io/control-plane: ""
   unhealthyConditions:
-    - type: Ready
-      status: Unknown
-      timeout: 300s
-    - type: Ready
-      status: "False"
-      timeout: 300s
+  - type: Ready
+    status: Unknown
+    timeout: 300s
+  - type: Ready
+    status: "False"
+    timeout: 300s
   remediationTemplate: # added infrastructure reference
     kind: Metal3RemediationTemplate
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     name: controlplane-remediation-request
-
 ```
 
 ```yaml
-
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3RemediationTemplate
 metadata:
-    name: controlplane-remediation-request
-    namespace: metal3
+  name: controlplane-remediation-request
+  namespace: metal3
 spec:
   template:
     spec:
@@ -132,5 +159,4 @@ spec:
         type: "Reboot"
         retryLimit: 1
         timeout: 300s
-
 ```

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -7,7 +7,7 @@ CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
     TOP_DIR="${1:-.}"
-    find "${TOP_DIR}" -type d \( -path ./vendor -o -path ./.github \) -prune -o -name '*.md' -exec mdl --style all --warnings {} \+
+    find "${TOP_DIR}" -type d -path ./.github -prune -o -name '*.md' -exec mdl --style all --rules "~MD013" --warnings {} \+
 else
     "${CONTAINER_RUNTIME}" run --rm \
         --env IS_CONTAINER=TRUE \

--- a/test/README.md
+++ b/test/README.md
@@ -4,6 +4,9 @@
 
 This package is not subject to deprecation notices or compatibility guarantees.
 
-- We iterate on the test framework quickly and frequently, and breaking changes are likely.
-- External providers using this package should update to the latest API changes when updating.
-- Maintainers and contributors must give notice in release notes when a breaking change happens.
+- We iterate on the test framework quickly and frequently, and breaking changes
+  are likely.
+- External providers using this package should update to the latest API changes
+  when updating.
+- Maintainers and contributors must give notice in release notes when a breaking
+  change happens.


### PR DESCRIPTION
Remove .mdlrc to have the same markdownlint rules as all other repos. We have plenty of long lines in shell sections and tables, so we move the MD013 rule ignore to the command line of the script to make it clear.
