### PR TITLE
🌱 Bumping CAPI to 1.4.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.19.9@sha256:86af5649fa1d9265d3fe7caf633231340b93e4164b96e14bc4e1131a191c1ddd
+ARG BUILD_IMAGE=docker.io/golang:1.20.8@sha256:6b29720c5598cb40b23dd38f522050a698d427c3a5696c5efe1ed22bd45b1396
 ARG BASE_IMAGE=gcr.io/distroless/static@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f  # nonroot
 
 # Build the manager binary on golang image

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ provider:
   when running the clusterctl and set the level of the logging verbose with a positive integer number, ie. -v5.
 
     ```shell
-    clusterctl init --core cluster-api:v1.4.6 --bootstrap kubeadm:v1.4.6 \
-        --control-plane kubeadm:v1.4.6 -v5
+    clusterctl init --core cluster-api:v1.4.7 --bootstrap kubeadm:v1.4.7 \
+        --control-plane kubeadm:v1.4.7 -v5
     ```
 
 1. Install Metal3 provider. This will install the latest version of Cluster API Provider Metal3 CRDs and controllers.

--- a/Tiltfile
+++ b/Tiltfile
@@ -15,7 +15,7 @@ settings = {
     "kind_cluster_name": "capm3",
     "capi_version": "$CAPIRELEASE",
     "kubernetes_version": "$KUBERNETES_VERSION",
-    "cert_manager_version": "v1.12.3",
+    "cert_manager_version": "v1.13.0",
     "enable_providers": [],
 }
 
@@ -129,7 +129,7 @@ def fixup_yaml_empty_arrays(yaml_str):
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.19 as tilt-helper
+FROM golang:1.20 as tilt-helper
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \

--- a/api/go.mod
+++ b/api/go.mod
@@ -12,7 +12,7 @@ require (
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
-	sigs.k8s.io/cluster-api v1.4.6
+	sigs.k8s.io/cluster-api v1.4.7
 	sigs.k8s.io/controller-runtime v0.14.5
 
 )
@@ -69,6 +69,6 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.4.6
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.4.7
 
 replace github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.17

--- a/api/go.sum
+++ b/api/go.sum
@@ -634,8 +634,8 @@ k8s.io/utils v0.0.0-20221128185143-99ec85e7a448/go.mod h1:OLgZIPagt7ERELqWJFomSt
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/cluster-api v1.4.6 h1:ZOAtQsPW7zh2iY7RdvvUozPR7OYRDCPSFEBS0979Vys=
-sigs.k8s.io/cluster-api v1.4.6/go.mod h1:B+QIe/B4Yp+NqMSd6f36Oh+7pIgalsClAX976rIn9J0=
+sigs.k8s.io/cluster-api v1.4.7 h1:24UFXLDy6eiL37wquWSofKJAmFP691PLKBIA9VSUX2A=
+sigs.k8s.io/cluster-api v1.4.7/go.mod h1:B+QIe/B4Yp+NqMSd6f36Oh+7pIgalsClAX976rIn9J0=
 sigs.k8s.io/controller-runtime v0.14.5 h1:6xaWFqzT5KuAQ9ufgUaj1G/+C4Y1GRkhrxl+BJ9i+5s=
 sigs.k8s.io/controller-runtime v0.14.5/go.mod h1:WqIdsAY6JBsjfc/CqO0CORmNtoCtE4S6qbPc9s68h+0=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -117,7 +117,7 @@ echo "Generated ${METAL3PLANE_GENERATED_FILE}"
 echo "Generated ${MACHINEDEPLOYMENT_GENERATED_FILE}"
 
 # Get Cert-manager provider components file
-curl --fail -Ss -L -o "${COMPONENTS_CERT_MANAGER_GENERATED_FILE}" https://github.com/cert-manager/cert-manager/releases/download/v1.12.3/cert-manager.yaml
+curl --fail -Ss -L -o "${COMPONENTS_CERT_MANAGER_GENERATED_FILE}" https://github.com/cert-manager/cert-manager/releases/download/v1.13.0/cert-manager.yaml
 echo "Downloaded ${COMPONENTS_CERT_MANAGER_GENERATED_FILE}"
 
 # Generate Cluster API provider components file.

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	k8s.io/component-base v0.26.1
 	k8s.io/klog/v2 v2.80.1
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
-	sigs.k8s.io/cluster-api v1.4.6
+	sigs.k8s.io/cluster-api v1.4.7
 	sigs.k8s.io/controller-runtime v0.14.5
 	sigs.k8s.io/yaml v1.3.0
 )

