### PR TITLE
✨ Use Out-of-service taint in Node remediation in place of deletion

### DIFF
--- a/baremetal/mocks/zz_generated.metal3remediation_manager.go
+++ b/baremetal/mocks/zz_generated.metal3remediation_manager.go
@@ -60,6 +60,20 @@ func (m *MockRemediationManagerInterface) EXPECT() *MockRemediationManagerInterf
 	return m.recorder
 }
 
+// AddOutOfServiceTaint mocks base method.
+func (m *MockRemediationManagerInterface) AddOutOfServiceTaint(ctx context.Context, clusterClient v11.CoreV1Interface, node *v1.Node) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddOutOfServiceTaint", ctx, clusterClient, node)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddOutOfServiceTaint indicates an expected call of AddOutOfServiceTaint.
+func (mr *MockRemediationManagerInterfaceMockRecorder) AddOutOfServiceTaint(ctx, clusterClient, node interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOutOfServiceTaint", reflect.TypeOf((*MockRemediationManagerInterface)(nil).AddOutOfServiceTaint), ctx, clusterClient, node)
+}
+
 // DeleteNode mocks base method.
 func (m *MockRemediationManagerInterface) DeleteNode(ctx context.Context, clusterClient v11.CoreV1Interface, node *v1.Node) error {
 	m.ctrl.T.Helper()
@@ -220,6 +234,20 @@ func (mr *MockRemediationManagerInterfaceMockRecorder) HasFinalizer() *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasFinalizer", reflect.TypeOf((*MockRemediationManagerInterface)(nil).HasFinalizer))
 }
 
