### PR TITLE
🌱 Fix dependabot release branch config to bump only patch versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -107,8 +107,9 @@ updates:
   target-branch: release-1.7
   ## group all dependencies with a k8s.io prefix into a single PR.
   groups:
-    kubernetes:
-      patterns: ["k8s.io/*"]
+    all-go-mod-patch:
+      patterns: ["*"]
+      update-types: ["patch"]
   ignore:
   # Ignore controller-runtime as its upgraded manually.
   - dependency-name: "sigs.k8s.io/controller-runtime"
@@ -128,8 +129,9 @@ updates:
   target-branch: release-1.7
   ## group all dependencies with a k8s.io prefix into a single PR.
   groups:
-    kubernetes:
-      patterns: ["k8s.io/*"]
+    all-go-mod-patch:
+      patterns: ["*"]
+      update-types: ["patch"]
   ignore:
   # Ignore controller-runtime as its upgraded manually.
   - dependency-name: "sigs.k8s.io/controller-runtime"
@@ -149,8 +151,9 @@ updates:
   target-branch: release-1.7
   ## group all dependencies with a k8s.io prefix into a single PR.
   groups:
-    kubernetes:
-      patterns: ["k8s.io/*"]
+    all-go-mod-patch:
+      patterns: ["*"]
+      update-types: ["patch"]
   ignore:
   # Ignore controller-runtime as its upgraded manually.
   - dependency-name: "sigs.k8s.io/controller-runtime"
@@ -168,6 +171,10 @@ updates:
   schedule:
     interval: "weekly"
   target-branch: release-1.7
+  groups:
+    all-go-mod-patch:
+      patterns: ["*"]
+      update-types: ["patch"]
   ignore:
   # Ignore controller-runtime as its upgraded manually.
   - dependency-name: "sigs.k8s.io/controller-runtime"


### PR DESCRIPTION
With the recent introduction of release branch configuration for dependabot, it is pushing bumps for minor versions of dependancies as well. We don't want minor version bumps for release branches. Setting it to patch versions.
Signed-off-by: Kashif Khan <kashif.khan@est.tech>
