### PR TITLE
Bump k8s version to v1.27.4

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -127,7 +127,7 @@ spec:
     rollingUpdate:
       maxSurge: 1
     type: RollingUpdate
-  version: v1.27.1
+  version: v1.27.4
   kubeadmConfigSpec:
     joinConfiguration:
       controlPlane: {}
@@ -243,7 +243,7 @@ spec:
     namespace: metal3
   nodeDrainTimeout: 0s
   providerID: metal3://68be298f-ed11-439e-9d51-6c5260faede6
-  version: v1.27.1
+  version: v1.27.4
 ```
 
 ## Metal3Machine
@@ -413,10 +413,10 @@ metadata:
 spec:
   automatedCleaningMode: metadata
   image:
-    checksum: http://172.22.0.1/images/UBUNTU_22.04_NODE_IMAGE_K8S_v1.27.1-raw.img.sha256sum
+    checksum: http://172.22.0.1/images/UBUNTU_22.04_NODE_IMAGE_K8S_v1.27.4-raw.img.sha256sum
     checksumType: sha256
     format: raw
-    url: http://172.22.0.1/images/UBUNTU_22.04_NODE_IMAGE_K8S_v1.27.1-raw.img
+    url: http://172.22.0.1/images/UBUNTU_22.04_NODE_IMAGE_K8S_v1.27.4-raw.img
   hostSelector:
     matchLabels:
       key1: value1
@@ -473,7 +473,7 @@ spec:
         name: md-0
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
-      version: v1.27.1
+      version: v1.27.4
 ```
 
 ## KubeadmConfigTemplate
@@ -555,10 +555,10 @@ spec:
     spec:
       automatedCleaningMode: metadata
       image:
-        checksum: http://172.22.0.1/images/UBUNTU_22.04_NODE_IMAGE_K8S_v1.27.1-raw.img.sha256sum
+        checksum: http://172.22.0.1/images/UBUNTU_22.04_NODE_IMAGE_K8S_v1.27.4-raw.img.sha256sum
         checksumType: sha256
         format: raw
-        url: http://172.22.0.1/images/UBUNTU_22.04_NODE_IMAGE_K8S_v1.27.1-raw.img
+        url: http://172.22.0.1/images/UBUNTU_22.04_NODE_IMAGE_K8S_v1.27.4-raw.img
       hostSelector:
         matchLabels:
           key1: value1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -404,7 +404,7 @@ spec:
     etcd: {}
     imageRepository: ""
     kind: ClusterConfiguration
-    kubernetesVersion: v1.27.1
+    kubernetesVersion: v1.27.4
     networking:
       dnsDomain: cluster.local
       podSubnet: 192.168.0.0/18

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -287,7 +287,7 @@ Please note, the precedence of variables is as follows:
         },
         "metadata": {,
             "CONTROL_PLANE_MACHINE_COUNT": "1",
-            "KUBERNETES_VERSION": "v1.27.1",
+            "KUBERNETES_VERSION": "v1.27.4",
             "WORKER_MACHINE_COUNT": "2",
         }
     }

--- a/docs/e2e-test.md
+++ b/docs/e2e-test.md
@@ -135,9 +135,9 @@ clusters:
 
 | tests               | bootstrap cluster | metal3 cluster init | metal3 cluster final |
 | ------------------- | ----------------- | ------------------- | -------------------- |
-| integration         | v1.27.1           | v1.27.1             | x                    |
-| remediation         | v1.27.1           | v1.27.1             | x                    |
-| pivot based feature | v1.27.1           | v1.26.4             | v1.27.1              |
-| upgrade             | v1.27.1           | v1.26.4             | v1.27.1              |
+| integration         | v1.27.4           | v1.27.4             | x                    |
+| remediation         | v1.27.4           | v1.27.4             | x                    |
+| pivot based feature | v1.27.4           | v1.26.4             | v1.27.4              |
+| upgrade             | v1.27.4           | v1.26.4             | v1.27.4              |
 
 <!-- markdownlint-enable MD013 -->

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -18,17 +18,17 @@ set -o nounset
 set -o pipefail
 
 # Directories.
-SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 OUTPUT_DIR=${OUTPUT_DIR:-${SOURCE_DIR}/_out}
 KUSTOMIZE="${SOURCE_DIR}/../hack/tools/bin/kustomize"
 
 # Cluster.
 export CLUSTER_NAME="${CLUSTER_NAME:-test1}"
-export KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.27.1}"
+export KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.27.4}"
 export CLUSTER_APIENDPOINT_HOST="${CLUSTER_APIENDPOINT_HOST:-192.168.111.249}"
 export CLUSTER_APIENDPOINT_PORT="${CLUSTER_APIENDPOINT_PORT:-6443}"
-export IMAGE_URL="${IMAGE_URL:-http://172.22.0.1/images/UBUNTU_22.04_NODE_IMAGE_K8S_v1.27.1-raw.img}"
-export IMAGE_CHECKSUM="${IMAGE_CHECKSUM:-http://172.22.0.1/images/UBUNTU_22.04_NODE_IMAGE_K8S_v1.27.1-raw.img.sha256sum}"
+export IMAGE_URL="${IMAGE_URL:-http://172.22.0.1/images/UBUNTU_22.04_NODE_IMAGE_K8S_v1.27.4-raw.img}"
+export IMAGE_CHECKSUM="${IMAGE_CHECKSUM:-http://172.22.0.1/images/UBUNTU_22.04_NODE_IMAGE_K8S_v1.27.4-raw.img.sha256sum}"
 export IMAGE_CHECKSUM_TYPE="${IMAGE_CHECKSUM_TYPE:-sha256}"
 export IMAGE_FORMAT="${IMAGE_FORMAT:-raw}"
 
@@ -57,29 +57,29 @@ OVERWRITE=0
 
 SCRIPT=$(basename "$0")
 while test $# -gt 0; do
-        case "$1" in
-          -h|--help)
-            echo "$SCRIPT - generates input yaml files for Cluster API on metal3"
-            echo " "
-            echo "$SCRIPT [options]"
-            echo " "
-            echo "options:"
-            echo "-h, --help                show brief help"
-            echo "-f, --force-overwrite     if file to be generated already exists, force script to overwrite it"
-            exit 0
-            ;;
-          -f)
-            OVERWRITE=1
-            shift
-            ;;
-          --force-overwrite)
-            OVERWRITE=1
-            shift
-            ;;
-          *)
-            break
-            ;;
-        esac
+  case "$1" in
+  -h | --help)
+    echo "$SCRIPT - generates input yaml files for Cluster API on metal3"
+    echo " "
+    echo "$SCRIPT [options]"
+    echo " "
+    echo "options:"
+    echo "-h, --help                show brief help"
+    echo "-f, --force-overwrite     if file to be generated already exists, force script to overwrite it"
+    exit 0
+    ;;
+  -f)
+    OVERWRITE=1
+    shift
+    ;;
+  --force-overwrite)
+    OVERWRITE=1
+    shift
+    ;;
+  *)
+    break
+    ;;
+  esac
 done
 
 if [ $OVERWRITE -ne 1 ] && [ -d "$OUTPUT_DIR" ]; then
@@ -89,31 +89,29 @@ fi
 
 mkdir -p "${OUTPUT_DIR}"
 
-
 # Get enhanced envsubst version to evaluate expressions like ${VAR:=default}
 ENVSUBST="${SOURCE_DIR}/envsubst-go"
 curl --fail -Ss -L -o "${ENVSUBST}" https://github.com/a8m/envsubst/releases/download/v1.2.0/envsubst-"$(uname -s)"-"$(uname -m)"
 chmod +x "$ENVSUBST"
 
-
 # Generate cluster resources.
