### PR TITLE
🐛 Set M3M concurrency to 1 and add warning

### DIFF
--- a/main.go
+++ b/main.go
@@ -266,8 +266,8 @@ func initFlags(fs *pflag.FlagSet) {
 		"The address the health endpoint binds to.",
 	)
 
-	fs.IntVar(&metal3MachineConcurrency, "metal3machine-concurrency", 10,
-		"Number of metal3machines to process simultaneously")
+	fs.IntVar(&metal3MachineConcurrency, "metal3machine-concurrency", 1,
+		"Number of metal3machines to process simultaneously. WARNING! Currently not safe to set > 1.")
 
 	fs.IntVar(&metal3ClusterConcurrency, "metal3cluster-concurrency", 10,
 		"Number of metal3clusters to process simultaneously")


### PR DESCRIPTION
**What this PR does / why we need it**:

We currently have an issue with concurrency when associating a BMH to a M3M. A mutex was already added before to the Associate function. However, this does not completely solve the issue, because a caching client is used. In other words, the next M3M to associate can sometimes use cached data about the BMHs and pick one that is already associated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

This is a temporary workaround for #1004
