### PR TITLE
:seedling: bump golang to 1.23.3 and golangci-lint to 1.60.3

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -2,9 +2,8 @@ name: golangci-lint
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [ opened, edited, synchronize, reopened ]
 
-# Remove all permissions from GITHUB_TOKEN except metadata.
 permissions: {}
 
 jobs:
@@ -32,5 +31,6 @@ jobs:
     - name: golangci-lint-${{matrix.working-directory}}
       uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
       with:
-        version: v1.56.2
+        version: v1.60.3
         working-directory: ${{matrix.working-directory}}
+        args: --timeout=15m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,10 +1,6 @@
 run:
-  deadline: 5m
-  skip-dirs:
-  - mock*
-  skip-files:
-  - "zz_generated.*\\.go$"
-  - ".*conversion.*\\.go$"
+  deadline: 15m
+  go: "1.23"
 linters:
   disable-all: true
   enable:
@@ -13,12 +9,12 @@ linters:
   - bidichk
   - bodyclose
   - containedctx
+  - copyloopvar
   - dogsled
   - dupword
   - durationcheck
   - errcheck
   - errchkjson
-  - exportloopref
   - gci
   - ginkgolinter
   - goconst
@@ -57,7 +53,7 @@ linters:
 
 linters-settings:
   gosec:
-    go: "1.22"
+    go: "1.23"
     severity: medium
     confidence: medium
     concurrency: 8
@@ -100,10 +96,6 @@ linters-settings:
     allow-unused: false
     allow-leading-space: false
     require-specific: true
-  staticcheck:
-    go: "1.22"
-  stylecheck:
-    go: "1.22"
   gocritic:
     enabled-tags:
     - experimental
@@ -122,8 +114,13 @@ linters-settings:
     - whyNoLint
     - wrapperFunc
   unused:
-    go: "1.22"
+    go: "1.23"
 issues:
+  exclude-dirs:
+  - mock*
+  exclude-files:
+  - "zz_generated.*\\.go$"
+  - ".*conversion.*\\.go$"
   exclude-rules:
   - path: test/e2e
     linters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.22.8@sha256:b274ff14d8eb9309b61b1a45333bf0559a554ebcf6732fa2012dbed9b01ea56f
+ARG BUILD_IMAGE=docker.io/golang:1.23.3@sha256:d56c3e08fe5b27729ee3834854ae8f7015af48fd651cd25d1e3bcf3c19830174
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary on golang image

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SHELL:=/usr/bin/env bash
 
 .DEFAULT_GOAL:=help
 
-GO_VERSION ?= 1.22.8
+GO_VERSION ?= 1.23.3
 GO := $(shell type -P go)
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell $(GO) env GOPROXY)

--- a/Tiltfile
+++ b/Tiltfile
@@ -171,7 +171,7 @@ def fixup_yaml_empty_arrays(yaml_str):
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.22 as tilt-helper
+FROM golang:1.23 as tilt-helper
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \

