### PR TITLE
🌱 Set ARCH based on go env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ BMO_IMAGE_NAME ?= baremetal-operator
 BMO_CONTROLLER_IMG ?= $(REGISTRY)/$(BMO_IMAGE_NAME)
 TAG ?= v1beta1
 BMO_TAG ?= capm3-$(TAG)
-ARCH ?= amd64
+ARCH ?= $(shell go env GOARCH)
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 
 # Allow overriding manifest generation destination directory
@@ -96,7 +96,6 @@ ENVTEST_OS := linux
 ifeq ($(shell uname -s), Darwin)
 	ENVTEST_OS := darwin
 endif
-ARCH ?= amd64
 
 ## --------------------------------------
 ## Help


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

We had ARCH hard-coded to amd64. This commit changes it so that we take it from go env instead. That way we should automatically get the proper architecture on different devices.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
