### PR TITLE
🌱 Add release markers to e2e config

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -34,6 +34,7 @@ import (
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -52,6 +53,8 @@ const (
 	osTypeUbuntu           = "ubuntu"
 	ironicSuffix           = "-ironic"
 )
+
+var releaseMarkerPrefix = "go://github.com/metal3-io/cluster-api-provider-metal3@v%s"
 
 func Byf(format string, a ...interface{}) {
 	By(fmt.Sprintf(format, a...))
@@ -783,4 +786,10 @@ func LabelCRD(ctx context.Context, c client.Client, crdName string, labels map[s
 	}
 	Logf("CRD '%s' labeled successfully\n", crdName)
 	return nil
+}
+
+// GetCAPM3StableReleaseOfMinor returns latest stable version of minorRelease.
+func GetCAPM3StableReleaseOfMinor(ctx context.Context, minorRelease string) (string, error) {
+	releaseMarker := fmt.Sprintf(releaseMarkerPrefix, minorRelease)
+	return clusterctl.ResolveRelease(ctx, releaseMarker)
 }

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -17,8 +17,8 @@ providers:
 - name: cluster-api
   type: CoreProvider
   versions:
-  - name: v1.6.3
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.3/core-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.6}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.6}/core-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -26,8 +26,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1.6/metadata.yaml"
-  - name: v1.5.7
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.7/core-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.5}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.5}/core-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -38,8 +38,8 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
-  - name: v1.6.3
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.3/bootstrap-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.6}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.6}/bootstrap-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -47,8 +47,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1.6/metadata.yaml"
-  - name: v1.5.7
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.7/bootstrap-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.5}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.5}/bootstrap-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -59,8 +59,8 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
-  - name: v1.6.3
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.3/control-plane-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.6}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.6}/control-plane-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -68,8 +68,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1.6/metadata.yaml"
-  - name: v1.5.7
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.7/control-plane-components.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.5}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.5}/control-plane-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -77,11 +77,15 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1.5/metadata.yaml"
+    # https://proxy.golang.org/sigs.k8s.io/cluster-api/@v/list
+
+
+# https://proxy.golang.org/github.com/metal3-io/cluster-api-provider-metal3/@v/list
 - name: metal3
   type: InfrastructureProvider
   versions:
-  - name: v1.6.1
-    value: "https://github.com/metal3-io/cluster-api-provider-metal3/releases/download/v1.6.1/infrastructure-components.yaml"
+  - name: "{go://github.com/metal3-io/cluster-api-provider-metal3@v1.6}"
+    value: "https://github.com/metal3-io/cluster-api-provider-metal3/releases/download/{go://github.com/metal3-io/cluster-api-provider-metal3@v1.6}/infrastructure-components.yaml"
     type: "url"
     contract: v1beta1
     files:
@@ -91,8 +95,8 @@ providers:
       targetName: "cluster-template-ubuntu.yaml"
     - sourcePath: "../_out/cluster-template-upgrade-workload.yaml"
       targetName: "cluster-template-upgrade-workload.yaml"
-  - name: v1.5.3
-    value: "https://github.com/metal3-io/cluster-api-provider-metal3/releases/download/v1.5.3/infrastructure-components.yaml"
+  - name: "{go://github.com/metal3-io/cluster-api-provider-metal3@v1.5}"
+    value: "https://github.com/metal3-io/cluster-api-provider-metal3/releases/download/{go://github.com/metal3-io/cluster-api-provider-metal3@v1.5}/infrastructure-components.yaml"
     type: "url"
     contract: v1beta1
     files:
@@ -102,18 +106,6 @@ providers:
       targetName: "cluster-template-ubuntu.yaml"
     - sourcePath: "../_out/cluster-template-upgrade-workload.yaml"
       targetName: "cluster-template-upgrade-workload.yaml"
-  - name: v1.6.99
-    value: "${PWD}/config/default"
-    replacements:
-    - old: "--leader-elect"
-      new: "--leader-elect\n        - --logging-format=json"
-    files:
-    - sourcePath: "../data/infrastructure-metal3/v1.6/metadata.yaml"
-      targetName: "metadata.yaml"
-    - sourcePath: "../_out/cluster-template-ubuntu.yaml"
-      targetName: "cluster-template-ubuntu.yaml"
-    - sourcePath: "../_out/cluster-template-centos.yaml"
-      targetName: "cluster-template-centos.yaml"
   - name: v1.7.99
     value: "${PWD}/config/default"
     files:

