### PR TITLE
✨ Added a log collector implementation for Metal3

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -146,7 +146,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	kubeconfigPath := parts[3]
 
 	e2eConfig = loadE2EConfig(configPath)
-	bootstrapClusterProxy = framework.NewClusterProxy("bootstrap", kubeconfigPath, initScheme())
+	withMetal3LogCollectorOpt := framework.WithMachineLogCollector(Metal3LogCollector{})
+	bootstrapClusterProxy = framework.NewClusterProxy("bootstrap", kubeconfigPath, initScheme(), withMetal3LogCollectorOpt)
 })
 
 // Using a SynchronizedAfterSuite for controlling how to delete resources shared across ParallelNodes (~ginkgo threads).

--- a/test/e2e/integration_test.go
+++ b/test/e2e/integration_test.go
@@ -3,19 +3,18 @@ package e2e
 import (
 	"path/filepath"
 
-	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	"sigs.k8s.io/cluster-api/test/framework"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("When testing integration [integration]", func() {
+
 	It("CI Test Provision", func() {
 		numberOfWorkers = int(*e2eConfig.GetInt32PtrVariable("WORKER_MACHINE_COUNT"))
 		numberOfControlplane = int(*e2eConfig.GetInt32PtrVariable("CONTROL_PLANE_MACHINE_COUNT"))
 		k8sVersion := e2eConfig.GetVariable("KUBERNETES_VERSION")
 		By("Provision Workload cluster")
-		targetCluster, result := createTargetCluster(k8sVersion)
+		targetCluster, _ = createTargetCluster(k8sVersion)
 		By("Pivot objects to target cluster")
 		pivoting(ctx, func() PivotingInput {
 			return PivotingInput{
@@ -49,31 +48,9 @@ var _ = Describe("When testing integration [integration]", func() {
 				ClusterctlConfigPath:  clusterctlConfigPath,
 			}
 		})
-		By("Deprovision target cluster")
-		bootstrapClient := bootstrapClusterProxy.GetClient()
-		intervals := e2eConfig.GetIntervals(specName, "wait-deprovision-cluster")
-		// In pivoting step we labeled the BMO CRDs (so that the objects are moved
-		// by CAPI pivoting feature), which made CAPI DeleteClusterAndWait()
-		// fail as it has a check to make sure all resources managed by CAPI
-		// is gone after Cluster deletion. Therefore, we opted not to use
-		// DeleteClusterAndWait(), but only delete the cluster and then wait
-		// for it to be deleted.
-		framework.DeleteCluster(ctx, framework.DeleteClusterInput{
-			Deleter: bootstrapClient,
-			Cluster: result.Cluster,
-		})
-		Logf("Waiting for the Cluster object to be deleted")
-		framework.WaitForClusterDeleted(ctx, framework.WaitForClusterDeletedInput{
-			Getter:  bootstrapClient,
-			Cluster: result.Cluster,
-		}, intervals...)
-		numberOfAvailableBMHs := numberOfWorkers + numberOfControlplane
-		intervals = e2eConfig.GetIntervals(specName, "wait-bmh-deprovisioning-available")
-		WaitForNumBmhInState(ctx, bmov1alpha1.StateAvailable, WaitForNumInput{
-			Client:    bootstrapClient,
-			Options:   []client.ListOption{client.InNamespace(namespace)},
-			Replicas:  numberOfAvailableBMHs,
-			Intervals: intervals,
-		})
+	})
+
+	AfterEach(func() {
+		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 	})
 })


### PR DESCRIPTION
Now only collects qemu serial logs.

**What this PR does / why we need it**:

This PR contains the basic implementation of [CAPI log collector,](https://github.com/kubernetes-sigs/cluster-api/blob/ddb18986a0e325c8a877b19be817079938e32bae/test/framework/cluster_proxy.go#L105) and the collecting of serial logs. In the future, different logs can also be collected.

The collected logs can be checked in the tarball from the path: `e2e_artifacts/_artifacts/machines/`