### PR TITLE
🌱 Increase wait-deployment timeout

### DIFF
--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -222,7 +222,7 @@ intervals:
   default/wait-vm-state: ["20m", "100ms"]
   default/monitor-vm-state: ["1m", "500ms"]
   default/monitor-provisioning: ["5m", "500ms"]
-  default/wait-deployment: ["10m", "10s"]
+  default/wait-deployment: ["15m", "10s"]
   default/wait-job: ["10m", "10s"]
   default/wait-service: ["10m", "10s"]
   default/wait-object-provisioned: ["10m", "10s"]


### PR DESCRIPTION
This PR increases wait-deployment timeout as we hit this in CI quite often in private cloud.  
