### PR TITLE
🌱 Remove CP scaling from e2e-feature-test

### DIFF
--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -78,6 +78,13 @@ if [[ ${GINKGO_FOCUS:-} == "integration" || ${GINKGO_FOCUS:-} == "basic" ]]; the
   export WORKER_MACHINE_COUNT=${WORKER_MACHINE_COUNT:-"1"}
 fi
 
+# IPReuse feature test environment vars and config
+if [[ ${GINKGO_FOCUS:-} == "features" && ${GINKGO_SKIP:-} == "pivoting remediation" ]]; then
+  export NUM_NODES="5"
+  export CONTROL_PLANE_MACHINE_COUNT=${CONTROL_PLANE_MACHINE_COUNT:-"3"}
+  export WORKER_MACHINE_COUNT=${WORKER_MACHINE_COUNT:-"2"}
+fi
+
 # Exported to the cluster templates
 # Generate user ssh key
 if [ ! -f "${HOME}/.ssh/id_rsa" ]; then

--- a/test/e2e/basic_integration_test.go
+++ b/test/e2e/basic_integration_test.go
@@ -23,7 +23,21 @@ var _ = Describe("When testing basic cluster creation [basic]", Label("basic"), 
 		By("Fetching cluster configuration")
 		k8sVersion := e2eConfig.GetVariable("KUBERNETES_VERSION")
 		By("Provision Workload cluster")
-		targetCluster, _ = createTargetCluster(k8sVersion)
+		targetCluster, _ = CreateTargetCluster(ctx, func() CreateTargetClusterInput {
+			return CreateTargetClusterInput{
+				E2EConfig:             e2eConfig,
+				BootstrapClusterProxy: bootstrapClusterProxy,
+				SpecName:              specName,
+				ClusterName:           clusterName,
+				K8sVersion:            k8sVersion,
+				KCPMachineCount:       int64(numberOfControlplane),
+				WorkerMachineCount:    int64(numberOfWorkers),
+				ClusterctlLogFolder:   clusterctlLogFolder,
+				ClusterctlConfigPath:  clusterctlConfigPath,
+				OSType:                osType,
+				Namespace:             namespace,
+			}
+		})
 	})
 
 	AfterEach(func() {

--- a/test/e2e/integration_test.go
+++ b/test/e2e/integration_test.go
@@ -25,7 +25,21 @@ var _ = Describe("When testing integration [integration]", Label("integration"),
 		numberOfControlplane = int(*e2eConfig.GetInt32PtrVariable("CONTROL_PLANE_MACHINE_COUNT"))
 		k8sVersion := e2eConfig.GetVariable("KUBERNETES_VERSION")
 		By("Provision Workload cluster")
-		targetCluster, _ = createTargetCluster(k8sVersion)
+		targetCluster, _ = CreateTargetCluster(ctx, func() CreateTargetClusterInput {
+			return CreateTargetClusterInput{
+				E2EConfig:             e2eConfig,
+				BootstrapClusterProxy: bootstrapClusterProxy,
+				SpecName:              specName,
+				ClusterName:           clusterName,
+				K8sVersion:            k8sVersion,
+				KCPMachineCount:       int64(numberOfControlplane),
+				WorkerMachineCount:    int64(numberOfWorkers),
+				ClusterctlLogFolder:   clusterctlLogFolder,
+				ClusterctlConfigPath:  clusterctlConfigPath,
+				OSType:                osType,
+				Namespace:             namespace,
+			}
+		})
 		By("Pivot objects to target cluster")
 		pivoting(ctx, func() PivotingInput {
 			return PivotingInput{

--- a/test/e2e/ip_reuse_test.go
+++ b/test/e2e/ip_reuse_test.go
@@ -21,8 +21,22 @@ var _ = Describe("When testing ip reuse [ip-reuse] [features]", Label("ip-reuse"
 		clusterctlLogFolder = filepath.Join(os.TempDir(), "target_cluster_logs", bootstrapClusterProxy.GetName())
 	})
 	It("Should create a workload cluster then verify ip allocation reuse while upgrading k8s", func() {
+		targetCluster, _ = CreateTargetCluster(ctx, func() CreateTargetClusterInput {
+			return CreateTargetClusterInput{
+				E2EConfig:             e2eConfig,
+				BootstrapClusterProxy: bootstrapClusterProxy,
+				SpecName:              specName,
+				ClusterName:           clusterName,
+				K8sVersion:            e2eConfig.GetVariable("FROM_K8S_VERSION"),
+				KCPMachineCount:       int64(numberOfControlplane),
+				WorkerMachineCount:    int64(numberOfWorkers),
+				ClusterctlLogFolder:   clusterctlLogFolder,
+				ClusterctlConfigPath:  clusterctlConfigPath,
+				OSType:                osType,
+				Namespace:             namespace,
+			}
+		})
 		IPReuse(ctx, func() IPReuseInput {
-			targetCluster, _ = createTargetCluster(e2eConfig.GetVariable("FROM_K8S_VERSION"))
 			return IPReuseInput{
 				E2EConfig:             e2eConfig,
 				BootstrapClusterProxy: bootstrapClusterProxy,

--- a/test/e2e/remediation_based_feature_test.go
+++ b/test/e2e/remediation_based_feature_test.go
@@ -72,8 +72,21 @@ var _ = Describe("Testing nodes remediation [remediation] [features]", Label("re
 
 	It("Should create a cluster and run remediation based tests", func() {
 		By("Creating target cluster")
-		targetCluster, _ = createTargetCluster(e2eConfig.GetVariable("KUBERNETES_VERSION"))
-
+		targetCluster, _ = CreateTargetCluster(ctx, func() CreateTargetClusterInput {
+			return CreateTargetClusterInput{
+				E2EConfig:             e2eConfig,
+				BootstrapClusterProxy: bootstrapClusterProxy,
+				SpecName:              specName,
+				ClusterName:           clusterName,
+				K8sVersion:            e2eConfig.GetVariable("FROM_K8S_VERSION"),
+				KCPMachineCount:       int64(numberOfControlplane),
+				WorkerMachineCount:    int64(numberOfWorkers),
+				ClusterctlLogFolder:   clusterctlLogFolder,
+				ClusterctlConfigPath:  clusterctlConfigPath,
+				OSType:                osType,
+				Namespace:             namespace,
+			}
+		})
 		// Run Metal3Remediation test first, doesn't work after remediation...
 		By("Running node remediation tests")
 		nodeRemediation(ctx, func() NodeRemediation {

--- a/test/e2e/upgrade_kubernetes_test.go
+++ b/test/e2e/upgrade_kubernetes_test.go
@@ -40,7 +40,21 @@ var _ = Describe("Kubernetes version upgrade in target nodes [k8s-upgrade]", Lab
 
 	It("Should create a cluster and run k8s_upgrade tests", func() {
 		By("Creating target cluster")
-		targetCluster, _ = createTargetCluster(e2eConfig.GetVariable("FROM_K8S_VERSION"))
+		targetCluster, _ = CreateTargetCluster(ctx, func() CreateTargetClusterInput {
+			return CreateTargetClusterInput{
+				E2EConfig:             e2eConfig,
+				BootstrapClusterProxy: bootstrapClusterProxy,
+				SpecName:              specName,
+				ClusterName:           clusterName,
+				K8sVersion:            e2eConfig.GetVariable("FROM_K8S_VERSION"),
+				KCPMachineCount:       int64(numberOfControlplane),
+				WorkerMachineCount:    int64(numberOfWorkers),
+				ClusterctlLogFolder:   clusterctlLogFolder,
+				ClusterctlConfigPath:  clusterctlConfigPath,
+				OSType:                osType,
+				Namespace:             namespace,
+			}
+		})
 
 		By("Running Kubernetes Upgrade tests")
 		upgradeKubernetes(ctx, func() upgradeKubernetesInput {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Tests failing with following error after 1.9 because MachineSetPreflightChecks is moved to beta and the default value for it is set to true, before it was false:
```
I1227 11:18:04.605619    1 machineset_preflight.go:139] "Scale up on hold because MachineSet version (1.32.0) and ControlPlane version (1.31.2) do not conform to the kubernetes version skew policy as MachineSet version is higher than ControlPlane version (\"KubernetesVersionSkew\" preflight check failed); MachineSet version (1.32.0) and ControlPlane version (1.31.2) do not conform to kubeadm version skew policy as kubeadm only supports joining with the same major+minor version as the control plane (\"KubeadmVersionSkew\" preflight check failed). The operation will continue after the preflight check(s) pass" controller="machineset" controllerGroup="cluster.x-k8s.io" controllerKind="MachineSet" MachineSet=
```
 in some tests, we are upgrading MDs only and not KCPs which is causing this issue.

This PR is fixing the test by also upgrading KCPs. Now flow of test is like that:
- 3 KCP, 2 worker 1.31 k8s
- Upgrade KCP to 1.32
- From IPPOOL fetch allocated IPs so we check them later
- Upgrade worker nodes to 1.32
- Check New IPs with old ones they should be the same

In addition to that this PR is also moving CreateTargetCluster to common.go

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
