### PR TITLE
✨ Conditionally watch M3 IPClaims and CAPI IPAddressClaims

### DIFF
--- a/main.go
+++ b/main.go
@@ -479,6 +479,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 
 	if err = (&controllers.Metal3DataReconciler{
 		Client:           mgr.GetClient(),
+		ClientReader:     mgr.GetAPIReader(),
 		ClusterCache:     clusterCache,
 		ManagerFactory:   baremetal.NewManagerFactory(mgr.GetClient()),
 		Log:              ctrl.Log.WithName("controllers").WithName("Metal3Data"),


### PR DESCRIPTION
**What this PR does / why we need it**:

- only watch for IPClaims if the CRD is available (use direct API calls as cache is not ready yet)
- also watch for CAPI IPAM IPAddressClaims when CRD is available (direct)
- also fixes an AddToScheme typo

Fixes #2654.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #2654.
