### PR TITLE
🐛 remove ipam pool reference defaulting to metal3

### DIFF
--- a/api/v1beta1/metal3datatemplate_webhook.go
+++ b/api/v1beta1/metal3datatemplate_webhook.go
@@ -18,11 +18,9 @@ import (
 	"strconv"
 
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
@@ -39,53 +37,7 @@ func (c *Metal3DataTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Defaulter = &Metal3DataTemplate{}
 var _ webhook.Validator = &Metal3DataTemplate{}
 
-func defaultPoolToM3IPAM(p *FromPool) {
-	if p.APIGroup == "" {
-		p.APIGroup = "ipam.metal3.io"
-	}
-	if p.Kind == "" {
-		p.Kind = "IPPool"
-	}
-}
-
-func defaultRefToM3IPAM(r *corev1.TypedLocalObjectReference) {
-	if r.APIGroup == nil || *r.APIGroup == "" {
-		r.APIGroup = pointer.String("ipam.metal3.io")
-	}
-	if r.Kind == "" {
-		r.Kind = "IPPool"
-	}
-}
-
-func (c *Metal3DataTemplate) Default() {
-	if c.Spec.MetaData != nil {
-		for k := range c.Spec.MetaData.IPAddressesFromPool {
-			defaultPoolToM3IPAM(&c.Spec.MetaData.IPAddressesFromPool[k])
-		}
-		for k := range c.Spec.MetaData.PrefixesFromPool {
-			defaultPoolToM3IPAM(&c.Spec.MetaData.PrefixesFromPool[k])
-		}
-		for k := range c.Spec.MetaData.GatewaysFromPool {
-			defaultPoolToM3IPAM(&c.Spec.MetaData.GatewaysFromPool[k])
-		}
-		for k := range c.Spec.MetaData.DNSServersFromPool {
-			defaultPoolToM3IPAM(&c.Spec.MetaData.DNSServersFromPool[k])
-		}
-	}
-	if c.Spec.NetworkData != nil {
-		for k, network := range c.Spec.NetworkData.Networks.IPv4 {
-			if network.FromPoolRef != nil && network.FromPoolRef.Name != "" {
-				defaultRefToM3IPAM(c.Spec.NetworkData.Networks.IPv4[k].FromPoolRef)
-			}
-		}
-
-		for k, network := range c.Spec.NetworkData.Networks.IPv6 {
-			if network.FromPoolRef != nil && network.FromPoolRef.Name != "" {
-				defaultRefToM3IPAM(c.Spec.NetworkData.Networks.IPv6[k].FromPoolRef)
-			}
-		}
-	}
-}
+func (c *Metal3DataTemplate) Default() {}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (c *Metal3DataTemplate) ValidateCreate() error {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
#769 introduced defaulting for IPAM pool references that changes group and kind to metal3 IPAM. Since Metal3DataTemplates are immutable, this causes issues with existing resources when they are continuously applied (gitops).

The easiest option is to remove the defaulting in the webhook, since there are two more instances of defaulting in the DataManager ([here](https://github.com/metal3-io/cluster-api-provider-metal3/blob/main/baremetal/metal3data_manager.go#L400) and [here](https://github.com/metal3-io/cluster-api-provider-metal3/blob/main/baremetal/metal3data_manager.go#L434)).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1010 
