### PR TITLE
🐛 Handle NICs without IP addresses

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -1218,6 +1218,9 @@ func (m *MachineManager) nodeAddresses(host *bmov1alpha1.BareMetalHost) []cluste
 			Type:    clusterv1.MachineInternalIP,
 			Address: nic.IP,
 		}
+		if address.Address == "" {
+			continue
+		}
 		addrs = append(addrs, address)
 	}
 


### PR DESCRIPTION
This PR improves how NICs without IP addresses are handled during MachineStatus population.

Skips adding NICs that have an ip address field to prevent invalid Metal3Machine status updates. Interfaces with no ip addresses are visible on bmh.

Otherwise,  patching Metal3Machine status will fail with following error:

`status.addresses[n].address: Invalid value: "": addresses[n].address in body should be at least 1 chars long`

Issue seen in [BML tests](https://jenkins.nordix.org/view/Metal3%20Periodic/job/metal3-periodic-bml-integration-test-centos/318/)
