### PR TITLE
🐛 Fix for kubectl version command for different versions of k8s

### DIFF
--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -40,7 +40,7 @@ verify_kubectl_version()
     fi
 
     local kubectl_version
-    IFS=" " read -ra kubectl_version <<< "$(kubectl version --client)"
+    IFS=" " read -ra kubectl_version <<< "$(kubectl version --client --short 2>/dev/null || kubectl version --client 2>/dev/null)"
     if [[ "${MINIMUM_KUBECTL_VERSION}" != $(echo -e "${MINIMUM_KUBECTL_VERSION}\n${kubectl_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]; then
         cat << EOF
 Detected kubectl version: ${kubectl_version[2]}.


### PR DESCRIPTION
Co-authored-by: Tuomo Tanskanen <tuomo.tanskanen@est.tech>

In `ensure-kubectl.sh `script, for older versions of k8s (<= v1.27.x) the check produces an expected output like  `echo -e 'v1.29.0\nversion.Info{Major:"1",` the comparison cannot make sense of it and instead of erroring out, the test continues. Whereas for newer version the output is as expected `echo -e 'v1.29.0\nv1.28.1'` and the comparison in the script errors out if the kubectl version is not correct. We fix it here by making sure we use the old kubectl version flag first (`--client --short`) and if it fails we check with the `--client ` only since `--short` is now removed in v1.29.x for example. 
