### PR TITLE
🌱 Fixing issues in healthcheck test

### DIFF
--- a/test/e2e/basic_integration_test.go
+++ b/test/e2e/basic_integration_test.go
@@ -16,7 +16,7 @@ var _ = Describe("When testing basic cluster creation [basic]", Label("basic"), 
 		validateGlobals(specName)
 
 		// We need to override clusterctl apply log folder to avoid getting our credentials exposed.
-		clusterctlLogFolder = filepath.Join(os.TempDir(), "clusters", bootstrapClusterProxy.GetName())
+		clusterctlLogFolder = filepath.Join(os.TempDir(), "target_cluster_logs", bootstrapClusterProxy.GetName())
 	})
 
 	It("Should create a workload cluster", func() {
@@ -27,6 +27,6 @@ var _ = Describe("When testing basic cluster creation [basic]", Label("basic"), 
 	})
 
 	AfterEach(func() {
-		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
+		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, targetCluster, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 	})
 })

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -220,6 +220,7 @@ intervals:
   default/wait-machine-upgrade: ["50m", "10s"]
   default/wait-machine-remediation: ["30m", "10s"]
   default/wait-vm-state: ["20m", "100ms"]
+  default/wait-nodes-ready: ["15m", "5s"]
   default/monitor-vm-state: ["1m", "500ms"]
   default/monitor-provisioning: ["5m", "500ms"]
   default/wait-deployment: ["30m", "10s"]
@@ -238,3 +239,5 @@ intervals:
   default/wait-pod-restart: ["6m", "10s"]
   default/wait-deprovision-cluster: ["30m", "10s"]
   default/wait-all-pod-to-be-running-on-target-cluster: ["30m", "10s"]
+  default/wait-command: ["2m", "10s"]
+  default/wait-delete-remediation-template: ["5m", "10s"]

--- a/test/e2e/integration_test.go
+++ b/test/e2e/integration_test.go
@@ -62,6 +62,6 @@ var _ = Describe("When testing integration [integration]", Label("integration"),
 	})
 
 	AfterEach(func() {
-		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
+		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, targetCluster, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 	})
 })

--- a/test/e2e/ip_reuse_test.go
+++ b/test/e2e/ip_reuse_test.go
@@ -18,7 +18,7 @@ var _ = Describe("When testing ip reuse [ip-reuse] [features]", Label("ip-reuse"
 		validateGlobals(specName)
 
 		// We need to override clusterctl apply log folder to avoid getting our credentials exposed.
-		clusterctlLogFolder = filepath.Join(os.TempDir(), "clusters", bootstrapClusterProxy.GetName())
+		clusterctlLogFolder = filepath.Join(os.TempDir(), "target_cluster_logs", bootstrapClusterProxy.GetName())
 	})
 	It("Should create a workload cluster then verify ip allocation reuse while upgrading k8s", func() {
 		IPReuse(ctx, func() IPReuseInput {
@@ -39,6 +39,6 @@ var _ = Describe("When testing ip reuse [ip-reuse] [features]", Label("ip-reuse"
 		ListMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		ListMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		ListNodes(ctx, targetCluster.GetClient())
-		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
+		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, targetCluster, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 	})
 })

--- a/test/e2e/logcollector.go
+++ b/test/e2e/logcollector.go
@@ -135,7 +135,8 @@ func FetchClusterLogs(clusterProxy framework.ClusterProxy, outputPath string) er
 		// Get all pods in the namespace
 		pods, err := clientset.CoreV1().Pods(namespace.Name).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return fmt.Errorf("couldn't list pods in namespace %s: %v", namespace.Name, err)
+			fmt.Printf("couldn't list pods in namespace %s: %v", namespace.Name, err)
+			continue
 		}
 		for _, pod := range pods.Items {
 			machineName := pod.Spec.NodeName
@@ -144,7 +145,8 @@ func FetchClusterLogs(clusterProxy framework.ClusterProxy, outputPath string) er
 			podDir := filepath.Join(baseDir, "machines", machineName, namespace.Name, pod.Name)
 			err = os.MkdirAll(podDir, 0775)
 			if err != nil {
-				return fmt.Errorf("couldn't write to file: %v", err)
+				fmt.Printf("couldn't write to file: %v", err)
+				continue
 			}
 
 			// Get detailed information about the Pod
@@ -158,14 +160,16 @@ func FetchClusterLogs(clusterProxy framework.ClusterProxy, outputPath string) er
 			}
 			podDescription, err := podDescriber.Describe(namespace.Name, pod.Name, describerSettings)
 			if err != nil {
-				return fmt.Errorf("couldn't describe pod %s in namespace %s: %v", pod.Name, namespace.Name, err)
+				fmt.Printf("couldn't describe pod %s in namespace %s: %v", pod.Name, namespace.Name, err)
+				continue
 			}
 
 			// Print the Pod information to file
 			file := filepath.Join(podDir, "stdout_describe.log")
 			err = os.WriteFile(file, []byte(podDescription), 0600)
 			if err != nil {
-				return fmt.Errorf("couldn't write to file: %v", err)
+				fmt.Printf("couldn't write to file: %v", err)
+				continue
 			}
 
 			// Get containers of the Pod
@@ -175,7 +179,8 @@ func FetchClusterLogs(clusterProxy framework.ClusterProxy, outputPath string) er
 
 				err := CollectContainerLogs(ctx, namespace.Name, pod.Name, container.Name, clientset, containerDir)
 				if err != nil {
-					return err
+					fmt.Printf("Error %v.", err)
+					continue
 				}
 			}
 		}

