### PR TITLE
🐛  Use pflag instead of go flag for TLSMinVersion

### DIFF
--- a/main.go
+++ b/main.go
@@ -296,7 +296,7 @@ func initFlags(fs *pflag.FlagSet) {
 
 	fs.IntVar(&restConfigBurst, "kube-api-burst", 30,
 		"Maximum number of queries that should be allowed in one burst from the controller client to the Kubernetes API server. Default 30")
-	flag.StringVar(&tlsOptions.TLSMinVersion, "tls-min-version", TLSVersion12,
+	fs.StringVar(&tlsOptions.TLSMinVersion, "tls-min-version", TLSVersion12,
 		"The minimum TLS version in use by the webhook server.\n"+
 			fmt.Sprintf("Possible values are %s.", strings.Join(tlsSupportedVersions, ", ")),
 	)


### PR DESCRIPTION
Rest of the flags in main.go are pflag, perhaps this was a typo/mistake to declare this as a go flag. 
