### PR TITLE
🌱 Fix issues in running local hack scripts

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC2292
 
 set -eux
 

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# Ignore the rule that says we should always quote variables, because
+# in this script we *do* want globbing.
+# shellcheck disable=SC2086,SC2292
+
 set -eux
 
 IS_CONTAINER="${IS_CONTAINER:-false}"
@@ -7,30 +11,17 @@ ARTIFACTS="${ARTIFACTS:-/tmp}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
-    export XDG_CACHE_HOME=/tmp/.cache
-    eval "$(go env)"
-    cd "${GOPATH}"/src/github.com/metal3-io/cluster-api-provider-metal3
-    INPUT_FILES="\
-    config/certmanager/*.yaml
-    config/crd/*.yaml
-    config/crd/bases/*.yaml
-    config/crd/patches/*.yaml
-    config/default/*.yaml
-    config/default/capm3/*.yaml
-    config/ipam/*.yaml
-    config/manager/*.yaml
-    config/rbac/*.yaml
-    config/webhook/*.yaml
-    api/v1beta1/zz_generated.*.go
-    baremetal/mocks/zz_generated.*.go"
+    # we need to tell git its OK to use dir owned by someone else
+    git config --global safe.directory /workdir
+    export XDG_CACHE_HOME="/tmp/.cache"
 
-    # shellcheck disable=SC2086
+    INPUT_FILES="$(git ls-files config) $(git ls-files | grep zz_generated)"
     cksum ${INPUT_FILES} > "${ARTIFACTS}/lint.cksums.before"
     export VERBOSE="--verbose"
     make generate
-    # shellcheck disable=SC2086
     cksum ${INPUT_FILES} > "${ARTIFACTS}/lint.cksums.after"
     diff "${ARTIFACTS}/lint.cksums.before" "${ARTIFACTS}/lint.cksums.after"
+
 else
     "${CONTAINER_RUNTIME}" run --rm \
         --env IS_CONTAINER=TRUE \
@@ -38,5 +29,5 @@ else
         --entrypoint sh \
         --workdir /workdir \
         docker.io/golang:1.22 \
-        /workdir/hack/codegen.sh
+        /workdir/hack/codegen.sh "$@"
 fi

--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -4,6 +4,7 @@
 # 2.  Verify that running the above doesn't change go.mod and go.sum
 #
 # NOTE: This won't work unless the build environment has internet access
+# shellcheck disable=SC2292
 
 set -eux
 

--- a/hack/manifestlint.sh
+++ b/hack/manifestlint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC2292
 
 set -eux
 

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # markdownlint-cli2 has config file(s) named .markdownlint-cli2.yaml in the repo
+# shellcheck disable=SC2292
 
 set -eux
 

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC2292
 
 set -eux
 

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC2292
 
 set -eux
 


### PR DESCRIPTION
In CAPM3, there was only issues in codegen. Fix that, plus made it dynamically detect all the config and generated files, so they're included if they'd be generated elsewhere. It is in line with BMO generate.sh now.

For others, simply adding one shellcheck ignore for a optional check many people have enabled about, tired of seeing my editor complain :)
