### PR TITLE
✨ Remove the code which removes M3M owner reference from BMH 

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -458,6 +458,7 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 		if !consumerRefMatches(host.Spec.ConsumerRef, m.Metal3Machine) {
 			m.Log.Info("host already associated with another metal3 machine",
 				"host", host.Name)
+			// The following removal of ownerreference code will be removed in v1.11
 			// Remove the ownerreference to this machine, even if the consumer ref
 			// references another machine.
 			host.OwnerReferences, err = m.DeleteOwnerRef(host.OwnerReferences)
@@ -644,6 +645,7 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 
 		host.Spec.ConsumerRef = nil
 
+		// The following removal of ownerreference code will be removed in v1.11
 		// Remove the ownerreference to this machine.
 		host.OwnerReferences, err = m.DeleteOwnerRef(host.OwnerReferences)
 		if err != nil {
@@ -1098,13 +1100,6 @@ func (m *MachineManager) setHostConsumerRef(_ context.Context, host *bmov1alpha1
 		Namespace:  m.Metal3Machine.Namespace,
 		APIVersion: m.Metal3Machine.APIVersion,
 	}
-
-	// Set OwnerReferences.
-	hostOwnerReferences, err := m.SetOwnerRef(host.OwnerReferences, true)
-	if err != nil {
-		return err
-	}
-	host.OwnerReferences = hostOwnerReferences
 
 	// Delete nodeReuseLabelName from host.
 	m.Log.Info("Deleting nodeReuseLabelName from host, if any")

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -458,13 +458,6 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 		if !consumerRefMatches(host.Spec.ConsumerRef, m.Metal3Machine) {
 			m.Log.Info("host already associated with another metal3 machine",
 				"host", host.Name)
-			// The following removal of ownerreference code will be removed in v1.11
-			// Remove the ownerreference to this machine, even if the consumer ref
-			// references another machine.
-			host.OwnerReferences, err = m.DeleteOwnerRef(host.OwnerReferences)
-			if err != nil {
-				return err
-			}
 			return nil
 		}
 
@@ -644,13 +637,6 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 		}
 
 		host.Spec.ConsumerRef = nil
-
-		// The following removal of ownerreference code will be removed in v1.11
-		// Remove the ownerreference to this machine.
-		host.OwnerReferences, err = m.DeleteOwnerRef(host.OwnerReferences)
-		if err != nil {
-			return err
-		}
 
 		if host.Labels != nil && host.Labels[clusterv1.ClusterNameLabel] == m.Machine.Spec.ClusterName {
 			delete(host.Labels, clusterv1.ClusterNameLabel)

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -1213,8 +1213,6 @@ var _ = Describe("Metal3Machine manager", func() {
 			Expect(tc.Host.Spec.ConsumerRef.Namespace).
 				To(Equal(m3mconfig.Namespace))
 			Expect(tc.Host.Spec.ConsumerRef.Kind).To(Equal("Metal3Machine"))
-			_, err = machineMgr.FindOwnerRef(tc.Host.OwnerReferences)
-			Expect(err).NotTo(HaveOccurred())
 
 			if tc.expectNodeReuseLabelDeleted {
 				Expect(tc.Host.Labels[nodeReuseLabelName]).To(Equal(""))
@@ -3024,7 +3022,6 @@ var _ = Describe("Metal3Machine manager", func() {
 		Data               *infrav1.Metal3Data
 		ExpectRequeue      bool
 		ExpectClusterLabel bool
-		ExpectOwnerRef     bool
 	}
 
 	DescribeTable("Test Associate function",
@@ -3075,12 +3072,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				&savedHost,
 			)
 			Expect(err).NotTo(HaveOccurred())
-			_, err = machineMgr.FindOwnerRef(savedHost.OwnerReferences)
-			if tc.ExpectOwnerRef {
-				Expect(err).NotTo(HaveOccurred())
-			} else {
-				Expect(err).To(HaveOccurred())
-			}
+
 			if tc.ExpectClusterLabel {
 				// get the BMC credential
 				savedCred := corev1.Secret{}
@@ -3105,8 +3097,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil,
 					false, "metadata", false, "",
 				),
-				ExpectRequeue:  false,
-				ExpectOwnerRef: true,
+				ExpectRequeue: false,
 			},
 		),
 		Entry("Associate empty machine, Metal3 machine spec set",
@@ -3118,9 +3109,8 @@ var _ = Describe("Metal3Machine manager", func() {
 				Host: newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil,
 					false, "metadata", false, "",
 				),
-				BMCSecret:      newBMCSecret("mycredentials", false),
-				ExpectRequeue:  false,
-				ExpectOwnerRef: true,
+				BMCSecret:     newBMCSecret("mycredentials", false),
+				ExpectRequeue: false,
 			},
 		),
 		Entry("Associate empty machine, host empty, Metal3 machine spec set",
@@ -3129,9 +3119,8 @@ var _ = Describe("Metal3Machine manager", func() {
 				M3Machine: newMetal3Machine(metal3machineName, m3mSpecAll(), nil,
 					m3mObjectMetaWithValidAnnotations(),
 				),
-				Host:           newBareMetalHost("", nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
-				ExpectRequeue:  true,
-				ExpectOwnerRef: false,
+				Host:          newBareMetalHost("", nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
+				ExpectRequeue: true,
 			},
 		),
 		Entry("Associate machine, host nil, Metal3 machine spec set, requeue",
@@ -3152,7 +3141,6 @@ var _ = Describe("Metal3Machine manager", func() {
 				BMCSecret:          newBMCSecret("mycredentials", false),
 				ExpectClusterLabel: true,
 				ExpectRequeue:      false,
-				ExpectOwnerRef:     true,
 			},
 		),
 		Entry("Associate machine with DataTemplate missing",
@@ -3179,7 +3167,6 @@ var _ = Describe("Metal3Machine manager", func() {
 				BMCSecret:          newBMCSecret("mycredentials", false),
 				ExpectClusterLabel: true,
 				ExpectRequeue:      true,
-				ExpectOwnerRef:     true,
 			},
 		),
 		Entry("Associate machine with DataTemplate and Data ready",
@@ -3225,7 +3212,6 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 				ExpectClusterLabel: true,
 				ExpectRequeue:      false,
-				ExpectOwnerRef:     true,
 			},
 		),
 	)

--- a/test/e2e/pivoting.go
+++ b/test/e2e/pivoting.go
@@ -396,6 +396,8 @@ func RemoveDeployment(ctx context.Context, inputGetter func() RemoveDeploymentIn
 func labelBMOCRDs(ctx context.Context, targetCluster framework.ClusterProxy) {
 	labels := map[string]string{}
 	labels[clusterctlv1.ClusterctlLabel] = ""
+	labels[clusterctlv1.ClusterctlMoveLabel] = ""
+	labels[clusterctlv1.ClusterctlMoveHierarchyLabel] = ""
 	labels[clusterv1.ProviderNameLabel] = "metal3"
 	crdName := "baremetalhosts.metal3.io"
 	err := LabelCRD(ctx, targetCluster.GetClient(), crdName, labels)


### PR DESCRIPTION
We have removed the code which sets M3M owner reference in v1.10 release cycle. Now we also remove the code which removes the owner reference from BMH.

This PR should land in v1.11 release cycle.

Signed-off-by: Kashif Khan <kashif.khan@est.tech>
