### PR TITLE
 🌱 Add dependabot groups and allow patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,12 +16,18 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ## group all dependencies with a k8s.io prefix into a single PR.
+    groups:
+      kubernetes:
+        patterns: [ "k8s.io/*" ]
     ignore:
       # Ignore controller-runtime as its upgraded manually.
       - dependency-name: "sigs.k8s.io/controller-runtime"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       # Ignore k8s and its transitives modules as they are upgraded manually
       # together with controller-runtime.
       - dependency-name: "k8s.io/*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       # ignore ipam, as it needs more than just gomod
       - dependency-name: "github.com/metal3-io/ip-address-manager/api"
     commit-message:
@@ -32,12 +38,18 @@ updates:
     directory: "/api"
     schedule:
       interval: "weekly"
+    ## group all dependencies with a k8s.io prefix into a single PR.
+    groups:
+      kubernetes:
+        patterns: [ "k8s.io/*" ]
     ignore:
       # Ignore controller-runtime as its upgraded manually.
       - dependency-name: "sigs.k8s.io/controller-runtime"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       # Ignore k8s and its transitives modules as they are upgraded manually
       # together with controller-runtime.
       - dependency-name: "k8s.io/*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       # ignore ipam, as it needs more than just gomod
       - dependency-name: "github.com/metal3-io/ip-address-manager/api"
     commit-message:
@@ -48,12 +60,18 @@ updates:
     directory: "/test"
     schedule:
       interval: "weekly"
+    ## group all dependencies with a k8s.io prefix into a single PR.
+    groups:
+      kubernetes:
+        patterns: [ "k8s.io/*" ]
     ignore:
       # Ignore controller-runtime as its upgraded manually.
       - dependency-name: "sigs.k8s.io/controller-runtime"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       # Ignore k8s and its transitives modules as they are upgraded manually
       # together with controller-runtime.
       - dependency-name: "k8s.io/*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       # ignore ipam, as it needs more than just gomod
       - dependency-name: "github.com/metal3-io/ip-address-manager/api"
     commit-message:
@@ -67,9 +85,11 @@ updates:
     ignore:
       # Ignore controller-runtime as its upgraded manually.
       - dependency-name: "sigs.k8s.io/controller-runtime"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]    
       # Ignore k8s and its transitives modules as they are upgraded manually
       # together with controller-runtime.
       - dependency-name: "sigs.k8s.io/controller-tools"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]    
     commit-message:
       prefix: ":seedling:"
     labels:


### PR DESCRIPTION
This PR allows patch updates for the ignored dependencies and group the k8s.io dependencies to reduce the number of individual PRs.