### PR TITLE
:seedling: Bump BMO to v0.8.0-rc.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.3
 require (
 	github.com/go-logr/logr v1.4.2
 	github.com/golang/mock v1.6.0
-	github.com/metal3-io/baremetal-operator/apis v0.7.0-rc.0
+	github.com/metal3-io/baremetal-operator/apis v0.8.0-rc.0
 	github.com/metal3-io/cluster-api-provider-metal3/api v0.0.0
 	github.com/metal3-io/ip-address-manager/api v1.8.0-rc.0
 	github.com/onsi/ginkgo/v2 v2.20.1
@@ -63,7 +63,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
-	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.7.0-rc.0 // indirect
+	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.8.0-rc.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,10 +129,10 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
-github.com/metal3-io/baremetal-operator/apis v0.7.0-rc.0 h1:+eOzr2APO+wMuVG96PllccI1rMNT+NwdFFOFYHNeXuQ=
-github.com/metal3-io/baremetal-operator/apis v0.7.0-rc.0/go.mod h1:eeCH0K7XD17AbEp479XtmYTF0QwOqNkoTCQf3bdZSzk=
-github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.7.0-rc.0 h1:i47DClCJmwdvSDEcc9sNvEELyfxpiqPz9r6nrDkj6Xk=
-github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.7.0-rc.0/go.mod h1:f1a/eqi7MA+mf1xFshToVfn02jcPDMw3aYQinLTlMVQ=
+github.com/metal3-io/baremetal-operator/apis v0.8.0-rc.0 h1:Kq7vE910VkEnIXJMt9wESHCqL976eCt/S01BsJzqYII=
+github.com/metal3-io/baremetal-operator/apis v0.8.0-rc.0/go.mod h1:eeCH0K7XD17AbEp479XtmYTF0QwOqNkoTCQf3bdZSzk=
+github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.8.0-rc.0 h1:xZVvdWyBBOUvKbiWsnwyuijVjPhpSjiSId9zs0uU6nM=
+github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.8.0-rc.0/go.mod h1:f1a/eqi7MA+mf1xFshToVfn02jcPDMw3aYQinLTlMVQ=
 github.com/metal3-io/ip-address-manager/api v1.8.0-rc.0 h1:cAHXlwguKbFdt3iPfeV5EXLmd3+7YYAmJvhlIi+7Qzk=
 github.com/metal3-io/ip-address-manager/api v1.8.0-rc.0/go.mod h1:0PjnN4ke64Jh6A3U04mMvV2sBwePa7HKkiZXazktCTk=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=

--- a/scripts/fetch_manifests.sh
+++ b/scripts/fetch_manifests.sh
@@ -48,6 +48,8 @@ manifests=(
   m3datatemplate
 )
 
+set +x
+
 NAMESPACES="$(kubectl --kubeconfig="${kconfig}" get namespace -o jsonpath='{.items[*].metadata.name}')"
 for NAMESPACE in ${NAMESPACES}; do
   for kind in "${manifests[@]}"; do

--- a/scripts/fetch_target_logs.sh
+++ b/scripts/fetch_target_logs.sh
@@ -5,6 +5,9 @@ set -x
 DIR_NAME="/tmp/target_cluster_logs"
 NAMESPACES="$(kubectl --kubeconfig="${KUBECONFIG_WORKLOAD}" get namespace -o jsonpath='{.items[*].metadata.name}')"
 mkdir -p "${DIR_NAME}"
+
+set +x
+
 for NAMESPACE in ${NAMESPACES}
 do
   mkdir -p "${DIR_NAME}/${NAMESPACE}"

--- a/test/go.mod
+++ b/test/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/docker/docker v27.1.2+incompatible
 	github.com/jinzhu/copier v0.4.0
-	github.com/metal3-io/baremetal-operator/apis v0.7.0-rc.0
+	github.com/metal3-io/baremetal-operator/apis v0.8.0-rc.0
 	github.com/metal3-io/cluster-api-provider-metal3/api v0.0.0
 	github.com/metal3-io/ip-address-manager/api v1.8.0-rc.0
 	github.com/onsi/ginkgo/v2 v2.20.1
@@ -89,7 +89,7 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
-	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.7.0-rc.0 // indirect
+	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.8.0-rc.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -189,10 +189,10 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
-github.com/metal3-io/baremetal-operator/apis v0.7.0-rc.0 h1:+eOzr2APO+wMuVG96PllccI1rMNT+NwdFFOFYHNeXuQ=
-github.com/metal3-io/baremetal-operator/apis v0.7.0-rc.0/go.mod h1:eeCH0K7XD17AbEp479XtmYTF0QwOqNkoTCQf3bdZSzk=
-github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.7.0-rc.0 h1:i47DClCJmwdvSDEcc9sNvEELyfxpiqPz9r6nrDkj6Xk=
-github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.7.0-rc.0/go.mod h1:f1a/eqi7MA+mf1xFshToVfn02jcPDMw3aYQinLTlMVQ=
+github.com/metal3-io/baremetal-operator/apis v0.8.0-rc.0 h1:Kq7vE910VkEnIXJMt9wESHCqL976eCt/S01BsJzqYII=
+github.com/metal3-io/baremetal-operator/apis v0.8.0-rc.0/go.mod h1:eeCH0K7XD17AbEp479XtmYTF0QwOqNkoTCQf3bdZSzk=
+github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.8.0-rc.0 h1:xZVvdWyBBOUvKbiWsnwyuijVjPhpSjiSId9zs0uU6nM=
+github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.8.0-rc.0/go.mod h1:f1a/eqi7MA+mf1xFshToVfn02jcPDMw3aYQinLTlMVQ=
 github.com/metal3-io/ip-address-manager/api v1.8.0-rc.0 h1:cAHXlwguKbFdt3iPfeV5EXLmd3+7YYAmJvhlIi+7Qzk=
 github.com/metal3-io/ip-address-manager/api v1.8.0-rc.0/go.mod h1:0PjnN4ke64Jh6A3U04mMvV2sBwePa7HKkiZXazktCTk=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=


### PR DESCRIPTION
As we accidentally published BMO v0.8.0-rc.0 instead of v0.7.0-rc.0, we decided to skip release-0.7 and jump directly to release-0.8.
