### PR TITLE
:seedling: group all github action bumps into single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     interval: "monthly"
     day: "tuesday"
   target-branch: main
+  ## group all action bumps into single PR
+  groups:
+    all-github-actions:
+      patterns: ["*"]
   commit-message:
     prefix: ":seedling:"
   labels:
@@ -56,6 +60,10 @@ updates:
     interval: "monthly"
     day: "tuesday"
   target-branch: release-1.9
+  ## group all action bumps into single PR
+  groups:
+    all-github-actions:
+      patterns: ["*"]
   ignore:
   # Ignore major and minor bumps for release branch
   - dependency-name: "*"
@@ -104,6 +112,10 @@ updates:
     interval: "monthly"
     day: "tuesday"
   target-branch: release-1.8
+  ## group all action bumps into single PR
+  groups:
+    all-github-actions:
+      patterns: ["*"]
   ignore:
   # Ignore major and minor bumps for release branch
   - dependency-name: "*"
@@ -142,4 +154,5 @@ updates:
     prefix: ":seedling:"
   labels:
   - "ok-to-test"
+
 ## release-1.8 branch config ends here


### PR DESCRIPTION
Group all GitHub Action bumps into single bump PR. We cannot really test them anyways, so the review process is more or less eyeballing the release notes and Github provided compatibility numbers.

In addition, having many action bump "pollutes" our release notes with user-irrelevant seedling PRs.
