### PR TITLE
🌱  Remove ironic-inspector from container list for e2e tests

### DIFF
--- a/test/e2e/cert_rotation.go
+++ b/test/e2e/cert_rotation.go
@@ -66,7 +66,6 @@ func certRotation(ctx context.Context, inputGetter func() CertRotationInput) {
 	By("Force the cert-manager to regenerate the certificate by deleting the secrets")
 	secretList := []string{
 		"ironic-cert",
-		"ironic-inspector-cert",
 	}
 	if mariadbEnabled {
 		secretList = append(secretList, "mariadb-cert")


### PR DESCRIPTION
Some leftovers were still there even after #1483 and #1481, which is only caught in feature test. 
