### PR TITLE
:seedling:  Change deprecated ginkgo functionality

### DIFF
--- a/test/e2e/data/kubetest/conformance.yaml
+++ b/test/e2e/data/kubetest/conformance.yaml
@@ -1,7 +1,6 @@
 ginkgo.focus: \[Conformance\]
 ginkgo.skip: \[Serial\]
 disable-log-dump: true
-ginkgo.slow-spec-threshold: 120s
 ginkgo.flake-attempts: 3
 ginkgo.trace: true
 ginkgo.v: true


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Remove deprecated --slow-spec-threshold. I tested the suggested --poll-progress-after but for me it seemed that the outputs might not be too useful for us as the time limit exceeds in many tests in normal situation, too. If some test fails it will be anyhow logged.

```
You're using deprecated Ginkgo functionality:
=============================================
--ginkgo.slow-spec-threshold is deprecated --slow-spec-threshold has been deprecated
and will be removed in a future version of Ginkgo.  This feature has proved to be more
noisy than useful.  You can use --poll-progress-after, instead, to get more actionable 
feedback about potentially slow specs and understand where they might be getting stuck.
```
