### PR TITLE
Add features label for e2e feature tests for ginkgo focus to release 1.4

### DIFF
--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -48,8 +48,8 @@ else
   export EPHEMERAL_CLUSTER="minikube"
 fi
 
-export FROM_K8S_VERSION="v1.25.2"
-export KUBERNETES_VERSION="v1.26.4"
+export FROM_K8S_VERSION=${FROM_K8S_VERSION:-"v1.26.4"}
+export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.27.1"}
 
 # Can be overriden from jjbs
 export CAPI_VERSION=${CAPI_VERSION:-"v1beta1"}
@@ -60,7 +60,7 @@ export CAPM3_LOCAL_IMAGE="${CAPM3PATH}"
 export PATH=$PATH:$HOME/.krew/bin
 
 # Upgrade test environment vars and config
-if [[ ${GINKGO_FOCUS:-} == "upgrade" ]]; then
+if [[ ${GINKGO_FOCUS:-} = "clusterctl-upgrade" ]]; then
   export NUM_NODES=${NUM_NODES:-"5"}
 fi
 

--- a/test/e2e/data/infrastructure-metal3/bases/centos-kubeadm-config/centos-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/bases/centos-kubeadm-config/centos-kubeadm-config.yaml
@@ -113,7 +113,6 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cgroup-driver: systemd
-          container-runtime: remote
           container-runtime-endpoint: unix:///var/run/crio/crio.sock
           feature-gates: AllAlpha=false
           node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
@@ -125,7 +124,6 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cgroup-driver: systemd
-          container-runtime: remote
           container-runtime-endpoint: unix:///var/run/crio/crio.sock
           feature-gates: AllAlpha=false
           node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}

--- a/test/e2e/data/infrastructure-metal3/bases/cluster/md.yaml
+++ b/test/e2e/data/infrastructure-metal3/bases/cluster/md.yaml
@@ -107,7 +107,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             cgroup-driver: systemd
-            container-runtime: remote
             container-runtime-endpoint: unix:///var/run/crio/crio.sock
             feature-gates: AllAlpha=false
             node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}

--- a/test/e2e/data/infrastructure-metal3/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
@@ -87,7 +87,6 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cgroup-driver: systemd
-          container-runtime: remote
           container-runtime-endpoint: unix:///var/run/crio/crio.sock
           feature-gates: AllAlpha=false
           node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
@@ -98,7 +97,6 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cgroup-driver: systemd
-          container-runtime: remote
           container-runtime-endpoint: unix:///var/run/crio/crio.sock
           feature-gates: AllAlpha=false
           node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}

--- a/test/e2e/upgrade_kubernetes_test.go
+++ b/test/e2e/upgrade_kubernetes_test.go
@@ -19,7 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Kubernetes version upgrade in target nodes [upgrade]", func() {
+var _ = Describe("Kubernetes version upgrade in target nodes [k8s-upgrade]", func() {
 
 	var (
 		ctx                 = context.TODO()

--- a/test/e2e/upgrade_management_cluster_test.go
+++ b/test/e2e/upgrade_management_cluster_test.go
@@ -15,7 +15,7 @@ import (
 
 const workDir = "/opt/metal3-dev-env/"
 
-var _ = Describe("When testing cluster upgrade v1alpha5 > current [upgrade]", func() {
+var _ = Describe("When testing cluster upgrade v1alpha5 > current [clusterctl-upgrade]", func() {
 	BeforeEach(func() {
 		osType := strings.ToLower(os.Getenv("OS"))
 		Expect(osType).ToNot(Equal(""))


### PR DESCRIPTION
Manual backport of #982.
This PR also removes container-runtime flag from Kubelet since it is unsupported from v1.27