### PR TITLE
🌱 Fix v1.5 clusterctl upgrade tests

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -111,6 +111,10 @@ v1.4*)
     export CONTRACT_FROM="v1beta1"
     export INIT_WITH_KUBERNETES_VERSION="v1.28.1"
     ;;
+v1.5*)
+    export CONTRACT_FROM="v1beta1"
+    export INIT_WITH_KUBERNETES_VERSION="v1.28.1"
+    ;;
 *)
     echo "UNKNOWN CAPI_FROM_RELEASE !"
     exit 1


### PR DESCRIPTION
This PR adds v1.5 case to CAPI_FROM_RELEASE variable for clusterctl upgrade test 
