### PR TITLE
:rocket: Release v1.10.0-beta.0

### DIFF
--- a/releasenotes/v1.10.0-beta.0.md
+++ b/releasenotes/v1.10.0-beta.0.md
@@ -28,6 +28,7 @@ If you find any bugs, file an [issue](https://github.com/metal3-io/cluster-api-p
 
 ## :seedling: Others
 
+- Set GITHUB_TOKEN in env release wf (#2498)
 - Bump CAPI to v1.10.0-rc.0 (#2487)
 - Fix: pulling unused images in the middle of tests (#2271)
 - Add use of IPAMprovider to e2e tests (#2348)


### PR DESCRIPTION
Round two of the release as the release workflow was broken.
