### PR TITLE
🌱 Allow minor version bumps for golang.org/x/* dependancies for release branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -114,6 +114,9 @@ updates:
       patterns: ["k8s.io/*"]
   ignore:
   # Ignore major and minor bumps for release branch
+  # golang.org/x/* only releases minors no patches, so minors have to be allowed
+  - dependency-name: "golang.org/x/*"
+    update-types: ["version-update:semver-major"]
   - dependency-name: "*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # ignore ipam, as it needs more than just gomod
@@ -131,6 +134,9 @@ updates:
       patterns: ["k8s.io/*"]
   ignore:
   # Ignore major and minor bumps for release branch
+  # golang.org/x/* only releases minors no patches, so minors have to be allowed
+  - dependency-name: "golang.org/x/*"
+    update-types: ["version-update:semver-major"]
   - dependency-name: "*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # ignore ipam, as it needs more than just gomod
@@ -148,6 +154,9 @@ updates:
       patterns: ["k8s.io/*"]
   ignore:
   # Ignore major and minor bumps for release branch
+  # golang.org/x/* only releases minors no patches, so minors have to be allowed
+  - dependency-name: "golang.org/x/*"
+    update-types: ["version-update:semver-major"]
   - dependency-name: "*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # ignore ipam, as it needs more than just gomod
@@ -164,6 +173,9 @@ updates:
       patterns: ["k8s.io/*"]
   ignore:
   # Ignore major and minor bumps for release branch
+  # golang.org/x/* only releases minors no patches, so minors have to be allowed
+  - dependency-name: "golang.org/x/*"
+    update-types: ["version-update:semver-major"]
   - dependency-name: "*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   commit-message:


### PR DESCRIPTION
golang.org/x/* libs only release minor versions. No patch versions. We need to allow minor version bumps for these libs for release branches for this reason.
