### PR TITLE
🌱 support beta and rc releases in release note generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ endif
 
 .PHONY: e2e-tests
 e2e-tests: CONTAINER_RUNTIME?=docker # Env variable can override this default
-export CONTAINER_RUNTIME 
+export CONTAINER_RUNTIME
 
 e2e-tests: $(GINKGO) e2e-substitutions cluster-templates # This target should be called from scripts/ci-e2e.sh
 	for image in $(E2E_CONTAINERS); do \
@@ -226,7 +226,7 @@ build-api: ## Builds api directory.
 .PHONY: build-e2e
 build-e2e: ## Builds test directory.
 	cd $(TEST_DIR) && $(GO) build ./...
-	
+
 ## --------------------------------------
 ## Tooling Binaries
 ## --------------------------------------
@@ -270,7 +270,7 @@ $(ENVSUBST):
 $(KUSTOMIZE_BIN): $(KUSTOMIZE) ## Build a local copy of kustomize.
 
 .PHONY: $(KUSTOMIZE)
-$(KUSTOMIZE): $(TOOLS_DIR)/go.mod 
+$(KUSTOMIZE): $(TOOLS_DIR)/go.mod
 	cd $(TOOLS_DIR) && $(GO) build -tags=tools -o $(BIN_DIR)/$(KUSTOMIZE_BIN) sigs.k8s.io/kustomize/kustomize/v5
 
 .PHONY: $(ENVSUBST_BIN)
@@ -494,7 +494,7 @@ ifneq (,$(findstring -,$(RELEASE_TAG)))
     PRE_RELEASE=true
 endif
 # the previous release tag, e.g., v1.4.0, excluding pre-release tags
