### PR TITLE
🌱 bump golang build_image to 1.20.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.20.4@sha256:3fccedea46315261e4b6205bcffe91ece1e2aea60c23aab0f033f35461849b42
+ARG BUILD_IMAGE=docker.io/golang:1.20.7@sha256:741d6f9bcab778441efe05c8e4369d4f8ff56c9a635a97d77f55d8b0ec62f907
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary on golang image


### PR DESCRIPTION
Bump BUILD_IMAGE to golang:1.20.7
