### PR TITLE
 📖 overridable variables in the clusterctl-cluster.yaml template

### DIFF
--- a/examples/clusterctl-templates/clusterctl-cluster.yaml
+++ b/examples/clusterctl-templates/clusterctl-cluster.yaml
@@ -6,11 +6,9 @@ metadata:
 spec:
   clusterNetwork:
     services:
-      cidrBlocks:
-      - 10.96.0.0/12
+      cidrBlocks: ${SERVICE_CIDR:=["10.96.0.0/12"]}
     pods:
-      cidrBlocks:
-      - 192.168.0.0/18
+      cidrBlocks: ${SERVICE_CIDR:=["192.168.0.0/18"]}
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster

--- a/examples/clusterctl-templates/clusterctl-cluster.yaml
+++ b/examples/clusterctl-templates/clusterctl-cluster.yaml
@@ -8,7 +8,8 @@ spec:
     services:
       cidrBlocks: ${SERVICE_CIDR:=["10.96.0.0/12"]}
     pods:
-      cidrBlocks: ${SERVICE_CIDR:=["192.168.0.0/18"]}
+      cidrBlocks: ${POD_CIDR:=["192.168.0.0/18"]}
+    serviceDomain: ${SERVICE_DOMAIN:="cluster.local"}
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The PR adds variables to override the default cidrblocks for the services and pods in the clusterctl-cluster.yaml template file. 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
fixes #1484 