### PR TITLE
:bug: correct metadata.yaml release-1.11 contract

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,7 +3,7 @@ kind: Metadata
 releaseSeries:
 - major: 1
   minor: 11
-  contract: v1beta2
+  contract: v1beta1
 - major: 1
   minor: 10
   contract: v1beta1


### PR DESCRIPTION
This PR:
 - correct metadata.yaml release-1.11 contract as it was set incorrectly to
   v1beta2

Part of release activities.