### PR TITLE
🐛 Fix IP-reuse deletion bug

### DIFF
--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -1440,6 +1440,7 @@ func fetchM3IPClaim(ctx context.Context, cl client.Client, mLog logr.Logger,
 func (m *DataManager) fetchIPClaimsWithLabels(ctx context.Context, pool string) ([]ipamv1.IPClaim, error) {
 	allIPClaims := ipamv1.IPClaimList{}
 	opts := []client.ListOption{
+		&client.ListOptions{Namespace: m.Data.Namespace},
 		client.MatchingLabels{
 			DataLabelName: m.Data.Name,
 			PoolLabelName: pool,


### PR DESCRIPTION
**What this PR does / why we need it**:

This limits the listing of IPClaims to the namespace of the Metal3Data. Without this limit, CAPM3 could delete IPClaims in other namespaces, provided that they have the same labels. The labels are based on the name of the IPPool and Metal3Data(Template), which can be the same in other namespaces.
This also adds a few unit tests that check specifically the behavior when deleting IPClaims when there are multiple, in multiple namespaces. One of these tests trigger the bug described in #1250.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1250
