### PR TITLE
:bug:  fix too tight file permissions in e2e

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -162,7 +162,7 @@ func EnsureImage(k8sVersion string) (imageURL string, imageChecksum string) {
 		sha256sum, err := getSha256Hash(rawImagePath)
 		Expect(err).To(BeNil())
 		formattedSha256sum := fmt.Sprintf("%x", sha256sum)
-		err = os.WriteFile(fmt.Sprintf("%s/%s.sha256sum", ironicImageDir, rawImageName), []byte(formattedSha256sum), 0600)
+		err = os.WriteFile(fmt.Sprintf("%s/%s.sha256sum", ironicImageDir, rawImageName), []byte(formattedSha256sum), 0544) //#nosec G306:gosec
 		Expect(err).To(BeNil())
 		Logf("Image: %v downloaded", rawImagePath)
 	} else {


### PR DESCRIPTION
A different user is generating sha256sum for the images than is reading them back in. Change back to 544 as it was before #1213.

