### PR TITLE
🐛 IP reuse: Fix M3d/IPClaim deletion bug

### DIFF
--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -1433,6 +1433,7 @@ func fetchM3IPClaim(ctx context.Context, cl client.Client, mLog logr.Logger,
 func (m *DataManager) fetchIPClaimsWithLabels(ctx context.Context, pool string) ([]ipamv1.IPClaim, error) {
 	allIPClaims := ipamv1.IPClaimList{}
 	opts := []client.ListOption{
+		&client.ListOptions{Namespace: m.Data.Namespace},
 		client.MatchingLabels{
 			DataLabelName: m.Data.Name,
 			PoolLabelName: pool,

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -1546,6 +1546,169 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 	)
 
+	type testCaseMultiReleaseAddressFromM3Pool struct {
+		m3d      *infrav1.Metal3Data
+		poolRef  corev1.TypedLocalObjectReference
+		ipClaims []ipamv1.IPClaim
+	}
+
+	DescribeTable("Test releaseAddressFromM3Pool with multiple namespaces",
+		func(tc testCaseMultiReleaseAddressFromM3Pool) {
+			objects := []client.Object{}
+			for i := range tc.ipClaims {
+				// To make the test entries a bit smaller, we add the
+				// .spec.pool here based on the labels.
+				tc.ipClaims[i].Spec.Pool.Name = tc.ipClaims[i].Labels[PoolLabelName]
+				objects = append(objects, &tc.ipClaims[i])
+			}
+			fake := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			dataMgr, err := NewDataManager(fake, tc.m3d,
+				logr.Discard(),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			err = dataMgr.releaseAddressFromM3Pool(
+				context.TODO(), tc.poolRef,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			for i := range tc.ipClaims {
+				capm3IPClaim := &ipamv1.IPClaim{}
+				claimNamespacedName := types.NamespacedName{
+					Name:      tc.ipClaims[i].Name,
+					Namespace: tc.ipClaims[i].Namespace,
+				}
+
+				err = dataMgr.client.Get(context.TODO(), claimNamespacedName, capm3IPClaim)
+				if tc.ipClaims[i].Namespace != dataMgr.Data.Namespace {
+					// We should not touch other namespaces!
+					Expect(err).To(BeNil())
+				} else if tc.ipClaims[i].Spec.Pool.Name != tc.poolRef.Name {
+					// We should not touch other pools!
+					Expect(err).To(BeNil())
+				} else {
+					Expect(err).To(HaveOccurred())
+					Expect(apierrors.IsNotFound(err)).To(BeTrue())
+				}
+			}
+		},
+		Entry("Singe IPClaim deleted", testCaseMultiReleaseAddressFromM3Pool{
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Metal3Data",
+					APIVersion: infrav1.GroupVersion.String(),
+				},
+			},
+			poolRef: corev1.TypedLocalObjectReference{Name: testPoolName},
+			ipClaims: []ipamv1.IPClaim{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "host-0-" + testPoolName,
+					Namespace: namespaceName,
+					Labels: map[string]string{
+						DataLabelName: metal3DataName,
+						PoolLabelName: testPoolName,
+					},
+				},
+			}},
+		}),
+		Entry("Multiple IPClaims related to the same M3D", testCaseMultiReleaseAddressFromM3Pool{
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Metal3Data",
+					APIVersion: infrav1.GroupVersion.String(),
+				},
+			},
+			poolRef: corev1.TypedLocalObjectReference{Name: "first-pool"},
+			ipClaims: []ipamv1.IPClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "host-0-" + "first-pool",
+						Namespace: namespaceName,
+						Labels: map[string]string{
+							DataLabelName: metal3DataName,
+							PoolLabelName: "first-pool",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "host-0-" + "second-pool",
+						Namespace: namespaceName,
+						Labels: map[string]string{
+							DataLabelName: metal3DataName,
+							PoolLabelName: "second-pool",
+						},
+					},
+				},
+			},
+		}),
+		Entry("Multiple IPClaims in different namespaces exists with different labels", testCaseMultiReleaseAddressFromM3Pool{
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Metal3Data",
+					APIVersion: infrav1.GroupVersion.String(),
+				},
+			},
+			poolRef: corev1.TypedLocalObjectReference{Name: testPoolName},
+			ipClaims: []ipamv1.IPClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "host-0-" + testPoolName,
+						Namespace: namespaceName,
+						Labels: map[string]string{
+							DataLabelName: metal3DataName,
+							PoolLabelName: testPoolName,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "host-1-" + testPoolName,
+						Namespace: "other-namespace",
+						Labels: map[string]string{
+							DataLabelName: "different-dataname",
+							PoolLabelName: testPoolName,
+						},
+					},
+				},
+			},
+		}),
+		Entry("Multiple IPClaims in different namespaces exists with same labels", testCaseMultiReleaseAddressFromM3Pool{
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Metal3Data",
+					APIVersion: infrav1.GroupVersion.String(),
+				},
+			},
+			poolRef: corev1.TypedLocalObjectReference{Name: testPoolName},
+			ipClaims: []ipamv1.IPClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "host-0-" + testPoolName,
+						Namespace: namespaceName,
+						Labels: map[string]string{
+							DataLabelName: metal3DataName,
+							PoolLabelName: testPoolName,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "host-1-" + testPoolName,
+						Namespace: "other-namespace",
+						Labels: map[string]string{
+							DataLabelName: metal3DataName,
+							PoolLabelName: testPoolName,
+						},
+					},
+				},
+			},
+		}),
+	)
+
 	type testCaseEnsureClaim struct {
 		poolRef          corev1.TypedLocalObjectReference
 		ipClaim          *caipamv1.IPAddressClaim


### PR DESCRIPTION
Manual cherry-pick of #1251

**What this PR does / why we need it**:

When listing the IPClaims, we currently only select by labels, so there is no limit on what namespace the IPClaim belongs to. The labels are based on the name of the IPPool and the name of the Metal3Data. Within the same namespace these will be unique, but not necessarily cluster wide.

This commit limits the list of IPClaims to the same namespace as the Metal3Data. It also adds a few unit tests to check the behavior when we have multiple IPClaims, potentially in separate namespaces and with identical labels.

