### PR TITLE
:bug: bootstrap: add support for data secret

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -171,7 +171,11 @@ func (m *MachineManager) IsProvisioned() bool {
 
 // IsBootstrapReady checks if the machine is given Bootstrap data.
 func (m *MachineManager) IsBootstrapReady() bool {
-	return m.Machine.Status.BootstrapReady
+	if m.Machine.Spec.Bootstrap.ConfigRef != nil {
+		return m.Machine.Status.BootstrapReady
+	}
+
+	return m.Machine.Spec.Bootstrap.DataSecretName != nil
 }
 
 // isControlPlane returns true if the machine is a control plane.

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -429,6 +429,8 @@ var _ = Describe("Metal3Machine manager", func() {
 		ExpectTrue bool
 	}
 
+	testCaseBootstrapReadySecretName := "secret"
+
 	DescribeTable("Test BootstrapReady",
 		func(tc testCaseBootstrapReady) {
 			machineMgr, err := NewMachineManager(nil, nil, nil, &tc.Machine, nil,
@@ -442,6 +444,11 @@ var _ = Describe("Metal3Machine manager", func() {
 		},
 		Entry("ready", testCaseBootstrapReady{
 			Machine: clusterv1.Machine{
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &corev1.ObjectReference{},
+					},
+				},
 				Status: clusterv1.MachineStatus{
 					BootstrapReady: true,
 				},
@@ -451,6 +458,16 @@ var _ = Describe("Metal3Machine manager", func() {
 		Entry("not ready", testCaseBootstrapReady{
 			Machine:    clusterv1.Machine{},
 			ExpectTrue: false,
+		}),
+		Entry("ready data secret", testCaseBootstrapReady{
+			Machine: clusterv1.Machine{
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						DataSecretName: &testCaseBootstrapReadySecretName,
+					},
+				},
+			},
+			ExpectTrue: true,
 		}),
 	)
 


### PR DESCRIPTION
We can configure bootstrap by setting `ConfigRef` or `DataSecretName`. Here, we correct the logic that determines if bootstrapping is ready to allow the data secret method as well as `ConfigRef`.

