### PR TITLE
🌱 Add IPA_BASEURI in ironic config to fix IPA download from cache

### DIFF
--- a/test/e2e/data/ironic-deployment/overlays/pr-test/ironic_bmo_configmap.env
+++ b/test/e2e/data/ironic-deployment/overlays/pr-test/ironic_bmo_configmap.env
@@ -10,3 +10,4 @@ DEPLOY_KERNEL_URL=http://172.22.0.2:6180/images/ironic-python-agent.kernel
 DEPLOY_RAMDISK_URL=http://172.22.0.2:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.2:6385/v1/
 USE_IRONIC_INSPECTOR=false
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib

--- a/test/e2e/data/ironic-deployment/overlays/release-26.0/ironic_bmo_configmap.env
+++ b/test/e2e/data/ironic-deployment/overlays/release-26.0/ironic_bmo_configmap.env
@@ -10,3 +10,4 @@ DEPLOY_KERNEL_URL=http://172.22.0.2:6180/images/ironic-python-agent.kernel
 DEPLOY_RAMDISK_URL=http://172.22.0.2:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.2:6385/v1/
 USE_IRONIC_INSPECTOR=false
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib

--- a/test/e2e/data/ironic-deployment/overlays/release-27.0/ironic_bmo_configmap.env
+++ b/test/e2e/data/ironic-deployment/overlays/release-27.0/ironic_bmo_configmap.env
@@ -10,3 +10,4 @@ DEPLOY_KERNEL_URL=http://172.22.0.2:6180/images/ironic-python-agent.kernel
 DEPLOY_RAMDISK_URL=http://172.22.0.2:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.2:6385/v1/
 USE_IRONIC_INSPECTOR=false
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib

--- a/test/e2e/data/ironic-deployment/overlays/release-29.0/ironic_bmo_configmap.env
+++ b/test/e2e/data/ironic-deployment/overlays/release-29.0/ironic_bmo_configmap.env
@@ -10,3 +10,4 @@ DEPLOY_KERNEL_URL=http://172.22.0.2:6180/images/ironic-python-agent.kernel
 DEPLOY_RAMDISK_URL=http://172.22.0.2:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.2:6385/v1/
 USE_IRONIC_INSPECTOR=false
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib

--- a/test/e2e/data/ironic-deployment/overlays/release-latest/ironic_bmo_configmap.env
+++ b/test/e2e/data/ironic-deployment/overlays/release-latest/ironic_bmo_configmap.env
@@ -9,3 +9,4 @@ DHCP_RANGE=172.22.0.10,172.22.0.100
 DEPLOY_KERNEL_URL=http://172.22.0.2:6180/images/ironic-python-agent.kernel
 DEPLOY_RAMDISK_URL=http://172.22.0.2:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.2:6385/v1/
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib


### PR DESCRIPTION
We have seen flaky behavior during e2e test where IPA downloader was having longer time to download image and which was causing failure to have available ironic deployment. This will fix the slowness in IPA image download process.

