### PR TITLE
🌱 set webhook min TLS version to 1.3

### DIFF
--- a/main.go
+++ b/main.go
@@ -324,7 +324,7 @@ func initFlags(fs *pflag.FlagSet) {
 
 	fs.IntVar(&restConfigBurst, "kube-api-burst", 30,
 		"Maximum number of queries that should be allowed in one burst from the controller client to the Kubernetes API server. Default 30")
-	fs.StringVar(&tlsOptions.TLSMinVersion, "tls-min-version", TLSVersion12,
+	fs.StringVar(&tlsOptions.TLSMinVersion, "tls-min-version", TLSVersion13,
 		"The minimum TLS version in use by the webhook server.\n"+
 			fmt.Sprintf("Possible values are %s.", strings.Join(tlsSupportedVersions, ", ")),
 	)


### PR DESCRIPTION
Webhook is connected to by kube-apiserver, and it has supported TLS 1.3 connections since Go 1.14, over 4 years ago. By default, the connection has been negoatiated to TLS 1.3 anyways between the client and webhook. Turning it to TLS 1.3 should not affect anything, but it shouldn't also break anything.

In case this is an issue for some consumer, they can always use the --tls-min-version TLS12 to turn it back to TLS 1.2.
