### PR TITLE
🌱 Fix remediation test

### DIFF
--- a/test/e2e/healthcheck.go
+++ b/test/e2e/healthcheck.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
@@ -179,7 +178,6 @@ func DeployMachineHealthCheck(ctx context.Context, cli client.Client, namespace,
 				MatchLabels: matchLabels,
 			},
 			Checks: clusterv1.MachineHealthCheckChecks{
-				NodeStartupTimeoutSeconds: ptr.To(int32(0)),
 				UnhealthyNodeConditions: []clusterv1.UnhealthyNodeCondition{
 					{
 						Type:           corev1.NodeReady,
@@ -217,9 +215,9 @@ func DeployMachineHealthCheck(ctx context.Context, cli client.Client, namespace,
 
 // WaitForHealthCheckCurrentHealthyToMatch waits for current healthy machines watched by healthcheck to match the number given.
 func WaitForHealthCheckCurrentHealthyToMatch(ctx context.Context, cli client.Client, number int32, healthcheck *clusterv1.MachineHealthCheck, timeout, frequency time.Duration) {
-	Eventually(func(g Gomega) *int32 {
+	Eventually(func(g Gomega) int32 {
 		g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(healthcheck), healthcheck)).To(Succeed())
-		return healthcheck.Status.CurrentHealthy
+		return *healthcheck.Status.CurrentHealthy
 	}, timeout, frequency).Should(Equal(number))
 }
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Fix remediation test
We were comparing int32 with *int32 which was failing.
healthcheck.Status.CurrentHealthy was previously int32 now its *int32. This PR is fixing that, making sure we compare right types.

On line 182 `NodeStartupTimeoutSeconds: ptr.To(int32(0)),` is removed, this is not related to the fix, just refactor. it was not there before recent CAPI uplift but mistakenly added when converting v1beta1 object to v1beta2. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
