### PR TITLE
🌱 E2E: Adjust Ironic kustomization patch for BMO 0.8

### DIFF
--- a/test/e2e/data/ironic-deployment/overlays/release-26.0/kustomization.yaml
+++ b/test/e2e/data/ironic-deployment/overlays/release-26.0/kustomization.yaml
@@ -44,5 +44,6 @@ replacements:
       version: v1
       group: cert-manager.io
       kind: Certificate
+      name: ironic-cert
     fieldPaths:
     - .spec.ipAddresses.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Same as https://github.com/metal3-io/cluster-api-provider-metal3/pull/2308 but now for BMO release-0.8 that is being changed in https://github.com/metal3-io/baremetal-operator/pull/2276

We have removed the IP address from the CA in the source manifests. This
breaks the replacement because it was selecting ALL certificates. This
commit changes it to only select the ironic-certificate.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/hold
until https://github.com/metal3-io/baremetal-operator/pull/2276 is merged