### PR TITLE
🌱 ignore ipam in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
       # Ignore k8s and its transitives modules as they are upgraded manually
       # together with controller-runtime.
       - dependency-name: "k8s.io/*"
+      # ignore ipam, as it needs more than just gomod
+      - dependency-name: "github.com/metal3-io/ip-address-manager/api"
     commit-message:
       prefix: ":seedling:"
     labels:
@@ -36,6 +38,8 @@ updates:
       # Ignore k8s and its transitives modules as they are upgraded manually
       # together with controller-runtime.
       - dependency-name: "k8s.io/*"
+      # ignore ipam, as it needs more than just gomod
+      - dependency-name: "github.com/metal3-io/ip-address-manager/api"
     commit-message:
       prefix: ":seedling:"
     labels:
@@ -50,6 +54,8 @@ updates:
       # Ignore k8s and its transitives modules as they are upgraded manually
       # together with controller-runtime.
       - dependency-name: "k8s.io/*"
+      # ignore ipam, as it needs more than just gomod
+      - dependency-name: "github.com/metal3-io/ip-address-manager/api"
     commit-message:
       prefix: ":seedling:"
     labels:


### PR DESCRIPTION
IPAM bump in CAPM3 needs more than just gomod bump, so having dependabot create PR for it is waste of resources. We do releasing of IPAM and CAPM3 back to back, and will do IPAM uplift in CAPM3 right after we've released it.
