### PR TITLE
🌱 Bump golang to v1.22

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Install go
       uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
       with:
-        go-version: '1.21'
+        go-version: '1.22'
     - name: Generate release artifacts and notes
       run: |
         make release

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -57,7 +57,7 @@ linters:
 
 linters-settings:
   gosec:
-    go: "1.21"
+    go: "1.22"
     severity: medium
     confidence: medium
     concurrency: 8
@@ -101,9 +101,9 @@ linters-settings:
     allow-leading-space: false
     require-specific: true
   staticcheck:
-    go: "1.21"
+    go: "1.22"
   stylecheck:
-    go: "1.21"
+    go: "1.22"
   gocritic:
     enabled-tags:
     - experimental
@@ -122,7 +122,7 @@ linters-settings:
     - whyNoLint
     - wrapperFunc
   unused:
-    go: "1.21"
+    go: "1.22"
 issues:
   exclude-rules:
   - path: test/e2e

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.21.9@sha256:7d0dcbe5807b1ad7272a598fbf9d7af15b5e2bed4fd6c4c2b5b3684df0b317dd
+ARG BUILD_IMAGE=docker.io/golang:1.22.3@sha256:f43c6f049f04cbbaeb28f0aad3eea15274a7d0a7899a617d0037aec48d7ab010
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary on golang image

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SHELL:=/usr/bin/env bash
 
 .DEFAULT_GOAL:=help
 
-GO_VERSION ?= 1.21.9
+GO_VERSION ?= 1.22.3
 GO := $(shell type -P go)
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell $(GO) env GOPROXY)

--- a/Tiltfile
+++ b/Tiltfile
@@ -171,7 +171,7 @@ def fixup_yaml_empty_arrays(yaml_str):
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.21 as tilt-helper
+FROM golang:1.22 as tilt-helper
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/cluster-api-provider-metal3/api
 
-go 1.21
+go 1.22
 
 require (
 	github.com/metal3-io/ip-address-manager/api v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/cluster-api-provider-metal3
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.4.1

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -17,6 +17,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.21 \
+        docker.io/golang:1.22 \
         /workdir/hack/build.sh "$@"
 fi

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -37,6 +37,6 @@ else
         --volume "${PWD}:/workdir:rw,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.21 \
+        docker.io/golang:1.22 \
         /workdir/hack/codegen.sh
 fi

--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -39,6 +39,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.21 \
+        docker.io/golang:1.22 \
         /workdir/hack/gomod.sh "$@"
 fi

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/cluster-api-provider-metal3/hack/tools
 
-go 1.21
+go 1.22
 
 require (
 	github.com/drone/envsubst v1.0.3

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -17,6 +17,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.21 \
+        docker.io/golang:1.22 \
         /workdir/hack/unit.sh "$@"
 fi

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/cluster-api-provider-metal3/test
 
-go 1.21
+go 1.22
 
 require (
 	github.com/docker/docker v26.1.3+incompatible


### PR DESCRIPTION
This PR bumps golang to v1.22.3 in Dockerfile, gomodules and container images for different tests in hack/ directory.

