### PR TITLE
:book: clarify tag usage in releasing.md

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -85,12 +85,13 @@ We also need to create one or more tags for the Go modules ecosystem:
 
 - For any subdirectory with `go.mod` in it (excluding `hack/tools`), create
   another Git tag with directory prefix, ie.
-  `git tag -s api/v1.x.y`.
-  For CAPM3, these directories are: `api` and `test`. This enables the
+  `git tag api/v1.x.y` and `git tag test/v1.x.y`. This enables the
   tags to be used as a Go module version for any downstream users.
-  **NOTE**: Do not create annotated tags (`-a` or `-m`) for Go modules. Release
-  notes expects only the main tag to be annotated, otherwise it might create
-  incorrect release notes.
+
+  **NOTE**: Do not create annotated tags (`-a`, or implicitly via `-m` or `-s`)
+  for Go modules. Release notes expects only the main tag to be annotated,
+  otherwise it might create incorrect release notes.
+  Push both of the tags to `origin`.
 
 ### Release artifacts
 


### PR DESCRIPTION
Clarify module tagging instructions one more time. Signing is also creating annotated tags. Also add reminder to push the tags too.
