### PR TITLE
🌱 Reuse PR verifier workflow from project-infra

### DIFF
--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -1,22 +1,12 @@
 name: PR Verifier
 
+permissions: {}
+
 on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
-permissions: {}
-
 jobs:
   verify:
-    runs-on: ubuntu-latest
     name: verify PR contents
-
-    permissions:
-      checks: write
-
-    steps:
-    - name: Verifier action
-      id: verifier
-      uses: kubernetes-sigs/kubebuilder-release-tools@012269a88fa4c034a0acf1ba84c26b195c0dbab4 # v0.4.3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+    uses: metal3-io/project-infra/.github/workflows/pr-verifier.yaml@main


### PR DESCRIPTION
Reuse PR verifier workflow from project-infra, so it is easier to maintain in a single place and reduces number of dependabot bump PRs targeting Github Actions, creating less noise.