### PR TITLE
🌱Apply BMH from CAPM3 e2e feature tests

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -1060,8 +1060,9 @@ func CreateTargetCluster(ctx context.Context, inputGetter func() CreateTargetClu
 
 func ApplyBmh(ctx context.Context, e2eConfig *clusterctl.E2EConfig, clusterProxy framework.ClusterProxy, clusterNamespace string, specName string) {
 	workingDir := "/opt/metal3-dev-env/"
+	numNodes := int(*e2eConfig.MustGetInt32PtrVariable("NUM_NODES"))
 	// Apply secrets and bmhs for [node_0 and node_1] in the management cluster to host the target management cluster
-	for i := range 2 {
+	for i := range numNodes {
 		resource, err := os.ReadFile(filepath.Join(workingDir, fmt.Sprintf("bmhs/node_%d.yaml", i)))
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(CreateOrUpdateWithNamespace(ctx, clusterProxy, resource, clusterNamespace)).ShouldNot(HaveOccurred())
@@ -1071,7 +1072,7 @@ func ApplyBmh(ctx context.Context, e2eConfig *clusterctl.E2EConfig, clusterProxy
 	WaitForNumBmhInState(ctx, bmov1alpha1.StateAvailable, WaitForNumInput{
 		Client:    clusterClient,
 		Options:   []client.ListOption{client.InNamespace(clusterNamespace)},
-		Replicas:  2,
+		Replicas:  numNodes,
 		Intervals: e2eConfig.GetIntervals(specName, "wait-bmh-available"),
 	})
 	ListBareMetalHosts(ctx, clusterClient, client.InNamespace(clusterNamespace))

--- a/test/e2e/ip_reuse_test.go
+++ b/test/e2e/ip_reuse_test.go
@@ -21,6 +21,9 @@ var _ = Describe("When testing ip reuse [ip-reuse] [features]", Label("ip-reuse"
 		clusterctlLogFolder = filepath.Join(os.TempDir(), "target_cluster_logs", bootstrapClusterProxy.GetName())
 	})
 	It("Should create a workload cluster then verify ip allocation reuse while upgrading k8s", func() {
+		By("Apply BMH for workload cluster")
+		ApplyBmh(ctx, e2eConfig, bootstrapClusterProxy, namespace, specName)
+		By("Provision Workload cluster")
 		targetCluster, _ = CreateTargetCluster(ctx, func() CreateTargetClusterInput {
 			return CreateTargetClusterInput{
 				E2EConfig:             e2eConfig,

--- a/test/e2e/pivoting_based_feature_test.go
+++ b/test/e2e/pivoting_based_feature_test.go
@@ -86,6 +86,9 @@ var _ = Describe("Testing features in ephemeral or target cluster [pivoting] [fe
 		})
 
 		It("Should get a management cluster then test cert rotation and node reuse", func() {
+			By("Apply BMH for workload cluster")
+			ApplyBmh(ctx, e2eConfig, bootstrapClusterProxy, namespace, specName)
+			By("Provision Workload cluster")
 			targetCluster, _ = CreateTargetCluster(ctx, func() CreateTargetClusterInput {
 				return CreateTargetClusterInput{
 					E2EConfig:             e2eConfig,

--- a/test/e2e/remediation_based_feature_test.go
+++ b/test/e2e/remediation_based_feature_test.go
@@ -71,6 +71,8 @@ var _ = Describe("Testing nodes remediation [remediation] [features]", Label("re
 	})
 
 	It("Should create a cluster and run remediation based tests", func() {
+		By("Apply BMH for workload cluster")
+		ApplyBmh(ctx, e2eConfig, bootstrapClusterProxy, namespace, specName)
 		By("Creating target cluster")
 		targetCluster, _ = CreateTargetCluster(ctx, func() CreateTargetClusterInput {
 			return CreateTargetClusterInput{

--- a/test/e2e/upgrade_kubernetes_test.go
+++ b/test/e2e/upgrade_kubernetes_test.go
@@ -38,6 +38,8 @@ var _ = Describe("Kubernetes version upgrade in target nodes [k8s-upgrade]", Lab
 	})
 
 	It("Should create a cluster and run k8s_upgrade tests", func() {
+		By("Apply BMH for workload cluster")
+		ApplyBmh(ctx, e2eConfig, bootstrapClusterProxy, namespace, specName)
 		By("Creating target cluster")
 		targetCluster, _ = CreateTargetCluster(ctx, func() CreateTargetClusterInput {
 			return CreateTargetClusterInput{


### PR DESCRIPTION
This PR is a part of the SKIP_BMH_APPLY from dev-env side and it will apply from CAPM3 e2e test. This is a sub task which will fix part of the [issue](https://github.com/metal3-io/cluster-api-provider-metal3/issues/1996) which will add the BMH apply for feature tests.
