### PR TITLE
🌱 Silence fetch logs and fetch manifests scripts

### DIFF
--- a/scripts/fetch_manifests.sh
+++ b/scripts/fetch_manifests.sh
@@ -48,6 +48,8 @@ manifests=(
   m3datatemplate
 )
 
+set +x
+
 NAMESPACES="$(kubectl --kubeconfig="${kconfig}" get namespace -o jsonpath='{.items[*].metadata.name}')"
 for NAMESPACE in ${NAMESPACES}; do
   for kind in "${manifests[@]}"; do

--- a/scripts/fetch_target_logs.sh
+++ b/scripts/fetch_target_logs.sh
@@ -5,6 +5,9 @@ set -x
 DIR_NAME="/tmp/target_cluster_logs"
 NAMESPACES="$(kubectl --kubeconfig="${KUBECONFIG_WORKLOAD}" get namespace -o jsonpath='{.items[*].metadata.name}')"
 mkdir -p "${DIR_NAME}"
+
+set +x
+
 for NAMESPACE in ${NAMESPACES}
 do
   mkdir -p "${DIR_NAME}/${NAMESPACE}"


### PR DESCRIPTION
 Silence fetch logs and fetch manifests scripts as they are too noisy in jenkins logs which makes debugging unpleasant. 