### PR TITLE
🌱 Move golang.org/x/* ignore rules after the * rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -114,11 +114,11 @@ updates:
       patterns: ["k8s.io/*"]
   ignore:
   # Ignore major and minor bumps for release branch
+  - dependency-name: "*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # golang.org/x/* only releases minors no patches, so minors have to be allowed
   - dependency-name: "golang.org/x/*"
     update-types: ["version-update:semver-major"]
-  - dependency-name: "*"
-    update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # ignore ipam, as it needs more than just gomod
   - dependency-name: "github.com/metal3-io/ip-address-manager/api"
   commit-message:
@@ -134,11 +134,11 @@ updates:
       patterns: ["k8s.io/*"]
   ignore:
   # Ignore major and minor bumps for release branch
+  - dependency-name: "*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # golang.org/x/* only releases minors no patches, so minors have to be allowed
   - dependency-name: "golang.org/x/*"
     update-types: ["version-update:semver-major"]
-  - dependency-name: "*"
-    update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # ignore ipam, as it needs more than just gomod
   - dependency-name: "github.com/metal3-io/ip-address-manager/api"
   commit-message:
@@ -154,11 +154,11 @@ updates:
       patterns: ["k8s.io/*"]
   ignore:
   # Ignore major and minor bumps for release branch
+  - dependency-name: "*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # golang.org/x/* only releases minors no patches, so minors have to be allowed
   - dependency-name: "golang.org/x/*"
     update-types: ["version-update:semver-major"]
-  - dependency-name: "*"
-    update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # ignore ipam, as it needs more than just gomod
   - dependency-name: "github.com/metal3-io/ip-address-manager/api"
   commit-message:
@@ -173,11 +173,11 @@ updates:
       patterns: ["k8s.io/*"]
   ignore:
   # Ignore major and minor bumps for release branch
+  - dependency-name: "*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # golang.org/x/* only releases minors no patches, so minors have to be allowed
   - dependency-name: "golang.org/x/*"
     update-types: ["version-update:semver-major"]
-  - dependency-name: "*"
-    update-types: ["version-update:semver-major", "version-update:semver-minor"]
   commit-message:
     prefix: ":seedling:"
 ## release-1.7 branch config ends here


### PR DESCRIPTION
Dependabot is not picking up the ignore rule for `golang.org/x/*`  and hence not updating it. It might be the `*` is superseding everything. We will try to move it below the `*` rule to check if it helps dependabot picking it up
Signed-off-by: Kashif Khan <kashif.khan@est.tech>

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