--- a/hack/gen_tilt_settings.sh
+++ b/hack/gen_tilt_settings.sh
@@ -48,7 +48,7 @@ export CAPIRELEASE="${CAPIRELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "v1
 cat << EOF > tilt-settings.json
 {
     "capi_version": "${CAPIRELEASE}",
-    "cert_manager_version": "v1.12.3",
+    "cert_manager_version": "v1.13.0",
     "kubernetes_version": "${KUBERNETES_VERSION:-v1.26.4}"
 }
 EOF

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -135,7 +135,7 @@ variables:
   # Pin Calico version
   CALICO_PATCH_RELEASE: "v3.24.1"
   # Pin CertManager for upgrade tests
-  CERT_MANAGER_RELEASE: v1.12.3
+  CERT_MANAGER_RELEASE: v1.13.0
   # Default vars for the template, those values could be overridden by the env-vars.
   CAPI_VERSION: "v1beta1"
   CAPM3_VERSION: "v1beta1"

--- a/test/go.mod
+++ b/test/go.mod
@@ -14,14 +14,14 @@ require (
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
-	sigs.k8s.io/cluster-api v1.4.6
+	sigs.k8s.io/cluster-api v1.4.7
 	sigs.k8s.io/cluster-api/test v1.4.6
 	sigs.k8s.io/controller-runtime v0.14.5
 )
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.4.6
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.4.7
 
-replace sigs.k8s.io/cluster-api/test => sigs.k8s.io/cluster-api/test v1.4.6
+replace sigs.k8s.io/cluster-api/test => sigs.k8s.io/cluster-api/test v1.4.7
 
 replace github.com/metal3-io/cluster-api-provider-metal3/api => ./../api
 

--- a/test/go.sum
+++ b/test/go.sum
@@ -939,10 +939,10 @@ k8s.io/utils v0.0.0-20221128185143-99ec85e7a448/go.mod h1:OLgZIPagt7ERELqWJFomSt
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/cluster-api v1.4.6 h1:ZOAtQsPW7zh2iY7RdvvUozPR7OYRDCPSFEBS0979Vys=
-sigs.k8s.io/cluster-api v1.4.6/go.mod h1:B+QIe/B4Yp+NqMSd6f36Oh+7pIgalsClAX976rIn9J0=
-sigs.k8s.io/cluster-api/test v1.4.6 h1:a+sVWioQfir1Bw7fQJbd162RFjgiWX2078Yh3fEm4qw=
-sigs.k8s.io/cluster-api/test v1.4.6/go.mod h1:SBKZ9SR50acvjQyE/d+tVB88jky7mbVDZ4UURdEkNjk=
+sigs.k8s.io/cluster-api v1.4.7 h1:24UFXLDy6eiL37wquWSofKJAmFP691PLKBIA9VSUX2A=
+sigs.k8s.io/cluster-api v1.4.7/go.mod h1:B+QIe/B4Yp+NqMSd6f36Oh+7pIgalsClAX976rIn9J0=
+sigs.k8s.io/cluster-api/test v1.4.7 h1:/RsOGIa17S0Fox3DpgbCvKxMEHLNGjuo6/wF0k6lsqM=
+sigs.k8s.io/cluster-api/test v1.4.7/go.mod h1:SBKZ9SR50acvjQyE/d+tVB88jky7mbVDZ4UURdEkNjk=
 sigs.k8s.io/controller-runtime v0.14.5 h1:6xaWFqzT5KuAQ9ufgUaj1G/+C4Y1GRkhrxl+BJ9i+5s=
 sigs.k8s.io/controller-runtime v0.14.5/go.mod h1:WqIdsAY6JBsjfc/CqO0CORmNtoCtE4S6qbPc9s68h+0=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

- Bump CAPI to v1.4.7
- Bump Cert-manager to v1.13.0
- Bump GO to 1.20.8

