### PR TITLE
:bug: Removed mariadb restart check in certRotation test

### DIFF
--- a/test/e2e/cert_rotation_test.go
+++ b/test/e2e/cert_rotation_test.go
@@ -40,7 +40,6 @@ func certRotation(clientSet *kubernetes.Clientset, clusterClient client.Client) 
 	By("Get the current number of time containers were restarted")
 	containerNumRestart := make(map[string]int32)
 	containerNumRestart["ironic-httpd"] = 0
-	containerNumRestart["mariadb"] = 0
 	Expect(err).To(BeNil())
 	ironicPod, err := getPodFromDeployment(clientSet, ironicDeployment, ironicNamespace)
 	Expect(err).To(BeNil())


### PR DESCRIPTION


**What this PR does / why we need it**:
Removed mariadb restart check in certRotation test. Because we do not run any tests with mariadb for 1.2 release.
