### PR TITLE
:bug: bump actions/cache to v4.2.2

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
       with:
         go-version: ${{ steps.vars.outputs.go_version }}
-    - uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+    - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       name: Restore go cache
       with:
         path: |


### PR DESCRIPTION
Cache functionality from actions/toolkit used by actions/cache is unsupported before actions/cache v4.2.

https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

It fails with:
https://github.com/metal3-io/cluster-api-provider-metal3/pull/2367#issuecomment-2702830003