### PR TITLE
🌱 E2E: Unify logging and cleanup

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -561,7 +561,7 @@ func GenerateIPPoolPreallocations(ctx context.Context, ippool ipamv1.IPPool, poo
 	Expect(c.List(ctx, &m3MachineList, &client.ListOptions{})).To(Succeed())
 	newAllocations := make(map[string]ipamv1.IPAddressStr)
 	for m3dataPoolName, ipaddress := range allocations {
-		fmt.Println("datapoolName:", m3dataPoolName, "=>", "ipaddress:", ipaddress)
+		Logf("datapoolName:", m3dataPoolName, "=>", "ipaddress:", ipaddress)
 		BMHName := strings.Split(m3dataPoolName, "-"+poolName)[0]
 		Logf("poolName: %s", poolName)
 		Logf("BMHName: %s", BMHName)
@@ -950,10 +950,10 @@ func KubectlDelete(ctx context.Context, kubeconfigPath string, resources []byte,
 		testexec.WithStdin(rbytes),
 	)
 
-	fmt.Printf("Running kubectl %s\n", strings.Join(aargs, " "))
+	Logf("Running kubectl %s\n", strings.Join(aargs, " "))
 	stdout, stderr, err := deleteCmd.Run(ctx)
-	fmt.Printf("stderr:\n%s\n", string(stderr))
-	fmt.Printf("stdout:\n%s\n", string(stdout))
+	Logf("stderr:\n%s", string(stderr))
+	Logf("stdout:\n%s", string(stdout))
 	return err
 }
 

--- a/test/e2e/logcollector.go
+++ b/test/e2e/logcollector.go
@@ -184,7 +184,7 @@ func FetchManifests(clusterProxy framework.ClusterProxy, outputPath string) erro
 			}
 		}
 	}
-	fmt.Printf("Successfully collected manifests for cluster %s.", clusterProxy.GetName())
+	Logf("Successfully collected manifests for cluster %s.", clusterProxy.GetName())
 	return nil
 }
 
@@ -244,7 +244,7 @@ func FetchClusterLogs(clusterProxy framework.ClusterProxy, outputPath string) er
 		// Get all pods in the namespace
 		pods, err := clientset.CoreV1().Pods(namespace.Name).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			fmt.Printf("couldn't list pods in namespace %s: %v", namespace.Name, err)
+			Logf("couldn't list pods in namespace %s: %v", namespace.Name, err)
 			continue
 		}
 		for _, pod := range pods.Items {
@@ -259,7 +259,7 @@ func FetchClusterLogs(clusterProxy framework.ClusterProxy, outputPath string) er
 			}
 			podDescription, err := podDescriber.Describe(namespace.Name, pod.Name, describerSettings)
 			if err != nil {
-				fmt.Printf("couldn't describe pod %s in namespace %s: %v", pod.Name, namespace.Name, err)
+				Logf("couldn't describe pod %s in namespace %s: %v", pod.Name, namespace.Name, err)
 				continue
 			}
 
@@ -274,13 +274,13 @@ func FetchClusterLogs(clusterProxy framework.ClusterProxy, outputPath string) er
 
 				err := CollectContainerLogs(ctx, namespace.Name, pod.Name, container.Name, clientset, containerDir)
 				if err != nil {
-					fmt.Printf("Error %v.", err)
+					Logf("Error %v.", err)
 					continue
 				}
 			}
 		}
 	}
-	fmt.Printf("Successfully collected logs for cluster %s.", clusterProxy.GetName())
+	Logf("Successfully collected logs for cluster %s.", clusterProxy.GetName())
 	return nil
 }
 
@@ -318,13 +318,13 @@ func writeToFile(content []byte, fileName string, filePath string) {
 	// Create any missing directories in the path
 	err := os.MkdirAll(filePath, 0775)
 	if err != nil {
-		fmt.Printf("couldn't create directory: %v", err)
+		Logf("couldn't create directory: %v", err)
 	}
 	// Write content to file
 	file := filepath.Join(filePath, fileName)
 	err = os.WriteFile(file, content, 0600)
 	if err != nil {
-		fmt.Printf("couldn't write to file: %v", err)
+		Logf("couldn't write to file: %v", err)
 	}
 }
 

