### PR TITLE
🌱  Use k8s apimachinery scheme builder instead of controller-runtime scheme builder

### DIFF
--- a/api/v1beta1/groupversion_info.go
+++ b/api/v1beta1/groupversion_info.go
@@ -23,23 +23,29 @@ limitations under the License.
 package v1beta1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
 	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	/// schemeBuilder is used to add go types to the GroupVersionKind scheme.
+	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
-	AddToScheme = SchemeBuilder.AddToScheme
+	AddToScheme = schemeBuilder.AddToScheme
 
-	// localSchemeBuilder is for automatically generated conversions
-	// localSchemeBuilder = SchemeBuilder.SchemeBuilder.
+	objectTypes = []runtime.Object{}
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion, objectTypes...)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}
 
 // Resource is required by pkg/client/listers/...
 // func Resource(resource string) schema.GroupResource {

--- a/api/v1beta1/metal3cluster_types.go
+++ b/api/v1beta1/metal3cluster_types.go
@@ -130,5 +130,5 @@ func (c *Metal3Cluster) SetConditions(conditions clusterv1.Conditions) {
 }
 
 func init() {
-	SchemeBuilder.Register(&Metal3Cluster{}, &Metal3ClusterList{})
+	objectTypes = append(objectTypes, &Metal3Cluster{}, &Metal3ClusterList{})
 }

--- a/api/v1beta1/metal3data_types.go
+++ b/api/v1beta1/metal3data_types.go
@@ -94,5 +94,5 @@ type Metal3DataList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&Metal3Data{}, &Metal3DataList{})
+	objectTypes = append(objectTypes, &Metal3Data{}, &Metal3DataList{})
 }

--- a/api/v1beta1/metal3dataclaim_types.go
+++ b/api/v1beta1/metal3dataclaim_types.go
@@ -73,5 +73,5 @@ type Metal3DataClaimList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&Metal3DataClaim{}, &Metal3DataClaimList{})
+	objectTypes = append(objectTypes, &Metal3DataClaim{}, &Metal3DataClaimList{})
 }

--- a/api/v1beta1/metal3datatemplate_types.go
+++ b/api/v1beta1/metal3datatemplate_types.go
@@ -576,5 +576,5 @@ type Metal3DataTemplateList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&Metal3DataTemplate{}, &Metal3DataTemplateList{})
+	objectTypes = append(objectTypes, &Metal3DataTemplate{}, &Metal3DataTemplateList{})
 }

--- a/api/v1beta1/metal3machine_types.go
+++ b/api/v1beta1/metal3machine_types.go
@@ -209,5 +209,5 @@ func (c *Metal3Machine) SetConditions(conditions clusterv1.Conditions) {
 }
 
 func init() {
-	SchemeBuilder.Register(&Metal3Machine{}, &Metal3MachineList{})
+	objectTypes = append(objectTypes, &Metal3Machine{}, &Metal3MachineList{})
 }

--- a/api/v1beta1/metal3machinetemplate_types.go
+++ b/api/v1beta1/metal3machinetemplate_types.go
@@ -58,7 +58,7 @@ type Metal3MachineTemplateList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&Metal3MachineTemplate{}, &Metal3MachineTemplateList{})
+	objectTypes = append(objectTypes, &Metal3MachineTemplate{}, &Metal3MachineTemplateList{})
 }
 
 // Metal3MachineTemplateResource describes the data needed to create a Metal3Machine from a template.

--- a/api/v1beta1/metal3remediation_types.go
+++ b/api/v1beta1/metal3remediation_types.go
@@ -121,5 +121,5 @@ type Metal3RemediationList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&Metal3Remediation{}, &Metal3RemediationList{})
+	objectTypes = append(objectTypes, &Metal3Remediation{}, &Metal3RemediationList{})
 }

--- a/api/v1beta1/metal3remediationtemplate_types.go
+++ b/api/v1beta1/metal3remediationtemplate_types.go
@@ -66,5 +66,5 @@ type Metal3RemediationTemplateList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&Metal3RemediationTemplate{}, &Metal3RemediationTemplateList{})
+	objectTypes = append(objectTypes, &Metal3RemediationTemplate{}, &Metal3RemediationTemplateList{})
 }

--- a/api/v1beta1/v1beta1_suite_test.go
+++ b/api/v1beta1/v1beta1_suite_test.go
@@ -36,7 +36,7 @@ func TestMain(m *testing.M) {
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
 	}
 
-	err := SchemeBuilder.AddToScheme(scheme.Scheme)
+	err := schemeBuilder.AddToScheme(scheme.Scheme)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This is recommend for the CAPI providers as mentioned the v1.5 to v1.6 migration guide: https://cluster-api.sigs.k8s.io/developer/providers/migrations/v1.5-to-v1.6#suggested-changes-for-providers.

The original issue was discussed in https://github.com/kubernetes-sigs/cluster-api/issues/9011. The issue is using controller-runtime based scheme builder causes a lot of unnecessary dependancies added in go modules. Compared to that apimachinery was chosen as a better alternative. 
