### PR TITLE
:sparkles: Bump golang to v1.20 and golangci-lint to v1.52.1

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,34 @@
+name: golangci-lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+# Remove all permissions from GITHUB_TOKEN except metadata.
+permissions: {}
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        working-directory:
+          - ""
+          - test
+          - api
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - name: Calculate go version
+        id: vars
+        run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
+      - name: Set up Go
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        with:
+          go-version: ${{ steps.vars.outputs.go_version }}
+      - name: golangci-lint-${{matrix.working-directory}}
+        uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
+        with:
+          version: v1.52.1
+          working-directory: ${{matrix.working-directory}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       - name: Generate release artifacts and notes
         run: |
           make release

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,7 +46,7 @@ linters:
 
 linters-settings:
   gosec:
-    go: "1.19"
+    go: "1.20"
     severity: medium
     confidence: medium
     excludes:
@@ -93,9 +93,9 @@ linters-settings:
     allow-leading-space: false
     require-specific: true
   staticcheck:
-    go: "1.19"
+    go: "1.20"
   stylecheck:
-    go: "1.19"
+    go: "1.20"
   gocritic:
     enabled-tags:
       - experimental
@@ -114,7 +114,7 @@ linters-settings:
       - whyNoLint
       - wrapperFunc
   unused:
-    go: "1.19"
+    go: "1.20"
 issues:
   exclude-rules:
     - path: test/e2e

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -51,6 +51,7 @@ linters-settings:
     confidence: medium
     excludes:
       - G107
+      - G306
   importas:
     no-unaliased: true
     alias:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.19.9@sha256:86af5649fa1d9265d3fe7caf633231340b93e4164b96e14bc4e1131a191c1ddd
+ARG BUILD_IMAGE=docker.io/golang:1.20.4@sha256:3fccedea46315261e4b6205bcffe91ece1e2aea60c23aab0f033f35461849b42
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary on golang image

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ SHELL:=/usr/bin/env bash
 
 .DEFAULT_GOAL:=help
 
+GO_VERSION ?= 1.20.4
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell go env GOPROXY)
 ifeq ($(GOPROXY),)
@@ -229,8 +230,8 @@ $(CLUSTERCTL): go.mod ## Build clusterctl binary.
 $(CONTROLLER_GEN): $(TOOLS_DIR)/go.mod # Build controller-gen from tools folder.
 	cd $(TOOLS_DIR) && go build -tags=tools -o $(BIN_DIR)/controller-gen sigs.k8s.io/controller-tools/cmd/controller-gen
 
-$(GOLANGCI_LINT): $(TOOLS_DIR)/go.mod # Build golangci-lint from tools folder.
-	cd $(TOOLS_DIR) && go build -tags=tools -o $(BIN_DIR)/golangci-lint github.com/golangci/golangci-lint/cmd/golangci-lint
+$(GOLANGCI_LINT): 
+		hack/ensure-golangci-lint.sh $(TOOLS_DIR)/$(BIN_DIR)
 
 $(MOCKGEN): $(TOOLS_DIR)/go.mod # Build mockgen from tools folder.
 	cd $(TOOLS_DIR) && go build -tags=tools -o $(BIN_DIR)/mockgen github.com/golang/mock/mockgen
@@ -655,3 +656,6 @@ verify-modules: modules
 	@if !(git diff --quiet HEAD -- go.sum go.mod hack/tools/go.mod hack/tools/go.sum); then \
 		echo "go module files are out of date"; exit 1; \
 	fi
+
+go-version: ## Print the go version we use to compile our binaries and images
+	@echo $(GO_VERSION)

--- a/Tiltfile
+++ b/Tiltfile
@@ -129,7 +129,7 @@ def fixup_yaml_empty_arrays(yaml_str):
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.19 as tilt-helper
+FROM golang:1.20 as tilt-helper
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/cluster-api-provider-metal3/api
 
