### PR TITLE
:bug: Fix unterminating DataTemplate deletion

### DIFF
--- a/baremetal/metal3datatemplate_manager_test.go
+++ b/baremetal/metal3datatemplate_manager_test.go
@@ -256,7 +256,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			nbIndexes, err := templateMgr.UpdateDatas(context.TODO())
+			hasData, _, err := templateMgr.UpdateDatas(context.TODO())
 			if tc.expectRequeue || tc.expectError {
 				Expect(err).To(HaveOccurred())
 				if tc.expectRequeue {
@@ -267,7 +267,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			} else {
 				Expect(err).NotTo(HaveOccurred())
 			}
-			Expect(nbIndexes).To(Equal(tc.expectedNbIndexes))
+			Expect(hasData).To(Equal(tc.expectedNbIndexes > 0))
 			Expect(tc.template.Status.LastUpdated.IsZero()).To(BeFalse())
 			Expect(tc.template.Status.Indexes).To(Equal(tc.expectedIndexes))
 

--- a/baremetal/mocks/zz_generated.metal3datatemplate_manager.go
+++ b/baremetal/mocks/zz_generated.metal3datatemplate_manager.go
@@ -92,12 +92,13 @@ func (mr *MockDataTemplateManagerInterfaceMockRecorder) UnsetFinalizer() *gomock
 }
 
 // UpdateDatas mocks base method.
