### PR TITLE
🌱 schedule dependabot on certain day, and add ok-to-test automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,18 @@
 
 version: 2
 updates:
-## Main branch config starts here
+## main branch config starts here
 - package-ecosystem: "github-actions"
   directory: "/" # Location of package manifests
   schedule:
     interval: "monthly"
+    day: "tuesday"
   target-branch: main
   commit-message:
     prefix: ":seedling:"
-    # Go
+  labels:
+  - "ok-to-test"
+  # Go
 - package-ecosystem: "gomod"
   directories:
   - "/"
@@ -20,6 +23,7 @@ updates:
   - "/test"
   schedule:
     interval: "weekly"
+    day: "wednesday"
   target-branch: main
   ## group all dependencies with a k8s.io prefix into a single PR.
   groups:
@@ -38,19 +42,25 @@ updates:
   - dependency-name: "github.com/metal3-io/ip-address-manager/api"
   commit-message:
     prefix: ":seedling:"
-## Main branch config ends here
+  labels:
+  - "ok-to-test"
+## main branch config ends here
 ## release-1.7 branch config starts here
 - package-ecosystem: "github-actions"
   directory: "/" # Location of package manifests
   schedule:
     interval: "monthly"
+    day: "tuesday"
   target-branch: release-1.7
-  commit-message:
-    prefix: ":seedling:"
   ignore:
   # Ignore major and minor bumps for release branch
   - dependency-name: "*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+  - "ok-to-test"
+  # Go
 - package-ecosystem: "gomod"
   directories:
   - "/"
@@ -59,6 +69,7 @@ updates:
   - "/test"
   schedule:
     interval: "weekly"
+    day: "wednesday"
   target-branch: release-1.7
   ## group all dependencies with a k8s.io prefix into a single PR.
   groups:
@@ -75,19 +86,25 @@ updates:
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   commit-message:
     prefix: ":seedling:"
+  labels:
+  - "ok-to-test"
 ## release-1.7 branch config ends here
 ## release-1.6 branch config starts here
 - package-ecosystem: "github-actions"
   directory: "/" # Location of package manifests
   schedule:
     interval: "monthly"
+    day: "tuesday"
   target-branch: release-1.6
-  commit-message:
-    prefix: ":seedling:"
   ignore:
   # Ignore major and minor bumps for release branch
   - dependency-name: "*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+  - "ok-to-test"
+  # Go
 - package-ecosystem: "gomod"
   directories:
   - "/"
@@ -96,6 +113,7 @@ updates:
   - "/test"
   schedule:
     interval: "weekly"
+    day: "wednesday"
   target-branch: release-1.6
   ## group all dependencies with a k8s.io prefix into a single PR.
   groups:
@@ -112,4 +130,6 @@ updates:
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   commit-message:
     prefix: ":seedling:"
+  labels:
+  - "ok-to-test"
 ## release-1.6 branch config ends here


### PR DESCRIPTION
CAPM3 schedule:
- GH actions: tuesday
- Gomod: wednesday

Automatically add labels:
- ok-to-test

We have dynamic Prow scheduling now and proper requests, we should not suffer from load failures in very basic tests anymore.
