### PR TITLE
🌱 Dockerfile: strip out symbol table by default for public images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /workspace
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
 ARG goproxy=https://proxy.golang.org
 ENV GOPROXY=$goproxy
-ARG LDFLAGS=-extldflags=-static
+ARG LDFLAGS=-s -w -extldflags=-static
 
 # Copy the Go Modules manifests
 COPY go.mod go.sum ./

--- a/Makefile
+++ b/Makefile
@@ -549,7 +549,6 @@ generate-examples-clusterclass: $(KUSTOMIZE) clean-examples ## Generate examples
 .PHONY: docker-build
 docker-build: ## Build the docker image for controller-manager
 	docker build --network=host --pull \
-	--build-arg LDFLAGS="-s -w -extldflags=-static" \
 	--build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
 	MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) $(MAKE) set-manifest-image
 	$(MAKE) set-manifest-pull-policy


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a follow up of https://github.com/metal3-io/cluster-api-provider-metal3/pull/2830, so that our public images in quay.io also benefit from this change. Since GitHub workflow in project-infra doesn't run the Makefile target but instead uses the Dockerfile directly, fix the defaulting of `-s -w` within the Dockerfile here. 
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
