### PR TITLE
:bug: Propagate errors during patch to reconcile

### DIFF
--- a/controllers/metal3cluster_controller.go
+++ b/controllers/metal3cluster_controller.go
@@ -88,6 +88,7 @@ func (r *Metal3ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	defer func() {
 		if err := patchMetal3Cluster(ctx, patchHelper, metal3Cluster); err != nil {
 			clusterLog.Error(err, "failed to Patch metal3Cluster")
+			rerr = err
 		}
 	}()
 

--- a/controllers/metal3data_controller.go
+++ b/controllers/metal3data_controller.go
@@ -79,6 +79,7 @@ func (r *Metal3DataReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		err := helper.Patch(ctx, metal3Data)
 		if err != nil {
 			metadataLog.Info("failed to Patch Metal3Data")
+			rerr = err
 		}
 	}()
 

--- a/controllers/metal3datatemplate_controller.go
+++ b/controllers/metal3datatemplate_controller.go
@@ -91,6 +91,7 @@ func (r *Metal3DataTemplateReconciler) Reconcile(ctx context.Context, req ctrl.R
 		err := helper.Patch(ctx, metal3DataTemplate)
 		if err != nil {
 			log.Info("failed to Patch Metal3DataTemplate")
+			rerr = err
 		}
 	}()
 

--- a/controllers/metal3labelsync_controller.go
+++ b/controllers/metal3labelsync_controller.go
@@ -105,6 +105,7 @@ func (r *Metal3LabelSyncReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		err := helper.Patch(ctx, host)
 		if err != nil {
 			controllerLog.Info("Failed to Patch BareMetalHost")
+			rerr = err
 		}
 	}()
 

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -96,6 +96,7 @@ func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	defer func() {
 		if err := patchMetal3Machine(ctx, patchHelper, capm3Machine); err != nil {
 			machineLog.Error(err, "failed to Patch metal3Machine")
+			rerr = err
 		}
 	}()
 

--- a/controllers/metal3machinetemplate_controller.go
+++ b/controllers/metal3machinetemplate_controller.go
@@ -77,6 +77,7 @@ func (r *Metal3MachineTemplateReconciler) Reconcile(ctx context.Context, req ctr
 		err := helper.Patch(ctx, metal3MachineTemplate)
 		if err != nil {
 			m3templateLog.Info("failed to patch Metal3MachineTemplate")
+			rerr = err
 		}
 	}()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
If an otherwise succesful reconcile has a failure during the deferred patch process (typically conflict), the error is ignored, the resource is never modified and the reconciliation may never be retriggerred.

The fix propagates error err to global variable rerr.

**Which issue(s) this PR fixes**
Fixes #2002

