### PR TITLE
🌱 cmd: strip out symbol table & DWARF debugging info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ WORKDIR /workspace
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
 ARG goproxy=https://proxy.golang.org
 ENV GOPROXY=$goproxy
+ARG LDFLAGS=-extldflags=-static
 
 # Copy the Go Modules manifests
 COPY go.mod go.sum ./
@@ -42,7 +43,7 @@ COPY internal/ internal/
 # Build
 ARG ARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
-    go build -a -ldflags '-extldflags "-static"' \
+    go build -a -ldflags "${LDFLAGS}" \
     -o manager .
 
 # Copy the controller-manager into a thin image

--- a/Makefile
+++ b/Makefile
@@ -546,10 +546,19 @@ generate-examples-clusterclass: $(KUSTOMIZE) clean-examples ## Generate examples
 ## Docker
 ## --------------------------------------
 ##@ docker buils:
-
 .PHONY: docker-build
 docker-build: ## Build the docker image for controller-manager
-	docker build --network=host --pull --build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	docker build --network=host --pull \
+	--build-arg LDFLAGS="-s -w -extldflags=-static" \
+	--build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) $(MAKE) set-manifest-image
+	$(MAKE) set-manifest-pull-policy
+
+.PHONY: docker-build-debug
+docker-build-debug: ## Build the docker image for controller-manager with debug info
+	docker build --network=host --pull \
+	--build-arg LDFLAGS="-extldflags=-static" \
+	--build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
 	MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) $(MAKE) set-manifest-image
 	$(MAKE) set-manifest-pull-policy
 


### PR DESCRIPTION
**What this PR does / why we need it**:
DWARF is mostly needed when we are using Delve. DWARF was originally created for C language and the need for it in go and other debugging features is very small in general. As such, switch to using `-ldflags="-s -w"` by default and have an option to opt in for debugging info for those who would really need it. As a real example, we can gain ~30% (i.e. 26MB) image size reduction for capm3 controller and faster build process.

**Before**
Size profiler comparison: 

```
$ bloaty -d sections manager
    FILE SIZE        VM SIZE
 --------------  --------------
  32.1%  25.6Mi  46.4%  25.6Mi    .text
  22.6%  18.0Mi  32.7%  18.0Mi    .gopclntab
  12.2%  9.70Mi  17.6%  9.70Mi    .rodata
   7.9%  6.28Mi   0.0%      64    .debug_info
   7.4%  5.90Mi   0.0%      64    .strtab
   5.7%  4.56Mi   0.0%      64    .debug_loc
   4.4%  3.47Mi   0.0%      64    .debug_line
   2.8%  2.26Mi   0.0%      64    .symtab
   1.8%  1.45Mi   0.0%      64    .debug_ranges
   1.3%  1.06Mi   1.9%  1.06Mi    .noptrdata
   1.1%   903Ki   0.0%      64    .debug_frame
   0.4%   340Ki   0.6%   340Ki    .data
   0.0%       0   0.4%   221Ki    .bss
   0.1%  80.9Ki   0.1%  80.9Ki    .typelink
   0.0%       0   0.1%  61.3Ki    .noptrbss
   0.0%  35.5Ki   0.1%  35.5Ki    .itablink
   0.0%  8.70Ki   0.0%  8.70Ki    .go.buildinfo
   0.0%  7.41Ki   0.0%       0    [Unmapped]
   0.0%  2.55Ki   0.0%  2.55Ki    [LOAD #2 [RX]]
   0.0%  1.02Ki   0.0%     720    [7 Others]
   0.0%     407   0.0%      64    .debug_abbrev
 100.0%  79.7Mi 100.0%  55.1Mi    TOTAL
```

**After**
```
$ bloaty -d sections manager
    FILE SIZE        VM SIZE
 --------------  --------------
  46.7%  25.6Mi  46.4%  25.6Mi    .text
  32.9%  18.0Mi  32.7%  18.0Mi    .gopclntab
  17.7%  9.70Mi  17.6%  9.70Mi    .rodata
   1.9%  1.06Mi   1.9%  1.06Mi    .noptrdata
   0.6%   340Ki   0.6%   340Ki    .data
   0.0%       0   0.4%   221Ki    .bss
   0.1%  80.9Ki   0.1%  80.9Ki    .typelink
   0.0%       0   0.1%  61.3Ki    .noptrbss
   0.1%  35.5Ki   0.1%  35.5Ki    .itablink
   0.0%  8.72Ki   0.0%  8.72Ki    .go.buildinfo
   0.0%  7.41Ki   0.0%       0    [Unmapped]
   0.0%  3.12Ki   0.0%  3.12Ki    [LOAD #2 [RX]]
   0.0%     248   0.0%      64    .shstrtab
   0.0%     184   0.0%     184    .go.fipsinfo
   0.0%     164   0.0%     164    .note.go.buildid
   0.0%     100   0.0%     100    .note.gnu.build-id
   0.0%      53   0.0%      69    [LOAD #4 [RW]]
   0.0%      59   0.0%      59    [LOAD #3 [R]]
 100.0%  54.9Mi 100.0%  55.1Mi    TOTAL
```
**Before**
Container image size comparison: 
```bash
docker images --format "{{.Repository}} {{.Size}}" | grep metal3
quay.io/metal3-io/cluster-api-provider-metal3-amd64 86MB
```
**After**
```bash
docker images --format "{{.Repository}} {{.Size}}" | grep metal3
quay.io/metal3-io/cluster-api-provider-metal3-amd64 60MB
```



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
/hold
