### PR TITLE
🌱 Group dependabot k8s bumps for release branches and ignore major, minor bumps for all dependancies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -107,16 +107,11 @@ updates:
   target-branch: release-1.7
   ## group all dependencies with a k8s.io prefix into a single PR.
   groups:
-    all-go-mod-patch:
-      patterns: ["*"]
-      update-types: ["patch"]
+    kubernetes:
+      patterns: ["k8s.io/*"]
   ignore:
-  # Ignore controller-runtime as its upgraded manually.
-  - dependency-name: "sigs.k8s.io/controller-runtime"
-    update-types: ["version-update:semver-major", "version-update:semver-minor"]
-  # Ignore k8s and its transitives modules as they are upgraded manually
-  # together with controller-runtime.
-  - dependency-name: "k8s.io/*"
+  # Ignore major and minor bumps for release branch
+  - dependency-name: "*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # ignore ipam, as it needs more than just gomod
   - dependency-name: "github.com/metal3-io/ip-address-manager/api"
@@ -129,16 +124,11 @@ updates:
   target-branch: release-1.7
   ## group all dependencies with a k8s.io prefix into a single PR.
   groups:
-    all-go-mod-patch:
-      patterns: ["*"]
-      update-types: ["patch"]
+    kubernetes:
+      patterns: ["k8s.io/*"]
   ignore:
-  # Ignore controller-runtime as its upgraded manually.
-  - dependency-name: "sigs.k8s.io/controller-runtime"
-    update-types: ["version-update:semver-major", "version-update:semver-minor"]
-  # Ignore k8s and its transitives modules as they are upgraded manually
-  # together with controller-runtime.
-  - dependency-name: "k8s.io/*"
+  # Ignore major and minor bumps for release branch
+  - dependency-name: "*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # ignore ipam, as it needs more than just gomod
   - dependency-name: "github.com/metal3-io/ip-address-manager/api"
@@ -151,16 +141,11 @@ updates:
   target-branch: release-1.7
   ## group all dependencies with a k8s.io prefix into a single PR.
   groups:
-    all-go-mod-patch:
-      patterns: ["*"]
-      update-types: ["patch"]
+    kubernetes:
+      patterns: ["k8s.io/*"]
   ignore:
-  # Ignore controller-runtime as its upgraded manually.
-  - dependency-name: "sigs.k8s.io/controller-runtime"
-    update-types: ["version-update:semver-major", "version-update:semver-minor"]
-  # Ignore k8s and its transitives modules as they are upgraded manually
-  # together with controller-runtime.
-  - dependency-name: "k8s.io/*"
+  # Ignore major and minor bumps for release branch
+  - dependency-name: "*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # ignore ipam, as it needs more than just gomod
   - dependency-name: "github.com/metal3-io/ip-address-manager/api"
@@ -172,16 +157,11 @@ updates:
     interval: "weekly"
   target-branch: release-1.7
   groups:
-    all-go-mod-patch:
-      patterns: ["*"]
-      update-types: ["patch"]
+    kubernetes:
+      patterns: ["k8s.io/*"]
   ignore:
-  # Ignore controller-runtime as its upgraded manually.
-  - dependency-name: "sigs.k8s.io/controller-runtime"
-    update-types: ["version-update:semver-major", "version-update:semver-minor"]
-  # Ignore k8s and its transitives modules as they are upgraded manually
-  # together with controller-runtime.
-  - dependency-name: "sigs.k8s.io/controller-tools"
+  # Ignore major and minor bumps for release branch
+  - dependency-name: "*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   commit-message:
     prefix: ":seedling:"


### PR DESCRIPTION
Fixing patch version bumps via groups for release branches was probably a bad idea here https://github.com/metal3-io/cluster-api-provider-metal3/pull/1708. It has caused chaos and multiple different dependencies are now being grouped together in one PR. Current fix tries to tackle that by bringing back k8s group and then add an ignore rule for all dependancies in release branch to only allow patch bumps. 


