### PR TITLE
 🌱 Remove unnecessary replace blocks from go modules and update release document

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -69,7 +69,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.5.0
-
-replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.17

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -10,6 +10,7 @@ Things you should do before making a release:
 - Check the
   [Metal3 release process](https://github.com/metal3-io/metal3-docs/blob/main/processes/releasing.md)
   for high-level process and possible follow-up actions
+- Check and uplift CAPI go module if its not the latest in root, `api/` and `test/` go modules and `cluster-api/test` module in `test/` go module.
 - Uplift controller Go modules to use latest corresponding CAPI modules
 - Uplift BMO's `apis` and `pkg/hardwareutils` dependencies
 - Uplift IPAM `api` dependency,

--- a/go.mod
+++ b/go.mod
@@ -27,10 +27,6 @@ require (
 
 replace github.com/metal3-io/cluster-api-provider-metal3/api => ./api
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.5.0
-
-replace github.com/docker/distribution => github.com/docker/distribution v2.8.2+incompatible
-
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect

--- a/test/go.mod
+++ b/test/go.mod
@@ -21,10 +21,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.15.1
 )
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.5.0
-
-replace sigs.k8s.io/cluster-api/test => sigs.k8s.io/cluster-api/test v1.5.0
-
 replace github.com/metal3-io/cluster-api-provider-metal3/api => ./../api
 
 require (


### PR DESCRIPTION
This PR removes unnecessary replace blocks from go modules and updates release doc to check CAPI bumps while releasing. 