-go 1.19
+go 1.20
 
 require (
 	github.com/google/gofuzz v1.2.0

--- a/api/v1beta1/metal3cluster_webhook.go
+++ b/api/v1beta1/metal3cluster_webhook.go
@@ -45,7 +45,7 @@ func (c *Metal3Cluster) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (c *Metal3Cluster) ValidateUpdate(old runtime.Object) error {
+func (c *Metal3Cluster) ValidateUpdate(_ runtime.Object) error {
 	return c.validate()
 }
 

--- a/api/v1beta1/metal3machine_webhook.go
+++ b/api/v1beta1/metal3machine_webhook.go
@@ -42,7 +42,7 @@ func (c *Metal3Machine) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (c *Metal3Machine) ValidateUpdate(old runtime.Object) error {
+func (c *Metal3Machine) ValidateUpdate(_ runtime.Object) error {
 	return c.validate()
 }
 

--- a/api/v1beta1/metal3machine_webhook_test.go
+++ b/api/v1beta1/metal3machine_webhook_test.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-func TestMetal3MachineDefault(t *testing.T) {
+func TestMetal3MachineDefault(_ *testing.T) {
 	// No-op because we do not default anything in M3M yet
 	c := &Metal3Machine{
 		ObjectMeta: metav1.ObjectMeta{

--- a/api/v1beta1/metal3machinetemplate_webhook.go
+++ b/api/v1beta1/metal3machinetemplate_webhook.go
@@ -42,7 +42,7 @@ func (c *Metal3MachineTemplate) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (c *Metal3MachineTemplate) ValidateUpdate(old runtime.Object) error {
+func (c *Metal3MachineTemplate) ValidateUpdate(_ runtime.Object) error {
 	return c.validate()
 }
 

--- a/api/v1beta1/metal3machinetemplate_webhook_test.go
+++ b/api/v1beta1/metal3machinetemplate_webhook_test.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-func TestMetal3MachineTemplateDefault(t *testing.T) {
+func TestMetal3MachineTemplateDefault(_ *testing.T) {
 	// No-op because we do not default anything in M3M yet
 	c := &Metal3MachineTemplate{
 		ObjectMeta: metav1.ObjectMeta{

--- a/api/v1beta1/metal3remediation_webhook.go
+++ b/api/v1beta1/metal3remediation_webhook.go
@@ -50,7 +50,7 @@ func (r *Metal3Remediation) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *Metal3Remediation) ValidateUpdate(old runtime.Object) error {
+func (r *Metal3Remediation) ValidateUpdate(_ runtime.Object) error {
 	return r.validate()
 }
 

--- a/api/v1beta1/metal3remediationtemplate_webhook.go
+++ b/api/v1beta1/metal3remediationtemplate_webhook.go
@@ -75,7 +75,7 @@ func (r *Metal3RemediationTemplate) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *Metal3RemediationTemplate) ValidateUpdate(old runtime.Object) error {
+func (r *Metal3RemediationTemplate) ValidateUpdate(_ runtime.Object) error {
 	metal3remediationtemplatelog.Info("validate update", "name", r.Name)
 	return r.validate()
 }

--- a/baremetal/metal3cluster_manager.go
+++ b/baremetal/metal3cluster_manager.go
@@ -93,7 +93,7 @@ func (s *ClusterManager) UnsetFinalizer() {
 }
 
 // Create creates a cluster manager for the cluster.
-func (s *ClusterManager) Create(ctx context.Context) error {
+func (s *ClusterManager) Create(_ context.Context) error {
 	config := s.Metal3Cluster.Spec
 	err := config.IsValid()
 	if err != nil {

--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -99,12 +99,12 @@ func (m *DataManager) UnsetFinalizer() {
 }
 
 // clearError clears error message from Metal3Data status.
-func (m *DataManager) clearError(ctx context.Context) {
+func (m *DataManager) clearError(_ context.Context) {
 	m.Data.Status.ErrorMessage = nil
 }
 
 // setError sets error message to Metal3Data status.
-func (m *DataManager) setError(ctx context.Context, msg string) {
+func (m *DataManager) setError(_ context.Context, msg string) {
 	m.Data.Status.ErrorMessage = &msg
 }
 
@@ -854,7 +854,7 @@ func (m *DataManager) ensureIPClaim(ctx context.Context, poolRef corev1.TypedLoc
 }
 
 // addressFromClaim retrieves the IPAddress for a CAPI IPAddressClaim.
-func (m *DataManager) addressFromClaim(ctx context.Context, poolRef corev1.TypedLocalObjectReference, claim *caipamv1.IPAddressClaim) (addressFromPool, bool, error) {
+func (m *DataManager) addressFromClaim(ctx context.Context, _ corev1.TypedLocalObjectReference, claim *caipamv1.IPAddressClaim) (addressFromPool, bool, error) {
 	if claim == nil {
 		return addressFromPool{}, true, errors.New("no claim provided")
 	}

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -328,7 +328,7 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 
 	// A machine bootstrap not ready case is caught in the controller
 	// ReconcileNormal function
-	err = m.getUserDataSecretName(ctx, host)
+	err = m.getUserDataSecretName(ctx)
 	if err != nil {
 		return err
 	}
@@ -415,10 +415,10 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 }
 
 // getUserDataSecretName gets the UserDataSecretName from the machine and exposes it as a secret
-// for the BareMetalHost. The UserDataSecretName might already be in a secret with
+// for the BareMetalHost through Metal3Machine. The UserDataSecretName might already be in a secret with
 // CABPK v0.3.0+, but if it is in a different namespace than the BareMetalHost,
 // then we need to create the secret.
-func (m *MachineManager) getUserDataSecretName(ctx context.Context, host *bmov1alpha1.BareMetalHost) error {
+func (m *MachineManager) getUserDataSecretName(_ context.Context) error {
 	if m.Metal3Machine.Status.UserData != nil {
 		return nil
 	}
@@ -986,7 +986,7 @@ func (m *MachineManager) nodeReuseLabelMatches(ctx context.Context, host *bmov1a
 }
 
 // nodeReuseLabelExists returns true if host contains nodeReuseLabelName label.
-func (m *MachineManager) nodeReuseLabelExists(ctx context.Context, host *bmov1alpha1.BareMetalHost) bool {
+func (m *MachineManager) nodeReuseLabelExists(_ context.Context, host *bmov1alpha1.BareMetalHost) bool {
 	if host == nil {
 		return false
 	}
@@ -1034,7 +1034,7 @@ func (m *MachineManager) setBMCSecretLabel(ctx context.Context, host *bmov1alpha
 }
 
 // setHostLabel will set the set cluster.x-k8s.io/cluster-name to bmh.
-func (m *MachineManager) setHostLabel(ctx context.Context, host *bmov1alpha1.BareMetalHost) error {
+func (m *MachineManager) setHostLabel(_ context.Context, host *bmov1alpha1.BareMetalHost) error {
 	if host.Labels == nil {
 		host.Labels = make(map[string]string)
 	}
@@ -1046,7 +1046,7 @@ func (m *MachineManager) setHostLabel(ctx context.Context, host *bmov1alpha1.Bar
 // setHostSpec will ensure the host's Spec is set according to the machine's
 // details. It will then update the host via the kube API. If UserData does not
 // include a Namespace, it will default to the Metal3Machine's namespace.
-func (m *MachineManager) setHostSpec(ctx context.Context, host *bmov1alpha1.BareMetalHost) error {
+func (m *MachineManager) setHostSpec(_ context.Context, host *bmov1alpha1.BareMetalHost) error {
 	// We only want to update the image setting if the host does not
 	// already have an image.
 	//
@@ -1098,7 +1098,7 @@ func (m *MachineManager) setHostSpec(ctx context.Context, host *bmov1alpha1.Bare
 
 // setHostConsumerRef will ensure the host's Spec is set to link to this
 // Metal3Machine.
-func (m *MachineManager) setHostConsumerRef(ctx context.Context, host *bmov1alpha1.BareMetalHost) error {
+func (m *MachineManager) setHostConsumerRef(_ context.Context, host *bmov1alpha1.BareMetalHost) error {
 	host.Spec.ConsumerRef = &corev1.ObjectReference{
 		Kind:       "Metal3Machine",
 		Name:       m.Metal3Machine.Name,
@@ -1129,7 +1129,7 @@ func (m *MachineManager) setHostConsumerRef(ctx context.Context, host *bmov1alph
 
 // ensureAnnotation makes sure the machine has an annotation that references the
 // host and uses the API to update the machine if necessary.
-func (m *MachineManager) ensureAnnotation(ctx context.Context, host *bmov1alpha1.BareMetalHost) error {
+func (m *MachineManager) ensureAnnotation(_ context.Context, host *bmov1alpha1.BareMetalHost) error {
 	annotations := m.Metal3Machine.ObjectMeta.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)
@@ -1202,7 +1202,7 @@ func (m *MachineManager) clearError() {
 }
 
 // updateMachineStatus updates a Metal3Machine object's status.
-func (m *MachineManager) updateMachineStatus(ctx context.Context, host *bmov1alpha1.BareMetalHost) error {
+func (m *MachineManager) updateMachineStatus(_ context.Context, host *bmov1alpha1.BareMetalHost) error {
 	addrs := m.nodeAddresses(host)
 
 	metal3MachineOld := m.Metal3Machine.DeepCopy()
@@ -1651,7 +1651,7 @@ func (m *MachineManager) DissociateM3Metadata(ctx context.Context) error {
 }
 
 // getKubeadmControlPlaneName retrieves the KubeadmControlPlane object corresponding to the CAPI machine.
-func (m *MachineManager) getKubeadmControlPlaneName(ctx context.Context) (string, error) {
+func (m *MachineManager) getKubeadmControlPlaneName(_ context.Context) (string, error) {
 	m.Log.Info("Fetching KubeadmControlPlane name")
 	if m.Machine == nil {
 		return "", errors.New("Could not find corresponding machine object")

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -705,14 +705,14 @@ var _ = Describe("Metal3Machine manager", func() {
 				ExpectedHostName: "",
 			}),
 			Entry("Pick availableHost which lacks ConsumerRef", testCaseChooseHost{
-				Machine:          newMachine(machineName, "", infrastructureRef),
+				Machine:          newMachine(machineName, infrastructureRef),
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithOtherConsRef, *availableHost}},
 				M3Machine:        m3mconfig,
 				ExpectedHostName: availableHost.Name,
 			}),
 			Entry("Ignore discoveredHost and pick availableHost, which lacks a ConsumerRef",
 				testCaseChooseHost{
-					Machine:          newMachine(machineName, "", infrastructureRef),
+					Machine:          newMachine(machineName, infrastructureRef),
 					Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{discoveredHost, hostWithOtherConsRef, *availableHost}},
 					M3Machine:        m3mconfig,
 					ExpectedHostName: availableHost.Name,
@@ -720,7 +720,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			),
 			Entry("Ignore hostWithUnhealthyAnnotation and pick availableHost, which lacks a ConsumerRef",
 				testCaseChooseHost{
-					Machine:          newMachine(machineName, "", infrastructureRef),
+					Machine:          newMachine(machineName, infrastructureRef),
 					Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithUnhealthyAnnotation, hostWithOtherConsRef, *availableHost}},
 					M3Machine:        m3mconfig,
 					ExpectedHostName: availableHost.Name,
@@ -728,22 +728,22 @@ var _ = Describe("Metal3Machine manager", func() {
 			),
 			Entry("Ignore hostWithPausedAnnotation and pick availableHost, which lacks a ConsumerRef",
 				testCaseChooseHost{
-					Machine:          newMachine(machineName, "", infrastructureRef),
+					Machine:          newMachine(machineName, infrastructureRef),
 					Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithPausedAnnotation, hostWithOtherConsRef, *availableHost}},
 					M3Machine:        m3mconfig,
 					ExpectedHostName: availableHost.Name,
 				},
 			),
 			Entry("Pick hostWithConRef, which has a matching ConsumerRef", testCaseChooseHost{
-				Machine:          newMachine(machineName, "", infrastructureRef2),
+				Machine:          newMachine(machineName, infrastructureRef2),
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithOtherConsRef, *availableHost, hostWithConRef}},
-				M3Machine:        newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(), nil),
+				M3Machine:        newMetal3Machine(metal3machineName, nil, m3mSecretStatus(), nil),
 				ExpectedHostName: hostWithConRef.Name,
 			}),
 
 			Entry("Two hosts already taken, third is in another namespace",
 				testCaseChooseHost{
-					Machine:          newMachine("machine2", "", infrastructureRef),
+					Machine:          newMachine("machine2", infrastructureRef),
 					Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithOtherConsRef, hostWithConRef, hostInOtherNS}},
 					M3Machine:        m3mconfig,
 					ExpectedHostName: "",
@@ -751,7 +751,7 @@ var _ = Describe("Metal3Machine manager", func() {
 
 			Entry("Choose hosts with a label, even without a label selector",
 				testCaseChooseHost{
-					Machine:          newMachine(machineName, "", infrastructureRef),
+					Machine:          newMachine(machineName, infrastructureRef),
 					Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithLabel}},
 					M3Machine:        m3mconfig,
 					ExpectedHostName: hostWithLabel.Name,
@@ -785,33 +785,33 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			),
 			Entry("Choose the host with the right label", testCaseChooseHost{
-				Machine:          newMachine(machineName, "", infrastructureRef2),
+				Machine:          newMachine(machineName, infrastructureRef2),
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithLabel, *availableHost}},
 				M3Machine:        m3mconfig2,
 				ExpectedHostName: hostWithLabel.Name,
 			}),
 			Entry("No host that matches required label", testCaseChooseHost{
-				Machine:          newMachine(machineName, "", infrastructureRef3),
+				Machine:          newMachine(machineName, infrastructureRef3),
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*availableHost, hostWithLabel}},
 				M3Machine:        m3mconfig3,
 				ExpectedHostName: "",
 			}),
 			Entry("Host that matches a matchExpression", testCaseChooseHost{
-				Machine:          newMachine(machineName, "", infrastructureRef4),
+				Machine:          newMachine(machineName, infrastructureRef4),
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*availableHost, hostWithLabel}},
 				M3Machine:        m3mconfig4,
 				ExpectedHostName: hostWithLabel.Name,
 			}),
 			Entry("No Host available that matches a matchExpression",
 				testCaseChooseHost{
-					Machine:          newMachine(machineName, "", infrastructureRef4),
+					Machine:          newMachine(machineName, infrastructureRef4),
 					Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*availableHost}},
 					M3Machine:        m3mconfig4,
 					ExpectedHostName: "",
 				},
 			),
 			Entry("No host chosen, invalid match expression", testCaseChooseHost{
-				Machine:          newMachine(machineName, "", infrastructureRef5),
+				Machine:          newMachine(machineName, infrastructureRef5),
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*availableHost, hostWithLabel, hostWithOtherConsRef}},
 				M3Machine:        m3mconfig5,
 				ExpectedHostName: "",
@@ -890,7 +890,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations()),
 			ExpectPausePresent: true,
 			ExpectError:        false,
@@ -907,7 +907,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations()),
 			ExpectPausePresent: true,
 			ExpectError:        false,
@@ -927,7 +927,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					OperationalStatus: "OK",
 				},
 			},
-			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations()),
 			ExpectPausePresent:  true,
 			ExpectStatusPresent: true,
@@ -993,7 +993,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations()),
 			ExpectPresent: false,
 			ExpectError:   false,
@@ -1011,7 +1011,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations()),
 			ExpectPresent: true,
 			ExpectError:   false,
@@ -1029,7 +1029,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations()),
 			ExpectPresent: false,
 			ExpectError:   false,
@@ -1052,7 +1052,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			m3mconfig, infrastructureRef := newConfig(tc.UserDataNamespace,
 				map[string]string{}, []infrav1.HostSelectorRequirement{},
 			)
-			machine := newMachine(machineName, "", infrastructureRef)
+			machine := newMachine(machineName, infrastructureRef)
 
 			machineMgr, err := NewMachineManager(fakeClient, nil, nil, machine, m3mconfig,
 				logr.Discard(),
@@ -1141,7 +1141,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			m3mconfig, infrastructureRef := newConfig(tc.UserDataNamespace,
 				map[string]string{}, []infrav1.HostSelectorRequirement{},
 			)
-			machine := newMachine(machineName, "", infrastructureRef)
+			machine := newMachine(machineName, infrastructureRef)
 
 			machineMgr, err := NewMachineManager(fakeClient, nil, nil, machine, m3mconfig,
 				logr.Discard(),
@@ -1232,7 +1232,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 			Entry("Failed to find the existing host", testCaseExists{
 				Machine: &clusterv1.Machine{},
-				M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
+				M3Machine: newMetal3Machine(metal3machineName, nil, nil,
 					m3mObjectMetaWithSomeAnnotations(),
 				),
 				Expected: true,
@@ -1240,7 +1240,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			Entry("Found host even though annotation value is incorrect",
 				testCaseExists{
 					Machine: &clusterv1.Machine{},
-					M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
+					M3Machine: newMetal3Machine(metal3machineName, nil, nil,
 						m3mObjectMetaWithInvalidAnnotations(),
 					),
 					Expected: false,
@@ -1248,7 +1248,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			),
 			Entry("Found host even though annotation not present", testCaseExists{
 				Machine: &clusterv1.Machine{},
-				M3Machine: newMetal3Machine("", nil, nil, nil,
+				M3Machine: newMetal3Machine("", nil, nil,
 					m3mObjectMetaEmptyAnnotations(),
 				),
 				Expected: false,
@@ -1288,7 +1288,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 			Entry("Should find the expected host", testCaseGetHost{
 				Machine: &clusterv1.Machine{},
-				M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
+				M3Machine: newMetal3Machine(metal3machineName, nil, nil,
 					m3mObjectMetaWithValidAnnotations(),
 				),
 				ExpectPresent: true,
@@ -1296,7 +1296,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			Entry("Should not find the host, annotation value incorrect",
 				testCaseGetHost{
 					Machine: &clusterv1.Machine{},
-					M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
+					M3Machine: newMetal3Machine(metal3machineName, nil, nil,
 						m3mObjectMetaWithInvalidAnnotations(),
 					),
 					ExpectPresent: false,
@@ -1304,7 +1304,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			),
 			Entry("Should not find the host, annotation not present", testCaseGetHost{
 				Machine: &clusterv1.Machine{},
-				M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
+				M3Machine: newMetal3Machine(metal3machineName, nil, nil,
 					m3mObjectMetaEmptyAnnotations(),
 				),
 				ExpectPresent: false,
@@ -1346,8 +1346,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			Expect(*tc.M3Machine.Spec.ProviderID).To(Equal(providerID))
 		},
 		Entry("Set ProviderID, empty annotations", testCaseGetSetProviderID{
-			Machine: newMachine("", "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
+			Machine: newMachine("", nil),
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
 				m3mObjectMetaEmptyAnnotations(),
 			),
 			Host: &bmov1alpha1.BareMetalHost{
@@ -1360,8 +1360,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectError:   true,
 		}),
 		Entry("Set ProviderID", testCaseGetSetProviderID{
-			Machine: newMachine("", "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
+			Machine: newMachine("", nil),
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Host: &bmov1alpha1.BareMetalHost{
@@ -1380,8 +1380,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectError:   false,
 		}),
 		Entry("Set ProviderID, wrong state", testCaseGetSetProviderID{
-			Machine: newMachine("", "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
+			Machine: newMachine("", nil),
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Host: &bmov1alpha1.BareMetalHost{
@@ -1438,8 +1438,8 @@ var _ = Describe("Metal3Machine manager", func() {
 				}
 			},
 			Entry("Test small functions, worker node", testCaseSmallFunctions{
-				Machine: newMachine("", "", nil),
-				M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
+				Machine: newMachine("", nil),
+				M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
 					m3mObjectMetaEmptyAnnotations(),
 				),
 				ExpectCtrlNode: false,
@@ -1458,7 +1458,7 @@ var _ = Describe("Metal3Machine manager", func() {
 						},
 					},
 				},
-				M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpec(), nil,
+				M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
 					m3mObjectMetaEmptyAnnotations(),
 				),
 				ExpectCtrlNode: true,
@@ -1502,7 +1502,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		},
 		Entry("Annotation exists and is correct", testCaseEnsureAnnotation{
 			Machine: clusterv1.Machine{},
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil,
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil,
@@ -1512,7 +1512,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Annotation exists but is wrong", testCaseEnsureAnnotation{
 			Machine: clusterv1.Machine{},
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil,
 				m3mObjectMetaWithInvalidAnnotations(),
 			),
 			Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone,
@@ -1522,7 +1522,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Annotations are empty", testCaseEnsureAnnotation{
 			Machine: clusterv1.Machine{},
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil,
 				m3mObjectMetaEmptyAnnotations(),
 			),
 			Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone,
@@ -1532,7 +1532,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("Annotations are nil", testCaseEnsureAnnotation{
 			Machine: clusterv1.Machine{},
-			M3Machine: newMetal3Machine("", nil, nil, nil,
+			M3Machine: newMetal3Machine("", nil, nil,
 				m3mObjectMetaNoAnnotations(),
 			),
 			Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone,
@@ -1719,8 +1719,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			Host: newBareMetalHost(baremetalhostName, bmhSpec(),
 				bmov1alpha1.StateProvisioned, bmhStatus(), false, "metadata", true, "",
 			),
-			Machine: newMachine(machineName, "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			ExpectedConsumerRef:     consumerRef(),
@@ -1732,8 +1732,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			Host: newBareMetalHost(baremetalhostName, bmhSpec(), bmov1alpha1.StateNone,
 				nil, false, "metadata", true, "",
 			),
-			Machine: newMachine(machineName, "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			ExpectedConsumerRef:     consumerRef(),
@@ -1745,8 +1745,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(), bmov1alpha1.StateNone, nil,
 				false, "metadata", true, "",
 			),
-			Machine: newMachine(machineName, "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Secret:              newSecret(),
@@ -1756,8 +1756,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(),
 				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "metadata", true, "",
 			),
-			Machine: newMachine(machineName, "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			ExpectedConsumerRef: consumerRef(),
@@ -1768,8 +1768,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(),
 				bmov1alpha1.StateExternallyProvisioned, bmhPowerStatus(), true, "metadata", true, "",
 			),
-			Machine: newMachine(machineName, "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			ExpectedConsumerRef: consumerRef(),
@@ -1781,8 +1781,8 @@ var _ = Describe("Metal3Machine manager", func() {
 				Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(),
 					bmov1alpha1.StateExternallyProvisioned, bmhPowerStatus(), false, "metadata", true, "",
 				),
-				Machine: newMachine(machineName, "", nil),
-				M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+				Machine: newMachine(machineName, nil),
+				M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 					m3mObjectMetaWithValidAnnotations(),
 				),
 				Secret:              newSecret(),
@@ -1794,8 +1794,8 @@ var _ = Describe("Metal3Machine manager", func() {
 				Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(),
 					bmov1alpha1.StateUnmanaged, bmhPowerStatus(), false, "metadata", true, "",
 				),
-				Machine: newMachine(machineName, "", nil),
-				M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+				Machine: newMachine(machineName, nil),
+				M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 					m3mObjectMetaWithValidAnnotations(),
 				),
 				Secret:              newSecret(),
@@ -1806,8 +1806,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(), bmov1alpha1.StateAvailable,
 				bmhStatus(), false, "metadata", true, "",
 			),
-			Machine: newMachine(machineName, "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Secret:              newSecret(),
@@ -1817,8 +1817,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(), bmov1alpha1.StateReady,
 				bmhStatus(), false, "metadata", true, "",
 			),
-			Machine: newMachine(machineName, "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Secret:              newSecret(),
@@ -1838,7 +1838,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Secret: newSecret(),
@@ -1848,8 +1848,8 @@ var _ = Describe("Metal3Machine manager", func() {
 				Host: newBareMetalHost(baremetalhostName, bmhSpecSomeImg(),
 					bmov1alpha1.StateProvisioned, bmhStatus(), false, "metadata", true, "",
 				),
-				Machine: newMachine("", "", nil),
-				M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+				Machine: newMachine("", nil),
+				M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 					m3mObjectMetaWithValidAnnotations(),
 				),
 				ExpectedConsumerRef:     consumerRefSome(),
@@ -1859,8 +1859,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		),
 		Entry("No consumer ref, so this is a no-op", testCaseDelete{
 			Host:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", true, ""),
-			Machine: newMachine("", "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+			Machine: newMachine("", nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Secret:              newSecret(),
@@ -1868,8 +1868,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 		Entry("No host at all, so this is a no-op", testCaseDelete{
 			Host:    nil,
-			Machine: newMachine("", "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+			Machine: newMachine("", nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Secret:              newSecret(),
@@ -1887,23 +1887,23 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Secret:              newSecret(),
 			ExpectSecretDeleted: false,
 		}),
 		Entry("Clusterlabel should be removed", testCaseDelete{
-			Machine:                   newMachine(machineName, metal3machineName, nil),
-			M3Machine:                 newMetal3Machine(metal3machineName, nil, m3mSpecAll(), m3mSecretStatus(), m3mObjectMetaWithValidAnnotations()),
+			Machine:                   newMachine(machineName, nil),
+			M3Machine:                 newMetal3Machine(metal3machineName, m3mSpecAll(), m3mSecretStatus(), m3mObjectMetaWithValidAnnotations()),
 			Host:                      newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", true, ""),
 			BMCSecret:                 newBMCSecret("mycredentials", true),
 			ExpectSecretDeleted:       true,
 			ExpectClusterLabelDeleted: true,
 		}),
 		Entry("PausedAnnotation/CAPM3 should be removed", testCaseDelete{
-			Machine:   newMachine(machineName, metal3machineName, nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpecAll(), m3mSecretStatus(), m3mObjectMetaWithValidAnnotations()),
+			Machine:   newMachine(machineName, nil),
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpecAll(), m3mSecretStatus(), m3mObjectMetaWithValidAnnotations()),
 			Host: &bmov1alpha1.BareMetalHost{
 				ObjectMeta: *bmhObjectMetaWithValidCAPM3PausedAnnotations(),
 				Spec:       *bmhSpecBMC(),
@@ -1919,8 +1919,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectedPausedAnnotationDeleted: true,
 		}),
 		Entry("No clusterLabel in BMH or BMC Secret so this is a no-op ", testCaseDelete{
-			Machine:                   newMachine(machineName, metal3machineName, nil),
-			M3Machine:                 newMetal3Machine(metal3machineName, nil, m3mSpecAll(), m3mSecretStatus(), m3mObjectMetaWithValidAnnotations()),
+			Machine:                   newMachine(machineName, nil),
+			M3Machine:                 newMetal3Machine(metal3machineName, m3mSpecAll(), m3mSecretStatus(), m3mObjectMetaWithValidAnnotations()),
 			Host:                      newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 			BMCSecret:                 newBMCSecret("mycredentials", false),
 			ExpectSecretDeleted:       true,
@@ -1930,8 +1930,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			Host: newBareMetalHost(baremetalhostName, bmhSpecSomeImg(),
 				bmov1alpha1.StateProvisioned, bmhStatus(), false, "metadata", true, "",
 			),
-			Machine: newMachine(machineName, metal3machineName, nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatusNil(),
+			Machine: newMachine(machineName, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatusNil(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Secret:                  newSecret(),
@@ -1942,8 +1942,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Capm3FastTrack is set to false, AutomatedCleaning mode is set to metadata, set bmh online field to false", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpec(),
 				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "metadata", true, ""),
-			Machine: newMachine(machineName, "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			ExpectedResult:          ReconcileError{},
@@ -1955,8 +1955,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Capm3FastTrack is set to true, AutomatedCleaning mode is set to metadata, set bmh online field to true", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpec(),
 				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "metadata", true, ""),
-			Machine: newMachine(machineName, "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			ExpectedResult:          ReconcileError{},
@@ -1968,8 +1968,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Capm3FastTrack is set to false, AutomatedCleaning mode is set to disabled, set bmh online field to false", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpec(),
 				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "disabled", true, ""),
-			Machine: newMachine(machineName, "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			ExpectedResult:          ReconcileError{},
@@ -1981,8 +1981,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Capm3FastTrack is set to true, AutomatedCleaning mode is set to disabled, set bmh online field to false", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpec(),
 				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "disabled", true, ""),
-			Machine: newMachine(machineName, "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			ExpectedResult:          ReconcileError{},
@@ -1994,8 +1994,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Capm3FastTrack is empty, AutomatedCleaning mode is set to disabled, set bmh online field to false", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpec(),
 				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "disabled", true, ""),
-			Machine: newMachine(machineName, "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			ExpectedResult:          ReconcileError{},
@@ -2007,8 +2007,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("Capm3FastTrack is empty, AutomatedCleaning mode is set to metadata, set bmh online field to false", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpec(),
 				bmov1alpha1.StateDeprovisioning, bmhStatus(), false, "metadata", true, ""),
-			Machine: newMachine(machineName, "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+			Machine: newMachine(machineName, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			ExpectedResult:          ReconcileError{},
@@ -2065,7 +2065,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				&metav1.ObjectMeta{
 					Name:      metal3machineName,
 					Namespace: namespaceName,
@@ -2146,7 +2146,7 @@ var _ = Describe("Metal3Machine manager", func() {
 						DataSecretName: pointer.String(metal3machineName + "-user-data")},
 				},
 			},
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, m3mSecretStatus(),
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				&metav1.ObjectMeta{
 					Name:      metal3machineName,
 					Namespace: namespaceName,
@@ -2792,7 +2792,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = machineMgr.getUserDataSecretName(context.TODO(), tc.BMHost)
+			err = machineMgr.getUserDataSecretName(context.TODO())
 			if tc.ExpectError {
 				Expect(err).To(HaveOccurred())
 				return
@@ -2863,7 +2863,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil),
 			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 		}),
 		Entry("Secret set in Machine, different namespace", testCaseGetUserDataSecretName{
@@ -2891,7 +2891,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil),
 			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 		}),
 		Entry("Secret in other namespace set in Machine", testCaseGetUserDataSecretName{
@@ -2923,7 +2923,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil),
 			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 		}),
 		Entry("UserDataSecretName set in Machine, secret exists", testCaseGetUserDataSecretName{
@@ -2936,7 +2936,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil),
 			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 		}),
 		Entry("UserDataSecretName set in Machine, no secret", testCaseGetUserDataSecretName{
@@ -2948,7 +2948,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			},
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil),
 			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 		}),
 	)
@@ -3036,8 +3036,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		},
 		Entry("Associate empty machine, Metal3 machine spec nil",
 			testCaseAssociate{
-				Machine: newMachine("", "", nil),
-				M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
+				Machine: newMachine("", nil),
+				M3Machine: newMetal3Machine(metal3machineName, nil, nil,
 					m3mObjectMetaWithValidAnnotations(),
 				),
 				Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil,
@@ -3049,8 +3049,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		),
 		Entry("Associate empty machine, Metal3 machine spec set",
 			testCaseAssociate{
-				Machine: newMachine("", "", nil),
-				M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpecAll(), nil,
+				Machine: newMachine("", nil),
+				M3Machine: newMetal3Machine(metal3machineName, m3mSpecAll(), nil,
 					m3mObjectMetaWithValidAnnotations(),
 				),
 				Host: newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil,
@@ -3063,8 +3063,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		),
 		Entry("Associate empty machine, host empty, Metal3 machine spec set",
 			testCaseAssociate{
-				Machine: newMachine("", "", nil),
-				M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpecAll(), nil,
+				Machine: newMachine("", nil),
+				M3Machine: newMetal3Machine(metal3machineName, m3mSpecAll(), nil,
 					m3mObjectMetaWithValidAnnotations(),
 				),
 				Host:           newBareMetalHost("", nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
@@ -3074,8 +3074,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		),
 		Entry("Associate machine, host nil, Metal3 machine spec set, requeue",
 			testCaseAssociate{
-				Machine: newMachine("myUniqueMachine", "", nil),
-				M3Machine: newMetal3Machine(metal3machineName, nil, m3mSpecAll(), nil,
+				Machine: newMachine("myUniqueMachine", nil),
+				M3Machine: newMetal3Machine(metal3machineName, m3mSpecAll(), nil,
 					m3mObjectMetaWithValidAnnotations(),
 				),
 				Host:          nil,
@@ -3084,8 +3084,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		),
 		Entry("Associate machine, host set, Metal3 machine spec set, set clusterLabel",
 			testCaseAssociate{
-				Machine:            newMachine(machineName, metal3machineName, nil),
-				M3Machine:          newMetal3Machine(metal3machineName, nil, m3mSpecAll(), nil, nil),
+				Machine:            newMachine(machineName, nil),
+				M3Machine:          newMetal3Machine(metal3machineName, m3mSpecAll(), nil, nil),
 				Host:               newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 				BMCSecret:          newBMCSecret("mycredentials", false),
 				ExpectClusterLabel: true,
@@ -3095,8 +3095,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		),
 		Entry("Associate machine with DataTemplate missing",
 			testCaseAssociate{
-				Machine: newMachine(machineName, metal3machineName, nil),
-				M3Machine: newMetal3Machine(metal3machineName, nil,
+				Machine: newMachine(machineName, nil),
+				M3Machine: newMetal3Machine(metal3machineName,
 					&infrav1.Metal3MachineSpec{
 						DataTemplate: &corev1.ObjectReference{
 							Name:      "abcd",
@@ -3122,8 +3122,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		),
 		Entry("Associate machine with DataTemplate and Data ready",
 			testCaseAssociate{
-				Machine: newMachine(machineName, metal3machineName, nil),
-				M3Machine: newMetal3Machine(metal3machineName, nil,
+				Machine: newMachine(machineName, nil),
+				M3Machine: newMetal3Machine(metal3machineName,
 					&infrav1.Metal3MachineSpec{
 						DataTemplate: &corev1.ObjectReference{
 							Name:      "abcd",
@@ -3198,15 +3198,15 @@ var _ = Describe("Metal3Machine manager", func() {
 			}
 		},
 		Entry("Update machine", testCaseUpdate{
-			Machine: newMachine(machineName, "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil,
+			Machine: newMachine(machineName, nil),
+			M3Machine: newMetal3Machine(metal3machineName, nil, nil,
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 		}),
 		Entry("Update machine, DataTemplate missing", testCaseUpdate{
-			Machine: newMachine(machineName, "", nil),
-			M3Machine: newMetal3Machine(metal3machineName, nil, &infrav1.Metal3MachineSpec{
+			Machine: newMachine(machineName, nil),
+			M3Machine: newMetal3Machine(metal3machineName, &infrav1.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{
 					Name: "abcd",
 				},
@@ -3242,12 +3242,12 @@ var _ = Describe("Metal3Machine manager", func() {
 			}
 		},
 		Entry("Empty list", testCaseFindOwnerRef{
-			M3Machine:   *newMetal3Machine("myName", nil, nil, nil, nil),
+			M3Machine:   *newMetal3Machine("myName", nil, nil, nil),
 			OwnerRefs:   []metav1.OwnerReference{},
 			ExpectError: true,
 		}),
 		Entry("Absent", testCaseFindOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil, nil),
+			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
 			OwnerRefs: []metav1.OwnerReference{
 				{
 					APIVersion: "abc.com/v1",
@@ -3259,7 +3259,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectError: true,
 		}),
 		Entry("Present 0", testCaseFindOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil, nil),
+			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
 			OwnerRefs: []metav1.OwnerReference{
 				{
 					Kind:       "M3Machine",
@@ -3278,7 +3278,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectedIndex: 0,
 		}),
 		Entry("Present 1", testCaseFindOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil, nil),
+			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
 			OwnerRefs: []metav1.OwnerReference{
 				{
 					APIVersion: "abc.com/v1",
@@ -3297,7 +3297,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectedIndex: 1,
 		}),
 		Entry("Present but different versions", testCaseFindOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil, nil),
+			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
 			OwnerRefs: []metav1.OwnerReference{
 				{
 					APIVersion: "abc.com/v1",
@@ -3316,7 +3316,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectedIndex: 1,
 		}),
 		Entry("Wrong group", testCaseFindOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil, nil),
+			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
 			OwnerRefs: []metav1.OwnerReference{
 				{
 					APIVersion: "abc.com/v1",
@@ -3354,11 +3354,11 @@ var _ = Describe("Metal3Machine manager", func() {
 			Expect(err).NotTo(BeNil())
 		},
 		Entry("Empty list", testCaseOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil, nil),
+			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
 			OwnerRefs: []metav1.OwnerReference{},
 		}),
 		Entry("Absent", testCaseOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil, nil),
+			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
 			OwnerRefs: []metav1.OwnerReference{
 				{
 					APIVersion: "abc.com/v1",
@@ -3369,7 +3369,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 		}),
 		Entry("Present 0", testCaseOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil, nil),
+			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
 			OwnerRefs: []metav1.OwnerReference{
 				{
 					Kind:       "M3Machine",
@@ -3386,7 +3386,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 		}),
 		Entry("Present 1", testCaseOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil, nil),
+			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
 			OwnerRefs: []metav1.OwnerReference{
 				{
 					APIVersion: "abc.com/v1",
@@ -3403,7 +3403,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 		}),
 		Entry("Present", testCaseOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil, nil),
+			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
 			OwnerRefs: []metav1.OwnerReference{
 				{
 					Kind:       "M3Machine",
@@ -3429,11 +3429,11 @@ var _ = Describe("Metal3Machine manager", func() {
 			Expect(*refList[index].Controller).To(BeEquivalentTo(tc.Controller))
 		},
 		Entry("Empty list", testCaseOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil, nil),
+			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
 			OwnerRefs: []metav1.OwnerReference{},
 		}),
 		Entry("Absent", testCaseOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil, nil),
+			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
 			OwnerRefs: []metav1.OwnerReference{
 				{
 					APIVersion: "abc.com/v1",
@@ -3444,7 +3444,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 		}),
 		Entry("Present 0", testCaseOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil, nil),
+			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
 			OwnerRefs: []metav1.OwnerReference{
 				{
 					Kind:       "M3Machine",
@@ -3461,7 +3461,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 		}),
 		Entry("Present 1", testCaseOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil, nil),
+			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
 			OwnerRefs: []metav1.OwnerReference{
 				{
 					APIVersion: "abc.com/v1",
@@ -3535,31 +3535,31 @@ var _ = Describe("Metal3Machine manager", func() {
 			}
 		},
 		Entry("Should return nil if No Spec available", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, nil, nil, nil),
+			M3Machine: newMetal3Machine("myName", nil, nil, nil),
 		}),
 		Entry("MetaData and NetworkData should be set in spec", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, &infrav1.Metal3MachineSpec{
+			M3Machine: newMetal3Machine("myName", &infrav1.Metal3MachineSpec{
 				MetaData:    &corev1.SecretReference{Name: "abcd"},
 				NetworkData: &corev1.SecretReference{Name: "defg"},
 			}, nil, nil),
 		}),
 		Entry("RenderedData should be set in status", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, nil, &infrav1.Metal3MachineStatus{
+			M3Machine: newMetal3Machine("myName", nil, &infrav1.Metal3MachineStatus{
 				RenderedData: &corev1.ObjectReference{Name: "abcd"},
 			}, nil),
 		}),
 		Entry("Should expect DataClaim if it does not exist yet", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, &infrav1.Metal3MachineSpec{
+			M3Machine: newMetal3Machine("myName", &infrav1.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{Name: "abcd"},
 			}, nil, nil),
-			Machine:     newMachine(machineName, "myName", nil),
+			Machine:     newMachine(machineName, nil),
 			expectClaim: true,
 		}),
 		Entry("Should not be an error if DataClaim exists", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, &infrav1.Metal3MachineSpec{
+			M3Machine: newMetal3Machine("myName", &infrav1.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{Name: "abcd"},
 			}, nil, nil),
-			Machine: newMachine(machineName, "myName", nil),
+			Machine: newMachine(machineName, nil),
 			DataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myName",
@@ -3576,18 +3576,18 @@ var _ = Describe("Metal3Machine manager", func() {
 			expectClaim: true,
 		}),
 		Entry("Should not be an error if DataClaim is empty", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, &infrav1.Metal3MachineSpec{
+			M3Machine: newMetal3Machine("myName", &infrav1.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{Name: "abcd"},
 			}, nil, nil),
-			Machine:     newMachine(machineName, "myName", nil),
+			Machine:     newMachine(machineName, nil),
 			DataClaim:   &infrav1.Metal3DataClaim{},
 			expectClaim: true,
 		}),
 		Entry("Should expect claim if DataClaim ready", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, &infrav1.Metal3MachineSpec{
+			M3Machine: newMetal3Machine("myName", &infrav1.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{Name: "abcd"},
 			}, nil, nil),
-			Machine: newMachine(machineName, "myName", nil),
+			Machine: newMachine(machineName, nil),
 			DataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myName",
@@ -3679,23 +3679,23 @@ var _ = Describe("Metal3Machine manager", func() {
 			}
 		},
 		Entry("Should return nil if Data Spec is empty", testCaseM3MetaData{
-			M3Machine:                      newMetal3Machine("myName", nil, nil, nil, nil),
+			M3Machine:                      newMetal3Machine("myName", nil, nil, nil),
 			Machine:                        nil,
 			ExpectMetal3DataReadyCondition: false,
 		}),
 		Entry("Should requeue if there is no Data template", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, &infrav1.Metal3MachineSpec{
+			M3Machine: newMetal3Machine("myName", &infrav1.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{Name: "abcd"},
 			}, nil, nil),
-			Machine:                        newMachine(machineName, "myName", nil),
+			Machine:                        newMachine(machineName, nil),
 			ExpectRequeue:                  true,
 			ExpectMetal3DataReadyCondition: false,
 		}),
 		Entry("Should requeue if Data claim without status", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, &infrav1.Metal3MachineSpec{
+			M3Machine: newMetal3Machine("myName", &infrav1.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{Name: "abcd"},
 			}, nil, nil),
-			Machine: newMachine(machineName, "myName", nil),
+			Machine: newMachine(machineName, nil),
 			DataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myName",
@@ -3705,10 +3705,10 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectRequeue: true,
 		}),
 		Entry("Should requeue if Data claim with empty status", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, &infrav1.Metal3MachineSpec{
+			M3Machine: newMetal3Machine("myName", &infrav1.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{Name: "abcd"},
 			}, nil, nil),
-			Machine: newMachine(machineName, "myName", nil),
+			Machine: newMachine(machineName, nil),
 			DataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myName",
@@ -3721,10 +3721,10 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectRequeue: true,
 		}),
 		Entry("Should requeue if Data does not exist", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, &infrav1.Metal3MachineSpec{
+			M3Machine: newMetal3Machine("myName", &infrav1.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{Name: "abcd"},
 			}, nil, nil),
-			Machine: newMachine(machineName, "myName", nil),
+			Machine: newMachine(machineName, nil),
 			DataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myName",
@@ -3747,18 +3747,18 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectDataStatus: true,
 		}),
 		Entry("Should requeue if M3M status set but Data does not exist", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, nil, &infrav1.Metal3MachineStatus{
+			M3Machine: newMetal3Machine("myName", nil, &infrav1.Metal3MachineStatus{
 				RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: namespaceName},
 			}, nil),
-			Machine:          newMachine(machineName, "myName", nil),
+			Machine:          newMachine(machineName, nil),
 			ExpectRequeue:    true,
 			ExpectDataStatus: true,
 		}),
 		Entry("Should requeue if Data is not ready", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, nil, &infrav1.Metal3MachineStatus{
+			M3Machine: newMetal3Machine("myName", nil, &infrav1.Metal3MachineStatus{
 				RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: namespaceName},
 			}, nil),
-			Machine: newMachine(machineName, "myName", nil),
+			Machine: newMachine(machineName, nil),
 			Data: &infrav1.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abcd-0",
@@ -3771,10 +3771,10 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectMetal3DataReadyConditionStatus: false,
 		}),
 		Entry("Should not error if Data is ready but no secrets", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, nil, &infrav1.Metal3MachineStatus{
+			M3Machine: newMetal3Machine("myName", nil, &infrav1.Metal3MachineStatus{
 				RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: namespaceName},
 			}, nil),
-			Machine: newMachine(machineName, "myName", nil),
+			Machine: newMachine(machineName, nil),
 			Data: &infrav1.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abcd-0",
@@ -3790,10 +3790,10 @@ var _ = Describe("Metal3Machine manager", func() {
 			ExpectMetal3DataReadyConditionStatus: true,
 		}),
 		Entry("Should not error if Data is ready with secrets", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, nil, &infrav1.Metal3MachineStatus{
+			M3Machine: newMetal3Machine("myName", nil, &infrav1.Metal3MachineStatus{
 				RenderedData: &corev1.ObjectReference{Name: "abcd-0", Namespace: namespaceName},
 			}, nil),
-			Machine: newMachine(machineName, "myName", nil),
+			Machine: newMachine(machineName, nil),
 			Data: &infrav1.Metal3Data{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "abcd-0",
@@ -3865,40 +3865,40 @@ var _ = Describe("Metal3Machine manager", func() {
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		},
 		Entry("Should return nil if No Spec", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, nil, &infrav1.Metal3MachineStatus{
+			M3Machine: newMetal3Machine("myName", nil, &infrav1.Metal3MachineStatus{
 				MetaData:    &corev1.SecretReference{Name: "abcd"},
 				NetworkData: &corev1.SecretReference{Name: "defg"},
 			}, nil),
-			Machine: newMachine(machineName, "myName", nil),
+			Machine: newMachine(machineName, nil),
 		}),
 		Entry("MetaData and NetworkData should be set in spec and status", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, &infrav1.Metal3MachineSpec{
+			M3Machine: newMetal3Machine("myName", &infrav1.Metal3MachineSpec{
 				MetaData:    &corev1.SecretReference{Name: "abcd"},
 				NetworkData: &corev1.SecretReference{Name: "defg"},
 			}, &infrav1.Metal3MachineStatus{
 				MetaData:    &corev1.SecretReference{Name: "abcd"},
 				NetworkData: &corev1.SecretReference{Name: "defg"},
 			}, nil),
-			Machine:            newMachine(machineName, "myName", nil),
+			Machine:            newMachine(machineName, nil),
 			ExpectSecretStatus: true,
 		}),
 		Entry("Should return nil if DataClaim not found", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, &infrav1.Metal3MachineSpec{
+			M3Machine: newMetal3Machine("myName", &infrav1.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{
 					Name:      "abc",
 					Namespace: namespaceName,
 				},
 			}, nil, nil),
-			Machine: newMachine(machineName, "myName", nil),
+			Machine: newMachine(machineName, nil),
 		}),
 		Entry("Should not error if DataClaim found", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, &infrav1.Metal3MachineSpec{
+			M3Machine: newMetal3Machine("myName", &infrav1.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{
 					Name:      "abcd",
 					Namespace: namespaceName,
 				},
 			}, nil, nil),
-			Machine: newMachine(machineName, "myName", nil),
+			Machine: newMachine(machineName, nil),
 			DataClaim: &infrav1.Metal3DataClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myName",
@@ -3907,13 +3907,13 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 		}),
 		Entry("Should return nil if DataClaim is empty", testCaseM3MetaData{
-			M3Machine: newMetal3Machine("myName", nil, &infrav1.Metal3MachineSpec{
+			M3Machine: newMetal3Machine("myName", &infrav1.Metal3MachineSpec{
 				DataTemplate: &corev1.ObjectReference{
 					Name:      "abc",
 					Namespace: namespaceName,
 				},
 			}, nil, nil),
-			Machine:   newMachine(machineName, "myName", nil),
+			Machine:   newMachine(machineName, nil),
 			DataClaim: &infrav1.Metal3DataClaim{},
 		}),
 	)
@@ -4726,8 +4726,7 @@ func newConfig(userDataNamespace string,
 	return &config, infrastructureRef
 }
 
-func newMachine(machineName string, metal3machineName string,
-	infraRef *corev1.ObjectReference,
+func newMachine(machineName string, infraRef *corev1.ObjectReference,
 ) *clusterv1.Machine {
 	if machineName == "" {
 		return &clusterv1.Machine{}
@@ -4759,7 +4758,6 @@ func newMachine(machineName string, metal3machineName string,
 }
 
 func newMetal3Machine(name string,
-	ownerRef *metav1.OwnerReference,
 	spec *infrav1.Metal3MachineSpec,
 	status *infrav1.Metal3MachineStatus,
 	objMeta *metav1.ObjectMeta) *infrav1.Metal3Machine {

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -187,7 +187,7 @@ func newCluster(clusterName string) *clusterv1.Cluster {
 	}
 }
 
-func newMetal3Cluster(baremetalName string, ownerRef *metav1.OwnerReference,
+func newMetal3Cluster(metal3ClusterName string, ownerRef *metav1.OwnerReference,
 	spec *infrav1.Metal3ClusterSpec, status *infrav1.Metal3ClusterStatus) *infrav1.Metal3Cluster {
 	if spec == nil {
 		spec = &infrav1.Metal3ClusterSpec{}

--- a/controllers/metal3remediation_controller.go
+++ b/controllers/metal3remediation_controller.go
@@ -457,7 +457,7 @@ func mergeMaps(prioritizedMap map[string]string, mapToMerge map[string]string) m
 }
 
 // SetupWithManager will add watches for Metal3Remediation controller.
-func (r *Metal3RemediationReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+func (r *Metal3RemediationReconciler) SetupWithManager(_ context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&infrav1.Metal3Remediation{}).
 		WithOptions(options).

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -229,7 +229,7 @@ func newCluster(clusterName string, spec *clusterv1.ClusterSpec, status *cluster
 	}
 }
 
-func newMetal3Cluster(baremetalName string, ownerRef *metav1.OwnerReference, spec *infrav1.Metal3ClusterSpec, status *infrav1.Metal3ClusterStatus, annotation map[string]string, pausedAnnotation bool) *infrav1.Metal3Cluster {
+func newMetal3Cluster(metal3ClusterName string, ownerRef *metav1.OwnerReference, spec *infrav1.Metal3ClusterSpec, status *infrav1.Metal3ClusterStatus, annotation map[string]string, pausedAnnotation bool) *infrav1.Metal3Cluster {
 	if spec == nil {
 		spec = &infrav1.Metal3ClusterSpec{}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/cluster-api-provider-metal3
 
-go 1.19
+go 1.20
 
 require (
 	github.com/go-logr/logr v1.2.4

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -17,6 +17,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.19 \
+        docker.io/golang:1.20 \
         /workdir/hack/build.sh "$@"
 fi

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -38,6 +38,6 @@ else
         --volume "${PWD}:/workdir:rw,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.19 \
+        docker.io/golang:1.20 \
         /workdir/hack/codegen.sh
 fi

--- a/hack/ensure-golangci-lint.sh
+++ b/hack/ensure-golangci-lint.sh
@@ -1,22 +1,80 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+# Copyright 2023 The Metal3 Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# download an url and verify the downloaded object has the same sha as
+# supplied in the function call
 
 set -eux
 
-IS_CONTAINER="${IS_CONTAINER:-false}"
-CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+CAPM3_DIR="$(dirname "$(readlink -f "$0")")/.."
 
-if [ "${IS_CONTAINER}" != "false" ]; then
-    export XDG_CACHE_HOME=/tmp/.cache
-    mkdir /tmp/unit
-    cp -r . /tmp/unit
-    cd /tmp/unit
-    make lint
-else
-    "${CONTAINER_RUNTIME}" run --rm \
-        --env IS_CONTAINER=TRUE \
-        --volume "${PWD}:/workdir:ro,z" \
-        --entrypoint sh \
-        --workdir /workdir \
-        docker.io/golang:1.19 \
-        /workdir/hack/ensure-golangci-lint.sh
-fi
+wget_and_verify()
+{
+    local url="${1:?url missing}"
+    local sha256="${2:?sha256 missing}"
+    local target="${3:?target missing}"
+    local checksum
+
+    declare -a args=(
+        --no-verbose
+        -O "${target}"
+        "${url}"
+    )
+
+    wget "${args[@]}"
+
+    checksum="$(sha256sum "${target}" | awk '{print $1;}')"
+    if [[ "${checksum}" != "${sha256}" ]]; then
+        if [[ "${INSECURE_SKIP_DOWNLOAD_VERIFICATION}" == "true" ]]; then
+            echo >&2 "warning: ${url} binary checksum '${checksum}' differs from expected checksum '${sha256}'"
+        else
+            echo >&2 "fatal: ${url} binary checksum '${checksum}' differs from expected checksum '${sha256}'"
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
+download_and_install_golangci_lint()
+{
+    local tmp_dir
+    local bin_dir="${1:?Binary path missing}"
+
+    tmp_dir="$(mktemp -d)"
+    pushd "${tmp_dir}" || return 1
+
+    KERNEL_OS="$(uname | tr '[:upper:]' '[:lower:]')"
+    ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')"
+    GOLANGCI_LINT="golangci-lint"
+    GOLANGCI_VERSION="1.52.1"
+    case "${KERNEL_OS}" in
+        darwin) GOLANGCI_SHA256="d21a157d37e5bc56cd7d5b39610c72974ffc5cb23a718579f56b735e008950c2" ;; 
+        linux) GOLANGCI_SHA256="f31a6dc278aff92843acdc2671f17c753c6e2cb374d573c336479e92daed161f"  ;;
+      *) 
+        echo >&2 "error:${KERNEL_OS} not supported. Please obtain the binary and calculate sha256 manually."
+        exit 1
+        ;;
+    esac
+    GOLANGCI_URL="https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_VERSION}/${GOLANGCI_LINT}-${GOLANGCI_VERSION}-${KERNEL_OS}-${ARCH}.tar.gz"
+    wget_and_verify "${GOLANGCI_URL}" "${GOLANGCI_SHA256}" "${GOLANGCI_LINT}".tar.gz
+    tar zxvf "${GOLANGCI_LINT}".tar.gz
+    rm -f "${GOLANGCI_LINT}".tar.gz
+    mkdir -p "${CAPM3_DIR}/${bin_dir}"
+    mv "${GOLANGCI_LINT}-${GOLANGCI_VERSION}-${KERNEL_OS}-${ARCH}/${GOLANGCI_LINT}" "${CAPM3_DIR}/${bin_dir}/"
+}
+
+download_and_install_golangci_lint "$1"

--- a/hack/gofmt.sh
+++ b/hack/gofmt.sh
@@ -29,6 +29,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.19 \
+        docker.io/golang:1.20 \
         /workdir/hack/gofmt.sh
 fi

--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -39,6 +39,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.19 \
+        docker.io/golang:1.20 \
         /workdir/hack/gomod.sh "$@"
 fi

--- a/hack/govet.sh
+++ b/hack/govet.sh
@@ -17,6 +17,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.19 \
+        docker.io/golang:1.20 \
         /workdir/hack/govet.sh
 fi

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -17,6 +17,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.19 \
+        docker.io/golang:1.20 \
         /workdir/hack/unit.sh "$@"
 fi

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -167,7 +167,7 @@ func EnsureImage(k8sVersion string) (imageURL string, imageChecksum string) {
 // DownloadFile will download a url and store it in local filepath.
 func DownloadFile(filePath string, url string) error {
 	// Get the data
-	resp, err := http.Get(url)
+	resp, err := http.Get(url) //nolint:noctx
 	if err != nil {
 		return err
 	}
@@ -448,7 +448,7 @@ func GetMachine(ctx context.Context, c client.Client, name client.ObjectKey) (re
 	return
 }
 
-func GetMetal3Machines(ctx context.Context, c client.Client, cluster, namespace string) ([]infrav1.Metal3Machine, []infrav1.Metal3Machine) {
+func GetMetal3Machines(ctx context.Context, c client.Client, _, namespace string) ([]infrav1.Metal3Machine, []infrav1.Metal3Machine) {
 	var controlplane, workers []infrav1.Metal3Machine
 	allMachines := &infrav1.Metal3MachineList{}
 	Expect(c.List(ctx, allMachines, client.InNamespace(namespace))).To(Succeed())
@@ -465,7 +465,7 @@ func GetMetal3Machines(ctx context.Context, c client.Client, cluster, namespace 
 }
 
 // GetIPPools return baremetal and provisioning IPPools.
-func GetIPPools(ctx context.Context, c client.Client, cluster, namespace string) ([]ipamv1.IPPool, []ipamv1.IPPool) {
+func GetIPPools(ctx context.Context, c client.Client, _, namespace string) ([]ipamv1.IPPool, []ipamv1.IPPool) {
 	var bmv4IPPool, provisioningIPPool []ipamv1.IPPool
 	allIPPools := &ipamv1.IPPoolList{}
 	Expect(c.List(ctx, allIPPools, client.InNamespace(namespace))).To(Succeed())

--- a/test/e2e/remediation.go
+++ b/test/e2e/remediation.go
@@ -393,14 +393,14 @@ func filterM3DataByReference(datas []infrav1.Metal3Data, referenceName string) (
 	return
 }
 
-func waitForVmsState(vmNames []string, state vmState, specName string, interval ...interface{}) {
+func waitForVmsState(vmNames []string, state vmState, _ string, interval ...interface{}) {
 	Byf("Waiting for VMs %v to become '%s'", vmNames, state)
 	Eventually(func() []string {
 		return listVms(state)
 	}, interval...).Should(ContainElements(vmNames))
 }
 
-func monitorNodesStatus(ctx context.Context, g Gomega, c client.Client, namespace string, names []string, status corev1.ConditionStatus, specName string, interval ...interface{}) {
+func monitorNodesStatus(ctx context.Context, g Gomega, c client.Client, namespace string, names []string, status corev1.ConditionStatus, _ string, interval ...interface{}) {
 	Byf("Ensuring Nodes %v consistently have ready=%s status", names, status)
 	g.Consistently(
 		func() error {
@@ -429,7 +429,7 @@ func assertNodeStatus(ctx context.Context, client client.Client, name client.Obj
 	return fmt.Errorf("node %s missing condition \"Ready\"", name.Name)
 }
 
-func waitForNodeStatus(ctx context.Context, client client.Client, name client.ObjectKey, status corev1.ConditionStatus, specName string, interval ...interface{}) {
+func waitForNodeStatus(ctx context.Context, client client.Client, name client.ObjectKey, status corev1.ConditionStatus, _ string, interval ...interface{}) {
 	Byf("Waiting for Node '%s' to have ready=%s status", name, status)
 	Eventually(
 		func() error { return assertNodeStatus(ctx, client, name, status) },

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/cluster-api-provider-metal3/test
 
-go 1.19
+go 1.20
 
 require (
 	github.com/docker/docker v24.0.2+incompatible


### PR DESCRIPTION
We also modify the way we install golangci-lint. Previously we were downloading and installing it through gomodules, however newer versions are not woorking properly with that installation method. Now, with this patch we will be installing it through the workflow file and the ensure-golangci-lint.sh which downloads the binary from github release. We also fix the lint errors here. It seems a lot of ununsed variables went undetected previously which are caught now with new version of linter. 