### PR TITLE
🐛 Default k8s version in ensure-kubectl script

### DIFF
--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 GOPATH_BIN="$(go env GOPATH)/bin/"
-MINIMUM_KUBECTL_VERSION=v1.29.0
+MINIMUM_KUBECTL_VERSION=${KUBERNETES_VERSION:-"v1.29.0"}
 
 # Ensure the kubectl tool exists and is a viable version, or installs it
 verify_kubectl_version()
@@ -31,7 +31,7 @@ verify_kubectl_version()
                 mkdir -p "${GOPATH_BIN}"
             fi
             echo 'kubectl not found, installing'
-            curl -sLo "${GOPATH_BIN}/kubectl" https://storage.googleapis.com/kubernetes-release/release/${MINIMUM_KUBECTL_VERSION}/bin/linux/amd64/kubectl
+            curl -sLo "${GOPATH_BIN}/kubectl" https://storage.googleapis.com/kubernetes-release/release/"${MINIMUM_KUBECTL_VERSION}"/bin/linux/amd64/kubectl
             chmod +x "${GOPATH_BIN}/kubectl"
         else
             echo "Missing required binary in path: kubectl"


### PR DESCRIPTION
If we don't default to the kubernetes version used for the test, it will always use v1.29.0 and it will error out for upgrade tests where we use older k8s version to begin with. 