### PR TITLE
🌱 bump IPAM to 1.5.1

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/google/gofuzz v1.2.0
-	github.com/metal3-io/ip-address-manager/api v1.5.0
+	github.com/metal3-io/ip-address-manager/api v1.5.1
 	github.com/onsi/gomega v1.28.0
 	github.com/pkg/errors v0.9.1
 	golang.org/x/net v0.15.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -111,8 +111,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/metal3-io/ip-address-manager/api v1.5.0 h1:bEellJd9Xh7xBaPptjQOUsge+KdW8Y4YRUS3EfTfEcI=
-github.com/metal3-io/ip-address-manager/api v1.5.0/go.mod h1:YurMpoFyB1ov6SN8ElELmvPpTNdKlZsPZ6p0/VfUWkM=
+github.com/metal3-io/ip-address-manager/api v1.5.1 h1:uQXvLLFjyn24ptYNYyPDUv3tw9pyCkxyaAemcEviE3I=
+github.com/metal3-io/ip-address-manager/api v1.5.1/go.mod h1:YurMpoFyB1ov6SN8ElELmvPpTNdKlZsPZ6p0/VfUWkM=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/config/ipam/image_patch.yaml
+++ b/config/ipam/image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: quay.io/metal3-io/ip-address-manager:v1.5.0
+      - image: quay.io/metal3-io/ip-address-manager:v1.5.1
         name: manager

--- a/config/ipam/kustomization.yaml
+++ b/config/ipam/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 # When updating the release, update also the image tag in image_patch.yaml
 resources:
-- https://github.com/metal3-io/ip-address-manager/releases/download/v1.5.0/ipam-components.yaml
+- https://github.com/metal3-io/ip-address-manager/releases/download/v1.5.1/ipam-components.yaml
 
 patchesStrategicMerge:
     - image_patch.yaml

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/metal3-io/baremetal-operator/apis v0.4.0
 	github.com/metal3-io/cluster-api-provider-metal3/api v0.0.0
-	github.com/metal3-io/ip-address-manager/api v1.5.0
+	github.com/metal3-io/ip-address-manager/api v1.5.1
 	github.com/onsi/ginkgo/v2 v2.12.1
 	github.com/onsi/gomega v1.28.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/metal3-io/baremetal-operator/apis v0.4.0 h1:1g5S3SKu9FqeD7OIf5jGKS623
 github.com/metal3-io/baremetal-operator/apis v0.4.0/go.mod h1:1GDBiA3XqdP63dLZHJ1JH5fRJrfjn7pshoPEd9jwY7Q=
 github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.4.0 h1:AnA8XLLp3RKYjjlB4KI0fyPSDN/d5gb3ZtM2cVyxwOc=
 github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.4.0/go.mod h1:399nvdaqoU9rTI25UdFw2EWcVjmJPpeZPIhfDAIx/XU=
-github.com/metal3-io/ip-address-manager/api v1.5.0 h1:bEellJd9Xh7xBaPptjQOUsge+KdW8Y4YRUS3EfTfEcI=
-github.com/metal3-io/ip-address-manager/api v1.5.0/go.mod h1:YurMpoFyB1ov6SN8ElELmvPpTNdKlZsPZ6p0/VfUWkM=
+github.com/metal3-io/ip-address-manager/api v1.5.1 h1:uQXvLLFjyn24ptYNYyPDUv3tw9pyCkxyaAemcEviE3I=
+github.com/metal3-io/ip-address-manager/api v1.5.1/go.mod h1:YurMpoFyB1ov6SN8ElELmvPpTNdKlZsPZ6p0/VfUWkM=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=

--- a/test/go.mod
+++ b/test/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/jinzhu/copier v0.4.0
 	github.com/metal3-io/baremetal-operator/apis v0.4.0
 	github.com/metal3-io/cluster-api-provider-metal3/api v0.0.0
-	github.com/metal3-io/ip-address-manager/api v1.5.0
+	github.com/metal3-io/ip-address-manager/api v1.5.1
 	github.com/onsi/ginkgo/v2 v2.12.1
 	github.com/onsi/gomega v1.28.0
 	golang.org/x/crypto v0.13.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -331,8 +331,8 @@ github.com/metal3-io/baremetal-operator/apis v0.4.0 h1:1g5S3SKu9FqeD7OIf5jGKS623
 github.com/metal3-io/baremetal-operator/apis v0.4.0/go.mod h1:1GDBiA3XqdP63dLZHJ1JH5fRJrfjn7pshoPEd9jwY7Q=
 github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.4.0 h1:AnA8XLLp3RKYjjlB4KI0fyPSDN/d5gb3ZtM2cVyxwOc=
 github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.4.0/go.mod h1:399nvdaqoU9rTI25UdFw2EWcVjmJPpeZPIhfDAIx/XU=
-github.com/metal3-io/ip-address-manager/api v1.5.0 h1:bEellJd9Xh7xBaPptjQOUsge+KdW8Y4YRUS3EfTfEcI=
-github.com/metal3-io/ip-address-manager/api v1.5.0/go.mod h1:YurMpoFyB1ov6SN8ElELmvPpTNdKlZsPZ6p0/VfUWkM=
+github.com/metal3-io/ip-address-manager/api v1.5.1 h1:uQXvLLFjyn24ptYNYyPDUv3tw9pyCkxyaAemcEviE3I=
+github.com/metal3-io/ip-address-manager/api v1.5.1/go.mod h1:YurMpoFyB1ov6SN8ElELmvPpTNdKlZsPZ6p0/VfUWkM=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=


### PR DESCRIPTION
Bump IPAM to latest release on main branch as well.

It was bumped in release-1.5 in #1230 