### PR TITLE
:book:  Remove IPAM manifests related links and check in release process

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -25,10 +25,7 @@ Things you should check before making a release:
    - Verify BMO's `apis` and `pkg/hardwareutils` dependencies are the latest. Prior
      art:
      [#1163](https://github.com/metal3-io/cluster-api-provider-metal3/pull/1163)
-   - Uplift IPAM `api` dependency,
-     [container image version](https://github.com/metal3-io/cluster-api-provider-metal3/blob/main/config/ipam/image_patch.yaml)
-     , and
-     [manifest resource](https://github.com/metal3-io/cluster-api-provider-metal3/blob/main/config/ipam/kustomization.yaml)
+   - Uplift IPAM `api` dependency
      . Prior art:
      [#999](https://github.com/metal3-io/cluster-api-provider-metal3/pull/999)
    - Verify any other direct or indirect dependency is uplifted to close any

--- a/hack/verify-release.sh
+++ b/hack/verify-release.sh
@@ -620,32 +620,6 @@ verify_module_releases()
     echo -e "Done\n"
 }
 
-verify_ipam_manifests()
-{
-    # verify version in ipam manifests match the ipam module version
-    # NOTE: this is CAPM3 specific check
-    local ipam_version
-
-    echo "Verifying IPAM manifests match go.mod ..."
-
-    # shellcheck disable=SC2311
-    ipam_version="$(_module_get_version "ip-address-manager/api")"
-
-    declare -A ipam_manifests=(
-        [config/ipam/image_patch.yaml]="quay.io/metal3-io/ip-address-manager:${ipam_version}"
-        [config/ipam/kustomization.yaml]="https://github.com/metal3-io/ip-address-manager/releases/download/${ipam_version}/ipam-components.yaml"
-    )
-
-    for file in "${!ipam_manifests[@]}"; do
-        str="${ipam_manifests[${file}]}"
-        if ! grep -q -- "${str}" "${file}"; then
-            echo "ERROR: IPAM version in go.mod and manifests mismatch!"
-        fi
-    done
-
-    echo -e "Done\n"
-}
-
 verify_vulnerabilities()
 {
     # run osv-scanner to verify if we have open vulnerabilities in deps


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Due to changes in the day IPAM is deployed manifests were deleted. Logic and links to these manifest have become obsolete.  