### PR TITLE
🌱 Remove keep test env related vars and configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,6 @@ E2E_CONF_FILE_ENVSUBST ?= $(E2E_OUT_DIR)/$(notdir $(E2E_CONF_FILE))
 E2E_CONTAINERS ?= quay.io/metal3-io/cluster-api-provider-metal3 quay.io/metal3-io/baremetal-operator quay.io/metal3-io/ip-address-manager
 
 SKIP_CLEANUP ?= false
-KEEP_TEST_ENV ?= false
 EPHEMERAL_TEST ?= false
 SKIP_CREATE_MGMT_CLUSTER ?= true
 
@@ -192,13 +191,11 @@ e2e-tests: $(GINKGO) e2e-substitutions cluster-templates # This target should be
 
 	$(GINKGO) --timeout=$(GINKGO_TIMEOUT) -v --trace --tags=e2e  \
 		--show-node-events --no-color=$(GINKGO_NOCOLOR) \
-		--fail-fast="$(KEEP_TEST_ENV)" \
 		--junit-report="junit.e2e_suite.1.xml" \
 		--focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) "$(ROOT_DIR)/$(TEST_DIR)/e2e/" -- \
 		-e2e.artifacts-folder="$(ARTIFACTS)" \
 		-e2e.config="$(E2E_CONF_FILE_ENVSUBST)" \
 		-e2e.skip-resource-cleanup=$(SKIP_CLEANUP) \
-		-e2e.keep-test-environment=$(KEEP_TEST_ENV) \
 		-e2e.trigger-ephemeral-test=$(EPHEMERAL_TEST) \
 		-e2e.use-existing-cluster=$(SKIP_CREATE_MGMT_CLUSTER)
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -47,9 +47,6 @@ var (
 
 	// ephemeralTest triggers only e2e test in ephemeral cluster if true.
 	ephemeralTest bool
-
-	// keepTestEnv keeps the test environment by aborting the test suite when e2e test fails.
-	keepTestEnv bool
 )
 
 // Test suite global vars.
@@ -82,7 +79,6 @@ func init() {
 	flag.StringVar(&configPath, "e2e.config", "", "path to the e2e config file")
 	flag.StringVar(&artifactFolder, "e2e.artifacts-folder", "", "folder where e2e test artifact should be stored")
 	flag.BoolVar(&skipCleanup, "e2e.skip-resource-cleanup", false, "if true, the resource cleanup after tests will be skipped")
-	flag.BoolVar(&keepTestEnv, "e2e.keep-test-environment", false, "if true, the test aborts when failed, keeping all the environment")
 	flag.BoolVar(&upgradeTest, "e2e.trigger-upgrade-test", false, "if true, the e2e upgrade test will be triggered and other tests will be skipped")
 	flag.BoolVar(&ephemeralTest, "e2e.trigger-ephemeral-test", false, "if true, all e2e tests run in the ephemeral cluster without pivoting to the target cluster")
 	flag.BoolVar(&useExistingCluster, "e2e.use-existing-cluster", true, "if true, the test uses the current cluster instead of creating a new one (default discovery rules apply)")

--- a/test/e2e/ip_reuse_test.go
+++ b/test/e2e/ip_reuse_test.go
@@ -39,12 +39,6 @@ var _ = Describe("When testing ip reuse [ip-reuse] [features]", Label("ip-reuse"
 		ListMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		ListMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		ListNodes(ctx, targetCluster.GetClient())
-		// Abort the test in case of failure and keepTestEnv is true during keep VM trigger
-		if CurrentSpecReport().Failed() {
-			if keepTestEnv {
-				AbortSuite("e2e test aborted and skip cleaning the VM", 4)
-			}
-		}
 		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 	})
 })