--- a/test/e2e/pivoting.go
+++ b/test/e2e/pivoting.go
@@ -92,7 +92,7 @@ func pivoting(ctx context.Context, inputGetter func() PivotingInput) {
 	By("Fetch manifest for bootstrap cluster before pivot")
 	err = FetchManifests(input.BootstrapClusterProxy, "/tmp/manifests/")
 	if err != nil {
-		fmt.Printf("Error fetching manifests for bootstrap cluster before pivot: %v\n", err)
+		Logf("Error fetching manifests for bootstrap cluster before pivot: %v", err)
 	}
 	By("Fetch target cluster kubeconfig for target cluster log collection")
 	kconfigPathWorkload := input.TargetCluster.GetKubeconfigPath()
@@ -377,7 +377,7 @@ func rePivoting(ctx context.Context, inputGetter func() RePivotingInput) {
 	workloadClusterProxy := framework.NewClusterProxy("workload-cluster-after-pivot", os.Getenv("KUBECONFIG"), runtime.NewScheme())
 	err = FetchManifests(workloadClusterProxy, "/tmp/manifests/")
 	if err != nil {
-		fmt.Printf("Error fetching manifests for workload cluster after pivot: %v\n", err)
+		Logf("Error fetching manifests for workload cluster after pivot: %v", err)
 	}
 	os.Unsetenv("KUBECONFIG_WORKLOAD")
 
@@ -401,7 +401,7 @@ func rePivoting(ctx context.Context, inputGetter func() RePivotingInput) {
 		//#nosec G204:gosec
 		cmd := exec.Command("sh", "-c", "export CONTAINER_RUNTIME=docker; "+ironicCommand)
 		stdoutStderr, err := cmd.CombinedOutput()
-		fmt.Printf("%s\n", stdoutStderr)
+		Logf("Output: %s", stdoutStderr)
 		Expect(err).ToNot(HaveOccurred(), "Cannot run local ironic")
 	} else {
 		By("Install Ironic in the bootstrap cluster")
@@ -498,7 +498,7 @@ func rePivoting(ctx context.Context, inputGetter func() RePivotingInput) {
 	By("Fetch manifest for bootstrap cluster after re-pivot")
 	err = FetchManifests(input.BootstrapClusterProxy, "/tmp/manifests/")
 	if err != nil {
-		fmt.Printf("Error fetching manifests for bootstrap cluster before pivot: %v\n", err)
+		Logf("Error fetching manifests for bootstrap cluster before pivot: %v", err)
 	}
 	os.Unsetenv("KUBECONFIG_BOOTSTRAP")
 

--- a/test/e2e/upgrade_clusterctl_test.go
+++ b/test/e2e/upgrade_clusterctl_test.go
@@ -210,7 +210,7 @@ func preInitFunc(clusterProxy framework.ClusterProxy, bmoRelease string, ironicR
 	By("Fetch manifest for bootstrap cluster")
 	err := FetchManifests(clusterProxy, "/tmp/manifests/")
 	if err != nil {
-		fmt.Printf("Error fetching manifests for bootstrap cluster: %v\n", err)
+		Logf("Error fetching manifests for bootstrap cluster: %v", err)
 	}
 
 	By("Fetch target cluster kubeconfig for target cluster log collection")
@@ -220,8 +220,7 @@ func preInitFunc(clusterProxy framework.ClusterProxy, bmoRelease string, ironicR
 	kubeconfigPathTemp := "/tmp/kubeconfig-test1.yaml"
 	cmd := exec.Command("cp", kconfigPathWorkload, kubeconfigPathTemp) // #nosec G204:gosec
 	stdoutStderr, er := cmd.CombinedOutput()
-	Logf("%s\n", stdoutStderr)
-	Expect(er).ToNot(HaveOccurred(), "Cannot fetch target cluster kubeconfig")
+	Expect(er).ToNot(HaveOccurred(), "Cannot fetch target cluster kubeconfig: %s", stdoutStderr)
 	// install certmanager
 	installCertManager(clusterProxy)
 	// Remove ironic
@@ -364,7 +363,7 @@ func preCleanupManagementCluster(clusterProxy framework.ClusterProxy, ironicRele
 			//#nosec G204 -- We take the BMOPATH from a variable.
 			cmd := exec.Command("sh", "-c", "export CONTAINER_RUNTIME=docker; "+ironicCommand)
 			stdoutStderr, err := cmd.CombinedOutput()
-			fmt.Printf("%s\n", stdoutStderr)
+			Logf("Output: %s", stdoutStderr)
 			Expect(err).ToNot(HaveOccurred(), "Cannot run local ironic")
 		} else {
 			By("Install Ironic in the source cluster as deployments")


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Use `Logf` throughout the e2e tests instead of various fmt.Print* here and there.
Also cleanup the `writeToFile` to return an error instead of just logging them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
