### PR TITLE
🌱 Add .gitattributes to ignore CRD diffs in PR UI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Hide generated crd yamls by default in the Github diff UX
+**/config/crd/bases/*.yaml linguist-generated=true


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds a `.gitattributes` file to tell the GitHub UI to ignore diffs in CRD files within the PR UI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2436 
