### PR TITLE
:seedling: Change Kubernetes version in e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ GINKGO_PKG := github.com/onsi/ginkgo/v2/ginkgo
 # Helper function to get dependency version from go.mod
 get_go_version = $(shell $(GO) list -m $1 | awk '{print $$2}')
 GINGKO_VER := $(call get_go_version,github.com/onsi/ginkgo/v2)
-ENVTEST_K8S_VERSION := 1.31.x
+ENVTEST_K8S_VERSION := 1.32.x
 
 # Define Docker related variables. Releases should modify and double check these vars.
 # REGISTRY ?= gcr.io/$(shell gcloud config get-value project)

--- a/docs/e2e-test.md
+++ b/docs/e2e-test.md
@@ -146,7 +146,11 @@ For example:
 
 Main branch k8s-upgrade tests:
 
-- `v1.31` => `v1.32`
+- `v1.32` => `v1.33`
+
+Release 1.10 branch k8s-upgrade test:
+
+- `v1.32` => `v1.33`
 
 Release 1.9 branch k8s-upgrade test:
 

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -48,7 +48,7 @@ else
   export EPHEMERAL_CLUSTER="minikube"
 fi
 
-export FROM_K8S_VERSION=${FROM_K8S_VERSION:-"v1.31.2"}
+export FROM_K8S_VERSION=${FROM_K8S_VERSION:-"v1.32.1"}
 export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.33.0"}
 
 # Can be overriden from jjbs

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -170,8 +170,8 @@ variables:
   # KUBERNETES_PATCH_FROM_VERSION and KUBERNETES_PATCH_TO_VERSION are used to
   # test upgrade scenarios where we only want to upgrade the patch version of
   # kubernetes.
-  KUBERNETES_PATCH_FROM_VERSION: "v1.31.0"
-  KUBERNETES_PATCH_TO_VERSION: "v1.31.2"
+  KUBERNETES_PATCH_FROM_VERSION: "v1.32.0"
+  KUBERNETES_PATCH_TO_VERSION: "v1.32.1"
   CONTROL_PLANE_MACHINE_COUNT: 3
   WORKER_MACHINE_COUNT: 1
   NUM_NODES: 4


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Change Kubernetes version in e2e tests
Envtest uplift to 1.33 is done in a separate PR https://github.com/metal3-io/cluster-api-provider-metal3/pull/2535 because the is an issue with it. 
