### PR TITLE
🌱 bump gosec to 2.17.0, and fix gosec for submodules

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -48,9 +48,7 @@ linters-settings:
     go: "1.20"
     severity: medium
     confidence: medium
-    excludes:
-      - G107
-      - G306
+    concurrency: 8
   importas:
     no-unaliased: true
     alias:
@@ -123,7 +121,7 @@ issues:
     - path: _test\.go
       linters:
         - unused
-    # Specific exclude rules for deprecated fields that are still part of the codebase. 
+    # Specific exclude rules for deprecated fields that are still part of the codebase.
     # These should be removed as the referenced deprecated item is removed from the project.
     - linters:
         - staticcheck

--- a/hack/gosec.sh
+++ b/hack/gosec.sh
@@ -4,16 +4,23 @@ set -eux
 
 IS_CONTAINER="${IS_CONTAINER:-false}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+GO_CONCURRENCY="${GO_CONCURRENCY:-8}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
     export XDG_CACHE_HOME="/tmp/.cache"
-    gosec -exclude=G107 -severity medium -confidence medium -concurrency 8 -quiet ./...
+    # It seems like gosec does not handle submodules well. Therefore we skip them and run separately.
+    gosec -severity medium --confidence medium -quiet \
+        -concurrency "${GO_CONCURRENCY}" -exclude-dir=api -exclude-dir=test ./...
+    (cd api && gosec -severity medium --confidence medium -quiet \
+        -concurrency "${GO_CONCURRENCY}" ./...)
+    (cd test && gosec -severity medium --confidence medium -quiet \
+        -concurrency "${GO_CONCURRENCY}" ./...)
 else
     "${CONTAINER_RUNTIME}" run --rm \
         --env IS_CONTAINER=TRUE \
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/securego/gosec:2.14.0@sha256:73858f8b1b9b7372917677151ec6deeceeaa40c5b02753080bd647dede14e213 \
+        docker.io/securego/gosec:2.17.0@sha256:4ea9b6053eac43abda841af5885bbd31ee1bf7289675545b8858bcedb40b4fa8 \
         /workdir/hack/gosec.sh
 fi

--- a/test/e2e/pivoting.go
+++ b/test/e2e/pivoting.go
@@ -406,9 +406,9 @@ func labelBMOCRDs(targetCluster framework.ClusterProxy) {
 	for _, label := range labels {
 		var cmd *exec.Cmd
 		if kubectlArgs == "" {
-			cmd = exec.Command("kubectl", "label", "--overwrite", "crds", crdName, label) // #nosec G204:gosec
+			cmd = exec.Command("kubectl", "label", "--overwrite", "crds", crdName, label) //#nosec G204:gosec
 		} else {
-			cmd = exec.Command("kubectl", kubectlArgs, "label", "--overwrite", "crds", crdName, label) // #nosec G204:gosec
+			cmd = exec.Command("kubectl", kubectlArgs, "label", "--overwrite", "crds", crdName, label) //#nosec G204:gosec
 		}
 		err := cmd.Run()
 		Expect(err).To(BeNil(), "Cannot label BMO CRDs")
@@ -509,7 +509,8 @@ func rePivoting(ctx context.Context, inputGetter func() RePivotingInput) {
 	if ephemeralCluster == Kind {
 		bmoPath := input.E2EConfig.GetVariable("BMOPATH")
 		ironicCommand := bmoPath + "/tools/run_local_ironic.sh"
-		cmd := exec.Command("sh", "-c", "export CONTAINER_RUNTIME=docker; "+ironicCommand) // #nosec G204:gosec
+		//#nosec G204:gosec
+		cmd := exec.Command("sh", "-c", "export CONTAINER_RUNTIME=docker; "+ironicCommand)
 		stdoutStderr, err := cmd.CombinedOutput()
 		fmt.Printf("%s\n", stdoutStderr)
 		Expect(err).To(BeNil(), "Cannot run local ironic")
@@ -621,11 +622,11 @@ func fetchContainerLogs(containerNames *[]string, folder string, containerComman
 		cmd := exec.Command("sudo", containerCommand, "logs", name) // #nosec G204:gosec
 		out, err := cmd.Output()
 		if err != nil {
-			writeErr := os.WriteFile(filepath.Join(logDir, "stderr.log"), []byte(err.Error()), 0444)
+			writeErr := os.WriteFile(filepath.Join(logDir, "stderr.log"), []byte(err.Error()), 0400)
 			Expect(writeErr).ToNot(HaveOccurred())
 			log.Fatal(err)
 		}
-		writeErr := os.WriteFile(filepath.Join(logDir, "stdout.log"), out, 0444)
+		writeErr := os.WriteFile(filepath.Join(logDir, "stdout.log"), out, 0400)
 		Expect(writeErr).ToNot(HaveOccurred())
 	}
 }

--- a/test/e2e/upgrade_clusterctl_test.go
+++ b/test/e2e/upgrade_clusterctl_test.go
@@ -331,7 +331,7 @@ func preCleanupManagementCluster(clusterProxy framework.ClusterProxy) {
 	// Fetch logs from management cluster
 	By("Fetch logs from management cluster")
 	path := filepath.Join(os.Getenv("CAPM3PATH"), "scripts")
-	cmd := exec.Command("./fetch_target_logs.sh") // #nosec G204:gosec
+	cmd := exec.Command("./fetch_target_logs.sh") //#nosec G204:gosec
 	cmd.Dir = path
 	errorPipe, _ := cmd.StderrPipe()
 	_ = cmd.Start()


### PR DESCRIPTION
Gosec does not handle submodules well. Ignore them and run them separately so they run against correct dependencies.

Bump gosec to 2.17.0, and fix new errors it has discovered.
Remove G107 exclude, it is no longer present.

NOTE: In CI, the gosec image is coming via project-infra, gosec image change is only affecting local runs for now.