--- a/test/e2e/pivoting_based_feature_test.go
+++ b/test/e2e/pivoting_based_feature_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Testing features in ephemeral or target cluster [pivoting] [fe
 			validateGlobals(specName)
 
 			// We need to override clusterctl apply log folder to avoid getting our credentials exposed.
-			clusterctlLogFolder = filepath.Join(os.TempDir(), "clusters", bootstrapClusterProxy.GetName())
+			clusterctlLogFolder = filepath.Join(os.TempDir(), "target_cluster_logs", bootstrapClusterProxy.GetName())
 		})
 
 		It("Should get a management cluster then test cert rotation and node reuse", func() {
@@ -165,7 +165,7 @@ var _ = Describe("Testing features in ephemeral or target cluster [pivoting] [fe
 					}
 				})
 			}
-			DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
+			DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, targetCluster, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 		})
 
 	})

--- a/test/e2e/remediation_based_feature_test.go
+++ b/test/e2e/remediation_based_feature_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Testing nodes remediation [remediation] [features]", Label("re
 		validateGlobals(specName)
 
 		// We need to override clusterctl apply log folder to avoid getting our credentials exposed.
-		clusterctlLogFolder = filepath.Join(os.TempDir(), "clusters", bootstrapClusterProxy.GetName())
+		clusterctlLogFolder = filepath.Join(os.TempDir(), "target_cluster_logs", bootstrapClusterProxy.GetName())
 	})
 
 	It("Should create a cluster and run remediation based tests", func() {
@@ -90,9 +90,11 @@ var _ = Describe("Testing nodes remediation [remediation] [features]", Label("re
 		By("Running healthcheck tests")
 		healthcheck(ctx, func() HealthCheckInput {
 			return HealthCheckInput{
+				E2EConfig:             e2eConfig,
 				BootstrapClusterProxy: bootstrapClusterProxy,
 				ClusterName:           clusterName,
 				Namespace:             namespace,
+				SpecName:              specName,
 			}
 		})
 
@@ -115,7 +117,7 @@ var _ = Describe("Testing nodes remediation [remediation] [features]", Label("re
 		ListMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		ListMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		ListNodes(ctx, targetCluster.GetClient())
-		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
+		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, targetCluster, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 	})
 
 })

--- a/test/e2e/upgrade_kubernetes_test.go
+++ b/test/e2e/upgrade_kubernetes_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Kubernetes version upgrade in target nodes [k8s-upgrade]", Lab
 		validateGlobals(specName)
 
 		// We need to override clusterctl apply log folder to avoid getting our credentials exposed.
-		clusterctlLogFolder = filepath.Join(os.TempDir(), "clusters", bootstrapClusterProxy.GetName())
+		clusterctlLogFolder = filepath.Join(os.TempDir(), "target_cluster_logs", bootstrapClusterProxy.GetName())
 	})
 
 	It("Should create a cluster and run k8s_upgrade tests", func() {
@@ -60,7 +60,7 @@ var _ = Describe("Kubernetes version upgrade in target nodes [k8s-upgrade]", Lab
 		ListMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		ListMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
 		ListNodes(ctx, targetCluster.GetClient())
-		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
+		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, targetCluster, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup)
 	})
 
 })


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Adding more logs and fixing issues in healthcheck test.
This PR is 
- Making sure that Metal3RemediationTemplate is deleted after the healthcheck test is done.
- Wrapping "kubelet stop" command around Eventually so it does not fail. If eventually is not used the ssh connection fails sometimes, and failure is most of the time in the first "kubelet stop"(https://github.com/metal3-io/cluster-api-provider-metal3/blob/aa67ad5c84af874212be142c92aac195114556c9/test/e2e/healthchek.go#L51). Adding some wait eventually fixes the issue.
- Fixing FetchClusterLogs function, in case of any error FetchClusterLogs was returning and missing logs for remaining pods, that is fixed in this PR.
- Changing logs folder from "clusters" to "target_cluster_logs", in project infra we are only checking "target_cluster_logs".
- This PR is also fixing the failure "No Control Plane machines came into existence. " in remediation tests, it started happening after this PR: https://github.com/metal3-io/cluster-api-provider-metal3/pull/2039/files 



