### PR TITLE
🌱 add OWNERS_ALIASES support

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,19 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- adilGhaffarDev
-- kashifest
-- lentzi90
-- mboukhalfa
-- smoshiur1237
-- Sunnatillo
-- tuminoid
-
+- cluster-api-provider-metal3-maintainers
 
 reviewers:
-- dtantsur
-- Rozzii
-- zhouhao3
+- cluster-api-provider-metal3-maintainers
+- cluster-api-provider-metal3-reviewers
 
 emeritus_approvers:
 - fmuyassarov

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,16 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  cluster-api-provider-metal3-maintainers:
+  - adilGhaffarDev
+  - kashifest
+  - lentzi90
+  - mboukhalfa
+  - smoshiur1237
+  - Sunnatillo
+  - tuminoid
+
+  cluster-api-provider-metal3-reviewers:
+  - dtantsur
+  - Rozzii
+  - zhouhao3


### PR DESCRIPTION
OWNERS_ALIASES groups are needed for fair blunderbuss review requests.
