### PR TITLE
:seedling: fix deprecation notice paragraph style

### DIFF
--- a/api/v1beta1/metal3data_types.go
+++ b/api/v1beta1/metal3data_types.go
@@ -36,7 +36,7 @@ type Metal3DataSpec struct {
 	// TemplateReference refers to the Template the Metal3MachineTemplate refers to.
 	// It can be matched against the key or it may also point to the name of the template
 	// Metal3Data refers to.
-
+	//
 	// Deprecated: This field is deprecated and will be removed in a future release.
 	// +optional
 	TemplateReference string `json:"templateReference,omitempty"`

--- a/api/v1beta1/metal3datatemplate_types.go
+++ b/api/v1beta1/metal3datatemplate_types.go
@@ -521,7 +521,7 @@ type Metal3DataTemplateSpec struct {
 	// TemplateReference refers to the Template the Metal3MachineTemplate refers to.
 	// It can be matched against the key or it may also point to the name of the template
 	// Metal3Data refers to.
-
+	//
 	// Deprecated: This field is deprecated and will be removed in a future release.
 	// +optional
 	TemplateReference string `json:"templateReference,omitempty"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3datas.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3datas.yaml
@@ -171,8 +171,12 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               templateReference:
-                description: 'Deprecated: This field is deprecated and will be removed
-                  in a future release.'
+                description: |-
+                  TemplateReference refers to the Template the Metal3MachineTemplate refers to.
+                  It can be matched against the key or it may also point to the name of the template
+                  Metal3Data refers to.
+
+                  Deprecated: This field is deprecated and will be removed in a future release.
                 type: string
             required:
             - claim

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3datatemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3datatemplates.yaml
@@ -987,8 +987,12 @@ spec:
                     type: object
                 type: object
               templateReference:
-                description: 'Deprecated: This field is deprecated and will be removed
-                  in a future release.'
+                description: |-
+                  TemplateReference refers to the Template the Metal3MachineTemplate refers to.
+                  It can be matched against the key or it may also point to the name of the template
+                  Metal3Data refers to.
+
+                  Deprecated: This field is deprecated and will be removed in a future release.
                 type: string
             required:
             - clusterName


### PR DESCRIPTION
Per godoc, it must be another paragraph in same comment block. Fix the two instances where they're not. This results documentation generate properly.

