### PR TITLE
:bug: Increase machine deletion timeout during e2e tests

### DIFF
--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -175,7 +175,7 @@ intervals:
   default/wait-bmh-deprovisioning: ["50m", "10s"]
   default/wait-bmh-available: ["50m", "20s"]
   default/wait-bmh-inspecting: ["10m", "2s"]
-  default/wait-machine-deleting: ["7m", "2s"]
+  default/wait-machine-deleting: ["15m", "2s"]
   default/wait-bmh-deprovisioning-available: ["7m", "500ms"]
   default/wait-bmh-available-provisioning: ["15m", "2s"]
   default/wait-machine-running: ["50m", "20s"]


### PR DESCRIPTION
In case of e2e feature tests, 7m has proven to be insufficient in situations when the machine marked for deletion is hosting all the Metal3, CAPI, cert manager and calico controllers .

7m seems to be enough for machines that have relatively few pods but it could happen that a heavily utilized node is being deleted and 7min is not enough.
