### PR TITLE
🌱 E2E: Fix Ironic kustomization

### DIFF
--- a/test/e2e/data/ironic-deployment/overlays/release-latest/kustomization.yaml
+++ b/test/e2e/data/ironic-deployment/overlays/release-latest/kustomization.yaml
@@ -44,5 +44,6 @@ replacements:
       version: v1
       group: cert-manager.io
       kind: Certificate
+      name: ironic-cert
     fieldPaths:
     - .spec.ipAddresses.0


### PR DESCRIPTION
**What this PR does / why we need it**:

We have removed the IP address from the CA in the source manifests. This breaks the replacement because it was selecting ALL certificates. This commit changes it to only select the ironic-certificate.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
