### PR TITLE
:bug: Fix crio - calico CNI config collision on centos during e2e tests

### DIFF
--- a/test/e2e/data/infrastructure-metal3/bases/centos-kubeadm-config/centos-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/bases/centos-kubeadm-config/centos-kubeadm-config.yaml
@@ -131,6 +131,7 @@ spec:
           runtime-request-timeout: 5m
         name: '{{ ds.meta_data.name }}'
     preKubeadmCommands:
+      - rm /etc/cni/net.d/*
       - systemctl restart NetworkManager.service
       - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
       - nmcli connection up ironicendpoint
@@ -225,6 +226,7 @@ spec:
           [registries.insecure]
           registries = ['${REGISTRY}']
       preKubeadmCommands:
+      - rm /etc/cni/net.d/*
       - systemctl restart NetworkManager.service
       - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
       - nmcli connection up ironicendpoint


### PR DESCRIPTION
- there is a default CNI configuration provided for crio during installation,
  that enables the default CNI plugin (bridge) and configures a default CNI network
  for crio using the default plugin.
- The default CNI config is switched to a CNI config procided by calico durin the
  e2e tests many times and this on-the-fly switching causes stabilitu issues during the tests

Example of stability issues:
- Pods receive IPs from and attached to CRIO's default pod network before calico node is deployed then
  when Calico node is deployed the old pod network is removed and a new is created and
  the old pods can't be reached causing all sorts of issues.

This commit:
- removes the default CNI configuration to force CRIO to wait on the CNI
  config generated by calico thus there won't be a collision between
  CRIO and Calico IP adress management processes.
  (Now the e2e test process won't be switching CNI during the test process)