### PR TITLE
🌱 Adapt e2e test after removal of kube-rbac-proxy in BMO manifest

### DIFF
--- a/test/e2e/data/bmo-deployment/overlays/release-0.8/kustomization.yaml
+++ b/test/e2e/data/bmo-deployment/overlays/release-0.8/kustomization.yaml
@@ -20,8 +20,6 @@ patches:
 images:
 - name: quay.io/metal3-io/baremetal-operator
   newTag: release-0.8
-- name: gcr.io/kubebuilder/kube-rbac-proxy
-  newTag: v0.8.0
 # We cannot use suffix hashes since the kustomizations we build on
 # cannot be aware of what suffixes we add.
 generatorOptions:

--- a/test/e2e/data/bmo-deployment/overlays/release-latest/kustomization.yaml
+++ b/test/e2e/data/bmo-deployment/overlays/release-latest/kustomization.yaml
@@ -20,8 +20,6 @@ patches:
 images:
 - name: quay.io/metal3-io/baremetal-operator
   newTag: latest
-- name: gcr.io/kubebuilder/kube-rbac-proxy
-  newTag: v0.16.0
 # We cannot use suffix hashes since the kustomizations we build on
 # cannot be aware of what suffixes we add.
 generatorOptions:


### PR DESCRIPTION
BMO manifests have removed kub-rbac-proxy due to deprecation. This PR adapts the e2e tests accordoingly.

For reference:
- https://github.com/metal3-io/baremetal-operator/pull/2102
- https://github.com/metal3-io/baremetal-operator/pull/2115

Fixes: #2121 