### PR TITLE
:seedling: add specific time to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
   schedule:
     interval: "monthly"
     day: "tuesday"
+    time: "02:30" # 2.30am utc
   target-branch: main
   ## group all action bumps into single PR
   groups:
@@ -32,7 +33,8 @@ updates:
   - "/test"
   schedule:
     interval: "weekly"
-    day: "wednesday"
+    day: "tuesday"
+    time: "03:00" # 3am utc
   target-branch: main
   ## group all dependencies with a k8s.io prefix into a single PR.
   groups:
@@ -63,6 +65,7 @@ updates:
   schedule:
     interval: "monthly"
     day: "tuesday"
+    time: "03:30" # 3.30am utc
   target-branch: release-1.11
   ## group all action bumps into single PR
   groups:
@@ -86,7 +89,8 @@ updates:
   - "/test"
   schedule:
     interval: "weekly"
-    day: "wednesday"
+    day: "tuesday"
+    time: "04:00" # 4am utc
   target-branch: release-1.11
   ## group all dependencies with a k8s.io prefix into a single PR.
   groups:
@@ -116,6 +120,7 @@ updates:
   schedule:
     interval: "monthly"
     day: "tuesday"
+    time: "04:30" # 4.30am utc
   target-branch: release-1.10
   ## group all action bumps into single PR
   groups:
@@ -139,7 +144,8 @@ updates:
   - "/test"
   schedule:
     interval: "weekly"
-    day: "wednesday"
+    day: "tuesday"
+    time: "05:00" # 5am utc
   target-branch: release-1.10
   ## group all dependencies with a k8s.io prefix into a single PR.
   groups:


### PR DESCRIPTION
Previously Dependabot executed the updates for all branches at the same time (00:00 UTC). If there were enough of the PRs, the Prow would choke, despite it has scaling on as infra provider was sometimes slow to create and provision another Prow worker.

By pacing the updated 0.5hr apart per branch (we already have repos on separate weekdays), we avoid pod scheduling failures and make merging the updates smoother process.

Also, fix the job so all CAPM3 bumps are on Tuesday.
