### PR TITLE
:seedling: Enable testing with CAPI nightly builds

### DIFF
--- a/docs/e2e-test.md
+++ b/docs/e2e-test.md
@@ -71,6 +71,17 @@ export GINKGO_SKIP=healthcheck remediation
 make test-e2e
 ```
 
+### Testing against CAPI nightly builds
+
+Cluster API publishes nightly versions of the project components’ manifests from
+the main branch. If you want to run tests against the nightly builds you can set:
+
+```sh
+export CAPI_NIGHTLY_BUILD=true
+```
+
+The used build is from the previous day.
+
 ## Cleanup
 
 After a finished test, cleanup is performed automatically. If the test setup

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -49,6 +49,18 @@ export FORCE_REPO_UPDATE="false"
 export USE_IRSO="${USE_IRSO:-false}"
 EOF
 
+# Always set DATE variable for nightly builds because it is needed to form
+# the URL for CAPI nightly build components in e2e_conf.yaml even if not used.
+DATE=$(date '+%Y%m%d' -d '1 day ago')
+export DATE
+
+# If CAPI_NIGHTLY_BUILD is true, it means that the tests are run against the
+# nightly build of CAPI components which are built from CAPI's main branch.
+if [[ "${CAPI_NIGHTLY_BUILD:-false}" == "true" ]]; then
+  export CAPIRELEASE="v1.12.99"
+  echo 'export CAPI_NIGHTLY_BUILD="true"' >>"${M3_DEV_ENV_PATH}/config_${USER}.sh"
+fi
+
 case "${GINKGO_FOCUS:-}" in
   clusterctl-upgrade|k8s-upgrade|basic|integration|remediation|k8s-conformance|capi-md-tests)
     # if running basic, integration, k8s upgrade, clusterctl-upgrade, remediation, k8s conformance or capi-md tests, skip apply bmhs in dev-env

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -17,6 +17,15 @@ providers:
 - name: cluster-api
   type: CoreProvider
   versions:
+  - name: "v1.12.99"
+    value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_${DATE}/core-components.yaml"
+    type: "url"
+    contract: v1beta2
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+    files:
+    - sourcePath: "../data/shared/capi/v1.12/metadata.yaml"
   - name: "{go://sigs.k8s.io/cluster-api@v1.11}"
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.11}/core-components.yaml"
     type: "url"
@@ -56,6 +65,15 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
+  - name: "v1.12.99"
+    value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_${DATE}/bootstrap-components.yaml"
+    type: "url"
+    contract: v1beta2
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+    files:
+    - sourcePath: "../data/shared/capi/v1.12/metadata.yaml"
   - name: "{go://sigs.k8s.io/cluster-api@v1.11}"
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.11}/bootstrap-components.yaml"
     type: "url"
@@ -95,6 +113,15 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
+  - name: "v1.12.99"
+    value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_${DATE}/control-plane-components.yaml"
+    type: "url"
+    contract: v1beta2
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+    files:
+    - sourcePath: "../data/shared/capi/v1.12/metadata.yaml"
   - name: "{go://sigs.k8s.io/cluster-api@v1.11}"
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.11}/control-plane-components.yaml"
     type: "url"

--- a/test/e2e/data/shared/capi/v1.12/metadata.yaml
+++ b/test/e2e/data/shared/capi/v1.12/metadata.yaml
@@ -1,0 +1,47 @@
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# update this file only when a new major or minor version is released
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+  - major: 1
+    minor: 12
+    contract: v1beta2
+  - major: 1
+    minor: 11
+    contract: v1beta2
+  - major: 1
+    minor: 10
+    contract: v1beta1
+  - major: 1
+    minor: 9
+    contract: v1beta1
+  - major: 1
+    minor: 8
+    contract: v1beta1
+  - major: 1
+    minor: 7
+    contract: v1beta1
+  - major: 1
+    minor: 6
+    contract: v1beta1
+  - major: 1
+    minor: 5
+    contract: v1beta1
+  - major: 1
+    minor: 4
+    contract: v1beta1
+  - major: 1
+    minor: 3
+    contract: v1beta1
+  - major: 1
+    minor: 2
+    contract: v1beta1
+  - major: 1
+    minor: 1
+    contract: v1beta1
+  - major: 1
+    minor: 0
+    contract: v1beta1


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Enable testing main branch against CAPI's nightly builds which are built from its main branch.
