### PR TITLE
🌱 Fix e2e pivoting(node_reuse) test

### DIFF
--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -241,6 +241,11 @@ providers:
 variables:
   CNI: "/tmp/calico.yaml"
   KUBERNETES_VERSION: "v1.32.0"
+  # KUBERNETES_PATCH_FROM_VERSION and KUBERNETES_PATCH_TO_VERSION are used to
+  # test upgrade scenarios where we only want to upgrade the patch version of
+  # kubernetes.
+  KUBERNETES_PATCH_FROM_VERSION: "v1.31.0"
+  KUBERNETES_PATCH_TO_VERSION: "v1.31.2"
   CONTROL_PLANE_MACHINE_COUNT: 3
   WORKER_MACHINE_COUNT: 1
   NUM_NODES: 4
@@ -294,7 +299,7 @@ variables:
   BMO_RELEASE_0.9: "data/bmo-deployment/overlays/release-0.9"
   BMO_RELEASE_LATEST: "data/bmo-deployment/overlays/release-latest"
   FKAS_RELEASE_LATEST: "data/fkas"
-  
+
 intervals:
   default/wait-controllers: ["10m", "10s"]
   default/wait-cluster: ["20m", "30s"] # The second time to check the availibility of the cluster should happen late, so kcp object has time to be created

--- a/test/e2e/pivoting_based_feature_test.go
+++ b/test/e2e/pivoting_based_feature_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Testing features in ephemeral or target cluster [pivoting] [fe
 					BootstrapClusterProxy: bootstrapClusterProxy,
 					SpecName:              specName,
 					ClusterName:           clusterName,
-					K8sVersion:            e2eConfig.GetVariable("FROM_K8S_VERSION"),
+					K8sVersion:            e2eConfig.GetVariable("KUBERNETES_PATCH_FROM_VERSION"),
 					KCPMachineCount:       int64(numberOfControlplane),
 					WorkerMachineCount:    int64(numberOfWorkers),
 					ClusterctlLogFolder:   clusterctlLogFolder,


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Fix e2e pivoting(node_reuse) test
In the Node Reuse test suite, we perform only patch uplifts rather than minor Kubernetes upgrades. This approach focuses solely on testing the Node Reuse feature during rollouts, as the specific details of the Kubernetes version update are not the primary concern.

Why This Approach?
During the Node Reuse test flow, there is a scenario where we scale MachineDeployment while the KCP is at version 1.32, and the MachineDeployment is at version 1.31.2. Recent changes in Cluster API introduced stricter checks via MachineSetPreflightChecks, which disallow this version mismatch. By limiting the tests to patch uplifts, we avoid these restrictions and ensure smooth execution of the Node Reuse test flow.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
