### PR TITLE
:seedling: Add ironic secrets files and junit e2e result file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ go.work.sum
 
 # Development containers (https://containers.dev/)
 .devcontainer
+
+# e2e result junit xml files
+junit.e2e_suite.*.xml

--- a/test/e2e/data/.gitignore
+++ b/test/e2e/data/.gitignore
@@ -1,0 +1,8 @@
+# ironic username and password files
+*/overlays/*/ironic-username
+*/overlays/*/ironic-password
+*/overlays/*/ironic-auth-config
+*/overlays/*/ironic-inspector-auth-config
+*/overlays/*/ironic-htpasswd
+*/overlays/*/ironic-inspector-htpasswd
+


### PR DESCRIPTION
`scripts/ci-e2e.sh` nowadays generates secrets as files for ironic and bmo overlays used in E2E, and at the end of the test, xml files to store result of the tests. All of these files need to be git-ignored.
