### PR TITLE
:seedling: Adopt md_rollout test from CAPI

### DIFF
--- a/test/e2e/md_rollout_test.go
+++ b/test/e2e/md_rollout_test.go
@@ -1,0 +1,32 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+)
+
+var _ = Describe("When testing MachineDeployment rolling upgrades [capi-md-tests]", Label("capi-md-tests"), func() {
+	BeforeEach(func() {
+		osType := strings.ToLower(os.Getenv("OS"))
+		Expect(osType).ToNot(Equal(""))
+		validateGlobals(specName)
+		// We need to override clusterctl apply log folder to avoid getting our credentials exposed.
+		clusterctlLogFolder = filepath.Join(os.TempDir(), "target_cluster_logs", bootstrapClusterProxy.GetName())
+	})
+	capi_e2e.MachineDeploymentRolloutSpec(ctx, func() capi_e2e.MachineDeploymentRolloutSpecInput {
+		return capi_e2e.MachineDeploymentRolloutSpecInput{
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+			Flavor:                osType,
+			PostNamespaceCreated:  createBMHsInNamespace,
+		}
+	})
+})


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Adopt MachineDeployment rolling upgrades test from CAPI: https://github.com/kubernetes-sigs/cluster-api/blob/main/test/e2e/md_rollout.go.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes partially #1080
