### PR TITLE
:bug: Clusterclass e2e test fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,13 +225,11 @@ e2e-clusterclass-tests: $(GINKGO) e2e-substitutions clusterclass-templates # Thi
 
 	$(GINKGO) --timeout=$(GINKGO_TIMEOUT) -v --trace --tags=e2e  \
 		--show-node-events --no-color=$(GINKGO_NOCOLOR) \
-		--fail-fast="$(KEEP_TEST_ENV)" \
 		--junit-report="junit.e2e_suite.1.xml" \
 		--focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) "$(ROOT_DIR)/$(TEST_DIR)/e2e/" -- \
 		-e2e.artifacts-folder="$(ARTIFACTS)" \
 		-e2e.config="$(E2E_CONF_FILE_ENVSUBST)" \
 		-e2e.skip-resource-cleanup=$(SKIP_CLEANUP) \
-		-e2e.keep-test-environment=$(KEEP_TEST_ENV) \
 		-e2e.trigger-ephemeral-test=$(EPHEMERAL_TEST) \
 		-e2e.use-existing-cluster=$(SKIP_CREATE_MGMT_CLUSTER)
 

--- a/examples/templates/clusterclass.yaml
+++ b/examples/templates/clusterclass.yaml
@@ -49,12 +49,6 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
   name: example-md-0
-spec:
-  template:
-    spec:
-      joinConfiguration:
-        nodeRegistration:
-          name: '{{ ds.meta_data.hostname }}'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate


### PR DESCRIPTION
This PR is a followup to #1405

It fixes issues with redundant test env related vars and configs that couses the test to fail at start. Those were removed in #1624 and should be also removed for clusterclass.

Also, it tries to fix issue with `{{ ds.meta_data.hostname }}'` reference reported [in the comment here](https://github.com/metal3-io/cluster-api-provider-metal3/pull/1405#discussion_r1584187652).

It seems that,[ according to the cluster-api repository](https://github.com/kubernetes-sigs/cluster-api/blob/main/bootstrap/kubeadm/api/v1beta1/kubeadm_types.go#L231), `NodeRegistration.Name` defaults to hostname, so I believe referencing hostname explicitly here is redundant and minght be deleted.