### PR TITLE
:bug: fix release-1.11 contract in metadata yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,7 +3,7 @@ kind: Metadata
 releaseSeries:
 - major: 1
   minor: 11
-  contract: v1beta2
+  contract: v1beta1
 - major: 1
   minor: 10
   contract: v1beta1


### PR DESCRIPTION
This commit:
 - Fixes the contract version in the root metadata.yaml as it was incorrectly set to v1beta2