### PR TITLE
🐛 Remove clearError() function for infrastructure objects

### DIFF
--- a/baremetal/metal3cluster_manager.go
+++ b/baremetal/metal3cluster_manager.go
@@ -97,10 +97,6 @@ func (s *ClusterManager) Create(_ context.Context) error {
 		s.setError("Invalid Metal3Cluster provided", capierrors.InvalidConfigurationClusterError)
 		return err
 	}
-
-	// clear an error if one was previously set.
-	s.clearError()
-
 	return nil
 }
 
@@ -155,15 +151,6 @@ func (s *ClusterManager) UpdateClusterStatus() error {
 func (s *ClusterManager) setError(message string, reason capierrors.ClusterStatusError) {
 	s.Metal3Cluster.Status.FailureMessage = &message
 	s.Metal3Cluster.Status.FailureReason = &reason
-}
-
-// clearError removes the ErrorMessage from the metal3Cluster Status if set. Returns
-// nil if ErrorMessage was already nil.
-func (s *ClusterManager) clearError() {
-	if s.Metal3Cluster.Status.FailureMessage != nil || s.Metal3Cluster.Status.FailureReason != nil {
-		s.Metal3Cluster.Status.FailureMessage = nil
-		s.Metal3Cluster.Status.FailureReason = nil
-	}
 }
 
 // CountDescendants will return the number of descendants objects of the

--- a/baremetal/metal3cluster_manager_test.go
+++ b/baremetal/metal3cluster_manager_test.go
@@ -142,7 +142,7 @@ var _ = Describe("Metal3Cluster manager", func() {
 		}),
 	)
 
