### PR TITLE
🌱 Fix small typo in verify release

### DIFF
--- a/hack/verify-release.sh
+++ b/hack/verify-release.sh
@@ -88,7 +88,7 @@ declare -a release_note_strings=(
 # required strings that are postfixed with correct release number
 declare -a release_note_tag_strings=(
     "The image for this release is: v${VERSION}"
-    "Mariadb image tag is capm3-v${VERSION}"
+    "Mariadb image tag is: capm3-v${VERSION}"
 )
 
 # release artefacts


### PR DESCRIPTION
Fixes a small typo in verify release while checking mariadb image tag in release notes. Currently it wrongly complains about missing the line since the text doesn't match. It was missing `:`

