### PR TITLE
🌱 try fix GH workflow for image building

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -3,10 +3,10 @@ name: build-images-action
 on:
   push:
     branches:
-    - 'main'
-    - 'release-*'
+    - main
+    - release-*
     tags:
-    - 'v*'
+    - v*
 
 permissions: {}
 


### PR DESCRIPTION
Image build action is not triggering for anything but main, which is the only trigger not having `*` in it. So, let's try removing the quotes as any of the [GH examples](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push)  do not use quotes unless it is mandatory (ie. leading `*`, or `[]`).
