### PR TITLE
🐛 Fix clusterclass KubeadmControlPlaneTemplate file

### DIFF
--- a/test/e2e/data/infrastructure-metal3/bases/clusterclass-centos-kubeadm-config/clusterclass-centos-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/bases/clusterclass-centos-kubeadm-config/clusterclass-centos-kubeadm-config.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ${CLUSTER_NAME}
   namespace: ${NAMESPACE}
 spec:
-template:
+  template:
     spec:
       kubeadmConfigSpec:
         clusterConfiguration: {}


### PR DESCRIPTION
`KubeadmControlPlaneTemplate` has indentation mistake in template field which was not intercepted by webhook but caused weird issues