### PR TITLE
 🌱  Fix log.SetLogger(...) was never called issue

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -18,10 +18,12 @@ import (
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 const (
@@ -104,6 +106,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	By("Initializing a runtime.Scheme with all the GVK relevant for this test")
 	scheme := initScheme()
+	ctrl.SetLogger(klog.Background())
 
 	By(fmt.Sprintf("Loading the e2e test configuration from %q", configPath))
 	e2eConfig = loadE2EConfig(configPath)

--- a/test/go.mod
+++ b/test/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.29.4
 	k8s.io/apimachinery v0.29.4
 	k8s.io/client-go v0.29.4
+	k8s.io/klog/v2 v2.110.1
 	k8s.io/utils v0.0.0-20231127182322-b307cd553661
 	sigs.k8s.io/cluster-api v1.7.1
 	sigs.k8s.io/cluster-api/test v1.7.1
@@ -136,7 +137,6 @@ require (
 	k8s.io/apiserver v0.29.4 // indirect
 	k8s.io/cluster-bootstrap v0.29.3 // indirect
 	k8s.io/component-base v0.29.4 // indirect
-	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kind v0.22.0 // indirect


### PR DESCRIPTION
This PR attempts to solve the log.SetLogger(...) was never called issue. 
In [CI e2e runs](url) we see the following stacktrace https://jenkins.nordix.org/view/Metal3/job/metal3-ubuntu-e2e-integration-test-main/176/consoleFull. This PR fixes the issue. 

```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
12:49:34  Detected at:
12:49:34  	>  goroutine 292 [running]:
12:49:34  	>  runtime/debug.Stack()
12:49:34  	>  	/usr/local/go/src/runtime/debug/stack.go:24 +0x5e
12:49:34  	>  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
12:49:34  	>  	/home/metal3ci/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.4/pkg/log/log.go:60 +0xcd
12:49:34  	>  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithName(0xc0000cf040, {0x2669614, 0x14})
12:49:34  	>  	/home/metal3ci/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.4/pkg/log/deleg.go:147 +0x45
12:49:34  	>  github.com/go-logr/logr.Logger.WithName({{0x2a50288, 0xc0000cf040}, 0x0}, {0x2669614?, 0x0?})
12:49:34  	>  	/home/metal3ci/go/pkg/mod/github.com/go-logr/logr@v1.4.1/logr.go:345 +0x3d
12:49:34  	>  sigs.k8s.io/controller-runtime/pkg/client.newClient(0xc0005e6f50?, {0x0, 0xc0003bce00, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
12:49:34  	>  	/home/metal3ci/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.4/pkg/client/client.go:129 +0xec
12:49:34  	>  sigs.k8s.io/controller-runtime/pkg/client.New(0x412805?, {0x0, 0xc0003bce00, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
12:49:34  	>  	/home/metal3ci/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.4/pkg/client/client.go:110 +0x7d
12:49:34  	>  sigs.k8s.io/cluster-api/test/framework.(*clusterProxy).GetClient.func1({0xb2d05e00, 0xc0003bcc50})
12:49:34  	>  	/home/metal3ci/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.7.1/framework/cluster_proxy.go:204 +0x79
12:49:34  	>  k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func1(0xc0003458c0?, {0x2a4a2b0?, 0xc0003bcc40?})
12:49:34  	>  	/home/metal3ci/go/pkg/mod/k8s.io/apimachinery@v0.29.4/pkg/util/wait/loop.go:53 +0x52
12:49:34  	>  k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext({0x2a4a2b0, 0xc0003bcc40}, {0x2a3f6c8?, 0xc0003458c0}, 0x1, 0x0, 0x0?)
12:49:34  	>  	/home/metal3ci/go/pkg/mod/k8s.io/apimachinery@v0.29.4/pkg/util/wait/loop.go:54 +0x117
12:49:34  	>  k8s.io/apimachinery/pkg/util/wait.PollUntilContextTimeout({0x2a4a198?, 0x3f534e0?}, 0xb2d05e00, 0x1?, 0x1?, 0x1000000000000?)
12:49:34  	>  	/home/metal3ci/go/pkg/mod/k8s.io/apimachinery@v0.29.4/pkg/util/wait/poll.go:48 +0x98
12:49:34  	>  sigs.k8s.io/cluster-api/test/framework.(*clusterProxy).GetClient(0xc000c80480)
12:49:34  	>  	/home/metal3ci/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.7.1/framework/cluster_proxy.go:203 +0xbe
12:49:34  	>  sigs.k8s.io/cluster-api/test/framework/clusterctl.ApplyCustomClusterTemplateAndWait.setDefaults.func3({_, _}, {{0x2a5acf8, 0xc000c80480}, {0xc000eaa001, 0x44fb5, 0x44fb6}, {0x2650038, 0x5}, {0x2650dec, ...}, ...}, ...)
12:49:34  	>  	/home/metal3ci/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.7.1/framework/clusterctl/clusterctl_helpers.go:464 +0x3d
12:49:34  	>  sigs.k8s.io/cluster-api/test/framework/clusterctl.ApplyCustomClusterTemplateAndWait({_, _}, {{0x2a5acf8, 0xc000c80480}, {0xc000eaa001, 0x44fb5, 0x44fb6}, {0x2650038, 0x5}, {0x2650dec, ...}, ...}, ...)
12:49:34  	>  	/home/metal3ci/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.7.1/framework/clusterctl/clusterctl_helpers.go:428 +0x1110
12:49:34  	>  sigs.k8s.io/cluster-api/test/framework/clusterctl.ApplyClusterTemplateAndWait({_, _}, {{0x2a5acf8, 0xc000c80480}, {{0x0, 0x0}, {0xc000688593, 0x42}, {0xc0006885d6, 0x1b}, ...}, ...}, ...)
12:49:34  	>  	/home/metal3ci/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.7.1/framework/clusterctl/clusterctl_helpers.go:323 +0x994
12:49:34  	>  github.com/metal3-io/cluster-api-provider-metal3/test/e2e.createTargetCluster({0xc000056193, 0x7})
12:49:34  	>  	/home/metal3ci/metal3/test/e2e/pivoting_based_feature_test.go:181 +0x3a5
12:49:34  	>  github.com/metal3-io/cluster-api-provider-metal3/test/e2e.glob..func6.1()
12:49:34  	>  	/home/metal3ci/metal3/test/e2e/integration_test.go:28 +0xa7
12:49:34  	>  github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3({0x7a0ee8, 0xc000351200})
12:49:34  	>  	/home/metal3ci/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.17.2/internal/node.go:472 +0x13
12:49:34  	>  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
12:49:34  	>  	/home/metal3ci/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.17.2/internal/suite.go:889 +0x8d
12:49:34  	>  created by github.com/onsi/ginkgo/v2/internal.(*Suite).runNode in goroutine 99
12:49:34  	>  	/home/metal3ci/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.17.2/internal/suite.go:876 +0xddb
```
