### PR TITLE
🌱 Bump golang 1.22 in release 1.6

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: '1.20'
+          go-version: '1.22'
       - name: Generate release artifacts and notes
         run: |
           make release

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -45,7 +45,7 @@ linters:
 
 linters-settings:
   gosec:
-    go: "1.20"
+    go: "1.22"
     severity: medium
     confidence: medium
     concurrency: 8
@@ -91,9 +91,9 @@ linters-settings:
     allow-leading-space: false
     require-specific: true
   staticcheck:
-    go: "1.20"
+    go: "1.22"
   stylecheck:
-    go: "1.20"
+    go: "1.22"
   gocritic:
     enabled-tags:
       - experimental
@@ -112,7 +112,7 @@ linters-settings:
       - whyNoLint
       - wrapperFunc
   unused:
-    go: "1.20"
+    go: "1.22"
 issues:
   exclude-rules:
     - path: test/e2e

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.21.11@sha256:a8edec58ba598e2f1259f4ec4ca1b06358468214225e73d7c841ab0980c12367
+ARG BUILD_IMAGE=docker.io/golang:1.22.5@sha256:f47a7952d08277f9816459d851319c9041637022f04517388d9f32e384fc2dab
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary on golang image

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SHELL:=/usr/bin/env bash
 
 .DEFAULT_GOAL:=help
 
-GO_VERSION ?= 1.21.11
+GO_VERSION ?= 1.22.5
 GO := $(shell type -P go)
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell $(GO) env GOPROXY)

--- a/Tiltfile
+++ b/Tiltfile
@@ -129,7 +129,7 @@ def fixup_yaml_empty_arrays(yaml_str):
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.20 as tilt-helper
+FROM golang:1.22 as tilt-helper
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \

--- a/controllers/metal3data_controller_test.go
+++ b/controllers/metal3data_controller_test.go
@@ -80,11 +80,11 @@ var _ = Describe("Metal3Data manager", func() {
 				}
 				if tc.m3d != nil && !tc.m3d.DeletionTimestamp.IsZero() {
 					if tc.releaseLeasesRequeue {
-						m.EXPECT().ReleaseLeases(context.TODO()).Return(baremetal.WithTransientError(errors.New(""), requeueAfter))
+						m.EXPECT().ReleaseLeases(context.Background()).Return(baremetal.WithTransientError(errors.New(""), requeueAfter))
 					} else if tc.releaseLeasesError {
-						m.EXPECT().ReleaseLeases(context.TODO()).Return(errors.New(""))
+						m.EXPECT().ReleaseLeases(context.Background()).Return(errors.New(""))
 					} else {
-						m.EXPECT().ReleaseLeases(context.TODO()).Return(nil)
+						m.EXPECT().ReleaseLeases(context.Background()).Return(nil)
 						m.EXPECT().UnsetFinalizer()
 					}
 				}
@@ -93,9 +93,9 @@ var _ = Describe("Metal3Data manager", func() {
 					tc.reconcileNormal {
 					m.EXPECT().SetFinalizer()
 					if tc.reconcileNormalError {
-						m.EXPECT().Reconcile(context.TODO()).Return(errors.New(""))
+						m.EXPECT().Reconcile(context.Background()).Return(errors.New(""))
 					} else {
-						m.EXPECT().Reconcile(context.TODO()).Return(nil)
+						m.EXPECT().Reconcile(context.Background()).Return(nil)
 					}
 				}
 

--- a/controllers/metal3datatemplate_controller_test.go
+++ b/controllers/metal3datatemplate_controller_test.go
@@ -85,9 +85,9 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				}
 			}
 			if tc.m3dt != nil && !tc.m3dt.DeletionTimestamp.IsZero() && tc.reconcileDeleteError {
-				m.EXPECT().UpdateDatas(context.TODO()).Return(0, errors.New(""))
+				m.EXPECT().UpdateDatas(context.Background()).Return(0, errors.New(""))
 			} else if tc.m3dt != nil && !tc.m3dt.DeletionTimestamp.IsZero() {
-				m.EXPECT().UpdateDatas(context.TODO()).Return(0, nil)
+				m.EXPECT().UpdateDatas(context.Background()).Return(0, nil)
 				m.EXPECT().UnsetFinalizer()
 			}
 
@@ -95,9 +95,9 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				tc.reconcileNormal {
 				m.EXPECT().SetFinalizer()
 				if tc.reconcileNormalError {
-					m.EXPECT().UpdateDatas(context.TODO()).Return(0, errors.New(""))
+					m.EXPECT().UpdateDatas(context.Background()).Return(0, errors.New(""))
 				} else {
-					m.EXPECT().UpdateDatas(context.TODO()).Return(1, nil)
+					m.EXPECT().UpdateDatas(context.Background()).Return(1, nil)
 				}
 			}
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -17,6 +17,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.20 \
+        docker.io/golang:1.22 \
         /workdir/hack/build.sh "$@"
 fi

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -38,6 +38,6 @@ else
         --volume "${PWD}:/workdir:rw,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.20 \
+        docker.io/golang:1.22 \
         /workdir/hack/codegen.sh
 fi

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -32,7 +32,7 @@ EOF
     local go_version
     IFS=" " read -ra go_version <<< "$(go version)"
     local minimum_go_version
-    minimum_go_version=go1.20
+    minimum_go_version=go1.22
     if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]] && [[ "${go_version[2]}" != "devel" ]]; then
         cat << EOF
 Detected go version: ${go_version[*]}.

--- a/hack/gofmt.sh
+++ b/hack/gofmt.sh
@@ -29,6 +29,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.20 \
+        docker.io/golang:1.22 \
         /workdir/hack/gofmt.sh
 fi

--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -39,6 +39,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.20 \
+        docker.io/golang:1.22 \
         /workdir/hack/gomod.sh "$@"
 fi

--- a/hack/govet.sh
+++ b/hack/govet.sh
@@ -17,6 +17,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.20 \
+        docker.io/golang:1.22 \
         /workdir/hack/govet.sh
 fi

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -17,6 +17,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.20 \
+        docker.io/golang:1.22 \
         /workdir/hack/unit.sh "$@"
 fi


### PR DESCRIPTION
This is done since golang 1.20 is already deprecated

Fixes #1829