-PREVIOUS_TAG ?= $(shell git tag -l | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$$" | sort -V | grep -B1 $(RELEASE_TAG) | head -n 1 2>/dev/null)
+PREVIOUS_TAG ?= $(shell git tag -l | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" | sort -V | grep -B1 $(RELEASE_TAG) | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$$" | head -n 1 2>/dev/null)
 RELEASE_DIR := out
 RELEASE_NOTES_DIR := releasenotes
 
@@ -513,11 +513,7 @@ release-manifests: $(KUSTOMIZE) $(RELEASE_DIR) ## Builds the manifests to publis
 
 .PHONY: release-notes
 release-notes: $(RELEASE_NOTES_DIR) $(RELEASE_NOTES)
-	if [ -n "${PRE_RELEASE}" ]; then \
-	echo ":rotating_light: This is a RELEASE CANDIDATE. Use it only for testing purposes. If you find any bugs, file an [issue](https://github.com/metal3-io/cluster-api-provider-metal3/issues/new/)." > $(RELEASE_NOTES_DIR)/$(RELEASE_TAG).md; \
-	else \
-	$(GO) run ./hack/tools/release/notes.go --from=$(PREVIOUS_TAG) > $(RELEASE_NOTES_DIR)/$(RELEASE_TAG).md; \
-	fi
+	$(GO) run ./hack/tools/release/notes.go --from=$(PREVIOUS_TAG) > $(RELEASE_NOTES_DIR)/$(RELEASE_TAG).md
 
 .PHONY: release
 release:

--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -45,6 +45,10 @@ const (
 	superseded    = ":recycle: Superseded or Reverted"
 )
 
+const (
+	warningTemplate = ":rotating_light: This is a %s. Use it only for testing purposes. If you find any bugs, file an [issue](https://github.com/metal3-io/cluster-api-provider-metal3/issues/new/).\n\n"
+)
+
 var (
 	outputOrder = []string{
 		warning,
@@ -85,6 +89,14 @@ func lastTag() string {
 	return string(bytes.TrimSpace(out))
 }
 
+func isBeta(tag string) bool {
+	return strings.Contains(tag, "-beta.")
+}
+
+func isRC(tag string) bool {
+	return strings.Contains(tag, "-rc.")
+}
+
 func firstCommit() string {
 	cmd := exec.Command("git", "rev-list", "--max-parents=0", "HEAD")
 	out, err := cmd.Output()
@@ -97,7 +109,7 @@ func firstCommit() string {
 func run() int {
 	lastTag := lastTag()
 	latestTag := latestTag()
-	cmd := exec.Command("git", "rev-list", lastTag+"..HEAD", "--merges", "--pretty=format:%B")
+	cmd := exec.Command("git", "rev-list", lastTag+"..HEAD", "--merges", "--pretty=format:%B") // #nosec G204:gosec
 
 	merges := map[string][]string{
 		features:      {},
@@ -174,12 +186,15 @@ func run() int {
 		merges[key] = append(merges[key], formatMerge(body, prNumber))
 	}
 
-	// Add empty superseded section
-	merges[superseded] = append(merges[superseded], "- `<insert superseded bumps and reverts here>`")
+	// Add empty superseded section, if not beta/rc, we don't cleanup those notes
+	if !isBeta(latestTag) && !isRC(latestTag) {
+		merges[superseded] = append(merges[superseded], "- `<insert superseded bumps and reverts here>`")
+	}
 
 	// TODO Turn this into a link (requires knowing the project name + organization)
 	fmt.Printf("Changes since %v\n---\n", lastTag)
 
+	// print the changes by category
 	for _, key := range outputOrder {
 		mergeslice := merges[key]
 		if len(mergeslice) > 0 {
@@ -189,10 +204,28 @@ func run() int {
 			}
 			fmt.Println()
 		}
+
+		// if we're doing beta/rc, print breaking changes and hide the rest of the changes
+		if key == warning {
+			if isBeta(latestTag) {
+				fmt.Printf(warningTemplate, "BETA RELEASE")
+			}
+			if isRC(latestTag) {
+				fmt.Printf(warningTemplate, "RELEASE CANDIDATE")
+			}
+			if isBeta(latestTag) || isRC(latestTag) {
+				fmt.Printf("<details>\n")
+				fmt.Printf("<summary>More details about the release</summary>\n\n")
+			}
+		}
+	}
+
+	// then close the details if we had it open
+	if isBeta(latestTag) || isRC(latestTag) {
+		fmt.Printf("</details>\n\n")
 	}
 
 	fmt.Printf("The image for this release is: %v\n", latestTag)
-	fmt.Printf("Ironic image tag is capm3-%v\n", latestTag)
 	fmt.Printf("Mariadb image tag is capm3-%v\n", latestTag)
 	fmt.Println("\n_Thanks to all our contributors!_ 😊")
 


### PR DESCRIPTION
Support beta and RC releases in release note generator. Move some logic from Makefile to the release note generator, and then add nice unfolding summary section to hide details in beta/rc notes.

Fix previous release tag pattern detection in Makefile.

Remove ironic-image related notes, as it has proper release process itself now.

Below, I'll add the output of `v1.7.0-beta.0` beta output:

---

```yaml
Changes since v1.6.1
---
## :warning: Breaking Changes
- Remove v1alpha5 API Version (#1525)

:rotating_light: This is a BETA RELEASE. Use it only for testing purposes. If you find any bugs, file an [issue](https://github.com/metal3-io/cluster-api-provider-metal3/issues/new/).

<details>
<summary>More details about the release</summary>

## :bug: Bug Fixes
- e2e: Specify ip address pool for retreiving ip for accessing node (#1528)
- bump google.golang.org/protobuf to v1.33.0 (#1508)
- EnsureImage download image fix (#1479)
- Fix for kubectl version command for different versions of k8s (#1433)
- Default k8s version in ensure-kubectl script (#1432)
- Install ginkgo directly instead of building it using go-modules (#1415)
- Fix for v1.6 clusterctl upgrade. (#1400)

## :book: Documentation
- switch markdownlint container to markdownlint-cli2 (#1414)
- Update Support matrix in Contributing guide (#1409)

## :seedling: Others
- Bump github.com/onsi/ginkgo/v2 from 2.17.0 to 2.17.1 in /test (#1566)
- Bump github.com/onsi/ginkgo/v2 from 2.17.0 to 2.17.1 (#1565)
- Bump cert-manager version v1.13.0 -> v1.14.0 (#1559)
- Uplift ipam 1.7.0-beta.0 release (#1562)
- Fix: Metal3Data Manager log levels (#1558)
- Simplifying and updating clusterctl upgrade tests (#1452)
- remove redundant make targets and scripts (#1561)
- Bump docker go module to v26.0.0 (#1560)
- Bump CAPI to v1.7.0-beta.0 (#1530)
- Bump github.com/docker/docker from 24.0.7+incompatible to 24.0.9+incompatible in /test (#1556)
- Bump github.com/onsi/ginkgo/v2 from 2.16.0 to 2.17.0 (#1534)
- Bump github.com/onsi/gomega from 1.31.1 to 1.32.0 (#1538)
- Bump github.com/onsi/ginkgo/v2 from 2.16.0 to 2.17.0 in /test (#1542)
- bump k8s.io deps to v0.29.3 (#1543)
- Update basic e2e trigger on README.md (#1493)
- Remove release-1.2 upgrade test description from README (#1529)
- Bump golang to v1.21.8 (#1520)
- add golang base image check to verify-release.sh (#1516)
- Bump golang.org/x/net from 0.21.0 to 0.22.0 (#1519)
- Bump github.com/metal3-io/baremetal-operator/apis from 0.5.0 to 0.5.1 (#1518)
- Bump github.com/metal3-io/baremetal-operator/apis from 0.5.0 to 0.5.1 in /test (#1517)
- bump shellcheck to v0.10.0 (#1509)
- Add labels on e2e tests (#1502)
- Bump github.com/onsi/ginkgo/v2 from 2.15.0 to 2.16.0 in /test (#1505)
- Bump github.com/onsi/ginkgo/v2 from 2.15.0 to 2.16.0 (#1506)
- Bump golang.org/x/crypto from 0.20.0 to 0.21.0 in /test (#1504)
- Bump golangci-lint to v1.56.2 (#1503)
- Revert "try fix GH workflow for build images" (#1494)
- Remove ironic-inspector from container list for e2e tests (#1487)
- Bump golangci/golangci-lint-action from 3.7.0 to 4.0.0 (#1491)
- Bump github/codeql-action from 3.23.2 to 3.24.6 (#1490)
- Bump actions/cache from 4.0.0 to 4.0.1 (#1489)
- try fix GH workflow for image building (#1488)
- Remove ironic-inspector from container list for ubuntu e2e tests (#1483)
- E2E: Remove inspector container (#1481)
- Bump golang to v1.21.7 (#1476)
- Bump golang.org/x/crypto from 0.19.0 to 0.20.0 in /test (#1470)
- Bump CAPI to v1.6.2 (#1467)
- Bump the kubernetes group with 2 updates (#1462)
- Bump the kubernetes group in /test with 1 update (#1463)
- Bump k8s.io/code-generator from 0.29.1 to 0.29.2 in /hack/tools (#1457)
- Bump sigs.k8s.io/controller-runtime from 0.17.1 to 0.17.2 in /api (#1456)
- Bump the kubernetes group in /api with 3 updates (#1455)
- Enable more linters for golangci-lint (#1443)
- Bump golang.org/x/net from 0.20.0 to 0.21.0 (#1450)
- Bump controller-runtime to v0.17.1 (#1444)
- Bump github/codeql-action from 3.22.12 to 3.23.2 (#1440)
- Bump actions/cache from 3.3.2 to 4.0.0 (#1439)
- Bump EndBug/add-and-commit from 9.1.3 to 9.1.4 (#1438)
- Fix Permission Issue for process.txt in Tiltfile Configuration (#1436)
- Bump golang to v1.21.6 (#1435)
- Bump k8s.io/code-generator from 0.29.0 to 0.29.1 in /hack/tools (#1416)
- Bump github.com/onsi/gomega from 1.30.0 to 1.31.1 (#1424)
- bump k8s.io/* deps to v0.28.6 (#1430)
- Add ginkgo phony in Makefile (#1412)
- Bump envtest to v1.29.x (#1411)
- Bump CAPI to v1.6.1 (#1406)
- bump ginkgo to v2.14.0 (#1403)
- Bump k8s to v1.29.0 (#1399)
- reduce github actions permissions (#1386)
- remove release-1.3 (#1397)
- Add github action to trigger container image build (#1338)
- Bump github.com/go-logr/logr from 1.3.0 to 1.4.1 (#1376)
- bump golang to 1.20.12 (#1392)
- Bump golang.org/x/net from 0.19.0 to 0.20.0 (#1389)

</details>

The image for this release is: v1.7.0-beta.0
Mariadb image tag is capm3-v1.7.0-beta.0

_Thanks to all our contributors!_ 😊
``` 