### PR TITLE
🌱 Include all gomods in different directories for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,45 @@ updates:
       prefix: ":seedling:"
     labels:
       - "ok-to-test"
+  - package-ecosystem: "gomod"
+    directory: "/api"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # Ignore controller-runtime as its upgraded manually.
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+      # Ignore k8s and its transitives modules as they are upgraded manually
+      # together with controller-runtime.
+      - dependency-name: "k8s.io/*"
+    commit-message:
+      prefix: ":seedling:"
+    labels:
+      - "ok-to-test"
+  - package-ecosystem: "gomod"
+    directory: "/test"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # Ignore controller-runtime as its upgraded manually.
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+      # Ignore k8s and its transitives modules as they are upgraded manually
+      # together with controller-runtime.
+      - dependency-name: "k8s.io/*"
+    commit-message:
+      prefix: ":seedling:"
+    labels:
+      - "ok-to-test"
+  - package-ecosystem: "gomod"
+    directory: "/hack/tools"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # Ignore controller-runtime as its upgraded manually.
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+      # Ignore k8s and its transitives modules as they are upgraded manually
+      # together with controller-runtime.
+      - dependency-name: "sigs.k8s.io/controller-tools"
+    commit-message:
+      prefix: ":seedling:"
+    labels:
+      - "ok-to-test"


### PR DESCRIPTION
Dependabot is currently not updating gomodules in api/, test/ and hack/tools dir. This PR updates it. 