### PR TITLE
🌱 Bump CAPI to 1.11.0-rc.0

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -10,7 +10,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.33.3
 	k8s.io/apimachinery v0.33.3
 	k8s.io/client-go v0.33.3
-	sigs.k8s.io/cluster-api v1.11.0-beta.2
+	sigs.k8s.io/cluster-api v1.11.0-rc.0
 	sigs.k8s.io/controller-runtime v0.21.0
 )
 

--- a/api/go.sum
+++ b/api/go.sum
@@ -183,8 +183,8 @@ k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff h1:/usPimJzUKKu+m+TE36gUy
 k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff/go.mod h1:5jIi+8yX4RIb8wk3XwBo5Pq2ccx4FP10ohkbSKCZoK8=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-sigs.k8s.io/cluster-api v1.11.0-beta.2 h1:uR9kci1V92xJK3Qaw49liK7zLOvZ5JEqrbeyWReVUyM=
-sigs.k8s.io/cluster-api v1.11.0-beta.2/go.mod h1:SSXGtB+mpuAjAydZH3psEKKQQfKV68llQb3Ph2MYPw4=
+sigs.k8s.io/cluster-api v1.11.0-rc.0 h1:sZihW/OjiucSnOKrFfo093wC/Qp0MBhmXiIcU9FtTBY=
+sigs.k8s.io/cluster-api v1.11.0-rc.0/go.mod h1:HVLZTAcnkzsM8bYvGgh4eC2Wfx/WzFerPvtCGfmggiw=
 sigs.k8s.io/controller-runtime v0.21.0 h1:CYfjpEuicjUecRk+KAeyYh+ouUBn4llGyDYytIGcJS8=
 sigs.k8s.io/controller-runtime v0.21.0/go.mod h1:OSg14+F65eWqIu4DceX7k/+QRAbTTvxeQSNSOQpukWM=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=

