### PR TITLE
:bug: Fix live-iso serial console boot verification in e2e 

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -67,7 +67,7 @@ source "${M3_DEV_ENV_PATH}/lib/ironic_basic_auth.sh"
 source "${M3_DEV_ENV_PATH}/lib/ironic_tls_setup.sh"
 
 # image for live iso testing
-export LIVE_ISO_IMAGE="https://artifactory.nordix.org/artifactory/metal3/images/iso/minimal_linux_live-v2.iso"
+export LIVE_ISO_IMAGE="https://artifactory.nordix.org/artifactory/metal3/images/iso/minimal_linux_live-v3-uefi.iso"
 
 # Generate credentials
 BMO_OVERLAYS=(

--- a/test/e2e/live_iso_test.go
+++ b/test/e2e/live_iso_test.go
@@ -92,7 +92,7 @@ func liveIsoTest() {
 
 		By("Reading serial logs to verify the node was booted from live ISO image")
 		Eventually(func(g Gomega) {
-			cmd := fmt.Sprintf("sudo cat %s | grep '#  Welcome'", serialLogFile)
+			cmd := fmt.Sprintf("sudo grep 'Minimal Linux Live' '%s'", serialLogFile)
 			output, err := exec.Command("/bin/sh", "-c", cmd).Output()
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(output).ToNot(BeNil(), fmt.Sprintf("Failed to read serial logs from %s", serialLogFile))


### PR DESCRIPTION
This commit:
 - Changes the target string looked for via the serial logs by the ginkgo live-iso test code to verify that the live iso image has been booted properly.
 - Removes the redundant use of the "cat" command from the boot verification process in the live-iso test
 -  Changes the name of the live-iso test image to the new image that is uefi compatible.

This change is needed because the release1.8 e2e feature test are failing the live-iso boot verification even when the live-iso boot menu is visible in the serial logs.