### PR TITLE
🌱 Bumping k8s version for e2e tests

### DIFF
--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -48,7 +48,7 @@ else
   export EPHEMERAL_CLUSTER="minikube"
 fi
 
-export FROM_K8S_VERSION=${FROM_K8S_VERSION:-"v1.31.2"}
+export FROM_K8S_VERSION=${FROM_K8S_VERSION:-"v1.32.1"}
 export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.33.0"}
 
 # Can be overriden from jjbs

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -170,8 +170,8 @@ variables:
   # KUBERNETES_PATCH_FROM_VERSION and KUBERNETES_PATCH_TO_VERSION are used to
   # test upgrade scenarios where we only want to upgrade the patch version of
   # kubernetes.
-  KUBERNETES_PATCH_FROM_VERSION: "v1.31.0"
-  KUBERNETES_PATCH_TO_VERSION: "v1.31.2"
+  KUBERNETES_PATCH_FROM_VERSION: "v1.32.0"
+  KUBERNETES_PATCH_TO_VERSION: "v1.32.1"
   CONTROL_PLANE_MACHINE_COUNT: 3
   WORKER_MACHINE_COUNT: 1
   NUM_NODES: 4


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Bumping k8s version to 1.33 for e2e tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
