### PR TITLE
🐛  Add missing CAPI v1.5 contract in e2e config

### DIFF
--- a/test/e2e/data/shared/main/metadata.yaml
+++ b/test/e2e/data/shared/main/metadata.yaml
@@ -2,6 +2,9 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
 - major: 1
+  minor: 5
+  contract: v1beta1
+- major: 1
   minor: 4
   contract: v1beta1
 - major: 1


### PR DESCRIPTION
We have missed adding the contract
