### PR TITLE
🌱 Bump capi/test module to v1.4.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,10 +27,6 @@ require (
 
 replace github.com/metal3-io/cluster-api-provider-metal3/api => ./api
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.4.6
-
-replace github.com/docker/distribution => github.com/docker/distribution v2.8.2+incompatible
-
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -808,8 +808,8 @@ k8s.io/utils v0.0.0-20221128185143-99ec85e7a448/go.mod h1:OLgZIPagt7ERELqWJFomSt
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/cluster-api v1.4.6 h1:ZOAtQsPW7zh2iY7RdvvUozPR7OYRDCPSFEBS0979Vys=
-sigs.k8s.io/cluster-api v1.4.6/go.mod h1:B+QIe/B4Yp+NqMSd6f36Oh+7pIgalsClAX976rIn9J0=
+sigs.k8s.io/cluster-api v1.4.7 h1:24UFXLDy6eiL37wquWSofKJAmFP691PLKBIA9VSUX2A=
+sigs.k8s.io/cluster-api v1.4.7/go.mod h1:B+QIe/B4Yp+NqMSd6f36Oh+7pIgalsClAX976rIn9J0=
 sigs.k8s.io/controller-runtime v0.14.5 h1:6xaWFqzT5KuAQ9ufgUaj1G/+C4Y1GRkhrxl+BJ9i+5s=
 sigs.k8s.io/controller-runtime v0.14.5/go.mod h1:WqIdsAY6JBsjfc/CqO0CORmNtoCtE4S6qbPc9s68h+0=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=

--- a/test/go.mod
+++ b/test/go.mod
@@ -15,13 +15,9 @@ require (
 	k8s.io/client-go v0.26.1
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/cluster-api v1.4.7
-	sigs.k8s.io/cluster-api/test v1.4.6
+	sigs.k8s.io/cluster-api/test v1.4.7
 	sigs.k8s.io/controller-runtime v0.14.5
 )
-
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.4.7
-
-replace sigs.k8s.io/cluster-api/test => sigs.k8s.io/cluster-api/test v1.4.7
 
 replace github.com/metal3-io/cluster-api-provider-metal3/api => ./../api
 


### PR DESCRIPTION
Also removes the unnecessary replaces which also was also wrongly pointing to v1.4.6
