### PR TITLE
:bug: Use GOPROXY to download releases

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -9,6 +9,8 @@ export WORKING_DIR=/opt/metal3-dev-env
 FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-false}"
 
 export CAPM3RELEASEBRANCH="${CAPM3RELEASEBRANCH:-main}"
+CAPIGOPROXY="${CAPIGOPROXY:-https://proxy.golang.org/sigs.k8s.io/cluster-api/@v/list}"
+CAPM3GOPROXY="${CAPM3GOPROXY:-https://proxy.golang.org/github.com/metal3-io/cluster-api-provider-metal3/@v/list}"
 
 # Starting from CAPI v1.5.0 version cluster-api config folder location has changed
 # to XDG_CONFIG_HOME folder. Following code defines the cluster-api config folder
@@ -79,7 +81,7 @@ source "${M3_DEV_ENV_PATH}/lib/ironic_tls_setup.sh"
 # By default UPGRADE_FROM_RELEASE is v0.5. if not explicitly exported
 export UPGRADE_FROM_RELEASE="${UPGRADE_FROM_RELEASE:-v0.5.}"
 # Get latest capm3 patch for a minor version $UPGRADE_FROM_RELEASE
-export CAPM3_FROM_RELEASE="${CAPM3_FROM_RELEASE:-$(get_latest_release "${CAPM3RELEASEPATH}" "${UPGRADE_FROM_RELEASE}")}"
+export CAPM3_FROM_RELEASE="${CAPM3_FROM_RELEASE:-$(get_latest_release_from_goproxy "${CAPM3GOPROXY}" "${UPGRADE_FROM_RELEASE}")}"
 # Get latest capi patch for the compatible version with capm3 $UPGRADE_FROM_RELEASE
 # for example the compatible version with capm3 0.5.x is capi 0.4.y
 # If we are not upgrading from v0.5 then the capi compatible has same minor version tag as capm3 e.g v1.1.x
@@ -89,7 +91,7 @@ else
     # If we are not upgrading from v0.5 then the capi compatible has same minor version tag e.g v1.1.x
     CAPI_UPGRADE_FROM_RELEASE=${UPGRADE_FROM_RELEASE}
 fi
-export CAPI_FROM_RELEASE="${CAPI_FROM_RELEASE:-$(get_latest_release "${CAPIRELEASEPATH}" "${CAPI_UPGRADE_FROM_RELEASE}")}"
+export CAPI_FROM_RELEASE="${CAPI_FROM_RELEASE:-$(get_latest_release_from_goproxy "${CAPIGOPROXY}" "${CAPI_UPGRADE_FROM_RELEASE}")}"
 # The e2e config file parameter for the capi release compatible with main (capm3 next version)
 export CAPI_TO_RELEASE="${CAPIRELEASE}"
 # K8s support based on https://cluster-api.sigs.k8s.io/reference/versions.html#core-provider-cluster-api-controller


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: 
Some e2e CI test are experiencing failure due to 
`./scripts/ci-e2e.sh: line 82: CAPM3RELEASEPATH: unbound variable`
`./scripts/ci-e2e.sh: line 92: CAPIRELEASEPATH: unbound variable`

script/ci-e2e.sh is using function `get_latest_release` that used to be set in the Metal-dev-env code base. In [this PR ](https://github.com/metal3-io/metal3-dev-env/pull/1474). Moving to use the function `get_latest_release_from_goproxy` that replaced the function should fix the problem. This function is no longer in CAPM3 release 1.8 but need to be patched to  releases 1.6 and 1.7.