--- a/test/e2e/live_iso_test.go
+++ b/test/e2e/live_iso_test.go
@@ -101,12 +101,6 @@ func liveIsoTest() {
 	})
 
 	AfterEach(func() {
-		// Abort the test in case of failure and keepTestEnv is true during keep VM trigger
-		if CurrentSpecReport().Failed() {
-			if keepTestEnv {
-				AbortSuite("e2e test aborted and skip cleaning the VM", 4)
-			}
-		}
 		By("Deprovisioning live ISO image booted BMH")
 
 		bootstrapClient := bootstrapClusterProxy.GetClient()

--- a/test/e2e/pivoting_based_feature_test.go
+++ b/test/e2e/pivoting_based_feature_test.go
@@ -143,12 +143,6 @@ var _ = Describe("Testing features in ephemeral or target cluster [pivoting] [fe
 				ListMachines(ctx, targetCluster.GetClient(), client.InNamespace(namespace))
 			}
 			ListNodes(ctx, targetCluster.GetClient())
-			// Abort the test in case of failure and keepTestEnv is true during keep VM trigger
-			if CurrentSpecReport().Failed() {
-				if keepTestEnv {
-					AbortSuite("e2e test aborted and skip cleaning the VM", 4)
-				}
-			}
 			if !ephemeralTest {
 				// Dump the target cluster resources before re-pivoting.
 				Logf("Dump the target cluster resources before re-pivoting")

--- a/test/e2e/remediation_based_feature_test.go
+++ b/test/e2e/remediation_based_feature_test.go
@@ -111,12 +111,6 @@ var _ = Describe("Testing nodes remediation [remediation] [features]", Label("re
 		ListMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		ListMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		ListNodes(ctx, targetCluster.GetClient())
-		// Abort the test in case of failure and keepTestEnv is true during keep VM trigger
-		if CurrentSpecReport().Failed() {
-			if keepTestEnv {
-				AbortSuite("e2e test aborted and skip cleaning the VM", 4)
-			}
-		}
 		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 	})
 

--- a/test/e2e/upgrade_clusterctl_test.go
+++ b/test/e2e/upgrade_clusterctl_test.go
@@ -328,7 +328,6 @@ func preUpgrade(clusterProxy framework.ClusterProxy) {
 // preCleanupManagementCluster hook should be called from ClusterctlUpgradeSpec before cleaning the target management cluster
 // it moves back Ironic to the bootstrap cluster.
 func preCleanupManagementCluster(clusterProxy framework.ClusterProxy) {
-	// Abort the test in case of failure and keepTestEnv is true during keep VM trigger
 	if CurrentSpecReport().Failed() {
 		// Fetch logs in case of failure in management cluster
 		By("Fetch logs from management cluster")
@@ -340,10 +339,6 @@ func preCleanupManagementCluster(clusterProxy framework.ClusterProxy) {
 		errorData, _ := io.ReadAll(errorPipe)
 		if len(errorData) > 0 {
 			Logf("Error of the shell: %v\n", string(errorData))
-		}
-
-		if keepTestEnv {
-			AbortSuite("e2e test aborted and skip cleaning the VM", 4)
 		}
 	}
 	// Fetch logs from management cluster

--- a/test/e2e/upgrade_kubernetes_test.go
+++ b/test/e2e/upgrade_kubernetes_test.go
@@ -60,12 +60,6 @@ var _ = Describe("Kubernetes version upgrade in target nodes [k8s-upgrade]", Lab
 		ListMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		ListMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		ListNodes(ctx, targetCluster.GetClient())
-		// // Abort the test in case of failure and keepTestEnv is true during keep VM trigger
-		if CurrentSpecReport().Failed() {
-			if keepTestEnv {
-				AbortSuite("e2e test aborted and skip cleaning the VM", 4)
-			}
-		}
 		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 	})
 


### PR DESCRIPTION
These vars are removed from project-infra https://github.com/metal3-io/project-infra/pull/703 , now it is throwing errors form project-infra [PRs ](https://jenkins.nordix.org/view/Metal3/job/metal3-ubuntu-e2e-integration-test-main/63/consoleFull) since we still have traces of these vars here in CAPM3, removing these unused vars. 