### PR TITLE
📖 Add Alpha release in release documentation

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -51,6 +51,7 @@ should not be given permissions directly.
 CAPM3 uses [semantic versioning](https://semver.org).
 
 - Regular releases: `v1.x.y`
+- Alpha releases: `v1.x.y-alpha.z`
 - Beta releases: `v1.x.y-beta.z`
 - Release candidate releases: `v1.x.y-rc.z`
 
@@ -79,7 +80,7 @@ This makes sure that all the tags are accessible.
      `releasenotes/<RELEASE_TAG>.md` .
 
 - Next step is to clean up the release note manually.
-   - If release is not a beta or release candidate, check for duplicates,
+   - If release is not an alpha or beta or release candidate, check for duplicates,
      reverts, and incorrect classifications of PRs, and whatever release
      creation tagged to be manually checked.
    - For any superseded PRs (like same dependency uplifted multiple times, or
@@ -110,8 +111,8 @@ Once PR is merged following GitHub actions are triggered:
      [Releases](https://github.com/metal3-io/cluster-api-provider-metal3/releases).
      If the release you're making is not a new major release, new minor release,
      or a new patch release from the latest release branch, uncheck the box for
-     latest release. If it is a release candidate (RC) or a beta release,
-     tick pre-release box.
+     latest release. If it is a release candidate (RC) or a beta or an alpha
+     release, tick pre-release box.
    - GitHub job `build_CAPM3` builds release image with the release tag,
      and pushes it to Quay. Make sure the release tag is visible in
      [Quay tags page](https://quay.io/repository/metal3-io/cluster-api-provider-metal3?tab=tags).


### PR DESCRIPTION
Alpha release mention was missing in release documentation. Alpha release should follow the same convention as beta release.

