### PR TITLE
:seedling: remove KUBECTL_SHA256 passthru

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -31,7 +31,6 @@ export CAPI_VERSION=${CAPI_VERSION:-"v1beta1"}
 export CAPM3_VERSION=${CAPM3_VERSION:-"v1beta1"}
 export NUM_NODES=${NUM_NODES:-"4"}
 export KUBERNETES_VERSION=${KUBERNETES_VERSION}
-export KUBECTL_SHA256=${KUBECTL_SHA256}
 export IMAGE_OS=${IMAGE_OS}
 export FORCE_REPO_UPDATE="false"
 EOF
@@ -77,4 +76,3 @@ if [ -n "${CLUSTER_TOPOLOGY:-}" ]; then
 else
     make e2e-tests
 fi
-

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -50,9 +50,6 @@ fi
 
 export FROM_K8S_VERSION=${FROM_K8S_VERSION:-"v1.29.0"}
 export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.30.0"}
-# NOTE: kubectl sha256 must match the provided KUBERNETES_VERSION, and must be
-# provided in JJB for upgrade tests where version is different from the default
-export KUBECTL_SHA256="${KUBECTL_SHA256:-7c3807c0f5c1b30110a2ff1e55da1d112a6d0096201f1beb81b269f582b5d1c5}"
 
 # Can be overriden from jjbs
 export CAPI_VERSION=${CAPI_VERSION:-"v1beta1"}


### PR DESCRIPTION
We no longer need to pass-thru KUBECTL_SHA256 as we download it and verify it from the downloaded checksum.

This depends on https://github.com/metal3-io/metal3-dev-env/pull/1437 merging first.
/hold