### PR TITLE
🐛Enable Mariadb instead of SQLite

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -20,12 +20,14 @@ M3_DEV_ENV_PATH="${M3_DEV_ENV_PATH:-${WORKING_DIR}/metal3-dev-env}"
 clone_repo "${M3_DEV_ENV_REPO}" "${M3_DEV_ENV_BRANCH}" "${M3_DEV_ENV_PATH}"
 
 # Config devenv
+# Enabling Mariadb instead of SQLite. This can be set to false once SQLite issue is resolved
 cat <<-EOF >"${M3_DEV_ENV_PATH}/config_${USER}.sh"
 export CAPI_VERSION=${CAPI_VERSION:-"v1beta1"}
 export CAPM3_VERSION=${CAPM3_VERSION:-"v1beta1"}
 export NUM_NODES=${NUM_NODES:-"4"}
 export KUBERNETES_VERSION=${KUBERNETES_VERSION}
 export IMAGE_OS=${IMAGE_OS}
+export IRONIC_USE_MARIADB="true"
 export FORCE_REPO_UPDATE="false"
 EOF
 if [[ ${GINKGO_FOCUS:-} == "features" ]]; then

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -122,7 +122,8 @@ variables:
   IRONIC_TLS_SETUP: "true"
   IRONIC_BASIC_AUTH: "true"
   IRONIC_KEEPALIVED: "true"
-  IRONIC_USE_MARIADB: "false"
+  # Enabling Mariadb instead of SQLite. This can be set to false once SQLite issue is resolved
+  IRONIC_USE_MARIADB: "true"
   RESTART_CONTAINER_CERTIFICATE_UPDATED: "true"
   CONTAINER_REGISTRY: "${CONTAINER_REGISTRY:-quay.io}"
   DOCKER_HUB_PROXY: "${DOCKER_HUB_PROXY:-docker.io}"


### PR DESCRIPTION
This PR will enable the Mariadb for ironic instead of SQLite, as we have database lock issue with SQLite. Community suggested to use Mariadb to resolve the issue in  CI. We can move back to SQLite once the issue is fixed from ironic.
Workaround for [#1082](https://github.com/metal3-io/cluster-api-provider-metal3/issues/1082) and keep the issue open to track the fixes of the SQLite issue