### PR TITLE
:bug: Add CustomDeploy to metal3machinetemplate webhook

### DIFF
--- a/api/v1beta1/metal3machinetemplate_webhook.go
+++ b/api/v1beta1/metal3machinetemplate_webhook.go
@@ -55,7 +55,9 @@ func (c *Metal3MachineTemplate) ValidateDelete() (admission.Warnings, error) {
 func (c *Metal3MachineTemplate) validate() error {
 	var allErrs field.ErrorList
 
-	allErrs = append(allErrs, c.Spec.Template.Spec.Image.Validate(*field.NewPath("Spec", "Template", "Spec", "Image"))...)
+	if c.Spec.Template.Spec.CustomDeploy == nil || c.Spec.Template.Spec.CustomDeploy.Method == "" {
+		allErrs = append(allErrs, c.Spec.Template.Spec.Image.Validate(*field.NewPath("Spec", "Template", "Spec", "Image"))...)
+	}
 
 	if len(allErrs) == 0 {
 		return nil

--- a/api/v1beta1/metal3machinetemplate_webhook_test.go
+++ b/api/v1beta1/metal3machinetemplate_webhook_test.go
@@ -58,6 +58,21 @@ func TestMetal3MachineTemplateValidation(t *testing.T) {
 	validIso.Spec.Template.Spec.Image.Checksum = ""
 	validIso.Spec.Template.Spec.Image.DiskFormat = ptr.To(LiveISODiskFormat)
 
+	validCustomDeploy := &Metal3MachineTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+		},
+		Spec: Metal3MachineTemplateSpec{
+			Template: Metal3MachineTemplateResource{
+				Spec: Metal3MachineSpec{
+					CustomDeploy: &CustomDeploy{
+						Method: "install_great_stuff",
+					},
+				},
+			},
+		},
+	}
+
 	tests := []struct {
 		name      string
 		expectErr bool
@@ -82,6 +97,11 @@ func TestMetal3MachineTemplateValidation(t *testing.T) {
 			name:      "should succeed when disk format is 'live-iso' even when checksum is empty",
 			expectErr: false,
 			c:         validIso,
+		},
+		{
+			name:      "should succeed with customDeploy",
+			expectErr: false,
+			c:         validCustomDeploy,
 		},
 	}
 


### PR DESCRIPTION
This mirrors the code in metal3machine webhook.  We are loosening the requirement on `Image`: when using `CustomDeploy`, `Image` is optional.

Ref: #1501 