### PR TITLE
🌱 Set value of CAPM3RELEASE instead of relying on metal3-dev-env

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -10,6 +10,16 @@ FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-false}"
 
 export CAPM3RELEASEBRANCH="${CAPM3RELEASEBRANCH:-main}"
 
+# Extract release version from release-branch name
+if [[ "${CAPM3RELEASEBRANCH}" == release-* ]]; then
+    CAPM3_RELEASE_PREFIX="${CAPM3RELEASEBRANCH#release-}"
+    export CAPM3RELEASE="v${CAPM3_RELEASE_PREFIX}.99"
+    export CAPI_RELEASE_PREFIX="v${CAPM3_RELEASE_PREFIX}."
+else
+    export CAPM3RELEASE="v1.10.99"
+    export CAPI_RELEASE_PREFIX="v1.9."
+fi
+
 # Default CAPI_CONFIG_FOLDER to $HOME/.config folder if XDG_CONFIG_HOME not set
 CONFIG_FOLDER="${XDG_CONFIG_HOME:-$HOME/.config}"
 export CAPI_CONFIG_FOLDER="${CONFIG_FOLDER}/cluster-api"


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Set value of CAPM3RELEASE instead of relying on metal3-dev-env

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2181
