### PR TITLE
:seedling: Fix deleting BMHs in md_remediation

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -50,8 +50,8 @@ export USE_IRSO="${USE_IRSO:-false}"
 EOF
 
 case "${GINKGO_FOCUS:-}" in
-  clusterctl-upgrade|k8s-upgrade|basic|integration|k8s-conformance)
-    # if running basic, integration, k8s upgrade, clusterctl-upgrade or k8s conformance test, skip apply bmhs in dev-env
+  clusterctl-upgrade|k8s-upgrade|basic|integration|remediation|k8s-conformance)
+    # if running basic, integration, k8s upgrade, clusterctl-upgrade, remediation or k8s conformance test, skip apply bmhs in dev-env
     echo 'export SKIP_APPLY_BMH="true"' >>"${M3_DEV_ENV_PATH}/config_${USER}.sh"
   ;;
 

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -262,6 +262,7 @@ intervals:
   default/wait-bmh-deprovisioning: ["50m", "10s"]
   default/wait-bmh-available: ["50m", "20s"]
   default/wait-bmh-inspecting: ["10m", "2s"]
+  default/wait-bmh-deleting: ["15m", "2s"]
   default/wait-machine-deleting: ["15m", "2s"]
   default/wait-bmh-deprovisioning-available: ["7m", "500ms"]
   default/wait-bmh-available-provisioning: ["15m", "2s"]

--- a/test/e2e/md_remediations_test.go
+++ b/test/e2e/md_remediations_test.go
@@ -2,16 +2,13 @@ package e2e
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
-	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -19,6 +16,12 @@ const (
 )
 
 var _ = Describe("When testing MachineDeployment remediation [healthcheck] [remediation] [features]", Label("healthcheck", "remediation", "features"), func() {
+
+	var (
+		specName  = "metal3"
+		namespace = "metal3"
+	)
+
 	BeforeEach(func() {
 		osType := strings.ToLower(os.Getenv("OS"))
 		Expect(osType).ToNot(Equal(""))
@@ -26,13 +29,28 @@ var _ = Describe("When testing MachineDeployment remediation [healthcheck] [reme
 		// We need to override clusterctl apply log folder to avoid getting our credentials exposed.
 		clusterctlLogFolder = filepath.Join(os.TempDir(), "target_cluster_logs", bootstrapClusterProxy.GetName())
 
-		Logf("Removing existing BMHs from source")
-		bmhData, err := os.ReadFile(filepath.Join(workDir, bmhCrsFile))
-		Expect(err).ToNot(HaveOccurred(), "BMH CRs file not found")
-		kubeConfigPath := bootstrapClusterProxy.GetKubeconfigPath()
-		err = KubectlDelete(ctx, kubeConfigPath, bmhData, "-n", "metal3")
-		Expect(err).ToNot(HaveOccurred(), "Failed to delete existing BMHs")
-		Logf("BMHs are removed")
+		By("Check if there are existing BMHs")
+		clusterClient := bootstrapClusterProxy.GetClient()
+		bmhList, err := GetAllBmhs(ctx, clusterClient, namespace)
+		Expect(err).ToNot(HaveOccurred(), "Could not list BMHs")
+
+		if len(bmhList) > 0 {
+			By("Removing existing BMHs from source")
+			bmhData, err := os.ReadFile(filepath.Join(workDir, bmhCrsFile))
+			Expect(err).ToNot(HaveOccurred(), "BMH CRs file not found")
+			kubeConfigPath := bootstrapClusterProxy.GetKubeconfigPath()
+			err = KubectlDelete(ctx, kubeConfigPath, bmhData, "-n", "metal3", "--ignore-not-found")
+			Expect(err).ToNot(HaveOccurred(), "Could not delete BMHs")
+
+			By("Waiting for all the BMHs deleted")
+			Eventually(func(g Gomega) {
+				bmhList, err := GetAllBmhs(ctx, clusterClient, namespace)
+				Expect(err).ToNot(HaveOccurred(), "Could not list BMHs")
+				g.Expect(bmhList).To(BeEmpty())
+			}, e2eConfig.GetIntervals(specName, "wait-bmh-deleting")...).Should(Succeed())
+			By("All BMHs are deleted")
+		}
+
 	})
 	capi_e2e.MachineDeploymentRemediationSpec(ctx, func() capi_e2e.MachineDeploymentRemediationSpecInput {
 		return capi_e2e.MachineDeploymentRemediationSpecInput{
@@ -44,27 +62,5 @@ var _ = Describe("When testing MachineDeployment remediation [healthcheck] [reme
 			PostNamespaceCreated:  createBMHsInNamespace,
 			Flavor:                ptr.To(osType + "-md-remediation"),
 		}
-	})
-	AfterEach(func() {
-		ListBareMetalHosts(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
-		ListMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
-		ListMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
-		// Recreate bmh that was used in capi namespace in metal3
-		//#nosec G204 -- We need to pass in the file name here.
-		cmd := exec.Command("bash", "-c", "kubectl apply -f bmhosts_crs.yaml  -n metal3")
-		cmd.Dir = workDir
-		output, err := cmd.CombinedOutput()
-		Logf("Applying bmh to metal3 namespace : \n %v", string(output))
-		Expect(err).ToNot(HaveOccurred())
-		// wait for all bmh to become available
-		bootstrapClient := bootstrapClusterProxy.GetClient()
-		ListBareMetalHosts(ctx, bootstrapClient, client.InNamespace(namespace))
-		WaitForNumBmhInState(ctx, bmov1alpha1.StateAvailable, WaitForNumInput{
-			Client:    bootstrapClient,
-			Options:   []client.ListOption{client.InNamespace(namespace)},
-			Replicas:  4,
-			Intervals: e2eConfig.GetIntervals(specName, "wait-bmh-available"),
-		})
-		ListBareMetalHosts(ctx, bootstrapClient, client.InNamespace(namespace))
 	})
 })


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Improve deleting BMHs in BeforeEach. Before BMHs weren't deleted conditionally and test failed if there wasn't any BMHs applied yet. Removed unnecessary reapplying of BMHs after the test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
