### PR TITLE
🌱 remove  kubebuilder:default=true for CloudProviderEnabled and set defaults in defaulting webhook

### DIFF
--- a/api/v1beta1/metal3cluster_types.go
+++ b/api/v1beta1/metal3cluster_types.go
@@ -47,7 +47,7 @@ type Metal3ClusterSpec struct {
 	// If set to false, CAPM3 will use node labels to set providerID on the kubernetes nodes.
 	// If set to true, providerID is set on nodes by other entities and CAPM3 uses the value of the providerID on the m3m resource.
 	// TODO: Change the default value to false in release 1.12. Ref: https://github.com/metal3-io/cluster-api-provider-metal3/issues/2255
-	// +kubebuilder:default=true
+	// Default value is true, it is set in the webhook.
 	// +optional
 	CloudProviderEnabled *bool `json:"cloudProviderEnabled,omitempty"`
 }

--- a/api/v1beta1/metal3cluster_webhook_test.go
+++ b/api/v1beta1/metal3cluster_webhook_test.go
@@ -111,7 +111,7 @@ func TestMetal3ClusterValidation(t *testing.T) {
 						Host: "abc.com",
 						Port: 443,
 					},
-					NoCloudProvider: ptr.To(false),
+					NoCloudProvider: ptr.To(true),
 				},
 			},
 			oldCluster: valid,

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3clusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3clusters.yaml
@@ -69,11 +69,11 @@ spec:
             description: Metal3ClusterSpec defines the desired state of Metal3Cluster.
             properties:
               cloudProviderEnabled:
-                default: true
                 description: |-
                   Determines if the cluster is to be deployed with an external cloud provider.
                   If set to false, CAPM3 will use node labels to set providerID on the kubernetes nodes.
                   If set to true, providerID is set on nodes by other entities and CAPM3 uses the value of the providerID on the m3m resource.
+                  Default value is true, it is set in the webhook.
                 type: boolean
               controlPlaneEndpoint:
                 description: ControlPlaneEndpoint represents the endpoint used to

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3clustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3clustertemplates.yaml
@@ -52,11 +52,11 @@ spec:
                     description: Metal3ClusterSpec defines the desired state of Metal3Cluster.
                     properties:
                       cloudProviderEnabled:
-                        default: true
                         description: |-
                           Determines if the cluster is to be deployed with an external cloud provider.
                           If set to false, CAPM3 will use node labels to set providerID on the kubernetes nodes.
                           If set to true, providerID is set on nodes by other entities and CAPM3 uses the value of the providerID on the m3m resource.
+                          Default value is true, it is set in the webhook.
                         type: boolean
                       controlPlaneEndpoint:
                         description: ControlPlaneEndpoint represents the endpoint


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Instead of using `// +kubebuilder:default=true` to set a default value for `CloudProviderEnabled`, we are configuring defaults through a defaulting webhook. This approach avoids conflicts with the `NoCloudProvider` field in the validation webhook.

Using `kubebuilder:default` makes it impossible to distinguish whether the value of `CloudProviderEnabled` was explicitly set by the user or automatically assigned by the default. This distinction is critical because our validation webhook ensures that `CloudProviderEnabled` and `NoCloudProvider` do not conflict when both are set. If we rely on `kubebuilder:default`, the validation webhook cannot function as intended, as it cannot determine the source of the `CloudProviderEnabled` value. By shifting defaulting logic to the webhook, we retain the ability to enforce these validation rules effectively.

This PR is a follow-up of this PR: https://github.com/metal3-io/cluster-api-provider-metal3/pull/2108 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
