### PR TITLE
 🌱 Fix pivoting feature tests in release 1.3

### DIFF
--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -48,8 +48,8 @@ else
   export EPHEMERAL_CLUSTER="minikube"
 fi
 
-export FROM_K8S_VERSION=${FROM_K8S_VERSION:-"v1.25.5"}
-export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.26.4"}
+export FROM_K8S_VERSION=${FROM_K8S_VERSION:-"v1.24.9"}
+export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.25.2"}
 
 # Can be overriden from jjbs
 export CAPI_VERSION=${CAPI_VERSION:-"v1beta1"}

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -111,7 +111,7 @@ variables:
   KUBERNETES_VERSION: "v1.25.2"
   # INIT_WITH_KUBERNETES_VERSION will be used here
   # https://github.com/kubernetes-sigs/cluster-api/blob/bb377163f141d69b7a61479756ee96891f6670bd/test/e2e/clusterctl_upgrade.go#L170
-  INIT_WITH_KUBERNETES_VERSION: "${INIT_WITH_KUBERNETES_VERSION}"
+  INIT_WITH_KUBERNETES_VERSION: "${KUBERNETES_VERSION}"
   CONTROL_PLANE_MACHINE_COUNT: 3
   WORKER_MACHINE_COUNT: 1
   APIVersion: "infrastructure.cluster.x-k8s.io/${CAPM3_VERSION}"


### PR DESCRIPTION
 fix setting INIT_WITH_KUBERNETES_VERSION (is used in clusterctl upgrade tests)
 downgrade KUBERNETES_VERSION in release 1.3