### PR TITLE
:bug: Revert "Remove Metal3Machine owner reference from BMH"

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -458,7 +458,6 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 		if !consumerRefMatches(host.Spec.ConsumerRef, m.Metal3Machine) {
 			m.Log.Info("host already associated with another metal3 machine",
 				"host", host.Name)
-			// The following removal of ownerreference code will be removed in v1.11
 			// Remove the ownerreference to this machine, even if the consumer ref
 			// references another machine.
 			host.OwnerReferences, err = m.DeleteOwnerRef(host.OwnerReferences)
@@ -645,7 +644,6 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 
 		host.Spec.ConsumerRef = nil
 
-		// The following removal of ownerreference code will be removed in v1.11
 		// Remove the ownerreference to this machine.
 		host.OwnerReferences, err = m.DeleteOwnerRef(host.OwnerReferences)
 		if err != nil {
@@ -1100,6 +1098,13 @@ func (m *MachineManager) setHostConsumerRef(_ context.Context, host *bmov1alpha1
 		Namespace:  m.Metal3Machine.Namespace,
 		APIVersion: m.Metal3Machine.APIVersion,
 	}
+
+	// Set OwnerReferences.
+	hostOwnerReferences, err := m.SetOwnerRef(host.OwnerReferences, true)
+	if err != nil {
+		return err
+	}
+	host.OwnerReferences = hostOwnerReferences
 
 	// Delete nodeReuseLabelName from host.
 	m.Log.Info("Deleting nodeReuseLabelName from host, if any")

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -1213,6 +1213,8 @@ var _ = Describe("Metal3Machine manager", func() {
 			Expect(tc.Host.Spec.ConsumerRef.Namespace).
 				To(Equal(m3mconfig.Namespace))
 			Expect(tc.Host.Spec.ConsumerRef.Kind).To(Equal("Metal3Machine"))
+			_, err = machineMgr.FindOwnerRef(tc.Host.OwnerReferences)
+			Expect(err).NotTo(HaveOccurred())
 
 			if tc.expectNodeReuseLabelDeleted {
 				Expect(tc.Host.Labels[nodeReuseLabelName]).To(Equal(""))
@@ -3022,6 +3024,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Data               *infrav1.Metal3Data
 		ExpectRequeue      bool
 		ExpectClusterLabel bool
+		ExpectOwnerRef     bool
 	}
 
 	DescribeTable("Test Associate function",
@@ -3072,7 +3075,12 @@ var _ = Describe("Metal3Machine manager", func() {
 				&savedHost,
 			)
 			Expect(err).NotTo(HaveOccurred())
-
+			_, err = machineMgr.FindOwnerRef(savedHost.OwnerReferences)
+			if tc.ExpectOwnerRef {
+				Expect(err).NotTo(HaveOccurred())
+			} else {
+				Expect(err).To(HaveOccurred())
+			}
 			if tc.ExpectClusterLabel {
 				// get the BMC credential
 				savedCred := corev1.Secret{}
@@ -3097,7 +3105,8 @@ var _ = Describe("Metal3Machine manager", func() {
 				Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil,
 					false, "metadata", false, "",
 				),
-				ExpectRequeue: false,
+				ExpectRequeue:  false,
+				ExpectOwnerRef: true,
 			},
 		),
 		Entry("Associate empty machine, Metal3 machine spec set",
@@ -3109,8 +3118,9 @@ var _ = Describe("Metal3Machine manager", func() {
 				Host: newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil,
 					false, "metadata", false, "",
 				),
-				BMCSecret:     newBMCSecret("mycredentials", false),
-				ExpectRequeue: false,
+				BMCSecret:      newBMCSecret("mycredentials", false),
+				ExpectRequeue:  false,
+				ExpectOwnerRef: true,
 			},
 		),
 		Entry("Associate empty machine, host empty, Metal3 machine spec set",
@@ -3119,8 +3129,9 @@ var _ = Describe("Metal3Machine manager", func() {
 				M3Machine: newMetal3Machine(metal3machineName, m3mSpecAll(), nil,
 					m3mObjectMetaWithValidAnnotations(),
 				),
-				Host:          newBareMetalHost("", nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
-				ExpectRequeue: true,
+				Host:           newBareMetalHost("", nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
+				ExpectRequeue:  true,
+				ExpectOwnerRef: false,
 			},
 		),
 		Entry("Associate machine, host nil, Metal3 machine spec set, requeue",
@@ -3141,6 +3152,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				BMCSecret:          newBMCSecret("mycredentials", false),
 				ExpectClusterLabel: true,
 				ExpectRequeue:      false,
+				ExpectOwnerRef:     true,
 			},
 		),
 		Entry("Associate machine with DataTemplate missing",
@@ -3167,6 +3179,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				BMCSecret:          newBMCSecret("mycredentials", false),
 				ExpectClusterLabel: true,
 				ExpectRequeue:      true,
+				ExpectOwnerRef:     true,
 			},
 		),
 		Entry("Associate machine with DataTemplate and Data ready",
@@ -3212,6 +3225,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 				ExpectClusterLabel: true,
 				ExpectRequeue:      false,
+				ExpectOwnerRef:     true,
 			},
 		),
 	)

--- a/test/e2e/pivoting.go
+++ b/test/e2e/pivoting.go
@@ -418,8 +418,6 @@ func RemoveDeployment(ctx context.Context, inputGetter func() RemoveDeploymentIn
 func labelBMOCRDs(ctx context.Context, targetCluster framework.ClusterProxy) {
 	labels := map[string]string{}
 	labels[clusterctlv1.ClusterctlLabel] = ""
-	labels[clusterctlv1.ClusterctlMoveLabel] = ""
-	labels[clusterctlv1.ClusterctlMoveHierarchyLabel] = ""
 	labels[clusterv1.ProviderNameLabel] = "metal3"
 	crdName := "baremetalhosts.metal3.io"
 	err := LabelCRD(ctx, targetCluster.GetClient(), crdName, labels)


### PR DESCRIPTION
This reverts commit 715a0d05d1eb85a16e61f2f0a6e9151d290e3dda from https://github.com/metal3-io/cluster-api-provider-metal3/pull/1742

For currently unknown reason, this breaks pivoting. Despite adding the move labels to BMH, something is not moved or the move order is random and relationships are not properly reconciled after move. Move works like 10% of the time, so technically it works, but clearly timing or random affects it. This must be figured out before reapplying the change.