### PR TITLE
:bug: Metal3DataTemplate: requeue if reconcileDelete did not clear finalizer

### DIFF
--- a/controllers/metal3datatemplate_controller_test.go
+++ b/controllers/metal3datatemplate_controller_test.go
@@ -159,6 +159,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			expectManager:        true,
 			reconcileDeleteError: true,
 			expectError:          true,
+			expectRequeue:        true,
 		}),
 		Entry("Paused cluster", testCaseReconcile{
 			m3dt: &infrav1.Metal3DataTemplate{
@@ -292,7 +293,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				m.EXPECT().UpdateDatas(context.TODO()).Return(0, errors.New(""))
 			}
 
-			res, err := r.reconcileDelete(context.TODO(), m)
+			res, err := r.reconcileDelete(context.TODO(), m, logr.Discard())
 			gomockCtrl.Finish()
 
 			if tc.ExpectError {
@@ -307,14 +308,14 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			}
 
 		},
-		Entry("No error", reconcileDeleteTestCase{
+		Entry("No error, not ready", reconcileDeleteTestCase{
 			ExpectError:   false,
-			ExpectRequeue: false,
+			ExpectRequeue: true,
 		}),
 		Entry("Delete error", reconcileDeleteTestCase{
 			DeleteError:   true,
 			ExpectError:   true,
-			ExpectRequeue: false,
+			ExpectRequeue: true,
 		}),
 		Entry("Delete ready", reconcileDeleteTestCase{
 			ExpectError:   false,


### PR DESCRIPTION
**What this PR does / why we need it**:

This MR is a proposal to address #1994.

The reconcileDelete implementation of the Metal3DataTemplate controller needs to requeue if it decided that it can't yet unset the finalizer on the Metal3DataTemplate.  If no requeue is made, there's a scenario where Metal3Data still exists when reconcileDelete is first called, which results in not unsetting the finalize - in that situation, if no change of the Metal3DataTemplate triggers a new reconciliation, the finalizer never gets unset.

To finalize this PR I had to adjust the expectations of the unit test (expect requeue where this initially wasn't expected). 

This made we realize that there is another situation where we want to requeue: the case where `dataTemplateMgr.UpdateDatas` returns an error. The code was relying on checkReconcileError, which (a) can only return requeue results on baremetal.ReconcileError errors (not on other errors), and (b) even for those would not return a requeue for "Terminal" errors, which I is I think only a valid choice for when this function is called for reconcileNormal ; for deletes, it seems that requeues should always be done to avoid the resource remaining stuck on a finalizer.

