### PR TITLE
🌱 Bump golangci-lint to v1.64.7

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -29,8 +29,8 @@ jobs:
       with:
         go-version: ${{ steps.vars.outputs.go_version }}
     - name: golangci-lint-${{matrix.working-directory}}
-      uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae # v6.2.0
+      uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
       with:
-        version: v1.60.3
+        version: v1.64.7
         working-directory: ${{matrix.working-directory}}
         args: --timeout=15m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,4 @@
 run:
-  deadline: 15m
   go: "1.23"
 linters:
   disable-all: true
@@ -53,7 +52,6 @@ linters:
 
 linters-settings:
   gosec:
-    go: "1.23"
     severity: medium
     confidence: medium
     concurrency: 8
@@ -94,7 +92,6 @@ linters-settings:
       alias: bmov1alpha1
   nolintlint:
     allow-unused: false
-    allow-leading-space: false
     require-specific: true
   gocritic:
     enabled-tags:
@@ -113,8 +110,6 @@ linters-settings:
     - unnecessaryDefer
     - whyNoLint
     - wrapperFunc
-  unused:
-    go: "1.23"
 issues:
   exclude-dirs:
   - mock*

--- a/api/v1beta1/groupversion_info.go
+++ b/api/v1beta1/groupversion_info.go
@@ -32,7 +32,7 @@ var (
 	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta1"}
 
-	/// schemeBuilder is used to add go types to the GroupVersionKind scheme.
+	// schemeBuilder is used to add go types to the GroupVersionKind scheme.
 	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/api/v1beta1/metal3datatemplate_types.go
+++ b/api/v1beta1/metal3datatemplate_types.go
@@ -226,7 +226,7 @@ type NetworkDataLinkEthernet struct {
 	Type string `json:"type"`
 
 	// Id is the ID of the interface (used for naming)
-	Id string `json:"id"` //nolint:revive,stylecheck
+	Id string `json:"id"` //nolint:stylecheck,revive
 
 	// +kubebuilder:default=1500
 	// +kubebuilder:validation:Maximum=9000
@@ -252,7 +252,7 @@ type NetworkDataLinkBond struct {
 	BondXmitHashPolicy string `json:"bondXmitHashPolicy"`
 
 	// Id is the ID of the interface (used for naming)
-	Id string `json:"id"` //nolint:revive,stylecheck
+	Id string `json:"id"` //nolint:stylecheck,revive
 
 	// +kubebuilder:default=1500
 	// +kubebuilder:validation:Maximum=9000
@@ -276,7 +276,7 @@ type NetworkDataLinkVlan struct {
 	VlanID int `json:"vlanID"`
 
 	// Id is the ID of the interface (used for naming)
-	Id string `json:"id"` //nolint:revive,stylecheck
+	Id string `json:"id"` //nolint:stylecheck,revive
 
 	// +kubebuilder:default=1500
 	// +kubebuilder:validation:Maximum=9000

--- a/hack/ensure-golangci-lint.sh
+++ b/hack/ensure-golangci-lint.sh
@@ -60,10 +60,10 @@ download_and_install_golangci_lint()
     KERNEL_OS="$(uname | tr '[:upper:]' '[:lower:]')"
     ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')"
     GOLANGCI_LINT="golangci-lint"
-    GOLANGCI_VERSION="1.60.3"
+    GOLANGCI_VERSION="1.64.7"
     case "${KERNEL_OS}-${ARCH}" in
-        darwin-arm64) GOLANGCI_SHA256="deb0fbd0b99992d97808614db1214f57d5bdc12b907581e2ef10d3a392aca11f" ;;
-        linux-amd64) GOLANGCI_SHA256="4037af8122871f401ed874852a471e54f147ff8ce80f5a304e020503bdb806ef" ;;
+        darwin-arm64) GOLANGCI_SHA256="9ff4b40bd4c8cd199d010c0e96e424416c32827fce0fb7eedebb48294106623b" ;;
+        linux-amd64) GOLANGCI_SHA256="dada4095eab53f868f931840f04b99cb4be654e45f50d4d3b2832dc9ad3bede8" ;;
       *)
         echo >&2 "error:${KERNEL_OS}-${ARCH} not supported. Please obtain the binary and calculate sha256 manually."
         exit 1

--- a/test/e2e/cert_rotation.go
+++ b/test/e2e/cert_rotation.go
@@ -45,7 +45,7 @@ func certRotation(ctx context.Context, inputGetter func() CertRotationInput) {
 		}
 
 		return errors.New("ironic pod is not in running state")
-	}, input.E2EConfig.GetIntervals(input.SpecName, "wait-deployment")...).Should(BeNil())
+	}, input.E2EConfig.GetIntervals(input.SpecName, "wait-deployment")...).Should(Succeed())
 
 	time.Sleep(5 * time.Minute)
 
@@ -86,7 +86,7 @@ func certRotation(ctx context.Context, inputGetter func() CertRotationInput) {
 			return nil
 		}
 		return errors.New("not all containers are running")
-	}, 200*time.Second, 20*time.Second).Should(BeNil(), "not all containers are in running state in ironic pod")
+	}, 200*time.Second, 20*time.Second).Should(Succeed(), "not all containers are in running state in ironic pod")
 	By("CERTIFICATE ROTATION TESTS PASSED!")
 }
 

--- a/test/e2e/pivoting.go
+++ b/test/e2e/pivoting.go
@@ -196,11 +196,11 @@ func pivoting(ctx context.Context, inputGetter func() PivotingInput) {
 	Consistently(func() error {
 		kubeSystem := &corev1.Namespace{}
 		return input.BootstrapClusterProxy.GetClient().Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
-	}, "5s", "100ms").Should(BeNil(), "Failed to assert bootstrap API server stability")
+	}, "5s", "100ms").Should(Succeed(), "Failed to assert bootstrap API server stability")
 	Consistently(func() error {
 		kubeSystem := &corev1.Namespace{}
 		return input.TargetCluster.GetClient().Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
-	}, "5s", "100ms").Should(BeNil(), "Failed to assert target API server stability")
+	}, "5s", "100ms").Should(Succeed(), "Failed to assert target API server stability")
 
 	By("Moving the cluster to self hosted")
 	clusterctl.Move(ctx, clusterctl.MoveInput{
@@ -443,7 +443,7 @@ func rePivoting(ctx context.Context, inputGetter func() RePivotingInput) {
 	Consistently(func() error {
 		kubeSystem := &corev1.Namespace{}
 		return input.BootstrapClusterProxy.GetClient().Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
-	}, "5s", "100ms").Should(BeNil(), "Failed to assert bootstrap API server stability")
+	}, "5s", "100ms").Should(Succeed(), "Failed to assert bootstrap API server stability")
 
 	By("Move back to bootstrap cluster")
 	clusterctl.Move(ctx, clusterctl.MoveInput{


### PR DESCRIPTION
This PR also bumps golangci-lint-action to 6.5.2. While doing that it removes some of the old unsupported golanci-lint settings.
Signed-off-by: Kashif Khan <kashif.khan@est.tech>
