### PR TITLE
:bug: Fix: pulling unused images in the middle of tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,8 +159,6 @@ ARTIFACTS ?= $(ROOT_DIR)/_artifacts
 E2E_CONF_FILE ?= $(ROOT_DIR)/test/e2e/config/e2e_conf.yaml
 E2E_OUT_DIR ?= $(ROOT_DIR)/test/e2e/_out
 E2E_CONF_FILE_ENVSUBST ?= $(E2E_OUT_DIR)/$(notdir $(E2E_CONF_FILE))
-E2E_CONTAINERS ?= quay.io/metal3-io/cluster-api-provider-metal3 quay.io/metal3-io/baremetal-operator quay.io/metal3-io/ip-address-manager
-
 SKIP_CLEANUP ?= false
 EPHEMERAL_TEST ?= false
 SKIP_CREATE_MGMT_CLUSTER ?= true
@@ -211,10 +209,6 @@ e2e-tests: CONTAINER_RUNTIME?=docker # Env variable can override this default
 export CONTAINER_RUNTIME
 
 e2e-tests: $(GINKGO) e2e-substitutions cluster-templates # This target should be called from scripts/ci-e2e.sh
-	for image in $(E2E_CONTAINERS); do \
-		$(CONTAINER_RUNTIME) pull $$image; \
-	done
-
 	$(GINKGO) --timeout=$(GINKGO_TIMEOUT) -v --trace --tags=e2e  \
 		--show-node-events --no-color=$(GINKGO_NOCOLOR) \
 		--junit-report="junit.e2e_suite.1.xml" \
@@ -232,10 +226,6 @@ e2e-clusterclass-tests: CONTAINER_RUNTIME?=docker # Env variable can override th
 export CONTAINER_RUNTIME
 
 e2e-clusterclass-tests: $(GINKGO) e2e-substitutions clusterclass-templates # This target should be called from scripts/ci-e2e.sh
-	for image in $(E2E_CONTAINERS); do \
-		$(CONTAINER_RUNTIME) pull $$image; \
-	done
-
 	$(GINKGO) --timeout=$(GINKGO_TIMEOUT) -v --trace --tags=e2e  \
 		--show-node-events --no-color=$(GINKGO_NOCOLOR) \
 		--junit-report="junit.e2e_suite.1.xml" \


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Let's take `metal3-periodic-ubuntu-e2e-integration-test-release-1-9` as an example. This test runs `make` in `metal3-dev-env` where container images (with correct tags) get pulled. Some time later the test moves into `cluster-api-provider-metal3` folder and runs `make e2e-test`. At this time CAPM3, BMO and IPAM images will get pulled again but this time the tag is set to latest. This is unnecessary. This fix will pull the correct images if they are missing instead of always bulling images that are unused in many cases. 


