### PR TITLE
🌱 Limit API listing to 200 at a time via pagination

### DIFF
--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -1498,7 +1498,7 @@ func fetchM3IPClaim(ctx context.Context, cl client.Client, mLog logr.Logger,
 func (m *DataManager) fetchIPClaimsWithLabels(ctx context.Context, pool string) ([]ipamv1.IPClaim, error) {
 	allIPClaims := ipamv1.IPClaimList{}
 	opts := []client.ListOption{
-		&client.ListOptions{Namespace: m.Data.Namespace},
+		&client.ListOptions{Namespace: m.Data.Namespace, Limit: DefaultListLimit},
 		client.MatchingLabels{
 			DataLabelName: m.Data.Name,
 			PoolLabelName: pool,

--- a/baremetal/metal3datatemplate_manager.go
+++ b/baremetal/metal3datatemplate_manager.go
@@ -158,6 +158,7 @@ func (m *DataTemplateManager) UpdateDatas(ctx context.Context) (bool, bool, erro
 	// without this ListOption, all namespaces would be including in the listing
 	opts := &client.ListOptions{
 		Namespace: m.DataTemplate.Namespace,
+		Limit:     DefaultListLimit,
 	}
 
 	err = m.client.List(ctx, &dataClaimObjects, opts)

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -797,6 +797,7 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmov1alpha1.BareMetal
 	// without this ListOption, all namespaces would be including in the listing.
 	opts := &client.ListOptions{
 		Namespace: m.Metal3Machine.Namespace,
+		Limit:     DefaultListLimit,
 	}
 
 	err := m.client.List(ctx, &hosts, opts)

--- a/baremetal/metal3machinetemplate_manager.go
+++ b/baremetal/metal3machinetemplate_manager.go
@@ -68,6 +68,7 @@ func (m *MachineTemplateManager) UpdateAutomatedCleaningMode(ctx context.Context
 	// without this ListOption, all namespaces would be included in the listing
 	opts := &client.ListOptions{
 		Namespace: m.Metal3MachineTemplate.Namespace,
+		Limit:     DefaultListLimit,
 	}
 
 	if err := m.client.List(ctx, m3ms, opts); err != nil {

--- a/baremetal/utils.go
+++ b/baremetal/utils.go
@@ -42,6 +42,7 @@ const (
 	metal3MachineKind   = "Metal3Machine"
 	VerbosityLevelDebug = 4
 	VerbosityLevelTrace = 5
+	DefaultListLimit    = 200
 )
 
 // Contains returns true if a list contains a string.


### PR DESCRIPTION
**What this PR does / why we need it**:
Control how many objects (`metal3data`,`metal3datatemplate`, `metal3machine`, `metal3machinetemplate`) should be retrieved per list call (200). This should in theory reduce the load on the API server's memory consumption, especially when there is a large number of objects with large amount of data on them.