-	DescribeTable("Test setting and clearing errors",
+	DescribeTable("Test setting errors",
 		func(tc testCaseBMClusterManager) {
 			clusterMgr := newBMClusterSetup(tc)
 			clusterMgr.setError("abc", capierrors.InvalidConfigurationClusterError)
@@ -151,11 +151,6 @@ var _ = Describe("Metal3Cluster manager", func() {
 				capierrors.InvalidConfigurationClusterError,
 			))
 			Expect(*tc.BMCluster.Status.FailureMessage).To(Equal("abc"))
-
-			clusterMgr.clearError()
-
-			Expect(tc.BMCluster.Status.FailureReason).To(BeNil())
-			Expect(tc.BMCluster.Status.FailureMessage).To(BeNil())
 		},
 		Entry("No pre-existing errors", testCaseBMClusterManager{
 			Cluster: newCluster(clusterName),

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -385,10 +385,9 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 		// specs
 		host, helper, err = m.getHost(ctx)
 		if err != nil {
-			m.SetError("Failed to get the BaremetalHost for the Metal3Machine",
-				capierrors.CreateMachineError,
-			)
-			return err
+			errMessage := "Failed to get BaremetalHost while setting Host Spec, requeuing"
+			m.Log.Info(errMessage)
+			return WithTransientError(errors.New(errMessage), requeueAfter)
 		}
 
 		if err = m.setHostSpec(ctx, host); err != nil {

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -304,9 +304,6 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 		return nil
 	}
 
-	// clear an error if one was previously set
-	m.clearError()
-
 	// look for associated BMH
 	host, helper, err := m.getHost(ctx)
 	if err != nil {
@@ -450,9 +447,6 @@ func (m *MachineManager) getUserDataSecretName(_ context.Context) error {
 // Delete deletes a metal3 machine and is invoked by the Machine Controller.
 func (m *MachineManager) Delete(ctx context.Context) error {
 	m.Log.Info("Deleting metal3 machine", "metal3machine", m.Metal3Machine.Name)
-
-	// clear an error if one was previously set.
-	m.clearError()
 
 	if Capm3FastTrack == "" {
 		Capm3FastTrack = "false"
@@ -686,10 +680,6 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 // Update updates a machine and is invoked by the Machine Controller.
 func (m *MachineManager) Update(ctx context.Context) error {
 	m.Log.Info("Updating machine")
-
-	// clear any error message that was previously set. This method doesn't set
-	// error messages yet, so we know that it's incorrect to have one here.
-	m.clearError()
 
 	host, helper, err := m.getHost(ctx)
 	if err != nil {
@@ -1203,16 +1193,6 @@ func (m *MachineManager) SetConditionMetal3MachineToFalse(t clusterv1.ConditionT
 // SetConditionMetal3MachineToTrue sets Metal3Machine condition status to True.
 func (m *MachineManager) SetConditionMetal3MachineToTrue(t clusterv1.ConditionType) {
 	conditions.MarkTrue(m.Metal3Machine, t)
-}
-
-// clearError removes the ErrorMessage from the machine's Status if set. Returns
-// nil if ErrorMessage was already nil. Returns a Transient error if the
-// machine was updated.
-func (m *MachineManager) clearError() {
-	if m.Metal3Machine.Status.FailureMessage != nil || m.Metal3Machine.Status.FailureReason != nil {
-		m.Metal3Machine.Status.FailureMessage = nil
-		m.Metal3Machine.Status.FailureReason = nil
-	}
 }
 
 // updateMachineStatus updates a Metal3Machine object's status.

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -454,7 +454,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		}),
 	)
 
-	DescribeTable("Test setting and clearing errors",
+	DescribeTable("Test setting errors",
 		func(bmMachine infrav1.Metal3Machine) {
 			machineMgr, err := NewMachineManager(nil, nil, nil, nil, &bmMachine,
 				logr.Discard(),
@@ -467,11 +467,6 @@ var _ = Describe("Metal3Machine manager", func() {
 				capierrors.InvalidConfigurationMachineError,
 			))
 			Expect(*bmMachine.Status.FailureMessage).To(Equal("abc"))
-
-			machineMgr.clearError()
-
-			Expect(bmMachine.Status.FailureReason).To(BeNil())
-			Expect(bmMachine.Status.FailureMessage).To(BeNil())
 		},
 		Entry("No errors", infrav1.Metal3Machine{}),
 		Entry("Overwrite existing error message", infrav1.Metal3Machine{

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -96,8 +96,6 @@ func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			machineLog.Error(err, "failed to Patch metal3Machine")
 		}
 	}()
-	// clear an error if one was previously set
-	clearErrorM3Machine(capm3Machine)
 
 	// Fetch the Machine.
 	capiMachine, err := util.GetOwnerMachine(ctx, r.Client, capm3Machine.ObjectMeta)
@@ -515,14 +513,6 @@ func (r *Metal3MachineReconciler) Metal3DataToMetal3Machines(_ context.Context, 
 func setErrorM3Machine(m3m *infrav1.Metal3Machine, message string, reason capierrors.MachineStatusError) {
 	m3m.Status.FailureMessage = ptr.To(message)
 	m3m.Status.FailureReason = &reason
-}
-
-// clearError removes the ErrorMessage from the metal3machine's Status if set.
-func clearErrorM3Machine(m3m *infrav1.Metal3Machine) {
-	if m3m.Status.FailureMessage != nil || m3m.Status.FailureReason != nil {
-		m3m.Status.FailureMessage = nil
-		m3m.Status.FailureReason = nil
-	}
 }
 
 func checkMachineError(machineMgr baremetal.MachineManagerInterface, err error,


### PR DESCRIPTION
This is a bug and it is a followup of https://github.com/metal3-io/cluster-api-provider-metal3/pull/1765. 
According to 
- https://github.com/fabriziopandini/cluster-api/blob/main/docs/book/src/developer/architecture/controllers/cluster.md, 
- https://github.com/fabriziopandini/cluster-api/blob/main/docs/book/src/developer/architecture/controllers/control-plane.md and 
- https://github.com/fabriziopandini/cluster-api/blob/main/docs/book/src/developer/architecture/controllers/machine-pool.md 

once `failureReason` or `failureMessage` surface on the CAPI object who is referencing the infra object, they cannot be restored anymore. Hence, CAPM3 should not clear them as well.

For the same reason, this PR is removing one of the occurrences of setError so as not to through terminal error while associating BMH but through transient error.  
Signed-off-by: Kashif Khan <kashif.khan@est.tech>


