### PR TITLE
🌱 Delete "ok-to-test" label from dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: ":seedling:"
-    labels:
-      - "ok-to-test"
     # Go
   - package-ecosystem: "gomod"
     directory: "/"
@@ -32,8 +30,6 @@ updates:
       - dependency-name: "github.com/metal3-io/ip-address-manager/api"
     commit-message:
       prefix: ":seedling:"
-    labels:
-      - "ok-to-test"
   - package-ecosystem: "gomod"
     directory: "/api"
     schedule:
@@ -54,8 +50,6 @@ updates:
       - dependency-name: "github.com/metal3-io/ip-address-manager/api"
     commit-message:
       prefix: ":seedling:"
-    labels:
-      - "ok-to-test"
   - package-ecosystem: "gomod"
     directory: "/test"
     schedule:
@@ -76,8 +70,6 @@ updates:
       - dependency-name: "github.com/metal3-io/ip-address-manager/api"
     commit-message:
       prefix: ":seedling:"
-    labels:
-      - "ok-to-test"
   - package-ecosystem: "gomod"
     directory: "/hack/tools"
     schedule:
@@ -92,5 +84,3 @@ updates:
         update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
     commit-message:
       prefix: ":seedling:"
-    labels:
-      - "ok-to-test"


### PR DESCRIPTION
Dependabot recently is creating quite a few unnecessary PRs which need to be closed manually, having ok-to-test creates a lot of unneeded tests. Removing the label would allow adding labels selectively by reviewers and save some test bandwidth
