### PR TITLE
fix setting CAPI_CONFIG_FOLDER variable

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -15,12 +15,12 @@ export CAPM3RELEASEBRANCH="${CAPM3RELEASEBRANCH:-main}"
 # location according to CAPM3(since CAPM3 minor versions are aligned to CAPI 
 # minors versions) release branch 
 
-if [[ ${CAPM3RELEASEBRANCH} == "main" ]]; then
+if [[ ${CAPM3RELEASEBRANCH} == "release-1.3" ]]  || [[ ${CAPM3RELEASEBRANCH} == "release-1.4" ]]; then
+    export CAPI_CONFIG_FOLDER="${HOME}/.cluster-api"
+else
     # Default CAPI_CONFIG_FOLDER to $HOME/.config folder if XDG_CONFIG_HOME not set
     CONFIG_FOLDER="${XDG_CONFIG_HOME:-$HOME/.config}"
     export CAPI_CONFIG_FOLDER="${CONFIG_FOLDER}/cluster-api" 
-else
-    export CAPI_CONFIG_FOLDER="${HOME}/.cluster-api"
 fi
 
 # shellcheck source=./scripts/environment.sh


### PR DESCRIPTION
This PR fixes setting CAPI_CONFIG_FOLDER variable:
- Sets CAPI_CONFIG_FOLDER according to old branches and sets default value for new branches.  