### PR TITLE
:book: switch markdownlint container to markdownlint-cli2

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,9 @@
+# Reference: https://github.com/DavidAnson/markdownlint-cli2#markdownlint-cli2yaml
+
+config:
+  ul-indent:
+    # Kramdown wanted us to have 3 earlier, tho this CLI recommends 2 or 4
+    indent: 3
+
+# Don't autofix anything, we're linting here
+fix: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,9 @@ Commit message should contain signed off section with full name and email. For e
   Signed-off-by: John Doe <jdoe@example.com>
  ```
 
-When making commits, include the `-s` flag and `Signed-off-by` section will be automatically
-added to your commit message. If you want GPG signing too, add the `-S` flag alongside `-s`.
+When making commits, include the `-s` flag and `Signed-off-by` section
+will be automatically added to your commit message. If you want GPG
+signing too, add the `-S` flag alongside `-s`.
 
 ```bash
   # Signing off commit

--- a/docs/api.md
+++ b/docs/api.md
@@ -534,12 +534,14 @@ Above field changes need to be made before you start upgrading your cluster.
 When `spec.nodeReuse` field of metal3MachineTemplate is set to `True`, CAPM3
 Machine controller:
 
-- Sets `infrastructure.cluster.x-k8s.io/node-reuse` label to the corresponding
-  CAPI object name (a `controlplane.cluster.x-k8s.io` object such as `KubeadmControlPlane` or a `MachineDeployment`) on the
+- Sets `infrastructure.cluster.x-k8s.io/node-reuse` label to the
+  corresponding CAPI object name (a `controlplane.cluster.x-k8s.io`
+  object such as `KubeadmControlPlane` or a `MachineDeployment`) on the
   BareMetalHost during deprovisioning;
 - Selects the BareMetalHost that contains
-  `infrastructure.cluster.x-k8s.io/node-reuse` label and matches exact same CAPI
-  object name set in the previous step during next provisioning.
+  `infrastructure.cluster.x-k8s.io/node-reuse` label and matches exact
+  same CAPI object name set in the previous step during next
+  provisioning.
 
 Example Metal3MachineTemplate :
 

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -1,19 +1,20 @@
 #!/bin/sh
+# markdownlint-cli2 has config file(s) named .markdownlint-cli2.yaml in the repo
 
 set -eux
 
 IS_CONTAINER="${IS_CONTAINER:-false}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
+# all md files, but ignore .github
 if [ "${IS_CONTAINER}" != "false" ]; then
-    TOP_DIR="${1:-.}"
-    find "${TOP_DIR}" -type d -path ./.github -prune -o -name '*.md' -exec mdl --style all --rules "~MD013" --warnings {} \+
+    markdownlint-cli2 "**/*.md" "#.github"
 else
     "${CONTAINER_RUNTIME}" run --rm \
         --env IS_CONTAINER=TRUE \
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/pipelinecomponents/markdownlint:0.13.0@sha256:9c0cdfb64fd3f1d3bdc5181629b39c2e43b6a52fc9fdc146611e1860845bbae0 \
+        docker.io/pipelinecomponents/markdownlint-cli2:0.9.0@sha256:71370df6c967bae548b0bfd0ae313ddf44bfad87da76f88180eff55c6264098c \
         /workdir/hack/markdownlint.sh "$@"
 fi


### PR DESCRIPTION
Switch markdownlint container to markdownline-cli2. This CLI version supports the enable/disable rules in markdown files and allows us to ignore issues locally, not just globally.

- project-infra PR https://github.com/metal3-io/project-infra/pull/619 needs to merge for markdownlint here to pass
