### PR TITLE
🐛 Delete child resources before machine

### DIFF
--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -336,17 +336,18 @@ func (r *Metal3MachineReconciler) reconcileDelete(ctx context.Context,
 
 	errType := capierrors.DeleteMachineError
 
+	// dissociate metadata if any
+	if err := machineMgr.DissociateM3Metadata(ctx); err != nil {
+		machineMgr.SetConditionMetal3MachineToFalse(infrav1.KubernetesNodeReadyCondition, infrav1.DisassociateM3MetaDataFailedReason, clusterv1beta1.ConditionSeverityWarning, err.Error())
+		return checkMachineError(machineMgr, err,
+			"failed to dissociate Metadata", errType)
+	}
+
 	// delete the machine
 	if err := machineMgr.Delete(ctx); err != nil {
 		machineMgr.SetConditionMetal3MachineToFalse(infrav1.KubernetesNodeReadyCondition, infrav1.DeletionFailedReason, clusterv1beta1.ConditionSeverityWarning, err.Error())
 		return checkMachineError(machineMgr, err,
 			"failed to delete Metal3Machine", errType)
-	}
-
-	if err := machineMgr.DissociateM3Metadata(ctx); err != nil {
-		machineMgr.SetConditionMetal3MachineToFalse(infrav1.KubernetesNodeReadyCondition, infrav1.DisassociateM3MetaDataFailedReason, clusterv1beta1.ConditionSeverityWarning, err.Error())
-		return checkMachineError(machineMgr, err,
-			"failed to dissociate Metadata", errType)
 	}
 
 	// metal3machine is marked for deletion and ready to be deleted,

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -115,10 +115,11 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 }
 
 type reconcileDeleteTestCase struct {
-	ExpectError   bool
-	ExpectRequeue bool
-	DeleteFails   bool
-	DeleteRequeue bool
+	ExpectError               bool
+	ExpectRequeue             bool
+	DeleteFails               bool
+	DissociateM3MetadataFails bool
+	DeleteRequeue             bool
 }
 
 func setReconcileDeleteExpectations(ctrl *gomock.Controller,
@@ -127,19 +128,28 @@ func setReconcileDeleteExpectations(ctrl *gomock.Controller,
 	m := baremetal_mocks.NewMockMachineManagerInterface(ctrl)
 	m.EXPECT().SetConditionMetal3MachineToFalse(infrav1.KubernetesNodeReadyCondition, infrav1.DeletingReason, clusterv1beta1.ConditionSeverityInfo, "")
 
-	if tc.DeleteFails {
-		m.EXPECT().SetConditionMetal3MachineToFalse(infrav1.KubernetesNodeReadyCondition, infrav1.DeletionFailedReason, clusterv1beta1.ConditionSeverityWarning, gomock.Any())
-		m.EXPECT().Delete(context.TODO()).Return(errors.New("failed"))
+	if tc.DissociateM3MetadataFails {
+		m.EXPECT().DissociateM3Metadata(context.TODO()).Return(errors.New("failed"))
+		m.EXPECT().SetConditionMetal3MachineToFalse(infrav1.KubernetesNodeReadyCondition, infrav1.DisassociateM3MetaDataFailedReason, clusterv1beta1.ConditionSeverityWarning, gomock.Any())
+		m.EXPECT().Delete(context.TODO()).MaxTimes(0)
 		m.EXPECT().UnsetFinalizer().MaxTimes(0)
-		m.EXPECT().DissociateM3Metadata(context.TODO()).MaxTimes(0)
-		return m
-	} else if tc.DeleteRequeue {
-		m.EXPECT().SetConditionMetal3MachineToFalse(infrav1.KubernetesNodeReadyCondition, infrav1.DeletionFailedReason, clusterv1beta1.ConditionSeverityWarning, gomock.Any())
-		m.EXPECT().Delete(context.TODO()).Return(baremetal.WithTransientError(errors.New("failed"), requeueAfter))
-		m.EXPECT().UnsetFinalizer().MaxTimes(0)
-		m.EXPECT().DissociateM3Metadata(context.TODO()).MaxTimes(0)
 		return m
 	}
+	if tc.DeleteFails {
+		m.EXPECT().DissociateM3Metadata(context.TODO())
+		m.EXPECT().Delete(context.TODO()).Return(errors.New("failed"))
+		m.EXPECT().SetConditionMetal3MachineToFalse(infrav1.KubernetesNodeReadyCondition, infrav1.DeletionFailedReason, clusterv1beta1.ConditionSeverityWarning, gomock.Any())
+		m.EXPECT().UnsetFinalizer().MaxTimes(0)
+		return m
+	}
+	if tc.DeleteRequeue {
+		m.EXPECT().DissociateM3Metadata(context.TODO())
+		m.EXPECT().Delete(context.TODO()).Return(baremetal.WithTransientError(errors.New("failed"), requeueAfter))
+		m.EXPECT().SetConditionMetal3MachineToFalse(infrav1.KubernetesNodeReadyCondition, infrav1.DeletionFailedReason, clusterv1beta1.ConditionSeverityWarning, gomock.Any())
+		m.EXPECT().UnsetFinalizer().MaxTimes(0)
+		return m
+	}
+
 	m.EXPECT().DissociateM3Metadata(context.TODO())
 	m.EXPECT().Delete(context.TODO()).Return(nil)
 	m.EXPECT().UnsetFinalizer()
@@ -276,6 +286,12 @@ var _ = Describe("Metal3Machine manager", func() {
 				ExpectError:   false,
 				ExpectRequeue: true,
 				DeleteRequeue: true,
+			}),
+			Entry("DissociateM3Metadata failure", reconcileDeleteTestCase{
+				ExpectError:               true,
+				ExpectRequeue:             false,
+				DeleteRequeue:             false,
+				DissociateM3MetadataFails: true,
 			}),
 		)
 	})

