### PR TITLE
🌱 E2E: Ensure cert-manager webhook is available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ out
 # goland
 .idea
 
+# zed
+.zed*
+
 # Common editor / temporary files
 *~
 *.tmp

--- a/test/e2e/data/cert-manager-test.yaml
+++ b/test/e2e/data/cert-manager-test.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: test
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: my-selfsigned-cert
+  namespace: test
+spec:
+  commonName: my-selfsigned-cert
+  secretName: root-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/test/e2e/upgrade_clusterctl_test.go
+++ b/test/e2e/upgrade_clusterctl_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 	framework "sigs.k8s.io/cluster-api/test/framework"
@@ -205,6 +206,41 @@ func preInitFunc(clusterProxy framework.ClusterProxy, bmoRelease string, ironicR
 				Deployment: deployment,
 			}, e2eConfig.GetIntervals(specName, "wait-deployment")...)
 		}
+		// Create an issuer and certificate to ensure that cert-manager is ready.
+		certManagerTest, err := os.ReadFile("data/cert-manager-test.yaml")
+		Expect(err).ToNot(HaveOccurred(), "Unable to read cert-manager test YAML file")
+		Eventually(func() error {
+			return clusterProxy.CreateOrUpdate(ctx, certManagerTest)
+		}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(Succeed())
+		// Wait for and check that the certificate becomes ready.
+		certKey := client.ObjectKey{
+			Name:      "my-selfsigned-cert",
+			Namespace: "test",
+		}
+		testCert := new(unstructured.Unstructured)
+		testCert.SetAPIVersion("cert-manager.io/v1")
+		testCert.SetKind("Certificate")
+		Eventually(func() error {
+			if err := clusterProxy.GetClient().Get(ctx, certKey, testCert); err != nil {
+				return err
+			}
+			conditions, found, err := unstructured.NestedSlice(testCert.Object, "status", "conditions")
+			if err != nil {
+				return err
+			}
+			if !found {
+				return fmt.Errorf("certificate doesn't have status.conditions (yet)")
+			}
+			// There is only one condition (Ready) on certificates.
+			condType := conditions[0].(map[string]any)["type"]
+			condStatus := conditions[0].(map[string]any)["status"]
+			if condType == "Ready" && condStatus == "True" {
+				return nil
+			}
+			return fmt.Errorf("certificate is not ready, type: %s, status: %s, message: %s", condType, condStatus, conditions[0].(map[string]any)["message"])
+		}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(Succeed())
+		// Delete test namespace
+		Expect(clusterProxy.GetClientSet().CoreV1().Namespaces().Delete(ctx, "test", metav1.DeleteOptions{})).To(Succeed())
 	}
 
 	By("Fetch manifest for bootstrap cluster")


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

The clusterctl-upgrade periodics that have been failing lately due to two issues. This is addressing the first of them. What happens is that the cert-manager webhook is not completely ready when we try to deploy ironic, even though we wait for the deployments to be `Available`. This is because it takes some time for the webhook to be registered, get a valid certificate and so on.
To fix this, we add a simple check that we can `Eventually` apply an Issuer and Certificate. When that succeeds we know the webhook is working.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