-"$KUSTOMIZE" build "${SOURCE_DIR}/cluster" | "$ENVSUBST" > "${CLUSTER_GENERATED_FILE}"
+"$KUSTOMIZE" build "${SOURCE_DIR}/cluster" | "$ENVSUBST" >"${CLUSTER_GENERATED_FILE}"
 echo "Generated ${CLUSTER_GENERATED_FILE}"
 
 # Generate controlplane resources.
-"$KUSTOMIZE" build "${SOURCE_DIR}/controlplane" | "$ENVSUBST" > "${CONTROLPLANE_GENERATED_FILE}"
+"$KUSTOMIZE" build "${SOURCE_DIR}/controlplane" | "$ENVSUBST" >"${CONTROLPLANE_GENERATED_FILE}"
 echo "Generated ${CONTROLPLANE_GENERATED_FILE}"
 
 # Generate metal3crds resources.
-"$KUSTOMIZE" build "${SOURCE_DIR}/metal3crds" | "$ENVSUBST" > "${METAL3CRDS_GENERATED_FILE}"
+"$KUSTOMIZE" build "${SOURCE_DIR}/metal3crds" | "$ENVSUBST" >"${METAL3CRDS_GENERATED_FILE}"
 echo "Generated ${METAL3CRDS_GENERATED_FILE}"
 
 # Generate metal3plane resources.
-"$KUSTOMIZE" build "${SOURCE_DIR}/metal3plane" | "$ENVSUBST" > "${METAL3PLANE_GENERATED_FILE}"
+"$KUSTOMIZE" build "${SOURCE_DIR}/metal3plane" | "$ENVSUBST" >"${METAL3PLANE_GENERATED_FILE}"
 echo "Generated ${METAL3PLANE_GENERATED_FILE}"
 
 # Generate machinedeployment resources.
-"$KUSTOMIZE" build "${SOURCE_DIR}/machinedeployment" | "$ENVSUBST" >> "${MACHINEDEPLOYMENT_GENERATED_FILE}"
+"$KUSTOMIZE" build "${SOURCE_DIR}/machinedeployment" | "$ENVSUBST" >>"${MACHINEDEPLOYMENT_GENERATED_FILE}"
 echo "Generated ${MACHINEDEPLOYMENT_GENERATED_FILE}"
 
 # Get Cert-manager provider components file
@@ -121,21 +119,21 @@ curl --fail -Ss -L -o "${COMPONENTS_CERT_MANAGER_GENERATED_FILE}" https://github
 echo "Downloaded ${COMPONENTS_CERT_MANAGER_GENERATED_FILE}"
 
 # Generate Cluster API provider components file.
-"$KUSTOMIZE" build "github.com/kubernetes-sigs/cluster-api/config/default/?ref=main" | "$ENVSUBST" > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
+"$KUSTOMIZE" build "github.com/kubernetes-sigs/cluster-api/config/default/?ref=main" | "$ENVSUBST" >"${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
 echo "Generated ${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
 
 # Generate Kubeadm Bootstrap Provider components file.
-"$KUSTOMIZE" build "github.com/kubernetes-sigs/cluster-api/bootstrap/kubeadm/config/default/?ref=main" | "$ENVSUBST" > "${COMPONENTS_KUBEADM_GENERATED_FILE}"
+"$KUSTOMIZE" build "github.com/kubernetes-sigs/cluster-api/bootstrap/kubeadm/config/default/?ref=main" | "$ENVSUBST" >"${COMPONENTS_KUBEADM_GENERATED_FILE}"
 echo "Generated ${COMPONENTS_KUBEADM_GENERATED_FILE}"
 
 # Generate Kubeadm Controlplane components file.
