### PR TITLE
🌱 Increase test time for lint job to avoid failure because of timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ e2e-tests: $(GINKGO) e2e-substitutions cluster-templates # This target should be
 
 .PHONY: e2e-clusterclass-tests
 e2e-clusterclass-tests: CONTAINER_RUNTIME?=docker # Env variable can override this default
-export CONTAINER_RUNTIME 
+export CONTAINER_RUNTIME
 
 e2e-clusterclass-tests: $(GINKGO) e2e-substitutions clusterclass-templates # This target should be called from scripts/ci-e2e.sh
 	for image in $(E2E_CONTAINERS); do \
@@ -285,7 +285,7 @@ $(CONVERSION_GEN): $(TOOLS_DIR)/go.mod
 $(KUBEBUILDER): $(TOOLS_DIR)/go.mod
 	cd $(TOOLS_DIR) && ./install_kubebuilder.sh
 
-$(SETUP_ENVTEST): 
+$(SETUP_ENVTEST):
 	GOBIN=$(TOOLS_BIN_DIR) $(GO) install $(SETUP_ENVTEST_PKG)@$(SETUP_ENVTEST_VER)
 
 .PHONY: $(GINKGO_BIN)
@@ -317,9 +317,9 @@ $(ENVSUBST_BIN): $(ENVSUBST) ## Build envsubst from tools folder.
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT) ## Lint codebase
-	$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
-	cd $(APIS_DIR) && $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
-	cd $(TEST_DIR) && $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
+	$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=15m
+	cd $(APIS_DIR) && $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=15m
+	cd $(TEST_DIR) && $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=15m
 
 .PHONY: lint-fix
 lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter
@@ -457,7 +457,7 @@ docker-push: ## Push the docker image
 CONTAINER_RUNTIME := $(if $(CONTAINER_RUNTIME),$(CONTAINER_RUNTIME),docker)
 export CONTAINER_RUNTIME
 
-build-fkas: 
+build-fkas:
 	cd $(FAKE_APISERVER_DIR) && $(CONTAINER_RUNTIME) build --build-arg ARCH=$(ARCH) -t "quay.io/metal3-io/metal3-fkas:latest" .
 
 ## --------------------------------------


### PR DESCRIPTION
Recently we have seen failure couple of times on our PR because of timeout on lint jobs. Previously we were having 10m timeout and now because of slow behavior during download or installation, it is taking more that 10 minutes to finish the job. So we are increasing the timeout to 15 minutes.
Example Error:
```
level=info msg="[loader] Go packages loading at mode 575 (imports|name|types_sizes|exports_file|deps|files|compiled_files) took 7m35.412810649s"
level=info msg="[runner/filename_unadjuster] Pre-built 0 adjustments in 128.217442ms"
level=info msg="Memory: 5297 samples, avg is 237.5MB, max is 1731.2MB"
level=info msg="Execution took 9m59.9976098[49](https://prow.apps.test.metal3.io/view/s3/prow-logs/pr-logs/pull/metal3-io_cluster-api-provider-metal3/2051/test/1849171193945395200#1:build-log.txt%3A49)s"
level=info msg="[linters_context/goanalysis] analyzers took 16m59.795047653s with top 10 stages: buildir: 13m38.187222976s, gocritic: 39.26[50](https://prow.apps.test.metal3.io/view/s3/prow-logs/pr-logs/pull/metal3-io_cluster-api-provider-metal3/2051/test/1849171193945395200#1:build-log.txt%3A50)77753s, nilness: 29.955480409s, inspect: 18.271902532s, fact_purity: 14.812827464s, the_only_name: 11.443065544s, printf: 10.936805377s, ctrlflow: 10.611117684s, fact_deprecated: 10.191963784s, typedness: 9.927419314s"
level=info msg="[runner] Issues before processing: 107, after processing: 0"
level=info msg="[runner] Processors filtering stat (out/in): cgo: 107/107, skip_files: 98/107, exclude-rules: 6/98, filename_unadjuster: 107/107, path_prettifier: 107/107, skip_dirs: 98/98, exclude: 98/98, nolint: 0/6, autogenerated_exclude: 98/98, identifier_marker: 98/98"
level=info msg="[runner] processing took 28.818655ms with stages: autogenerated_exclude: 6.580779ms, exclude-rules: 6.485584ms, nolint: 6.201115ms, identifier_marker: 4.76034ms, path_prettifier: 3.945564ms, skip_files: 449.36µs, skip_dirs: 281.22µs, cgo: 75.967µs, filename_unadjuster: 18.108µs, max_same_issues: 9.561µs, uniq_by_line: 2.43µs, exclude: 1.482µs, severity-rules: 1.348µs, fixer: 1.258µs, max_per_file_from_linter: 1.111µs, max_from_linter: 724ns, diff: 724ns, source_code: 611ns, sort_results: 574ns, path_prefixer: 453ns, path_shortener: 342ns"
level=info msg="[runner] linters took 2m45.616565474s with stages: goanalysis_metalinter: 2m45.550290406s"
level=info msg="File cache stats: [51](https://prow.apps.test.metal3.io/view/s3/prow-logs/pr-logs/pull/metal3-io_cluster-api-provider-metal3/2051/test/1849171193945395200#1:build-log.txt%3A51) entries of total size 882.0KiB"
level=error msg="Timeout exceeded: try increasing it by passing --timeout option"
make: *** [Makefile:319: lint] Error 4
```

[Lint test](https://prow.apps.test.metal3.io/view/s3/prow-logs/pr-logs/pull/metal3-io_cluster-api-provider-metal3/2051/test/1849171193945395200)