--- a/test/e2e/upgrade_clusterctl_test.go
+++ b/test/e2e/upgrade_clusterctl_test.go
@@ -20,6 +20,13 @@ import (
 
 const workDir = "/opt/metal3-dev-env/"
 
+var (
+	clusterctlDownloadURL = "https://github.com/kubernetes-sigs/cluster-api/releases/download/v%s/clusterctl-{OS}-{ARCH}"
+	providerCAPIPrefix    = "cluster-api:v%s"
+	providerKubeadmPrefix = "kubeadm:v%s"
+	providerMetal3Prefix  = "metal3:v%s"
+)
+
 var _ = Describe("When testing cluster upgrade from releases (v1.6=>current) [clusterctl-upgrade]", func() {
 	BeforeEach(func() {
 		osType := strings.ToLower(os.Getenv("OS"))
@@ -31,6 +38,13 @@ var _ = Describe("When testing cluster upgrade from releases (v1.6=>current) [cl
 		// We need to override clusterctl apply log folder to avoid getting our credentials exposed.
 		clusterctlLogFolder = filepath.Join(os.TempDir(), "clusters", bootstrapClusterProxy.GetName())
 	})
+
+	minorVersion := "1.6"
+	capiStableRelease, err := capi_e2e.GetStableReleaseOfMinor(ctx, minorVersion)
+	Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for CAPI minor release : %s", minorVersion)
+	capm3StableRelease, err := GetCAPM3StableReleaseOfMinor(ctx, minorVersion)
+	Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for CAPM3 minor release : %s", minorVersion)
+
 	capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
 		return capi_e2e.ClusterctlUpgradeSpecInput{
 			E2EConfig:                       e2eConfig,
@@ -38,13 +52,13 @@ var _ = Describe("When testing cluster upgrade from releases (v1.6=>current) [cl
 			BootstrapClusterProxy:           bootstrapClusterProxy,
 			ArtifactFolder:                  artifactFolder,
 			SkipCleanup:                     skipCleanup,
-			InitWithCoreProvider:            "cluster-api:v1.6.3",
-			InitWithBootstrapProviders:      []string{"kubeadm:v1.6.3"},
-			InitWithControlPlaneProviders:   []string{"kubeadm:v1.6.3"},
-			InitWithInfrastructureProviders: []string{"metal3:v1.6.1"},
+			InitWithCoreProvider:            fmt.Sprintf(providerCAPIPrefix, capiStableRelease),
+			InitWithBootstrapProviders:      []string{fmt.Sprintf(providerKubeadmPrefix, capiStableRelease)},
+			InitWithControlPlaneProviders:   []string{fmt.Sprintf(providerKubeadmPrefix, capiStableRelease)},
+			InitWithInfrastructureProviders: []string{fmt.Sprintf(providerMetal3Prefix, capm3StableRelease)},
 			InitWithKubernetesVersion:       "v1.29.0",
 			WorkloadKubernetesVersion:       "v1.29.0",
-			InitWithBinary:                  "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.3/clusterctl-{OS}-{ARCH}",
+			InitWithBinary:                  fmt.Sprintf(clusterctlDownloadURL, capiStableRelease),
 			PreInit: func(clusterProxy framework.ClusterProxy) {
 				preInitFunc(clusterProxy)
 				// Override capi/capm3 versions exported in preInit
@@ -91,6 +105,13 @@ var _ = Describe("When testing cluster upgrade from releases (v1.5=>current) [cl
 		// We need to override clusterctl apply log folder to avoid getting our credentials exposed.
 		clusterctlLogFolder = filepath.Join(os.TempDir(), "clusters", bootstrapClusterProxy.GetName())
 	})
+
+	minorVersion := "1.5"
+	capiStableRelease, err := capi_e2e.GetStableReleaseOfMinor(ctx, minorVersion)
+	Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for CAPI minor release : %s", minorVersion)
+	capm3StableRelease, err := GetCAPM3StableReleaseOfMinor(ctx, minorVersion)
+	Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for CAPM3 minor release : %s", minorVersion)
+
 	capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
 		return capi_e2e.ClusterctlUpgradeSpecInput{
 			E2EConfig:                       e2eConfig,
@@ -98,13 +119,13 @@ var _ = Describe("When testing cluster upgrade from releases (v1.5=>current) [cl
 			BootstrapClusterProxy:           bootstrapClusterProxy,
 			ArtifactFolder:                  artifactFolder,
 			SkipCleanup:                     skipCleanup,
-			InitWithCoreProvider:            "cluster-api:v1.5.7",
-			InitWithBootstrapProviders:      []string{"kubeadm:v1.5.7"},
-			InitWithControlPlaneProviders:   []string{"kubeadm:v1.5.7"},
-			InitWithInfrastructureProviders: []string{"metal3:v1.5.3"},
+			InitWithCoreProvider:            fmt.Sprintf(providerCAPIPrefix, capiStableRelease),
+			InitWithBootstrapProviders:      []string{fmt.Sprintf(providerKubeadmPrefix, capiStableRelease)},
+			InitWithControlPlaneProviders:   []string{fmt.Sprintf(providerKubeadmPrefix, capiStableRelease)},
+			InitWithInfrastructureProviders: []string{fmt.Sprintf(providerMetal3Prefix, capm3StableRelease)},
 			InitWithKubernetesVersion:       "v1.28.1",
 			WorkloadKubernetesVersion:       "v1.28.1",
-			InitWithBinary:                  "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.7/clusterctl-{OS}-{ARCH}",
+			InitWithBinary:                  fmt.Sprintf(clusterctlDownloadURL, capiStableRelease),
 			PreInit: func(clusterProxy framework.ClusterProxy) {
 				preInitFunc(clusterProxy)
 				// Override capi/capm3 versions exported in preInit


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Adding release markers in e2e config and clusterctl upgrade tests. These markers resolve to the latest patch release of the minor mentioned in the marker.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
