### PR TITLE
:book: improve release notes tool

### DIFF
--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -42,6 +42,7 @@ const (
 	warning       = ":warning: Breaking Changes"
 	other         = ":seedling: Others"
 	unknown       = ":question: Sort these by hand"
+	superseded    = ":recycle: Superseded or Reverted"
 )
 
 var (
@@ -52,6 +53,7 @@ var (
 		documentation,
 		other,
 		unknown,
+		superseded,
 	}
 
 	fromTag = flag.String("from", "", "The tag or commit to start from.")
@@ -104,6 +106,7 @@ func run() int {
 		warning:       {},
 		other:         {},
 		unknown:       {},
+		superseded:    {},
 	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -171,6 +174,9 @@ func run() int {
 		merges[key] = append(merges[key], formatMerge(body, prNumber))
 	}
 
+	// Add empty superseded section
+	merges[superseded] = append(merges[superseded], "- `<insert superseded bumps and reverts here>`")
+
 	// TODO Turn this into a link (requires knowing the project name + organization)
 	fmt.Printf("Changes since %v\n---\n", lastTag)
 
@@ -186,9 +192,9 @@ func run() int {
 	}
 
 	fmt.Printf("The image for this release is: %v\n", latestTag)
-	fmt.Printf("Ironic release is capm3-%v\n", latestTag)
-	fmt.Printf("Mariadb release is capm3-%v\n", latestTag)
-	fmt.Println("_Thanks to all our contributors!_ 😊")
+	fmt.Printf("Ironic image tag is capm3-%v\n", latestTag)
+	fmt.Printf("Mariadb image tag is capm3-%\nv", latestTag)
+	fmt.Println("\n_Thanks to all our contributors!_ 😊")
 
 	return 0
 }


### PR DESCRIPTION
Improve release notes generation by adding empty section for superseded or reverted PRs, adding empty line between image tags and thanking our contributors, as well as changing wording on the mariadb-image and ironic-image tags.
