### PR TITLE
🌱 Remove release-1.2 upgrade test description from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,10 +217,6 @@ We run upgrade test on main branch from different releases:
   API version v1alpha5/branch release-0.5 to CAPM3 API version v1beta1/branch
   main on Ubuntu
 
-- **/test-e2e-upgrade-main-from-release-1-2** runs e2e upgrade tests from CAPM3
-  API version v1beta1/branch release-1.2 to CAPM3 API version v1beta1/branch
-  main on Ubuntu
-
 - **/test-e2e-upgrade-main-from-release-1-3** runs e2e upgrade tests from CAPM3
   API version v1beta1/branch release-1.3 to CAPM3 API version v1beta1/branch
   main on Ubuntu


### PR DESCRIPTION
jjbs have no mention of release-1.2 branch. This is a leftover trigger
