### PR TITLE
WIP :bug: pin IPA version  to avoid incompatibility with BMO 0.6

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -43,6 +43,10 @@ export KUBERNETES_VERSION=${KUBERNETES_VERSION}
 export KUBECTL_SHA256=${KUBECTL_SHA256}
 export IMAGE_OS=${IMAGE_OS}
 export FORCE_REPO_UPDATE="false"
+export IPA_BASEURI="https://artifactory.nordix.org/artifactory/metal3/images/ipa/pinned/centos/9-stream/20240513T0408Z-c303bd9"
+export IPA_BRANCH="master"
+export IPA_FLAVOR="centos9"
+export BMOCOMMIT="c463618aa5de9671fab16cc926a8e4815f69cb55"
 EOF
 if [[ ${GINKGO_FOCUS:-} == "features" ]]; then
     mkdir -p "$CAPI_CONFIG_FOLDER"

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -166,6 +166,9 @@ variables:
   IMAGE_CHECKSUM_TYPE: "sha256"
   IMAGE_USERNAME: "metal3"
   NODE_DRAIN_TIMEOUT: "0s"
+  IPA_BASEURI: "https://artifactory.nordix.org/artifactory/metal3/images/ipa/pinned/centos/9-stream/20240513T0408Z-c303bd9"
+  IPA_BRANCH: "master"
+  IPA_FLAVOR: "centos9"
 
 intervals:
   default/wait-controllers: ["5m", "10s"]


### PR DESCRIPTION
This commit:
  - Pins the IPA image to an instance that is provided by the metal3-io community.
  - The pinning is done in order to avoid incompatibility issues between newer IPA images and BMO 0.6 .