### PR TITLE
🌱Add namespace directory in manifest collection

### DIFF
--- a/scripts/fetch_manifests.sh
+++ b/scripts/fetch_manifests.sh
@@ -51,9 +51,9 @@ manifests=(
 NAMESPACES="$(kubectl --kubeconfig="${kconfig}" get namespace -o jsonpath='{.items[*].metadata.name}')"
 for NAMESPACE in ${NAMESPACES}; do
   for kind in "${manifests[@]}"; do
-    mkdir -p "${DIR_NAME}/${kind}"
+    mkdir -p "${DIR_NAME}/${NAMESPACE}/${kind}"
     for name in $(kubectl --kubeconfig="${kconfig}" get -n "${NAMESPACE}" -o name "${kind}" || true); do
-      kubectl --kubeconfig="${kconfig}" get -n "${NAMESPACE}" -o yaml "${name}" | tee "${DIR_NAME}/${kind}/$(basename "${name}").yaml" || true
+      kubectl --kubeconfig="${kconfig}" get -n "${NAMESPACE}" -o yaml "${name}" | tee "${DIR_NAME}/${NAMESPACE}/${kind}/$(basename "${name}").yaml" || true
     done
   done
 done


### PR DESCRIPTION
There is a possibility to miss same kinds of manifest in different namespace. So this PR will add the namespace directory in manifest collection to gather all the manifests which will improve debugging capability.