### PR TITLE
:seedling: Parameterize scalability test

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -54,8 +54,10 @@ if [[ ${GINKGO_FOCUS:-} == "features" ]]; then
 fi
 # if running a scalability tests, configure dev-env with fakeIPA
 if [[ ${GINKGO_FOCUS:-} == "scalability" ]]; then
+    export NUM_NODES="${NUM_NODES:-100}"
     echo 'export NODES_PLATFORM="fake"' >>"${M3_DEV_ENV_PATH}/config_${USER}.sh"
     echo 'export SKIP_APPLY_BMH="true"' >>"${M3_DEV_ENV_PATH}/config_${USER}.sh"
+    sed -i "s/^export NUM_NODES=.*/export NUM_NODES=${NUM_NODES:-100}/" "${M3_DEV_ENV_PATH}/config_${USER}.sh"
     mkdir -p "$CAPI_CONFIG_FOLDER"
     echo 'CLUSTER_TOPOLOGY: true' >"$CAPI_CONFIG_FOLDER/clusterctl.yaml"
     echo 'export EPHEMERAL_CLUSTER="minikube"' >>"${M3_DEV_ENV_PATH}/config_${USER}.sh"

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -243,6 +243,8 @@ variables:
   KUBERNETES_VERSION: "v1.32.0"
   CONTROL_PLANE_MACHINE_COUNT: 3
   WORKER_MACHINE_COUNT: 1
+  NUM_NODES: 4
+  SCALE_SPEC_CONCURRENCY: 10
   APIVersion: "infrastructure.cluster.x-k8s.io/${CAPM3_VERSION}"
   IRONIC_NAMESPACE: "baremetal-operator-system"
   NAMEPREFIX: "baremetal-operator"

--- a/test/e2e/scalability_test.go
+++ b/test/e2e/scalability_test.go
@@ -43,6 +43,11 @@ type ClusterAPIServer struct {
 	Port int
 }
 
+var (
+	numberOfClusters     int64
+	scaleSpecConcurrency int64
+)
+
 var _ = Describe("When testing scalability with fakeIPA and FKAS [scalability]", Label("scalability"), func() {
 	BeforeEach(func() {
 		osType := strings.ToLower(os.Getenv("OS"))
@@ -52,6 +57,8 @@ var _ = Describe("When testing scalability with fakeIPA and FKAS [scalability]",
 		namespace = "scale"
 		numberOfWorkers = int(*e2eConfig.GetInt32PtrVariable("WORKER_MACHINE_COUNT"))
 		numberOfControlplane = int(*e2eConfig.GetInt32PtrVariable("CONTROL_PLANE_MACHINE_COUNT"))
+		numberOfClusters = int64(*e2eConfig.GetInt32PtrVariable("NUM_NODES"))
+		scaleSpecConcurrency = int64(*e2eConfig.GetInt32PtrVariable("SCALE_SPEC_CONCURRENCY"))
 		// We need to override clusterctl apply log folder to avoid getting our credentials exposed.
 		clusterctlLogFolder = filepath.Join(os.TempDir(), "clusters", bootstrapClusterProxy.GetName())
 		createFKASResources()
@@ -70,8 +77,8 @@ var _ = Describe("When testing scalability with fakeIPA and FKAS [scalability]",
 			ArtifactFolder:                    artifactFolder,
 			SkipCleanup:                       skipCleanup,
 			SkipUpgrade:                       true,
-			ClusterCount:                      ptr.To[int64](5),
-			Concurrency:                       ptr.To[int64](5),
+			ClusterCount:                      ptr.To[int64](numberOfClusters),
+			Concurrency:                       ptr.To[int64](scaleSpecConcurrency),
 			Flavor:                            ptr.To(fmt.Sprintf("%s-fake", osType)),
 			ControlPlaneMachineCount:          ptr.To[int64](int64(numberOfControlplane)),
 			MachineDeploymentCount:            ptr.To[int64](0),


### PR DESCRIPTION
Scalability test is currently running with hardcoded number of clusters and number of clusters provisioned in parallel (both are set to 5). Also, the number of clusters cannot be lower than the number of fake nodes set by dev-env, but so far we have not taken it into account.

We should parameterize these numbers, and use the NUM_NODES param from dev-env as number of clusters. This could change in the future, when we include multi-node clusters into scalability test, but that won't likely happen in a near future.