### PR TITLE
🐛 Add CAPI contract for e2e in release-1.5

### DIFF
--- a/test/e2e/data/shared/main/metadata.yaml
+++ b/test/e2e/data/shared/main/metadata.yaml
@@ -2,6 +2,9 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
 - major: 1
+  minor: 5
+  contract: v1beta1
+- major: 1
   minor: 4
   contract: v1beta1
 - major: 1
@@ -21,4 +24,4 @@ releaseSeries:
   contract: v1alpha4
 - major: 0
   minor: 3
-  contract: v1alpha3  
+  contract: v1alpha3


### PR DESCRIPTION
From #1168.
