### PR TITLE
🌱 Debug clusterctl upgrade test failure

### DIFF
--- a/test/e2e/upgrade_clusterctl_test.go
+++ b/test/e2e/upgrade_clusterctl_test.go
@@ -258,7 +258,7 @@ func preInitFunc(clusterProxy framework.ClusterProxy, bmoRelease string, ironicR
 		DeploymentNamespace: bmoIronicNamespace,
 		WaitIntervals:       e2eConfig.GetIntervals("default", "wait-deployment"),
 	})
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "Failed to install Ironic on target cluster %v", err)
 
 	// install bmo
 	By("Install BMO in the target cluster")
@@ -276,7 +276,7 @@ func preInitFunc(clusterProxy framework.ClusterProxy, bmoRelease string, ironicR
 		DeploymentNamespace: bmoIronicNamespace,
 		WaitIntervals:       e2eConfig.GetIntervals("default", "wait-deployment"),
 	})
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "Failed to install BMO on target cluster %v", err)
 
 	// Export capi/capm3 versions
 	os.Setenv("CAPI_VERSION", "v1beta1")


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Metal3-periodic-e2e-clusterctl-upgrade-test-main is failing with: 
```
When testing cluster upgrade from releases (v1.8=>current) [clusterctl-upgrade] [It] Should create a management cluster and then upgrade all the providers

[2025-02-19T22:48:03.512Z] /home/metal3ci/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.9.4/e2e/clusterctl_upgrade.go:258

[2025-02-19T22:48:03.512Z] 

[2025-02-19T22:48:03.512Z]   [FAILED] Unexpected error:

[2025-02-19T22:48:03.512Z]       <errors.aggregate | len:4, cap:4>: 

[2025-02-19T22:48:03.512Z]       Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "[https://cert-manager-webhook.cert-manager.svc:443/validate?timeout=30s](https://cert-manager-webhook.cert-manager.svc/validate?timeout=30s)": dial tcp 10.103.210.119:443: connect: connection refused

[2025-02-19T22:48:03.512Z]       [
```

I'm testing if this change will fix this issue as this issue is not seen in other parts of the test. And this is only difference in the Kustomization files (ironic 26, 27 and main)