--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -892,7 +892,7 @@ func (m *DataManager) addressFromClaim(ctx context.Context, _ corev1.TypedLocalO
 
 	a := addressFromPool{
 		Address:    ipamv1.IPAddressStr(address.Spec.Address),
-		Prefix:     int(address.Spec.Prefix),
+		Prefix:     int(*address.Spec.Prefix),
 		Gateway:    ipamv1.IPAddressStr(address.Spec.Gateway),
 		dnsServers: []ipamv1.IPAddressStr{},
 	}

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -2054,7 +2054,7 @@ var _ = Describe("Metal3Data manager", func() {
 				ObjectMeta: testObjectMeta("abc-192.168.0.10", namespaceName, ""),
 				Spec: capipamv1.IPAddressSpec{
 					Address: "192.168.0.10",
-					Prefix:  26,
+					Prefix:  ptr.To(int32(26)),
 					Gateway: "192.168.0.1",
 				},
 			},
@@ -2101,7 +2101,7 @@ var _ = Describe("Metal3Data manager", func() {
 				ObjectMeta: testObjectMeta("abc-192.168.0.10", namespaceName, ""),
 				Spec: capipamv1.IPAddressSpec{
 					Address: "192.168.0.10",
-					Prefix:  26,
+					Prefix:  ptr.To(int32(26)),
 					Gateway: "192.168.0.1",
 				},
 			},

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -196,7 +196,7 @@ func (m *MachineManager) IsBaremetalHostProvisioned(ctx context.Context) bool {
 
 // IsBootstrapReady checks if the machine is given Bootstrap data.
 func (m *MachineManager) IsBootstrapReady() bool {
-	if m.Machine.Spec.Bootstrap.ConfigRef != nil {
+	if m.Machine.Spec.Bootstrap.ConfigRef.IsDefined() {
 		bootstrapReadyCondition := deprecatedv1beta1conditions.Get(m.Machine, clusterv1.BootstrapReadyV1Beta1Condition)
 		return bootstrapReadyCondition.Status == corev1.ConditionTrue
 	}
@@ -205,7 +205,7 @@ func (m *MachineManager) IsBootstrapReady() bool {
 }
 
 func (m *MachineManager) MachineHasNodeRef() bool {
-	return m.Machine.Status.NodeRef != nil
+	return m.Machine.Status.NodeRef.IsDefined()
 }
 
 // isControlPlane returns true if the machine is a control plane.
@@ -438,7 +438,7 @@ func (m *MachineManager) getUserDataSecretName(_ context.Context) {
 			Namespace: m.Machine.Namespace,
 		}
 		return
-	} else if m.Machine.Spec.Bootstrap.ConfigRef != nil {
+	} else if m.Machine.Spec.Bootstrap.ConfigRef.IsDefined() {
 		m.Metal3Machine.Status.UserData = &corev1.SecretReference{
 			Name:      m.Machine.Spec.Bootstrap.ConfigRef.Name,
 			Namespace: m.Machine.Namespace,
@@ -1446,7 +1446,7 @@ func (m *MachineManager) SetProviderIDFromNodeLabel(ctx context.Context, clientF
 		m.Log.Info(errMessage)
 		return false, WithTransientError(errors.Wrap(err, errMessage), requeueAfter)
 	}
-	if countNodesWithLabel == 0 && m.Machine.Spec.Bootstrap.ConfigRef != nil {
+	if countNodesWithLabel == 0 && m.Machine.Spec.Bootstrap.ConfigRef.IsDefined() {
 		// The node could either be still running cloud-init or have been
 		// deleted manually. TODO: handle a manual deletion case.
 		errMessage := "requeuing, could not find node with label: " + nodeLabel

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -450,7 +450,9 @@ var _ = Describe("Metal3Machine manager", func() {
 			Machine: clusterv1.Machine{
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
-						ConfigRef: &clusterv1.ContractVersionedObjectReference{},
+						ConfigRef: clusterv1.ContractVersionedObjectReference{
+							Name: "abc",
+						},
 					},
 				},
 				Status: clusterv1.MachineStatus{
@@ -2684,7 +2686,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
-						ConfigRef: &clusterv1.ContractVersionedObjectReference{
+						ConfigRef: clusterv1.ContractVersionedObjectReference{
 							Name: "abc",
 						},
 						DataSecretName: ptr.To("Foobar"),
@@ -4645,7 +4647,7 @@ func newMachine(machineName string, infraRef *clusterv1.ContractVersionedObjectR
 			ClusterName:       clusterName,
 			InfrastructureRef: *infraRef,
 			Bootstrap: clusterv1.Bootstrap{
-				ConfigRef:      &clusterv1.ContractVersionedObjectReference{},
+				ConfigRef:      clusterv1.ContractVersionedObjectReference{},
 				DataSecretName: nil,
 			},
 		},

--- a/baremetal/metal3remediation_manager.go
+++ b/baremetal/metal3remediation_manager.go
@@ -389,7 +389,7 @@ func (r *RemediationManager) GetNode(ctx context.Context, clusterClient v1.CoreV
 		r.Log.Error(err, "metal3Remediation's node could not be retrieved")
 		return nil, errors.Wrapf(err, "metal3Remediation's node could not be retrieved")
 	}
-	if capiMachine.Status.NodeRef == nil {
+	if !capiMachine.Status.NodeRef.IsDefined() {
 		r.Log.Error(nil, "metal3Remediation's node could not be retrieved, machine's nodeRef is nil")
 		return nil, errors.Errorf("metal3Remediation's node could not be retrieved, machine's nodeRef is nil")
 	}

--- a/baremetal/metal3remediation_manager_test.go
+++ b/baremetal/metal3remediation_manager_test.go
@@ -937,7 +937,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 				},
 			},
 			Status: clusterv1.MachineStatus{
-				NodeRef: &clusterv1.MachineNodeReference{
+				NodeRef: clusterv1.MachineNodeReference{
 					Name: "mynode",
 				},
 			},

--- a/baremetal/suite_test.go
+++ b/baremetal/suite_test.go
@@ -181,7 +181,7 @@ func newCluster(clusterName string) *clusterv1.Cluster {
 			Namespace: namespaceName,
 		},
 		Spec: clusterv1.ClusterSpec{
-			InfrastructureRef: &clusterv1.ContractVersionedObjectReference{
+			InfrastructureRef: clusterv1.ContractVersionedObjectReference{
 				Name:     metal3ClusterName,
 				Kind:     "InfrastructureConfig",
 				APIGroup: "infrastructure.cluster.x-k8s.io/v1beta1",

--- a/controllers/metal3labelsync_controller.go
+++ b/controllers/metal3labelsync_controller.go
@@ -146,7 +146,7 @@ func (r *Metal3LabelSyncReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
 	controllerLog.V(baremetal.VerbosityLevelTrace).Info(fmt.Sprintf("Found Machine %v/%v", capiMachine.Name, capiMachine.Namespace))
-	if capiMachine.Status.NodeRef == nil {
+	if !capiMachine.Status.NodeRef.IsDefined() {
 		controllerLog.Info("Could not find Node Ref on Machine object, will retry")
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}

--- a/controllers/metal3labelsync_controller_test.go
+++ b/controllers/metal3labelsync_controller_test.go
@@ -363,7 +363,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 		nodeName := "testNode"
 		cluserCapiSpec := clusterv1.ClusterSpec{
 			Paused: ptr.To(true),
-			InfrastructureRef: &clusterv1.ContractVersionedObjectReference{
+			InfrastructureRef: clusterv1.ContractVersionedObjectReference{
 				Name:     metal3ClusterName,
 				Kind:     "Metal3Cluster",
 				APIGroup: infrav1.GroupVersion.Group,

--- a/controllers/metal3machine_controller_integration_test.go
+++ b/controllers/metal3machine_controller_integration_test.go
@@ -159,7 +159,7 @@ func machineWithBootstrap() *clusterv1.Machine {
 		clusterName, machineName, metal3machineName, "",
 	)
 	machine.Spec.Bootstrap = clusterv1.Bootstrap{
-		ConfigRef:      &clusterv1.ContractVersionedObjectReference{},
+		ConfigRef:      clusterv1.ContractVersionedObjectReference{},
 		DataSecretName: &bootstrapDataSecretName,
 	}
 	machine.Status = clusterv1.MachineStatus{

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -148,7 +148,7 @@ var deletionTimestamp = metav1.Now()
 func clusterPauseSpec() *clusterv1.ClusterSpec {
 	return &clusterv1.ClusterSpec{
 		Paused: ptr.To(true),
-		InfrastructureRef: &clusterv1.ContractVersionedObjectReference{
+		InfrastructureRef: clusterv1.ContractVersionedObjectReference{
 			Name:     metal3ClusterName,
 			Kind:     "Metal3Cluster",
 			APIGroup: infrav1.GroupVersion.Group,
@@ -205,7 +205,7 @@ func getKey(objectName string) *client.ObjectKey {
 func newCluster(clusterName string, spec *clusterv1.ClusterSpec, status *clusterv1.ClusterStatus) *clusterv1.Cluster {
 	if spec == nil {
 		spec = &clusterv1.ClusterSpec{
-			InfrastructureRef: &clusterv1.ContractVersionedObjectReference{
+			InfrastructureRef: clusterv1.ContractVersionedObjectReference{
 				Name:     metal3ClusterName,
 				Kind:     "Metal3Cluster",
 				APIGroup: infrav1.GroupVersion.Group,
@@ -310,7 +310,7 @@ func newMachine(clusterName, machineName string, metal3machineName string, nodeR
 		}
 	}
 	if nodeRefName != "" {
-		machine.Status.NodeRef = &clusterv1.MachineNodeReference{
+		machine.Status.NodeRef = clusterv1.MachineNodeReference{
 			Name: nodeRefName,
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	k8s.io/component-base v0.33.3
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
-	sigs.k8s.io/cluster-api v1.11.0-beta.2
+	sigs.k8s.io/cluster-api v1.11.0-rc.0
 	sigs.k8s.io/controller-runtime v0.21.0
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -96,7 +96,7 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect
-	google.golang.org/grpc v1.71.1 // indirect
+	google.golang.org/grpc v1.71.3 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422/go.mod h1:b6h1vNKhxaSoEI+5jc3PJUCustfli/mRab7295pY7rw=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f h1:OxYkA3wjPsZyBylwymxSHa7ViiW1Sml4ToBrncvFehI=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f/go.mod h1:+2Yz8+CLJbIfL9z73EW45avw8Lmge3xVElCP9zEKi50=
-google.golang.org/grpc v1.71.1 h1:ffsFWr7ygTUscGPI0KKK6TLrGz0476KUvvsbqWK0rPI=
-google.golang.org/grpc v1.71.1/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
+google.golang.org/grpc v1.71.3 h1:iEhneYTxOruJyZAxdAv8Y0iRZvsc5M6KoW7UA0/7jn0=
+google.golang.org/grpc v1.71.3/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
 google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
 google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -307,8 +307,8 @@ k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6J
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/cluster-api v1.11.0-beta.2 h1:uR9kci1V92xJK3Qaw49liK7zLOvZ5JEqrbeyWReVUyM=
-sigs.k8s.io/cluster-api v1.11.0-beta.2/go.mod h1:SSXGtB+mpuAjAydZH3psEKKQQfKV68llQb3Ph2MYPw4=
+sigs.k8s.io/cluster-api v1.11.0-rc.0 h1:sZihW/OjiucSnOKrFfo093wC/Qp0MBhmXiIcU9FtTBY=
+sigs.k8s.io/cluster-api v1.11.0-rc.0/go.mod h1:HVLZTAcnkzsM8bYvGgh4eC2Wfx/WzFerPvtCGfmggiw=
 sigs.k8s.io/controller-runtime v0.21.0 h1:CYfjpEuicjUecRk+KAeyYh+ouUBn4llGyDYytIGcJS8=
 sigs.k8s.io/controller-runtime v0.21.0/go.mod h1:OSg14+F65eWqIu4DceX7k/+QRAbTTvxeQSNSOQpukWM=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -22,7 +22,7 @@ else
     export IPAMRELEASE="v1.11.99"
     export CAPI_RELEASE_PREFIX="v1.11."
     # Hard code CAPI_RELEASE for now, as we are not using the latest CAPI release
-    export CAPIRELEASE="v1.11.0-beta.2"
+    export CAPIRELEASE="v1.11.0-rc.0"
 fi
 
 # Default CAPI_CONFIG_FOLDER to $HOME/.config folder if XDG_CONFIG_HOME not set

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -18,7 +18,7 @@ providers:
   type: CoreProvider
   versions:
   - name: "v1.11.99"
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.0-beta.2/core-components.yaml"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.0-rc.0/core-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:
@@ -48,7 +48,7 @@ providers:
   type: BootstrapProvider
   versions:
   - name: "v1.11.99"
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.0-beta.2/bootstrap-components.yaml"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.0-rc.0/bootstrap-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:
@@ -78,7 +78,7 @@ providers:
   type: ControlPlaneProvider
   versions:
   - name: "v1.11.99"
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.0-beta.2/control-plane-components.yaml"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.0-rc.0/control-plane-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:
@@ -107,6 +107,16 @@ providers:
 - name: metal3
   type: IPAMProvider
   versions:
+  - name: "v1.11.99"
+    value: "https://github.com/metal3-io/ip-address-manager/releases/download/v1.11.0-beta.0/ipam-components.yaml"
+    type: "url"
+    contract: v1beta1
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+    files:
+    - sourcePath: "../data/shared/ipam-metal3/v1.11/metadata.yaml"
+      targetName: "metadata.yaml"
   - name: "{go://github.com/metal3-io/ip-address-manager@v1.10}"
     value: "https://github.com/metal3-io/ip-address-manager/releases/download/{go://github.com/metal3-io/ip-address-manager@v1.10}/ipam-components.yaml"
     type: "url"
@@ -264,3 +274,4 @@ intervals:
   default/wait-all-pod-to-be-running-on-target-cluster: ["30m", "10s"]
   default/wait-command: ["2m", "10s"]
   default/wait-delete-remediation-template: ["5m", "10s"]
+  default/wait-resource-stabilize: ["15m", "15s"]

--- a/test/e2e/data/shared/ipam-metal3/v1.11/metadata.yaml
+++ b/test/e2e/data/shared/ipam-metal3/v1.11/metadata.yaml
@@ -1,0 +1,39 @@
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+- major: 1
+  minor: 11
+  contract: v1beta1
+- major: 1
+  minor: 10
+  contract: v1beta1
+- major: 1
+  minor: 9
+  contract: v1beta1
+- major: 1
+  minor: 8
+  contract: v1beta1
+- major: 1
+  minor: 7
+  contract: v1beta1
+- major: 1
+  minor: 6
+  contract: v1beta1
+- major: 1
+  minor: 5
+  contract: v1beta1
+- major: 1
+  minor: 4
+  contract: v1beta1
+- major: 1
+  minor: 3
+  contract: v1beta1
+- major: 1
+  minor: 2
+  contract: v1beta1
+- major: 1
+  minor: 1
+  contract: v1beta1
+- major: 1
+  minor: 0
+  contract: v1beta1

--- a/test/e2e/healthcheck.go
+++ b/test/e2e/healthcheck.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
@@ -182,17 +183,17 @@ func DeployMachineHealthCheck(ctx context.Context, cli client.Client, namespace,
 					{
 						Type:           corev1.NodeReady,
 						Status:         corev1.ConditionUnknown,
-						TimeoutSeconds: 300,
+						TimeoutSeconds: ptr.To(int32(300)),
 					},
 					{
 						Type:           corev1.NodeReady,
 						Status:         "False",
-						TimeoutSeconds: 300,
+						TimeoutSeconds: ptr.To(int32(300)),
 					},
 				},
 			},
 			Remediation: clusterv1.MachineHealthCheckRemediation{
-				TemplateRef: &clusterv1.MachineHealthCheckRemediationTemplateReference{
+				TemplateRef: clusterv1.MachineHealthCheckRemediationTemplateReference{
 					Kind:       "Metal3RemediationTemplate",
 					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
 					Name:       remediationTemplateName,

--- a/test/go.mod
+++ b/test/go.mod
@@ -23,8 +23,8 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kubectl v0.30.14
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
-	sigs.k8s.io/cluster-api v1.11.0-beta.2
-	sigs.k8s.io/cluster-api/test v1.11.0-beta.2
+	sigs.k8s.io/cluster-api v1.11.0-rc.0
+	sigs.k8s.io/cluster-api/test v1.11.0-rc.0
 	sigs.k8s.io/controller-runtime v0.21.0
 	sigs.k8s.io/kustomize/api v0.20.0
 	sigs.k8s.io/kustomize/kyaml v0.20.1

--- a/test/go.sum
+++ b/test/go.sum
@@ -379,8 +379,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422/go.mod h1:b6h1vNKhxaSoEI+5jc3PJUCustfli/mRab7295pY7rw=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f h1:OxYkA3wjPsZyBylwymxSHa7ViiW1Sml4ToBrncvFehI=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f/go.mod h1:+2Yz8+CLJbIfL9z73EW45avw8Lmge3xVElCP9zEKi50=
-google.golang.org/grpc v1.71.1 h1:ffsFWr7ygTUscGPI0KKK6TLrGz0476KUvvsbqWK0rPI=
-google.golang.org/grpc v1.71.1/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
+google.golang.org/grpc v1.71.3 h1:iEhneYTxOruJyZAxdAv8Y0iRZvsc5M6KoW7UA0/7jn0=
+google.golang.org/grpc v1.71.3/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
 google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
 google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -423,10 +423,10 @@ k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6J
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/cluster-api v1.11.0-beta.2 h1:uR9kci1V92xJK3Qaw49liK7zLOvZ5JEqrbeyWReVUyM=
-sigs.k8s.io/cluster-api v1.11.0-beta.2/go.mod h1:SSXGtB+mpuAjAydZH3psEKKQQfKV68llQb3Ph2MYPw4=
-sigs.k8s.io/cluster-api/test v1.11.0-beta.2 h1:v7BvUmmMhTNXYqF9vgVZ7BGohG0SwETWdd8NQzlwDgQ=
-sigs.k8s.io/cluster-api/test v1.11.0-beta.2/go.mod h1:d8LxG8eS4bIvd5hR5jA8x1DmiUTlC1f0mncGCT0q1Ao=
+sigs.k8s.io/cluster-api v1.11.0-rc.0 h1:sZihW/OjiucSnOKrFfo093wC/Qp0MBhmXiIcU9FtTBY=
+sigs.k8s.io/cluster-api v1.11.0-rc.0/go.mod h1:HVLZTAcnkzsM8bYvGgh4eC2Wfx/WzFerPvtCGfmggiw=
+sigs.k8s.io/cluster-api/test v1.11.0-rc.0 h1:PulJADupD3qF2F4Rwdt+OcH0YSrRgTTGYYgU/Pwu5gM=
+sigs.k8s.io/cluster-api/test v1.11.0-rc.0/go.mod h1:2f489Lp5TKPGVhNL6V3huq8fp6eb23APlY2cLbhuDBU=
 sigs.k8s.io/controller-runtime v0.21.0 h1:CYfjpEuicjUecRk+KAeyYh+ouUBn4llGyDYytIGcJS8=
 sigs.k8s.io/controller-runtime v0.21.0/go.mod h1:OSg14+F65eWqIu4DceX7k/+QRAbTTvxeQSNSOQpukWM=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Bump CAPI to 1.11.0-rc.0

- `IPAddressSpec.prefix` is changed from `int` to `*int32`
- `m.Machine.Spec.Bootstrap.ConfigRef` is changed from `*ContractVersionedObjectReference` to `ContractVersionedObjectReference`
- Added the postUpgradeWaitDeletingResources hook to clusterctlupgrade tests for workload cluster updates. This hook ensures that any Metal3Data, IPPool, IPClaim, or IPAddress resource in a deleting state is fully removed before proceeding to the next step.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
