### PR TITLE
🌱 E2E: Adjust Ironic kustomization patch

### DIFF
--- a/test/e2e/data/ironic-deployment/overlays/release-27.0/kustomization.yaml
+++ b/test/e2e/data/ironic-deployment/overlays/release-27.0/kustomization.yaml
@@ -44,5 +44,6 @@ replacements:
       version: v1
       group: cert-manager.io
       kind: Certificate
+      name: ironic-cert
     fieldPaths:
     - .spec.ipAddresses.0


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

We have removed the IP address from the CA in the source manifests. This
breaks the replacement because it was selecting ALL certificates. This
commit changes it to only select the ironic-certificate.

See https://github.com/metal3-io/baremetal-operator/pull/2222
