### PR TITLE
🌱 Use build cache mounts and tidy up the dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -550,16 +550,16 @@ generate-examples-clusterclass: $(KUSTOMIZE) clean-examples ## Generate examples
 docker-build: ## Build the docker image for controller-manager
 	docker build --network=host --pull \
 	--build-arg LDFLAGS="-s -w -extldflags=-static" \
-	--build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
-	MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) $(MAKE) set-manifest-image
+	. -t $(CONTROLLER_IMG):$(TAG)
+	MANIFEST_IMG=$(CONTROLLER_IMG) MANIFEST_TAG=$(TAG) $(MAKE) set-manifest-image
 	$(MAKE) set-manifest-pull-policy
 
 .PHONY: docker-build-debug
 docker-build-debug: ## Build the docker image for controller-manager with debug info
 	docker build --network=host --pull \
 	--build-arg LDFLAGS="-extldflags=-static" \
-	--build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
-	MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) $(MAKE) set-manifest-image
+	. -t $(CONTROLLER_IMG):$(TAG)
+	MANIFEST_IMG=$(CONTROLLER_IMG) MANIFEST_TAG=$(TAG) $(MAKE) set-manifest-image
 	$(MAKE) set-manifest-pull-policy
 
 .PHONY: docker-push


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Use build cache mounts so that dependencies are cached between Docker builds, reducing the need to redownload them every time the image is built.
2. Tidy up the Dockerfile a bit (remove the unused `ARCH` argument and etc)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
/hold