### PR TITLE
🐛 Fix k8s version based on clusterctl upgrade version

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -77,12 +77,27 @@ fi
 export CAPI_FROM_RELEASE="${CAPI_FROM_RELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "${CAPI_UPGRADE_FROM_RELEASE}")}"
 # The e2e config file parameter for the capi release compatible with main (capm3 next version)
 export CAPI_TO_RELEASE="${CAPIRELEASE}"
+# K8s support based on https://cluster-api.sigs.k8s.io/reference/versions.html#core-provider-cluster-api-controller
 case ${CAPI_FROM_RELEASE} in
 v0.4*)
     export CONTRACT_FROM="v1alpha4"
+    export INIT_WITH_KUBERNETES_VERSION="v1.23.8"
     ;;
-v1.*)
+v1.2*)
     export CONTRACT_FROM="v1beta1"
+    export INIT_WITH_KUBERNETES_VERSION="v1.26.4"
+    ;;
+v1.3*)
+    export CONTRACT_FROM="v1beta1"
+    export INIT_WITH_KUBERNETES_VERSION="v1.26.4"
+    ;;
+v1.4*)
+    export CONTRACT_FROM="v1beta1"
+    export INIT_WITH_KUBERNETES_VERSION="v1.27.1"
+    ;;
+*)
+    echo "UNKNOWN CAPI_FROM_RELEASE !"
+    exit 1
     ;;
 esac
 export CONTRACT_TO="v1beta1"

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -110,8 +110,8 @@ variables:
   KUBERNETES_VERSION: "v1.27.1"
   # INIT_WITH_KUBERNETES_VERSION will be used here
   # https://github.com/kubernetes-sigs/cluster-api/blob/bb377163f141d69b7a61479756ee96891f6670bd/test/e2e/clusterctl_upgrade.go#L170
-  # INIT_WITH_KUBERNETES_VERSION  used by management cluster upgrade and it is fixed to 1.23.8 because v1a4 capi does not support k8s version higher
-  INIT_WITH_KUBERNETES_VERSION: "v1.23.8"
+  # INIT_WITH_KUBERNETES_VERSION  used by management cluster upgrade
+  INIT_WITH_KUBERNETES_VERSION: "${INIT_WITH_KUBERNETES_VERSION}"
   CONTROL_PLANE_MACHINE_COUNT: 3
   WORKER_MACHINE_COUNT: 1
   APIVersion: "infrastructure.cluster.x-k8s.io/${CAPM3_VERSION}"

--- a/test/e2e/upgrade_management_cluster_test.go
+++ b/test/e2e/upgrade_management_cluster_test.go
@@ -41,6 +41,8 @@ var _ = Describe("When testing cluster upgrade v1alpha5 > current [clusterctl-up
 				InitWithBootstrapProviders:      []string{fmt.Sprintf("kubeadm:%s", os.Getenv("CAPI_FROM_RELEASE"))},
 				InitWithControlPlaneProviders:   []string{fmt.Sprintf("kubeadm:%s", os.Getenv("CAPI_FROM_RELEASE"))},
 				InitWithInfrastructureProviders: []string{fmt.Sprintf("metal3:%s", os.Getenv("CAPM3_FROM_RELEASE"))},
+				InitWithKubernetesVersion:       e2eConfig.GetVariable("INIT_WITH_KUBERNETES_VERSION"),
+				WorkloadKubernetesVersion:       e2eConfig.GetVariable("INIT_WITH_KUBERNETES_VERSION"),
 				InitWithBinary:                  e2eConfig.GetVariable("INIT_WITH_BINARY"),
 				PreInit: func(clusterProxy framework.ClusterProxy) {
 					preInitFunc(clusterProxy)
@@ -56,6 +58,7 @@ var _ = Describe("When testing cluster upgrade v1alpha5 > current [clusterctl-up
 			}
 		})
 	} else {
+
 		isPreRelease := strings.Contains(os.Getenv("CAPI_TO_RELEASE"), "-")
 
 		if isPreRelease {
@@ -72,6 +75,8 @@ var _ = Describe("When testing cluster upgrade v1alpha5 > current [clusterctl-up
 					ControlPlaneProviders:       []string{fmt.Sprintf("capi-kubeadm-control-plane-system/kubeadm:%s", os.Getenv("CAPI_TO_RELEASE"))},
 					InfrastructureProviders:     []string{fmt.Sprintf("capm3-system/metal3:%s", os.Getenv("CAPM3_TO_RELEASE"))},
 					InitWithBinary:              e2eConfig.GetVariable("INIT_WITH_BINARY"),
+					InitWithKubernetesVersion:   e2eConfig.GetVariable("INIT_WITH_KUBERNETES_VERSION"),
+					WorkloadKubernetesVersion:   e2eConfig.GetVariable("INIT_WITH_KUBERNETES_VERSION"),
 					PreInit:                     preInitFunc,
 					PreWaitForCluster:           preWaitForCluster,
 					PreUpgrade:                  preUpgrade,


### PR DESCRIPTION
CAPM3 v1.4 seems not supporting k8s v1.23.8 this PR set fixed k8s version for each upgrade from release based on capi k8s support https://cluster-api.sigs.k8s.io/reference/versions.html#core-provider-cluster-api-controller