+// HasOutOfServiceTaint mocks base method.
+func (m *MockRemediationManagerInterface) HasOutOfServiceTaint(node *v1.Node) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasOutOfServiceTaint", node)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasOutOfServiceTaint indicates an expected call of HasOutOfServiceTaint.
+func (mr *MockRemediationManagerInterfaceMockRecorder) HasOutOfServiceTaint(node interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasOutOfServiceTaint", reflect.TypeOf((*MockRemediationManagerInterface)(nil).HasOutOfServiceTaint), node)
+}
+
 // HasReachRetryLimit mocks base method.
 func (m *MockRemediationManagerInterface) HasReachRetryLimit() bool {
 	m.ctrl.T.Helper()
@@ -244,6 +272,20 @@ func (m *MockRemediationManagerInterface) IncreaseRetryCount() {
 func (mr *MockRemediationManagerInterfaceMockRecorder) IncreaseRetryCount() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncreaseRetryCount", reflect.TypeOf((*MockRemediationManagerInterface)(nil).IncreaseRetryCount))
+}
+
+// IsNodeDrained mocks base method.
+func (m *MockRemediationManagerInterface) IsNodeDrained(ctx context.Context, clusterClient v11.CoreV1Interface, node *v1.Node) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsNodeDrained", ctx, clusterClient, node)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsNodeDrained indicates an expected call of IsNodeDrained.
+func (mr *MockRemediationManagerInterfaceMockRecorder) IsNodeDrained(ctx, clusterClient, node interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNodeDrained", reflect.TypeOf((*MockRemediationManagerInterface)(nil).IsNodeDrained), ctx, clusterClient, node)
 }
 
 // IsPowerOffRequested mocks base method.
@@ -300,6 +342,20 @@ func (m *MockRemediationManagerInterface) RemoveNodeBackupAnnotations() {
 func (mr *MockRemediationManagerInterfaceMockRecorder) RemoveNodeBackupAnnotations() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveNodeBackupAnnotations", reflect.TypeOf((*MockRemediationManagerInterface)(nil).RemoveNodeBackupAnnotations))
+}
+
+// RemoveOutOfServiceTaint mocks base method.
+func (m *MockRemediationManagerInterface) RemoveOutOfServiceTaint(ctx context.Context, clusterClient v11.CoreV1Interface, node *v1.Node) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveOutOfServiceTaint", ctx, clusterClient, node)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveOutOfServiceTaint indicates an expected call of RemoveOutOfServiceTaint.
+func (mr *MockRemediationManagerInterfaceMockRecorder) RemoveOutOfServiceTaint(ctx, clusterClient, node interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveOutOfServiceTaint", reflect.TypeOf((*MockRemediationManagerInterface)(nil).RemoveOutOfServiceTaint), ctx, clusterClient, node)
 }
 
 // RemovePowerOffAnnotation mocks base method.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -119,6 +119,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+- apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:
   - metal3clusters
@@ -336,3 +342,10 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - list
+  - watch

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -58,6 +58,9 @@ const (
 	osTypeCentos           = "centos"
 	osTypeUbuntu           = "ubuntu"
 	ironicSuffix           = "-ironic"
+	// Out-of-service Taint test actions.
+	oostAdded   = "added"
+	oostRemoved = "removed"
 )
 
 var releaseMarkerPrefix = "go://github.com/metal3-io/cluster-api-provider-metal3@v%s"

--- a/test/e2e/remediation_based_feature_test.go
+++ b/test/e2e/remediation_based_feature_test.go
@@ -17,15 +17,19 @@ import (
  * These tests involve simulating failure scenarios, triggering the remediation process, and then verifying that the remediation actions successfully restore the nodes to the desired state.
  *
  * Test Types:
- * 1. Metal3Remediation Test: This test specifically evaluates the Metal3 Remediation Controller's node deletion feature in the reboot remediation strategy.
+ * 1. Metal3Remediation Test: This test specifically evaluates the Metal3 Remediation Controller's node management feature in the reboot remediation strategy.
  * 2. Remediation Test: This test focuses on verifying various annotations and actions related to remediation in the CAPM3 (Cluster API Provider for Metal3).
  *
- * NodeDeletionRemediation Test:
+ * NodeRemediation Test:
  * - Retrieve the list of Metal3 machines associated with the worker nodes.
  * - Identify the target worker Metal3Machine and its corresponding BareMetalHost (BMH) object.
  * - Create a Metal3Remediation resource with a remediation strategy of type "Reboot" and a specified timeout.
  * - Wait for the associated virtual machine (VM) to power off.
- * - Wait for the node (VM) to be deleted.
+ * - If kubernetes server version < 1.28:
+ *   - Wait for the node (VM) to be deleted.
+ * - If kubernetes server version >= 1.28:
+ *   - Wait for the out-of-service taint to be set on the node.
+ *   - Wait for the out-of-service taint to be removed from the node.
  * - Wait for the VM to power on.
  * - Wait for the node to be in a ready state.
  * - Delete the Metal3Remediation resource.
@@ -71,9 +75,9 @@ var _ = Describe("Testing nodes remediation [remediation] [features]", Label("re
 		targetCluster, _ = createTargetCluster(e2eConfig.GetVariable("KUBERNETES_VERSION"))
 
 		// Run Metal3Remediation test first, doesn't work after remediation...
-		By("Running node deletion remediation tests")
-		nodeDeletionRemediation(ctx, func() NodeDeletionRemediation {
-			return NodeDeletionRemediation{
+		By("Running node remediation tests")
+		nodeRemediation(ctx, func() NodeRemediation {
+			return NodeRemediation{
 				E2EConfig:             e2eConfig,
 				BootstrapClusterProxy: bootstrapClusterProxy,
 				TargetCluster:         targetCluster,

--- a/test/go.mod
+++ b/test/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/onsi/gomega v1.33.1
 	github.com/pkg/errors v0.9.1
 	golang.org/x/crypto v0.24.0
+	golang.org/x/mod v0.18.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.29.6
 	k8s.io/apiextensions-apiserver v0.29.6
@@ -124,7 +125,6 @@ require (
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
-	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/oauth2 v0.18.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -351,8 +351,8 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
-golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
-golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.18.0 h1:5+9lSbEzPSdWkH32vYPBwEpX8KwDbM52Ud9xBUvNlb0=
+golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, Metal3Remediation deletes the Node object to speed up the remediation, however, starting from Kubernetes 1.28 (GA) the new out-of-service taint is available, and CAPM3 can use it in place of deleting the node.

**Which issue(s) this PR fixes**:
Fixes #1725