--- a/baremetal/metal3cluster_manager.go
+++ b/baremetal/metal3cluster_manager.go
@@ -130,7 +130,7 @@ func (s *ClusterManager) UpdateClusterStatus() error {
 	if err != nil {
 		s.Metal3Cluster.Status.Ready = false
 		s.setError("Invalid ControlPlaneEndpoint values", capierrors.InvalidConfigurationClusterError)
-		conditions.MarkFalse(s.Metal3Cluster, infrav1.BaremetalInfrastructureReadyCondition, infrav1.ControlPlaneEndpointFailedReason, clusterv1.ConditionSeverityError, err.Error())
+		conditions.MarkFalse(s.Metal3Cluster, infrav1.BaremetalInfrastructureReadyCondition, infrav1.ControlPlaneEndpointFailedReason, clusterv1.ConditionSeverityError, "%s", err.Error())
 		return err
 	}
 
@@ -192,7 +192,7 @@ func (s *ClusterManager) listDescendants(ctx context.Context) (clusterv1.Machine
 
 	if s.client.List(ctx, &machines, listOptions...) != nil {
 		errMsg := fmt.Sprintf("failed to list metal3machines for cluster %s/%s", cluster.Namespace, cluster.Name)
-		return machines, errors.Wrapf(err, errMsg)
+		return machines, errors.Wrapf(err, "%s", errMsg)
 	}
 
 	return machines, nil

--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -784,7 +784,6 @@ func (m *DataManager) releaseAddressFromM3Pool(ctx context.Context, poolRef core
 	ipClaimsList, err := m.fetchIPClaimsWithLabels(ctx, poolRef.Name)
 	if err == nil {
 		for _, ipClaimWithLabels := range ipClaimsList {
-			ipClaimWithLabels := ipClaimWithLabels
 			// remove finalizers from Metal3IPClaim first before proceeding to deletion in case
 			// EnableBMHNameBasedPreallocation is set to True.
 			finalizerErr = m.removeFinalizers(ctx, &ipClaimWithLabels)

--- a/baremetal/metal3datatemplate_manager.go
+++ b/baremetal/metal3datatemplate_manager.go
@@ -185,7 +185,6 @@ func (m *DataTemplateManager) UpdateDatas(ctx context.Context) (bool, bool, erro
 	hasClaims := false
 	// Iterate over the Metal3Data objects to find all indexes and objects
 	for _, dataClaim := range dataClaimObjects.Items {
-		dataClaim := dataClaim
 		// If DataTemplate does not point to this object, discard
 		if dataClaim.Spec.Template.Name != m.DataTemplate.Name {
 			continue

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -329,15 +329,9 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 
 	// A machine bootstrap not ready case is caught in the controller
 	// ReconcileNormal function
-	err = m.getUserDataSecretName(ctx)
-	if err != nil {
-		return err
-	}
+	m.getUserDataSecretName(ctx)
 
-	err = m.setHostLabel(ctx, host)
-	if err != nil {
-		return err
-	}
+	m.setHostLabel(ctx, host)
 
 	err = m.setHostConsumerRef(ctx, host)
 	if err != nil {
@@ -418,9 +412,9 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 // for the BareMetalHost through Metal3Machine. The UserDataSecretName might already be in a secret with
 // CABPK v0.3.0+, but if it is in a different namespace than the BareMetalHost,
 // then we need to create the secret.
-func (m *MachineManager) getUserDataSecretName(_ context.Context) error {
+func (m *MachineManager) getUserDataSecretName(_ context.Context) {
 	if m.Metal3Machine.Status.UserData != nil {
-		return nil
+		return
 	}
 
 	if m.Metal3Machine.Spec.UserData != nil {
@@ -433,15 +427,13 @@ func (m *MachineManager) getUserDataSecretName(_ context.Context) error {
 			Name:      *m.Machine.Spec.Bootstrap.DataSecretName,
 			Namespace: m.Machine.Namespace,
 		}
-		return nil
+		return
 	} else if m.Machine.Spec.Bootstrap.ConfigRef != nil {
 		m.Metal3Machine.Status.UserData = &corev1.SecretReference{
 			Name:      m.Machine.Spec.Bootstrap.ConfigRef.Name,
 			Namespace: m.Machine.Spec.Bootstrap.ConfigRef.Namespace,
 		}
 	}
-
-	return nil
 }
 
 // Delete deletes a metal3 machine and is invoked by the Machine Controller.
@@ -834,7 +826,6 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmov1alpha1.BareMetal
 	availableHostsWithNodeReuse := []*bmov1alpha1.BareMetalHost{}
 
 	for i, host := range hosts.Items {
-		host := host
 		if host.Spec.ConsumerRef != nil && consumerRefMatches(host.Spec.ConsumerRef, m.Metal3Machine) {
 			m.Log.Info("Found host with existing ConsumerRef", "host", host.Name)
 			helper, err := patch.NewHelper(&hosts.Items[i], m.client)
@@ -1031,13 +1022,11 @@ func (m *MachineManager) setBMCSecretLabel(ctx context.Context, host *bmov1alpha
 }
 
 // setHostLabel will set the set cluster.x-k8s.io/cluster-name to bmh.
-func (m *MachineManager) setHostLabel(_ context.Context, host *bmov1alpha1.BareMetalHost) error {
+func (m *MachineManager) setHostLabel(_ context.Context, host *bmov1alpha1.BareMetalHost) {
 	if host.Labels == nil {
 		host.Labels = make(map[string]string)
 	}
 	host.Labels[clusterv1.ClusterNameLabel] = m.Machine.Spec.ClusterName
-
-	return nil
 }
 
 // setHostSpec will ensure the host's Spec is set according to the machine's

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -2859,12 +2859,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = machineMgr.getUserDataSecretName(context.TODO())
-			if tc.ExpectError {
-				Expect(err).To(HaveOccurred())
-				return
-			}
-			Expect(err).NotTo(HaveOccurred())
+			machineMgr.getUserDataSecretName(context.TODO())
 
 			// Expect the reference to the secret to be passed through
 			if tc.Machine.Spec.Bootstrap.DataSecretName != nil &&

--- a/controllers/metal3cluster_controller.go
+++ b/controllers/metal3cluster_controller.go
@@ -98,7 +98,7 @@ func (r *Metal3ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		invalidConfigError := capierrors.InvalidConfigurationClusterError
 		metal3Cluster.Status.FailureReason = &invalidConfigError
 		metal3Cluster.Status.FailureMessage = ptr.To("Unable to get owner cluster")
-		conditions.MarkFalse(metal3Cluster, infrav1.BaremetalInfrastructureReadyCondition, infrav1.InternalFailureReason, clusterv1.ConditionSeverityError, err.Error())
+		conditions.MarkFalse(metal3Cluster, infrav1.BaremetalInfrastructureReadyCondition, infrav1.InternalFailureReason, clusterv1.ConditionSeverityError, "%s", err.Error())
 		return ctrl.Result{}, err
 	}
 	if cluster == nil {

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -19,6 +19,6 @@ else
         --volume "${PWD}:${WORKDIR}:ro,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        docker.io/golang:1.22 \
+        docker.io/golang:1.23 \
         "${WORKDIR}"/hack/build.sh "$@"
 fi

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -29,6 +29,6 @@ else
         --volume "${PWD}:${WORKDIR}:rw,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        docker.io/golang:1.22 \
+        docker.io/golang:1.23 \
         "${WORKDIR}"/hack/codegen.sh "$@"
 fi

--- a/hack/ensure-golangci-lint.sh
+++ b/hack/ensure-golangci-lint.sh
@@ -60,10 +60,10 @@ download_and_install_golangci_lint()
     KERNEL_OS="$(uname | tr '[:upper:]' '[:lower:]')"
     ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')"
     GOLANGCI_LINT="golangci-lint"
-    GOLANGCI_VERSION="1.56.2"
+    GOLANGCI_VERSION="1.60.3"
     case "${KERNEL_OS}-${ARCH}" in
-        darwin-arm64) GOLANGCI_SHA256="5f9ecda712c7ae08fbf872336fae3db866720e5865903d4c53903184b2a2c2dc" ;;
-        linux-amd64) GOLANGCI_SHA256="e1c313fb5fc85a33890fdee5dbb1777d1f5829c84d655a47a55688f3aad5e501" ;;
+        darwin-arm64) GOLANGCI_SHA256="deb0fbd0b99992d97808614db1214f57d5bdc12b907581e2ef10d3a392aca11f" ;;
+        linux-amd64) GOLANGCI_SHA256="4037af8122871f401ed874852a471e54f147ff8ce80f5a304e020503bdb806ef" ;;
       *)
         echo >&2 "error:${KERNEL_OS}-${ARCH} not supported. Please obtain the binary and calculate sha256 manually."
         exit 1

--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -41,6 +41,6 @@ else
         --volume "${PWD}:${WORKDIR}:ro,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        docker.io/golang:1.22 \
+        docker.io/golang:1.23 \
         "${WORKDIR}"/hack/gomod.sh "$@"
 fi

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -19,6 +19,6 @@ else
         --volume "${PWD}:${WORKDIR}:ro,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        docker.io/golang:1.22 \
+        docker.io/golang:1.23 \
         "${WORKDIR}"/hack/unit.sh "$@"
 fi

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -323,13 +323,13 @@ func ScaleMachineDeployment(ctx context.Context, clusterClient client.Client, cl
 }
 
 // ScaleKubeadmControlPlane scales up/down KubeadmControlPlane object to desired replicas.
-func ScaleKubeadmControlPlane(ctx context.Context, c client.Client, name client.ObjectKey, newReplicaCount int) {
+func ScaleKubeadmControlPlane(ctx context.Context, c client.Client, name client.ObjectKey, newReplicaCount int32) {
 	ctrlplane := controlplanev1.KubeadmControlPlane{}
 	Expect(c.Get(ctx, name, &ctrlplane)).To(Succeed())
 	helper, err := patch.NewHelper(&ctrlplane, c)
 	Expect(err).ToNot(HaveOccurred(), "Failed to create new patch helper")
 
-	ctrlplane.Spec.Replicas = ptr.To(int32(newReplicaCount))
+	ctrlplane.Spec.Replicas = ptr.To(newReplicaCount)
 	Expect(helper.Patch(ctx, &ctrlplane)).To(Succeed())
 }
 
@@ -995,7 +995,6 @@ func CreateOrUpdateWithNamespace(ctx context.Context, p framework.ClusterProxy, 
 		}
 		existingObject.SetAPIVersion(o.GetAPIVersion())
 		existingObject.SetKind(o.GetKind())
-		o := o
 		if err := p.GetClient().Get(ctx, objectKey, existingObject); err != nil {
 			// Expected error -- if the object does not exist, create it
 			if apierrors.IsNotFound(err) {

--- a/test/e2e/remediation.go
+++ b/test/e2e/remediation.go
@@ -136,7 +136,7 @@ func remediation(ctx context.Context, inputGetter func() RemediationInput) {
 
 	By("Testing unhealthy and inspection annotations")
 	By("Scaling down KCP to 1 replica")
-	newReplicaCount := 1
+	newReplicaCount := int32(1)
 	ScaleKubeadmControlPlane(ctx, bootstrapClient, client.ObjectKey{Namespace: "metal3", Name: "test1"}, newReplicaCount)
 	WaitForNumBmhInState(ctx, bmov1alpha1.StateAvailable, WaitForNumInput{
 		Client:    bootstrapClient,


### PR DESCRIPTION
- [x] Bump Golang to 1.23.3.
- [x] Bump Golangci-lint to 1.60.3 to support Go 1.23.
    1. Get rid of deprecated golangci-lint configs
    2. add timeout to the action, otherwise it'll be timed out in 1 minute. 15 minutes is consistent with "make lint" timeout.
- [x] Fix issues coming via new golangci-lint
    1. Fix new linter errors by removing the return value which is always nil (unparam linter), and thus meaningless.                                                                              
    2. "exportloopref" is not needed from Go 1.22 onwards, replaced by "copyloopvar" in golangci-lint 1.60.2.                                                                                  
    3. Ambiguous string warnings in Wrapf fixed.
    4. Fix gosec issue about int32 overflow

Fixes: #2047