### PR TITLE
🌱 E2E: Remove inspector container

### DIFF
--- a/test/e2e/pivoting.go
+++ b/test/e2e/pivoting.go
@@ -64,7 +64,6 @@ func pivoting(ctx context.Context, inputGetter func() PivotingInput) {
 
 	ironicContainers := []string{
 		"ironic",
-		"ironic-inspector",
 		"ironic-endpoint-keepalived",
 		"ironic-log-watch",
 		"dnsmasq",


### PR DESCRIPTION
**What this PR does / why we need it**:

Inspector has been removed in BMO so we can no longer get logs from it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
