### PR TITLE
🌱Apply BMH from CAPM3 during test and skip BMH creation from dev-env

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -45,8 +45,8 @@ export IMAGE_OS=${IMAGE_OS}
 export FORCE_REPO_UPDATE="false"
 export USE_IRSO="${USE_IRSO:-false}"
 EOF
-# if running a scalability test skip apply bmhs in dev-env and run fakeIPA
-if [[ ${GINKGO_FOCUS:-} == "clusterctl-upgrade" ]]; then
+# if running basic integration or clusterctl-upgrade test skip apply bmhs in dev-env
+if [[ "${GINKGO_FOCUS:-}" == "clusterctl-upgrade" ]] || [[ "${GINKGO_FOCUS:-}" == "basic" ]] || [[ "${GINKGO_FOCUS:-}" == "integration" ]]; then
     echo 'export SKIP_APPLY_BMH="true"' >>"${M3_DEV_ENV_PATH}/config_${USER}.sh"
 fi
 if [[ ${GINKGO_FOCUS:-} == "features" ]]; then

--- a/test/e2e/basic_integration_test.go
+++ b/test/e2e/basic_integration_test.go
@@ -20,6 +20,8 @@ var _ = Describe("When testing basic cluster creation [basic]", Label("basic"), 
 	})
 
 	It("Should create a workload cluster", func() {
+		By("Apply BMH for workload cluster")
+		ApplyBmh(ctx, e2eConfig, bootstrapClusterProxy, namespace, specName)
 		By("Fetching cluster configuration")
 		k8sVersion := e2eConfig.MustGetVariable("KUBERNETES_VERSION")
 		By("Provision Workload cluster")

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -1059,3 +1059,22 @@ func CreateTargetCluster(ctx context.Context, inputGetter func() CreateTargetClu
 	}, input.E2EConfig.GetIntervals(input.SpecName, "wait-all-pod-to-be-running-on-target-cluster")...)
 	return targetCluster, &result
 }
+
+func ApplyBmh(ctx context.Context, e2eConfig *clusterctl.E2EConfig, clusterProxy framework.ClusterProxy, clusterNamespace string, specName string) {
+	workingDir := "/opt/metal3-dev-env/"
+	// Apply secrets and bmhs for [node_0 and node_1] in the management cluster to host the target management cluster
+	for i := range 2 {
+		resource, err := os.ReadFile(filepath.Join(workingDir, fmt.Sprintf("bmhs/node_%d.yaml", i)))
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(CreateOrUpdateWithNamespace(ctx, clusterProxy, resource, clusterNamespace)).ShouldNot(HaveOccurred())
+	}
+	clusterClient := clusterProxy.GetClient()
+	ListBareMetalHosts(ctx, clusterClient, client.InNamespace(clusterNamespace))
+	WaitForNumBmhInState(ctx, bmov1alpha1.StateAvailable, WaitForNumInput{
+		Client:    clusterClient,
+		Options:   []client.ListOption{client.InNamespace(clusterNamespace)},
+		Replicas:  2,
+		Intervals: e2eConfig.GetIntervals(specName, "wait-bmh-available"),
+	})
+	ListBareMetalHosts(ctx, clusterClient, client.InNamespace(clusterNamespace))
+}

--- a/test/e2e/integration_test.go
+++ b/test/e2e/integration_test.go
@@ -24,6 +24,9 @@ var _ = Describe("When testing integration [integration]", Label("integration"),
 		numberOfWorkers = int(*e2eConfig.MustGetInt32PtrVariable("WORKER_MACHINE_COUNT"))
 		numberOfControlplane = int(*e2eConfig.MustGetInt32PtrVariable("CONTROL_PLANE_MACHINE_COUNT"))
 		k8sVersion := e2eConfig.MustGetVariable("KUBERNETES_VERSION")
+		By("Apply BMH for workload cluster")
+		ApplyBmh(ctx, e2eConfig, bootstrapClusterProxy, namespace, specName)
+
 		By("Provision Workload cluster")
 		targetCluster, _ = CreateTargetCluster(ctx, func() CreateTargetClusterInput {
 			return CreateTargetClusterInput{


### PR DESCRIPTION
Here we have introduced SKIP_APPLY_BMH var for skipping BMH creation from dev-env and added the code to apply the BMH from CAPM3  during basic and integration test.  These changes  will be part of the decoupling dev-env [issue](https://github.com/metal3-io/cluster-api-provider-metal3/issues/1996) 
