### PR TITLE
🌱 E2E: Install independent Metal3 IPAM after upgrade

### DIFF
--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -158,6 +158,19 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1.5/metadata.yaml"
+- name: metal3
+  type: IPAMProvider
+  versions:
+  - name: "v1.10.0-beta.0"
+    value: "https://github.com/metal3-io/ip-address-manager/releases/download/v1.10.0-beta.0/ipam-components.yaml"
+    type: "url"
+    contract: v1beta1
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+    files:
+    - sourcePath: "../data/infrastructure-metal3/main/metadata.yaml"
+      targetName: "metadata.yaml"
 
 - name: metal3
   type: InfrastructureProvider

--- a/test/e2e/data/cert-manager-test/certificate.yaml
+++ b/test/e2e/data/cert-manager-test/certificate.yaml
@@ -1,16 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: test
----
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: selfsigned-issuer
-  namespace: test
-spec:
-  selfSigned: {}
----
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/test/e2e/data/cert-manager-test/issuer.yaml
+++ b/test/e2e/data/cert-manager-test/issuer.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: test
+spec:
+  selfSigned: {}

--- a/test/e2e/data/cert-manager-test/kustomization.yaml
+++ b/test/e2e/data/cert-manager-test/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- issuer.yaml
+- certificate.yaml

--- a/test/e2e/data/cert-manager-test/namespace.yaml
+++ b/test/e2e/data/cert-manager-test/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test

--- a/test/e2e/logcollector.go
+++ b/test/e2e/logcollector.go
@@ -193,6 +193,10 @@ func FetchManifests(clusterProxy framework.ClusterProxy, outputPath string) erro
 func FetchClusterLogs(clusterProxy framework.ClusterProxy, outputPath string) error {
 	ctx := context.Background()
 	baseDir := filepath.Join(outputPath, clusterProxy.GetName())
+	// Ensure the base directory exists
+	if err := os.MkdirAll(baseDir, 0o750); err != nil {
+		return fmt.Errorf("couldn't create directory: %v", err)
+	}
 
 	// Get the clientset
 	clientset := clusterProxy.GetClientSet()
@@ -265,6 +269,9 @@ func FetchClusterLogs(clusterProxy framework.ClusterProxy, outputPath string) er
 
 			machineName := pod.Spec.NodeName
 			podDir := filepath.Join(baseDir, "machines", machineName, namespace.Name, pod.Name)
+			if err := os.MkdirAll(podDir, 0o750); err != nil {
+				return fmt.Errorf("couldn't create directory: %v", err)
+			}
 			err = writeToFile([]byte(podDescription), "stdout_describe.log", podDir)
 			if err != nil {
 				return fmt.Errorf("couldn't write to file: %v", err)
@@ -274,6 +281,9 @@ func FetchClusterLogs(clusterProxy framework.ClusterProxy, outputPath string) er
 			for _, container := range pod.Spec.Containers {
 				// Create a directory for each container
 				containerDir := filepath.Join(podDir, container.Name)
+				if err := os.MkdirAll(containerDir, 0o750); err != nil {
+					return fmt.Errorf("couldn't create directory: %v", err)
+				}
 
 				err := CollectContainerLogs(ctx, namespace.Name, pod.Name, container.Name, clientset, containerDir)
 				if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

The Metal3 IPAM was previously bundled with CAPM3. Now we deploy it
separately as a CAPI IPAM provider. In clusterctl upgrade tests going
from a version where IPAM is bundled, to a version where it is not, we
must install it after the upgrade.
This commit adds a post upgrade hook to the clusterctl upgrade tests
that installs the Metal3 IPAM.

NOTE: This also includes https://github.com/metal3-io/cluster-api-provider-metal3/pull/2380 we can merge that first or we can close it. I just wanted to make sure I don't hit that issue when testing the upgrade.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
