### PR TITLE
🌱Enable TLS 1.3 flag in CAPM3

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,6 +25,7 @@ spec:
         - "--enableBMHNameBasedPreallocation=${ENABLE_BMH_NAME_BASED_PREALLOCATION:=false}"
         - "--diagnostics-address=${CAPM3_DIAGNOSTICS_ADDRESS:=:8443}"
         - "--insecure-diagnostics=${CAPM3_INSECURE_DIAGNOSTICS:=false}"
+        - "--tls-min-version=${TLS_MIN_VERSION:=VersionTLS13}"
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager


### PR DESCRIPTION
PR will add the --tls-min-version flag value to VersionTLS13 to use TLS 1.3.