### PR TITLE
 🌱 Configure dependabot for release-1.7 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,84 +3,179 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "monthly"
-    commit-message:
-      prefix: ":seedling:"
+## Main branch config starts here
+- package-ecosystem: "github-actions"
+  directory: "/" # Location of package manifests
+  schedule:
+    interval: "monthly"
+  target-branch: main
+  commit-message:
+    prefix: ":seedling:"
     # Go
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    ## group all dependencies with a k8s.io prefix into a single PR.
-    groups:
-      kubernetes:
-        patterns: [ "k8s.io/*" ]
-    ignore:
-      # Ignore controller-runtime as its upgraded manually.
-      - dependency-name: "sigs.k8s.io/controller-runtime"
-        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-      # Ignore k8s and its transitives modules as they are upgraded manually
-      # together with controller-runtime.
-      - dependency-name: "k8s.io/*"
-        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-      # ignore ipam, as it needs more than just gomod
-      - dependency-name: "github.com/metal3-io/ip-address-manager/api"
-    commit-message:
-      prefix: ":seedling:"
-  - package-ecosystem: "gomod"
-    directory: "/api"
-    schedule:
-      interval: "weekly"
-    ## group all dependencies with a k8s.io prefix into a single PR.
-    groups:
-      kubernetes:
-        patterns: [ "k8s.io/*" ]
-    ignore:
-      # Ignore controller-runtime as its upgraded manually.
-      - dependency-name: "sigs.k8s.io/controller-runtime"
-        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-      # Ignore k8s and its transitives modules as they are upgraded manually
-      # together with controller-runtime.
-      - dependency-name: "k8s.io/*"
-        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-      # ignore ipam, as it needs more than just gomod
-      - dependency-name: "github.com/metal3-io/ip-address-manager/api"
-    commit-message:
-      prefix: ":seedling:"
-  - package-ecosystem: "gomod"
-    directory: "/test"
-    schedule:
-      interval: "weekly"
-    ## group all dependencies with a k8s.io prefix into a single PR.
-    groups:
-      kubernetes:
-        patterns: [ "k8s.io/*" ]
-    ignore:
-      # Ignore controller-runtime as its upgraded manually.
-      - dependency-name: "sigs.k8s.io/controller-runtime"
-        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-      # Ignore k8s and its transitives modules as they are upgraded manually
-      # together with controller-runtime.
-      - dependency-name: "k8s.io/*"
-        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-      # ignore ipam, as it needs more than just gomod
-      - dependency-name: "github.com/metal3-io/ip-address-manager/api"
-    commit-message:
-      prefix: ":seedling:"
-  - package-ecosystem: "gomod"
-    directory: "/hack/tools"
-    schedule:
-      interval: "weekly"
-    ignore:
-      # Ignore controller-runtime as its upgraded manually.
-      - dependency-name: "sigs.k8s.io/controller-runtime"
-        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-      # Ignore k8s and its transitives modules as they are upgraded manually
-      # together with controller-runtime.
-      - dependency-name: "sigs.k8s.io/controller-tools"
-        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    commit-message:
-      prefix: ":seedling:"
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  target-branch: main
+  ## group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    kubernetes:
+      patterns: ["k8s.io/*"]
+  ignore:
+  # Ignore controller-runtime as its upgraded manually.
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Ignore k8s and its transitives modules as they are upgraded manually
+  # together with controller-runtime.
+  - dependency-name: "k8s.io/*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # ignore ipam, as it needs more than just gomod
+  - dependency-name: "github.com/metal3-io/ip-address-manager/api"
+  commit-message:
+    prefix: ":seedling:"
+- package-ecosystem: "gomod"
+  directory: "/api"
+  schedule:
+    interval: "weekly"
+  target-branch: main
+  ## group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    kubernetes:
+      patterns: ["k8s.io/*"]
+  ignore:
+  # Ignore controller-runtime as its upgraded manually.
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Ignore k8s and its transitives modules as they are upgraded manually
+  # together with controller-runtime.
+  - dependency-name: "k8s.io/*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # ignore ipam, as it needs more than just gomod
+  - dependency-name: "github.com/metal3-io/ip-address-manager/api"
+  commit-message:
+    prefix: ":seedling:"
+- package-ecosystem: "gomod"
+  directory: "/test"
+  schedule:
+    interval: "weekly"
+  target-branch: main
+  ## group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    kubernetes:
+      patterns: ["k8s.io/*"]
+  ignore:
+  # Ignore controller-runtime as its upgraded manually.
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Ignore k8s and its transitives modules as they are upgraded manually
+  # together with controller-runtime.
+  - dependency-name: "k8s.io/*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # ignore ipam, as it needs more than just gomod
+  - dependency-name: "github.com/metal3-io/ip-address-manager/api"
+  commit-message:
+    prefix: ":seedling:"
+- package-ecosystem: "gomod"
+  directory: "/hack/tools"
+  schedule:
+    interval: "weekly"
+  target-branch: main
+  ignore:
+  # Ignore controller-runtime as its upgraded manually.
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Ignore k8s and its transitives modules as they are upgraded manually
+  # together with controller-runtime.
+  - dependency-name: "sigs.k8s.io/controller-tools"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  commit-message:
+    prefix: ":seedling:"
+## Main branch config ends here
+## release-1.7 branch config starts here
+- package-ecosystem: "github-actions"
+  directory: "/" # Location of package manifests
+  schedule:
+    interval: "monthly"
+  target-branch: release-1.7
+  commit-message:
+    prefix: ":seedling:"
+    # Go
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  target-branch: release-1.7
+  ## group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    kubernetes:
+      patterns: ["k8s.io/*"]
+  ignore:
+  # Ignore controller-runtime as its upgraded manually.
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Ignore k8s and its transitives modules as they are upgraded manually
+  # together with controller-runtime.
+  - dependency-name: "k8s.io/*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # ignore ipam, as it needs more than just gomod
+  - dependency-name: "github.com/metal3-io/ip-address-manager/api"
+  commit-message:
+    prefix: ":seedling:"
+- package-ecosystem: "gomod"
+  directory: "/api"
+  schedule:
+    interval: "weekly"
+  target-branch: release-1.7
+  ## group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    kubernetes:
+      patterns: ["k8s.io/*"]
+  ignore:
+  # Ignore controller-runtime as its upgraded manually.
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Ignore k8s and its transitives modules as they are upgraded manually
+  # together with controller-runtime.
+  - dependency-name: "k8s.io/*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # ignore ipam, as it needs more than just gomod
+  - dependency-name: "github.com/metal3-io/ip-address-manager/api"
+  commit-message:
+    prefix: ":seedling:"
+- package-ecosystem: "gomod"
+  directory: "/test"
+  schedule:
+    interval: "weekly"
+  target-branch: release-1.7
+  ## group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    kubernetes:
+      patterns: ["k8s.io/*"]
+  ignore:
+  # Ignore controller-runtime as its upgraded manually.
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Ignore k8s and its transitives modules as they are upgraded manually
+  # together with controller-runtime.
+  - dependency-name: "k8s.io/*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # ignore ipam, as it needs more than just gomod
+  - dependency-name: "github.com/metal3-io/ip-address-manager/api"
+  commit-message:
+    prefix: ":seedling:"
+- package-ecosystem: "gomod"
+  directory: "/hack/tools"
+  schedule:
+    interval: "weekly"
+  target-branch: release-1.7
+  ignore:
+  # Ignore controller-runtime as its upgraded manually.
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Ignore k8s and its transitives modules as they are upgraded manually
+  # together with controller-runtime.
+  - dependency-name: "sigs.k8s.io/controller-tools"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  commit-message:
+    prefix: ":seedling:"
+## release-1.7 branch config ends here


### PR DESCRIPTION
This PR adds release-1.7 branch as the target branch. Also for this reason the current config adds the main branch as the target branch first and then copies the package ecosystems for release-1.7 branch.

Signed-off-by: Kashif Khan <kashif.khan@est.tech>