-"$KUSTOMIZE" build "github.com/kubernetes-sigs/cluster-api/controlplane/kubeadm/config/default/?ref=main" | "$ENVSUBST" > "${COMPONENTS_CTRLPLANE_GENERATED_FILE}"
+"$KUSTOMIZE" build "github.com/kubernetes-sigs/cluster-api/controlplane/kubeadm/config/default/?ref=main" | "$ENVSUBST" >"${COMPONENTS_CTRLPLANE_GENERATED_FILE}"
 echo "Generated ${COMPONENTS_CTRLPLANE_GENERATED_FILE}"
 
 # Generate METAL3 Infrastructure Provider components file.
-"$KUSTOMIZE" build "${SOURCE_DIR}/../config/default" | "$ENVSUBST" > "${COMPONENTS_METAL3_GENERATED_FILE}"
+"$KUSTOMIZE" build "${SOURCE_DIR}/../config/default" | "$ENVSUBST" >"${COMPONENTS_METAL3_GENERATED_FILE}"
 echo "Generated ${COMPONENTS_METAL3_GENERATED_FILE}"
 
 # Generate a single provider components file.
-"$KUSTOMIZE" build "${SOURCE_DIR}/provider-components" | "$ENVSUBST" > "${PROVIDER_COMPONENTS_GENERATED_FILE}"
+"$KUSTOMIZE" build "${SOURCE_DIR}/provider-components" | "$ENVSUBST" >"${PROVIDER_COMPONENTS_GENERATED_FILE}"
 echo "Generated ${PROVIDER_COMPONENTS_GENERATED_FILE}"

--- a/hack/gen_tilt_settings.sh
+++ b/hack/gen_tilt_settings.sh
@@ -17,8 +17,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-get_latest_release()
-{
+get_latest_release() {
     set +x
     if [ -z "${GITHUB_TOKEN:-}" ]; then
         release="$(curl -sL "$1")" || {
@@ -45,10 +44,10 @@ get_latest_release()
 CAPIRELEASEPATH="${CAPIRELEASEPATH:-https://api.github.com/repos/${CAPI_BASE_URL:-kubernetes-sigs/cluster-api}/releases}"
 export CAPIRELEASE="${CAPIRELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v1.3.")}"
 
-cat << EOF > tilt-settings.json
+cat <<EOF >tilt-settings.json
 {
     "capi_version": "${CAPIRELEASE}",
     "cert_manager_version": "v1.11.1",
-    "kubernetes_version": "${KUBERNETES_VERSION:-v1.27.1}"
+    "kubernetes_version": "${KUBERNETES_VERSION:-v1.27.4}"
 }
 EOF

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -93,7 +93,7 @@ v1.3*)
     ;;
 v1.4*)
     export CONTRACT_FROM="v1beta1"
-    export INIT_WITH_KUBERNETES_VERSION="v1.27.1"
+    export INIT_WITH_KUBERNETES_VERSION="v1.27.4"
     ;;
 *)
     echo "UNKNOWN CAPI_FROM_RELEASE !"

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -49,7 +49,7 @@ else
 fi
 
 export FROM_K8S_VERSION=${FROM_K8S_VERSION:-"v1.26.4"}
-export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.27.1"}
+export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.27.4"}
 
 # Can be overriden from jjbs
 export CAPI_VERSION=${CAPI_VERSION:-"v1beta1"}

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -107,7 +107,7 @@ providers:
 
 variables:
   CNI: "/tmp/calico.yaml"
-  KUBERNETES_VERSION: "v1.27.1"
+  KUBERNETES_VERSION: "v1.27.4"
   # INIT_WITH_KUBERNETES_VERSION will be used here
   # https://github.com/kubernetes-sigs/cluster-api/blob/bb377163f141d69b7a61479756ee96891f6670bd/test/e2e/clusterctl_upgrade.go#L170
   # INIT_WITH_KUBERNETES_VERSION  used by management cluster upgrade


### PR DESCRIPTION
This PR bumps the Kubernetes version in CAPM3 to v1.27.4. It aligns with the recent bump performed in the dev-env repository https://github.com/metal3-io/metal3-dev-env/pull/1263.