-func (m *MockDataTemplateManagerInterface) UpdateDatas(arg0 context.Context) (int, error) {
+func (m *MockDataTemplateManagerInterface) UpdateDatas(arg0 context.Context) (bool, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateDatas", arg0)
-	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // UpdateDatas indicates an expected call of UpdateDatas.

--- a/controllers/metal3data_controller.go
+++ b/controllers/metal3data_controller.go
@@ -115,11 +115,14 @@ func (r *Metal3DataReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if !metal3Data.ObjectMeta.DeletionTimestamp.IsZero() {
 		// Check if the Metal3DataClaim is gone. We cannot clean up until it is.
 		err := r.Client.Get(ctx, types.NamespacedName{Name: metal3Data.Spec.Claim.Name, Namespace: metal3Data.Spec.Claim.Namespace}, &infrav1.Metal3DataClaim{})
-		if err != nil && apierrors.IsNotFound(err) {
-			return r.reconcileDelete(ctx, metadataMgr)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return r.reconcileDelete(ctx, metadataMgr)
+			}
+			return ctrl.Result{}, err
 		}
-		// We were unable to determine if the Metal3DataClaim is gone
-		return ctrl.Result{}, err
+		// Requeue until Metal3DataClaim is gone.
+		return ctrl.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
 	}
 
 	// Handle non-deleted machines

--- a/controllers/metal3datatemplate_controller.go
+++ b/controllers/metal3datatemplate_controller.go
@@ -142,7 +142,7 @@ func (r *Metal3DataTemplateReconciler) reconcileNormal(ctx context.Context,
 	// If the Metal3DataTemplate doesn't have finalizer, add it.
 	dataTemplateMgr.SetFinalizer()
 
-	_, err := dataTemplateMgr.UpdateDatas(ctx)
+	_, _, err := dataTemplateMgr.UpdateDatas(ctx)
 	if err != nil {
 		return checkReconcileError(err, "Failed to recreate the status")
 	}
@@ -152,16 +152,19 @@ func (r *Metal3DataTemplateReconciler) reconcileNormal(ctx context.Context,
 func (r *Metal3DataTemplateReconciler) reconcileDelete(ctx context.Context,
 	dataTemplateMgr baremetal.DataTemplateManagerInterface,
 ) (ctrl.Result, error) {
-	allocationsCount, err := dataTemplateMgr.UpdateDatas(ctx)
+	hasData, hasClaims, err := dataTemplateMgr.UpdateDatas(ctx)
 	if err != nil {
 		return checkReconcileError(err, "Failed to recreate the status")
 	}
 
-	if allocationsCount == 0 {
-		// metal3datatemplate is marked for deletion and ready to be deleted,
-		// so remove the finalizer.
-		dataTemplateMgr.UnsetFinalizer()
+	if hasClaims {
+		return ctrl.Result{}, nil
 	}
+	if hasData {
+		return ctrl.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
+	}
+
+	dataTemplateMgr.UnsetFinalizer()
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/metal3datatemplate_controller_test.go
+++ b/controllers/metal3datatemplate_controller_test.go
@@ -83,9 +83,9 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				}
 			}
 			if tc.m3dt != nil && !tc.m3dt.DeletionTimestamp.IsZero() && tc.reconcileDeleteError {
-				m.EXPECT().UpdateDatas(context.Background()).Return(0, errors.New(""))
+				m.EXPECT().UpdateDatas(context.Background()).Return(false, false, errors.New(""))
 			} else if tc.m3dt != nil && !tc.m3dt.DeletionTimestamp.IsZero() {
-				m.EXPECT().UpdateDatas(context.Background()).Return(0, nil)
+				m.EXPECT().UpdateDatas(context.Background()).Return(false, false, nil)
 				m.EXPECT().UnsetFinalizer()
 			}
 
@@ -93,9 +93,9 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				tc.reconcileNormal {
 				m.EXPECT().SetFinalizer()
 				if tc.reconcileNormalError {
-					m.EXPECT().UpdateDatas(context.Background()).Return(0, errors.New(""))
+					m.EXPECT().UpdateDatas(context.Background()).Return(false, false, errors.New(""))
 				} else {
-					m.EXPECT().UpdateDatas(context.Background()).Return(1, nil)
+					m.EXPECT().UpdateDatas(context.Background()).Return(true, true, nil)
 				}
 			}
 
@@ -232,9 +232,9 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			m.EXPECT().SetFinalizer()
 
 			if !tc.UpdateError {
-				m.EXPECT().UpdateDatas(context.TODO()).Return(1, nil)
+				m.EXPECT().UpdateDatas(context.TODO()).Return(true, true, nil)
 			} else {
-				m.EXPECT().UpdateDatas(context.TODO()).Return(0, errors.New(""))
+				m.EXPECT().UpdateDatas(context.TODO()).Return(false, false, errors.New(""))
 			}
 
 			res, err := r.reconcileNormal(context.TODO(), m)
@@ -284,12 +284,12 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			m := baremetal_mocks.NewMockDataTemplateManagerInterface(gomockCtrl)
 
 			if !tc.DeleteError && tc.DeleteReady {
-				m.EXPECT().UpdateDatas(context.TODO()).Return(0, nil)
+				m.EXPECT().UpdateDatas(context.TODO()).Return(false, false, nil)
 				m.EXPECT().UnsetFinalizer()
 			} else if !tc.DeleteError {
-				m.EXPECT().UpdateDatas(context.TODO()).Return(1, nil)
+				m.EXPECT().UpdateDatas(context.TODO()).Return(true, true, nil)
 			} else {
-				m.EXPECT().UpdateDatas(context.TODO()).Return(0, errors.New(""))
+				m.EXPECT().UpdateDatas(context.TODO()).Return(false, false, errors.New(""))
 			}
 
 			res, err := r.reconcileDelete(context.TODO(), m)


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR fixes some non terminating Data/DataTemplate deletion. Some Metal3Data and Metal3DataTemplates were not destroyed  in rare circumstances due to missing reconcile events caused  by two distinct problems.

DataTemplate deletion has a watch over DataClaims but deletion  can only be performed when Data are completely removed (finalizer  executed) because Data resource requires the template.
    
We keep the facts that Data and DataClaims are still existing.
* When DataClaims exist, we do not remove the finalizer and wait   for reconcile events from the watch.
* If we have neither DataClaims or Data, we can safely  remove the finalizer. Deletion is complete.
* Otherwise we have to make a busy wait on Data deletion as there is no more claim to generate event but we still  need to wait until the Data finalizers have been executed.

The other source of problem is Metal3Data deletion : if Metal3Data is deleted before the Metal3DataClaim, we must actively wait for the claim deletion, as no other reconciliation event will be triggered.

**Alternative implementations**
Data resources may not need the template during deletion as we want to remove every ip claim associated to it. In that case,
we only need to wait for data claims deletion and we can remove the busy wait from templates over data resources.

Fixes #1994
