### PR TITLE
:seedling: update the used linters list

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,13 +9,24 @@ linters:
   - bodyclose
   - containedctx
   - copyloopvar
+  - decorder
   - dogsled
+  #- dupl
   - dupword
   - durationcheck
   - errcheck
   - errchkjson
+  #- errname
+  #- errorlint
+  #- exhaustive
+  - exptostd
+  - fatcontext
+  #- forbidigo
+  #- forcetypeassert
   - gci
   - ginkgolinter
+  - gocheckcompilerdirectives
+  - gochecksumtype
   - goconst
   - gocritic
   - godot
@@ -24,28 +35,42 @@ linters:
   - goprintffuncname
   - gosec
   - gosimple
+  - gosmopolitan
   - govet
+  - iface
   - importas
   - ineffassign
+  #- intrange
   - loggercheck
+  - makezero
+  - mirror
   - misspell
+  #- mnd
   - nakedret
   - nilerr
+  - nilnesserr
+  #- nilnil
   - noctx
   - nolintlint
   - nosprintfhostport
+  #- perfsprint
   - prealloc
   - predeclared
+  - reassign
   - revive
   - rowserrcheck
   - staticcheck
   - stylecheck
+  #- tagliatelle
+  - testifylint
   - thelper
+  - tparallel
   - typecheck
   - unconvert
   - unparam
   - unused
   - usestdlibvars
+  - usetesting
   - whitespace
   # Run with --fast=false for more extensive checks
   fast: true


### PR DESCRIPTION
We have [agreed a list of linters](https://github.com/orgs/metal3-io/discussions/2098) to be enabled in all of our Go repos. Sync that list to CAPM3 and leave disabled those that do not pass.

We could enable 14 more linters without any failures. We have 11 linters commented out.

I will make sub-issues of #2106 for the remaining items.