--- a/test/e2e/upgrade_clusterctl_test.go
+++ b/test/e2e/upgrade_clusterctl_test.go
@@ -9,13 +9,10 @@ import (
 	"strings"
 
 	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
-	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 	framework "sigs.k8s.io/cluster-api/test/framework"
@@ -89,8 +86,7 @@ var _ = Describe("When testing cluster upgrade from releases (v1.10=>current)", 
 			},
 			Upgrades: []capi_e2e.ClusterctlUpgradeSpecInputUpgrade{
 				{ // Upgrade to latest v1beta2.
-					Contract:    clusterv1.GroupVersion.Version,
-					PostUpgrade: postUpgradeWaitDeletingResources,
+					Contract: clusterv1.GroupVersion.Version,
 				},
 			},
 			PostNamespaceCreated: postClusterctlUpgradeNamespaceCreated,
@@ -150,8 +146,7 @@ var _ = Describe("When testing cluster upgrade from releases (v1.9=>current)", L
 			},
 			Upgrades: []capi_e2e.ClusterctlUpgradeSpecInputUpgrade{
 				{ // Upgrade to latest v1beta2.
-					Contract:    clusterv1.GroupVersion.Version,
-					PostUpgrade: postUpgradeWaitDeletingResources,
+					Contract: clusterv1.GroupVersion.Version,
 				},
 			},
 			PostNamespaceCreated: postClusterctlUpgradeNamespaceCreated,
@@ -431,17 +426,6 @@ func postUpgrade(managementClusterProxy framework.ClusterProxy, _ string, _ stri
 		IPAMProviders:        []string{ipamVersions[0]},
 	}
 	clusterctl.Init(ctx, input)
-}
-
-// postUpgradeWaitDeletingResources hook waits IPAddress, IPClaim, IPPool, Metal3Data and Secret reource that has deletion timestamp set to be deleted.
-func postUpgradeWaitDeletingResources(managementClusterProxy framework.ClusterProxy, clusterNamespace string, _ string) {
-	gvkList := []schema.GroupVersionKind{
-		{Group: infrav1.GroupVersion.Group, Version: infrav1.GroupVersion.Version, Kind: "Metal3Data"},
-		{Group: ipamv1.GroupVersion.Group, Version: ipamv1.GroupVersion.Version, Kind: "IPPool"},
-		{Group: ipamv1.GroupVersion.Group, Version: ipamv1.GroupVersion.Version, Kind: "IPAddress"},
-		{Group: ipamv1.GroupVersion.Group, Version: ipamv1.GroupVersion.Version, Kind: "IPClaim"},
-	}
-	WaitForResourceVersionsToStabilize(ctx, managementClusterProxy, clusterNamespace, gvkList, e2eConfig.GetIntervals(specName, "wait-resource-stabilize"))
 }
 
 // preCleanupManagementCluster hook should be called from ClusterctlUpgradeSpec before cleaning the target management cluster


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
- Delete child resources before machine
- remove postUpgradeWaitDeletingResources hook from clusterctl upgrade tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/metal3-io/cluster-api-provider-metal3/issues/2702
