### PR TITLE
🌱 Bump Kubernetes upgrade from version

### DIFF
--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -48,7 +48,7 @@ else
   export EPHEMERAL_CLUSTER="minikube"
 fi
 
-export FROM_K8S_VERSION=${FROM_K8S_VERSION:-"v1.28.1"}
+export FROM_K8S_VERSION=${FROM_K8S_VERSION:-"v1.29.0"}
 export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.30.0"}
 # NOTE: kubectl sha256 must match the provided KUBERNETES_VERSION, and must be
 # provided in JJB for upgrade tests where version is different from the default


### PR DESCRIPTION
**What this PR does / why we need it**:

The version we upgrade from needs to be close enough (one minor version) to the version we upgrade to.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This fixes the kubernetes upgrade test that was broken with this error:

```
"admission webhook \"validation.kubeadmcontrolplane.controlplane.cluster.x-k8s.io\" denied the request: KubeadmControlPlane.cluster.x-k8s.io \"test1\" is invalid: spec.version: Forbidden: cannot update Kubernetes version from v1.28.1 to v1.30.0"
```
