### PR TITLE
:bug: Changing errors in pause annotation functions from terminal to transient

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -195,10 +195,9 @@ func (m *MachineManager) RemovePauseAnnotation(ctx context.Context) error {
 	// look for associated BMH
 	host, helper, err := m.getHost(ctx)
 	if err != nil {
-		m.SetError("Failed to get a BaremetalHost for the Metal3Machine",
-			capierrors.CreateMachineError,
-		)
-		return err
+		errMessage := "Failed to get a BaremetalHost for the Metal3Machine, requeuing"
+		m.Log.Info(errMessage)
+		return WithTransientError(errors.New(errMessage), requeueAfter)
 	}
 
 	if host == nil {
@@ -226,10 +225,9 @@ func (m *MachineManager) SetPauseAnnotation(ctx context.Context) error {
 	// look for associated BMH
 	host, helper, err := m.getHost(ctx)
 	if err != nil {
-		m.SetError("Failed to get a BaremetalHost for the Metal3Machine",
-			capierrors.UpdateMachineError,
-		)
-		return err
+		errMessage := "Failed to get a BaremetalHost for the Metal3Machine, requeuing"
+		m.Log.Info(errMessage)
+		return WithTransientError(errors.New(errMessage), requeueAfter)
 	}
 	if host == nil {
 		return nil


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
 Changing errors in pause annotation functions from terminal to transient. When BMH is rebooted there is a chance we get a terminal error from these functions which can cause machines to be in a failed state.

