### PR TITLE
🌱 add KUBECTL_SHA256 export for upgrade tests

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -11,16 +11,16 @@ FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-false}"
 export CAPM3RELEASEBRANCH="${CAPM3RELEASEBRANCH:-main}"
 
 # Starting from CAPI v1.5.0 version cluster-api config folder location has changed
-# to XDG_CONFIG_HOME folder. Following code defines the cluster-api config folder 
-# location according to CAPM3(since CAPM3 minor versions are aligned to CAPI 
-# minors versions) release branch 
+# to XDG_CONFIG_HOME folder. Following code defines the cluster-api config folder
+# location according to CAPM3(since CAPM3 minor versions are aligned to CAPI
+# minors versions) release branch
 
 if [[ ${CAPM3RELEASEBRANCH} == "release-1.3" ]]  || [[ ${CAPM3RELEASEBRANCH} == "release-1.4" ]]; then
     export CAPI_CONFIG_FOLDER="${HOME}/.cluster-api"
 else
     # Default CAPI_CONFIG_FOLDER to $HOME/.config folder if XDG_CONFIG_HOME not set
     CONFIG_FOLDER="${XDG_CONFIG_HOME:-$HOME/.config}"
-    export CAPI_CONFIG_FOLDER="${CONFIG_FOLDER}/cluster-api" 
+    export CAPI_CONFIG_FOLDER="${CONFIG_FOLDER}/cluster-api"
 fi
 
 # shellcheck source=./scripts/environment.sh
@@ -40,6 +40,7 @@ export CAPI_VERSION=${CAPI_VERSION:-"v1beta1"}
 export CAPM3_VERSION=${CAPM3_VERSION:-"v1beta1"}
 export NUM_NODES=${NUM_NODES:-"4"}
 export KUBERNETES_VERSION=${KUBERNETES_VERSION}
+export KUBECTL_SHA256=${KUBECTL_SHA256}
 export IMAGE_OS=${IMAGE_OS}
 export FORCE_REPO_UPDATE="false"
 EOF

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -50,6 +50,11 @@ fi
 
 export FROM_K8S_VERSION=${FROM_K8S_VERSION:-"v1.27.4"}
 export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.28.1"}
+# kubectl sha256 must match the provided KUBERNETES_VERSION, and must be
+# provided in JJB for upgrade tests where version is different from the default
+# WIP: providing incorrect sha should fail
+#export KUBECTL_SHA256="${KUBECTL_SHA256:-e7a7d6f9d06fab38b4128785aa80f65c54f6675a0d2abef655259ddd852274e1}"
+export KUBECTL_SHA256="${KUBECTL_SHA256:-this_is_expected_failure_for_testing}"
 
 # Can be overriden from jjbs
 export CAPI_VERSION=${CAPI_VERSION:-"v1beta1"}


### PR DESCRIPTION
Pass thru KUBECTL_SHA256 from JJB for upgrade e2e tests.
