### PR TITLE
:seedling: do not bump major version of github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,12 @@ updates:
   target-branch: main
   ## group all action bumps into single PR
   groups:
-    all-github-actions:
+    github-actions:
       patterns: ["*"]
+  ignore:
+  # Ignore major bumps in main, as it breaks the group bump process
+  - dependency-name: "*"
+    update-types: ["version-update:semver-major"]
   commit-message:
     prefix: ":seedling:"
   labels:
@@ -62,7 +66,7 @@ updates:
   target-branch: release-1.9
   ## group all action bumps into single PR
   groups:
-    all-github-actions:
+    github-actions:
       patterns: ["*"]
   ignore:
   # Ignore major and minor bumps for release branch
@@ -114,7 +118,7 @@ updates:
   target-branch: release-1.8
   ## group all action bumps into single PR
   groups:
-    all-github-actions:
+    github-actions:
       patterns: ["*"]
   ignore:
   # Ignore major and minor bumps for release branch


### PR DESCRIPTION
Change dependabot config not to try major bumps of github actions. We now have grouped bumps to lessen the noise from dependabot, and if in that group, there is a major bump (like right now a golangci-lint v2 major bump) which isn't compatible as is and requires manual changes, it blocks bumping all the other actions as well.

Also, change the name of the all-github-actions group, as how it is inserted in PR title looks wrong. Plain "github-actions" group name works better there.
