### PR TITLE
🐛 Fix race condition getting IPAddress for Metal3Data

### DIFF
--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -709,14 +709,15 @@ func (m *DataManager) addressFromM3Claim(ctx context.Context, poolRef corev1.Typ
 		return addressFromPool{}, true, errors.New("no claim provided")
 	}
 
-	if !ipClaim.DeletionTimestamp.IsZero() {
-		// Is it "our" ipClaim, or does it belong to an old and deleted Metal3Data with the same name?
-		matchingOwnerRef := false
-		for _, ownerRef := range ipClaim.OwnerReferences {
-			if ownerRef.UID == m.Data.GetUID() {
-				matchingOwnerRef = true
-			}
+	// Is it "our" ipClaim, or does it belong to an old and deleted Metal3Data with the same name?
+	matchingOwnerRef := false
+	for _, ownerRef := range ipClaim.OwnerReferences {
+		if ownerRef.UID == m.Data.GetUID() {
+			matchingOwnerRef = true
 		}
+	}
+
+	if !ipClaim.DeletionTimestamp.IsZero() {
 		if !matchingOwnerRef {
 			// It is not our IPClaim so we should not use it. Attempt to remove finalizer if it is still there.
 			m.Log.Info("Found old IPClaim with deletion timestamp. Attempting to clean up and requeue.", "IPClaim", ipClaim)
@@ -730,6 +731,12 @@ func (m *DataManager) addressFromM3Claim(ctx context.Context, poolRef corev1.Typ
 			return addressFromPool{}, true, nil
 		}
 		m.Log.Info("IPClaim has deletion timestamp but is still in use!", "IPClaim", ipClaim)
+	} else if !matchingOwnerRef {
+		// It is not our IPClaim, but it does not appear to be deleting either.
+		// This could happen due to misconfiguration (nameclash) or because the IPClaim
+		// just didn't get the deletionTimestamp before the new Metal3Data was created (race condition).
+		m.Log.Info("Found IPClaim with same name but different UID. Requeing and hoping it will go away.", "IPClaim", ipClaim)
+		return addressFromPool{}, true, nil
 	}
 
 	if ipClaim.Status.ErrorMessage != nil {

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -1384,15 +1384,55 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			expectRequeue: false,
 		}),
+		Entry("Old IPClaim (wrong UID) without deletion timestamp", testCaseAddressFromM3Claim{
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, "abc-def-ghi-jkl"),
+			},
+			poolName: testPoolName,
+			poolRef:  corev1.TypedLocalObjectReference{Name: testPoolName},
+			ipClaim: &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       metal3DataName + "-" + testPoolName,
+					Namespace:  namespaceName,
+					Finalizers: []string{"ipclaim.ipam.metal3.io"},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "Metal3Data",
+							Name: metal3DataName,
+							UID:  "not-the-same",
+						},
+					},
+				},
+				Status: ipamv1.IPClaimStatus{
+					Address: &corev1.ObjectReference{
+						Name:      "abc-192.168.0.10",
+						Namespace: namespaceName,
+					},
+				},
+			},
+			expectRequeue: true,
+			expectError:   false,
+		}),
 		Entry("IPPool with allocation error", testCaseAddressFromM3Claim{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, "123-456-789"),
 			},
 			poolName:        testPoolName,
 			poolRef:         corev1.TypedLocalObjectReference{Name: testPoolName},
 			expectedAddress: addressFromPool{},
 			ipClaim: &ipamv1.IPClaim{
-				ObjectMeta: testObjectMeta(metal3DataName+"-"+testPoolName, namespaceName, ""),
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       metal3DataName + "-" + testPoolName,
+					Namespace:  namespaceName,
+					Finalizers: []string{"ipclaim.ipam.metal3.io"},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "Metal3Data",
+							Name: metal3DataName,
+							UID:  "123-456-789",
+						},
+					},
+				},
 				Status: ipamv1.IPClaimStatus{
 					ErrorMessage: pointer.String("Error happened"),
 				},
@@ -1427,7 +1467,7 @@ var _ = Describe("Metal3Data manager", func() {
 		}),
 		Entry("IPAddress found", testCaseAddressFromM3Claim{
 			m3d: &infrav1.Metal3Data{
-				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, "123-456-789"),
 				Spec: infrav1.Metal3DataSpec{
 					Template: *testObjectReference(metal3DataTemplateName),
 				},
@@ -1443,7 +1483,18 @@ var _ = Describe("Metal3Data manager", func() {
 				},
 			},
 			ipClaim: &ipamv1.IPClaim{
-				ObjectMeta: testObjectMeta(metal3DataName+"-"+testPoolName, namespaceName, ""),
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       metal3DataName + "-" + testPoolName,
+					Namespace:  namespaceName,
+					Finalizers: []string{"ipclaim.ipam.metal3.io"},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "Metal3Data",
+							Name: metal3DataName,
+							UID:  "123-456-789",
+						},
+					},
+				},
 				Status: ipamv1.IPClaimStatus{
 					Address: &corev1.ObjectReference{
 						Name:      "abc-192.168.0.10",


### PR DESCRIPTION
**What this PR does / why we need it**:

In certain conditions `addressFromM3Claim` can accept an old IPClaim (about to be deleted) for a new Metal3Data. This commit fixes this by checking the UID of the owner reference instead of just trusting the name.

Conditions to trigger the issue during a rollout:

1. The IPClaim name must be the same before and after rollout. This can happen when BMH name based pre-allocations are used and the same BMH is used for the old and new M3M. Alternatively, if the Metal3Data happens to be named the same (i.e. it has the same index).
2. The IPClaim must not get the deletion timestamp until after the new Metal3Data has gotten the IPAddress from it (race). The reason for this is that we already check and avoid using IPClaims that has a deletion timestamp.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1354


**NOTE**

I have heard that checking UID can be problematic after `clusterctl move`. This code is checking UID's, is it ok? Do we have any alternatives? The index or BMH name based naming of IPClaims and Metal3Data are very problematic here since they can very easily match for the old and new object.

Putting hold to make sure this is properly considered before merging.
/hold

Edit: Confirmed by checking CAPM3 logs that we do not end up with mismatching UIDs after `clusterctl move`.