### PR TITLE
🌱 Fix 1.11 cluster templates to use v1beta2

### DIFF
--- a/test/e2e/data/infrastructure-metal3/v1.11/bases/cluster-with-topology/cluster-with-topology.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.11/bases/cluster-with-topology/cluster-with-topology.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
     labels:
@@ -13,7 +13,8 @@ spec:
     services:
       cidrBlocks: ["${SERVICE_CIDR}"]
   topology:
-    class: metal3
+    classRef:
+      name: metal3
     version: ${KUBERNETES_VERSION}
     controlPlane:
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}

--- a/test/e2e/data/infrastructure-metal3/v1.11/bases/cluster/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.11/bases/cluster/cluster-with-kcp.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   labels:
@@ -12,11 +12,11 @@ spec:
     services:
       cidrBlocks: ["${SERVICE_CIDR}"]
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: KubeadmControlPlane
     name: ${CLUSTER_NAME}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/${CAPM3_VERSION}
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: ${CLUSTER_NAME}
 ---
@@ -31,29 +31,31 @@ spec:
     port: ${CLUSTER_APIENDPOINT_PORT}
   cloudProviderEnabled: false
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KubeadmControlPlane
 metadata:
   name: ${CLUSTER_NAME}
   namespace: ${NAMESPACE}
 spec:
   machineTemplate:
-    nodeDrainTimeout: "0s"
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/${CAPM3_VERSION}
-      kind: Metal3MachineTemplate
-      name: ${CLUSTER_NAME}-controlplane
+    spec:
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: Metal3MachineTemplate
+        name: ${CLUSTER_NAME}-controlplane
+      deletion:
+        nodeDrainTimeoutSeconds: ${NODE_DRAIN_TIMEOUT}
   kubeadmConfigSpec:
-    clusterConfiguration: {}
     users:
     - name: ${IMAGE_USERNAME}
       sshAuthorizedKeys:
       - ${SSH_PUB_KEY_CONTENT}
       sudo: ALL=(ALL) NOPASSWD:ALL
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
-  rolloutStrategy:
-    rollingUpdate:
-      maxSurge: 1
+  rollout:
+    strategy:
+      rollingUpdate:
+        maxSurge: 1
   version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/${CAPM3_VERSION}

--- a/test/e2e/data/infrastructure-metal3/v1.11/bases/cluster/crs.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.11/bases/cluster/crs.yaml
@@ -10,7 +10,7 @@ binaryData:
 ---
 # ClusterResourceSet object with
 # a selector that targets all the Cluster with label cni=${CLUSTER_NAME}-crs-0
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name:  "${CLUSTER_NAME}-crs-0"

--- a/test/e2e/data/infrastructure-metal3/v1.11/bases/cluster/md.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.11/bases/cluster/md.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   labels:
@@ -22,15 +22,16 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: KubeadmConfigTemplate
           name: ${CLUSTER_NAME}-workers
       clusterName: ${CLUSTER_NAME}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/${CAPM3_VERSION}
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: ${CLUSTER_NAME}-workers
-      nodeDrainTimeout: 0s
+      deletion:
+        nodeDrainTimeoutSeconds: 0
       version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/${CAPM3_VERSION}
@@ -95,7 +96,7 @@ spec:
       dns:
       - 8.8.8.8
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-workers
@@ -106,12 +107,18 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            cgroup-driver: systemd
-            container-runtime-endpoint: unix:///var/run/crio/crio.sock
-            feature-gates: AllAlpha=false
-            node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
-            provider-id: ${PROVIDER_ID_FORMAT}
-            runtime-request-timeout: 5m
+          - name: cgroup-driver
+            value: systemd
+          - name: container-runtime-endpoint
+            value: unix:///var/run/crio/crio.sock
+          - name: feature-gates
+            value: AllAlpha=false
+          - name: node-labels
+            value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+          - name: provider-id
+            value: '${PROVIDER_ID_FORMAT}'
+          - name: runtime-request-timeout
+            value: '5m'
           name: '{{ ds.meta_data.name }}'
       users:
       - name: metal3

--- a/test/e2e/data/infrastructure-metal3/v1.11/bases/clusterclass-centos-kubeadm-config/clusterclass-centos-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.11/bases/clusterclass-centos-kubeadm-config/clusterclass-centos-kubeadm-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KubeadmControlPlaneTemplate
 metadata:
   name: ${CLUSTER_NAME}
@@ -8,7 +8,6 @@ spec:
   template:
     spec:
       kubeadmConfigSpec:
-        clusterConfiguration: {}
         users:
         - name: ${IMAGE_USERNAME}
           sshAuthorizedKeys:
@@ -56,7 +55,7 @@ spec:
 
             vrrp_instance VI_1 {
                 state MASTER
-                interface eth1
+                interface enp2s0
                 virtual_router_id 1
                 priority 101
                 advert_int 1
@@ -67,14 +66,14 @@ spec:
                     k8s_api_check
                 }
             }
-        - path: /etc/NetworkManager/system-connections/eth0.nmconnection
+        - path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
           owner: root:root
           permissions: '0600'
           content: |
             [connection]
-            id=eth0
+            id=enp1s0
             type=ethernet
-            interface-name=eth0
+            interface-name=enp1s0
             master=ironicendpoint
             slave-type=bridge
         - content: |
@@ -120,31 +119,43 @@ spec:
         initConfiguration:
           nodeRegistration:
             kubeletExtraArgs:
-              cgroup-driver: systemd
-              container-runtime-endpoint: unix:///var/run/crio/crio.sock
-              feature-gates: AllAlpha=false
-              node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
-              provider-id: ${PROVIDER_ID_FORMAT}
-              runtime-request-timeout: 5m
+            - name: cgroup-driver
+              value: systemd
+            - name: container-runtime-endpoint
+              value: unix:///var/run/crio/crio.sock
+            - name: feature-gates
+              value: AllAlpha=false
+            - name: node-labels
+              value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+            - name: provider-id
+              value: '${PROVIDER_ID_FORMAT}'
+            - name: runtime-request-timeout
+              value: '5m'
             name: '{{ ds.meta_data.name }}'
         joinConfiguration:
           controlPlane: {}
           nodeRegistration:
             kubeletExtraArgs:
-              cgroup-driver: systemd
-              container-runtime-endpoint: unix:///var/run/crio/crio.sock
-              feature-gates: AllAlpha=false
-              node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
-              provider-id: ${PROVIDER_ID_FORMAT}
-              runtime-request-timeout: 5m
+            - name: cgroup-driver
+              value: systemd
+            - name: container-runtime-endpoint
+              value: unix:///var/run/crio/crio.sock
+            - name: feature-gates
+              value: AllAlpha=false
+            - name: node-labels
+              value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+            - name: provider-id
+              value: '${PROVIDER_ID_FORMAT}'
+            - name: runtime-request-timeout
+              value: '5m'
             name: '{{ ds.meta_data.name }}'
         preKubeadmCommands:
           - rm /etc/cni/net.d/*
           - systemctl restart NetworkManager.service
           - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
           - nmcli connection up ironicendpoint
-          - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
-          - nmcli connection up eth0
+          - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+          - nmcli connection up enp1s0
           - systemctl enable --now keepalived
           - sleep 60
           - systemctl enable --now crio kubelet
@@ -155,7 +166,7 @@ spec:
           - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube/config
 
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-workers
@@ -184,14 +195,14 @@ spec:
         permissions: "0755"
       - content: |
           [connection]
-          id=eth0
+          id=enp1s0
           type=ethernet
-          interface-name=eth0
+          interface-name=enp1s0
           master=ironicendpoint
           slave-type=bridge
           autoconnect=yes
           autoconnect-priority=999
-        path: /etc/NetworkManager/system-connections/eth0.nmconnection
+        path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
         owner: root:root
         permissions: '0600'
       - path: /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
@@ -238,7 +249,7 @@ spec:
       - systemctl restart NetworkManager.service
       - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
       - nmcli connection up ironicendpoint
-      - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
-      - nmcli connection up eth0
+      - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+      - nmcli connection up enp1s0
       - systemctl enable --now crio kubelet
       - sleep 120

--- a/test/e2e/data/infrastructure-metal3/v1.11/bases/clusterclass-cluster/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.11/bases/clusterclass-cluster/cluster-with-kcp.yaml
@@ -1,4 +1,4 @@
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KubeadmControlPlaneTemplate
 metadata:
   name: ${CLUSTER_NAME}
@@ -79,7 +79,7 @@ spec:
       dns:
       - 8.8.8.8
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
     labels:
@@ -93,7 +93,8 @@ spec:
     services:
       cidrBlocks: ["${SERVICE_CIDR}"]
   topology:
-    class: test-clusterclass
+    classRef:
+      name: test-clusterclass
     version: ${KUBERNETES_VERSION}
     controlPlane:
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}

--- a/test/e2e/data/infrastructure-metal3/v1.11/bases/clusterclass-cluster/crs.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.11/bases/clusterclass-cluster/crs.yaml
@@ -10,7 +10,7 @@ binaryData:
 ---
 # ClusterResourceSet object with
 # a selector that targets all the Cluster with label cni=${CLUSTER_NAME}-crs-0
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name:  "${CLUSTER_NAME}-crs-0"

--- a/test/e2e/data/infrastructure-metal3/v1.11/bases/clusterclass-cluster/md.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.11/bases/clusterclass-cluster/md.yaml
@@ -60,7 +60,7 @@ spec:
       dns:
       - 8.8.8.8
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-workers
@@ -71,12 +71,18 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            cgroup-driver: systemd
-            container-runtime-endpoint: unix:///var/run/crio/crio.sock
-            feature-gates: AllAlpha=false
-            node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
-            provider-id: ${PROVIDER_ID_FORMAT}
-            runtime-request-timeout: 5m
+          - name: cgroup-driver
+            value: systemd
+          - name: container-runtime-endpoint
+            value: unix:///var/run/crio/crio.sock
+          - name: feature-gates
+            value: AllAlpha=false
+          - name: node-labels
+            value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+          - name: provider-id
+            value: '${PROVIDER_ID_FORMAT}'
+          - name: runtime-request-timeout
+            value: '5m'
           name: '{{ ds.meta_data.name }}'
       users:
       - name: metal3

--- a/test/e2e/data/infrastructure-metal3/v1.11/bases/clusterclass-ubuntu-kubeadm-config/clusterclass-ubuntu-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.11/bases/clusterclass-ubuntu-kubeadm-config/clusterclass-ubuntu-kubeadm-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KubeadmControlPlaneTemplate
 metadata:
   name: ${CLUSTER_NAME}
@@ -8,7 +8,6 @@ spec:
   template:
     spec:
       kubeadmConfigSpec:
-        clusterConfiguration: {}
         users:
         - name: ${IMAGE_USERNAME}
           sshAuthorizedKeys:
@@ -94,22 +93,34 @@ spec:
           controlPlane: {}
           nodeRegistration:
             kubeletExtraArgs:
-              cgroup-driver: systemd
-              container-runtime-endpoint: unix:///var/run/crio/crio.sock
-              feature-gates: AllAlpha=false
-              node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
-              provider-id: ${PROVIDER_ID_FORMAT}
-              runtime-request-timeout: 5m
+            - name: cgroup-driver
+              value: systemd
+            - name: container-runtime-endpoint
+              value: unix:///var/run/crio/crio.sock
+            - name: feature-gates
+              value: AllAlpha=false
+            - name: node-labels
+              value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+            - name: provider-id
+              value: '${PROVIDER_ID_FORMAT}'
+            - name: runtime-request-timeout
+              value: '5m'
             name: '{{ ds.meta_data.name }}'
         initConfiguration:
           nodeRegistration:
             kubeletExtraArgs:
-              cgroup-driver: systemd
-              container-runtime-endpoint: unix:///var/run/crio/crio.sock
-              feature-gates: AllAlpha=false
-              node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
-              provider-id: ${PROVIDER_ID_FORMAT}
-              runtime-request-timeout: 5m
+            - name: cgroup-driver
+              value: systemd
+            - name: container-runtime-endpoint
+              value: unix:///var/run/crio/crio.sock
+            - name: feature-gates
+              value: AllAlpha=false
+            - name: node-labels
+              value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+            - name: provider-id
+              value: '${PROVIDER_ID_FORMAT}'
+            - name: runtime-request-timeout
+              value: '5m'
             name: '{{ ds.meta_data.name }}'
         postKubeadmCommands:
         - mkdir -p /home/${IMAGE_USERNAME}/.kube
@@ -124,7 +135,7 @@ spec:
         - if (curl -sk --max-time 10 https://${CLUSTER_APIENDPOINT_HOST}:${CLUSTER_APIENDPOINT_PORT}/healthz); then echo "keepalived already running";else systemctl start keepalived; fi
         - systemctl enable --now /lib/systemd/system/monitor.keepalived.service
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-workers

--- a/test/e2e/data/infrastructure-metal3/v1.11/bases/clusterclass/clusterclass.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.11/bases/clusterclass/clusterclass.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: ClusterClass
 metadata:
   name: test-clusterclass
@@ -10,17 +10,18 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
-        properties: 
-          host: 
+        properties:
+          host:
             type: string
           port:
             type: integer
   - name: image
+    required: false
     schema:
       openAPIV3Schema:
         type: object
-        properties: 
-          checksum: 
+        properties:
+          checksum:
             type: string
           checksumType:
             type: string
@@ -29,6 +30,7 @@ spec:
           url:
             type: string
   - name: workerDataTemplate
+    required: false
     schema:
       openAPIV3Schema:
         type: string
@@ -131,35 +133,34 @@ spec:
         valueFrom:
           variable: controlPlaneDataTemplate
   controlPlane:
-    ref:
-      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    templateRef:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
       kind: KubeadmControlPlaneTemplate
       name: ${CLUSTER_NAME}
     machineInfrastructure:
-      ref:
+      templateRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: ${CLUSTER_NAME}-controlplane
   workers:
     machineDeployments:
-    - class: worker
-      template:
+      - class: worker
         metadata:
           labels:
             cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
             nodepool: nodepool-0
         bootstrap:
-          ref:
-            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          templateRef:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
             kind: KubeadmConfigTemplate
             name: ${CLUSTER_NAME}-workers
         infrastructure:
-          ref:
+          templateRef:
             apiVersion: infrastructure.cluster.x-k8s.io/${CAPM3_VERSION}
             kind: Metal3MachineTemplate
             name: ${CLUSTER_NAME}-workers
   infrastructure:
-    ref:
+    templateRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: Metal3ClusterTemplate
       name: ${CLUSTER_NAME}

--- a/test/e2e/data/infrastructure-metal3/v1.11/bases/opensuse-leap-kubeadm-config/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.11/bases/opensuse-leap-kubeadm-config/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- ../cluster
+patches:
+- path: opensuse-leap-kubeadm-config.yaml

--- a/test/e2e/data/infrastructure-metal3/v1.11/bases/opensuse-leap-kubeadm-config/opensuse-leap-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.11/bases/opensuse-leap-kubeadm-config/opensuse-leap-kubeadm-config.yaml
@@ -9,24 +9,39 @@ spec:
     files:
     - content: |
         #!/bin/bash
-        set -e
-        url="$1"
-        dst="$2"
-        filename="$(basename $url)"
-        tmpfile="/tmp/$filename"
-        curl -sSL -w "%{http_code}" "$url" | sed "s:/usr/bin:/usr/local/bin:g" > /tmp/"$filename"
-        http_status=$(cat "$tmpfile" | tail -n 1)
-        if [ "$http_status" != "200" ]; then
-          echo "Error: unable to retrieve $filename file";
-          exit 1;
-        else
-          cat "$tmpfile"| sed '$d' > "$dst";
-        fi
+        while :; do
+          curl -sk https://127.0.0.1:6443/healthz 1>&2 > /dev/null
+          isOk=$?
+          isActive=$(systemctl show -p ActiveState keepalived.service | cut -d'=' -f2)
+          if [ $isOk == "0" ] &&  [ $isActive != "active" ]; then
+            logger 'API server is healthy, however keepalived is not running, starting keepalived'
+            echo 'API server is healthy, however keepalived is not running, starting keepalived'
+            sudo systemctl start keepalived.service
+          elif [ $isOk != "0" ] &&  [ $isActive == "active" ]; then
+            logger 'API server is not healthy, however keepalived running, stopping keepalived'
+            echo 'API server is not healthy, however keepalived running, stopping keepalived'
+            sudo systemctl stop keepalived.service
+          fi
+          sleep 5
+        done
       owner: root:root
-      path: /usr/local/bin/retrieve.configuration.files.sh
+      path: /usr/local/bin/monitor.keepalived.sh
       permissions: "0755"
-    - path: /etc/keepalived/keepalived.conf
-      content: |
+    - content: |
+        [Unit]
+        Description=Monitors keepalived adjusts status with that of API server
+        After=syslog.target network-online.target
+
+        [Service]
+        Type=simple
+        Restart=always
+        ExecStart=/usr/local/bin/monitor.keepalived.sh
+
+        [Install]
+        WantedBy=multi-user.target
+      owner: root:root
+      path: /lib/systemd/system/monitor.keepalived.service
+    - content: |
         ! Configuration File for keepalived
         global_defs {
             notification_email {
@@ -37,36 +52,25 @@ spec:
             smtp_server localhost
             smtp_connect_timeout 30
         }
-
-        vrrp_script k8s_api_check {
-            script "curl -sk https://127.0.0.1:6443/healthz"
-            interval 5
-            timeout 5
-            rise 3
-            fall 3
-        }
-
-        vrrp_instance VI_1 {
+        vrrp_instance VI_2 {
             state MASTER
-            interface enp2s0
-            virtual_router_id 1
+            interface eth1
+            virtual_router_id 2
             priority 101
             advert_int 1
             virtual_ipaddress {
                 ${CLUSTER_APIENDPOINT_HOST}
             }
-            track_script {
-                k8s_api_check
-            }
         }
-    - path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
+      path: /etc/keepalived/keepalived.conf
+    - path: /etc/NetworkManager/system-connections/eth0.nmconnection
       owner: root:root
       permissions: '0600'
       content: |
         [connection]
-        id=enp1s0
+        id=eth0
         type=ethernet
-        interface-name=enp1s0
+        interface-name=eth0
         master=ironicendpoint
         slave-type=bridge
     - content: |
@@ -91,17 +95,6 @@ spec:
       path: /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
       owner: root:root
       permissions: '0600'
-    - content: |
-        [kubernetes]
-        name=Kubernetes
-        baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
-        enabled=1
-        gpgcheck=1
-        repo_gpgcheck=0
-        gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-      owner: root:root
-      path: /etc/yum.repos.d/kubernetes.repo
-      permissions: '0644'
     - content: |
         [registries.search]
         registries = ['docker.io']
@@ -147,8 +140,8 @@ spec:
       - systemctl restart NetworkManager.service
       - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
       - nmcli connection up ironicendpoint
-      - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
-      - nmcli connection up enp1s0
+      - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
+      - nmcli connection up eth0
       - systemctl enable --now keepalived
       - sleep 60
       - systemctl enable --now crio kubelet
@@ -188,14 +181,14 @@ spec:
         permissions: "0755"
       - content: |
           [connection]
-          id=enp1s0
+          id=eth0
           type=ethernet
-          interface-name=enp1s0
+          interface-name=eth0
           master=ironicendpoint
           slave-type=bridge
           autoconnect=yes
           autoconnect-priority=999
-        path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
+        path: /etc/NetworkManager/system-connections/eth0.nmconnection
         owner: root:root
         permissions: '0600'
       - path: /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
@@ -217,17 +210,16 @@ spec:
           [ipv6]
           addr-gen-mode=eui64
           method=ignore
-      - path: /etc/yum.repos.d/kubernetes.repo
+      - path: /etc/zypp/repos.d/kubernetes.repo
         owner: root:root
         permissions: '0644'
         content: |
           [kubernetes]
           name=Kubernetes
-          baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+          baseurl=https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION_MINOR/rpm/
           enabled=1
           gpgcheck=1
-          repo_gpgcheck=0
-          gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+          gpgkey=https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION_MINOR/rpm/repodata/repomd.xml.key
       - path : /etc/containers/registries.conf
         owner: root:root
         permissions: '0644'
@@ -242,7 +234,7 @@ spec:
       - systemctl restart NetworkManager.service
       - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
       - nmcli connection up ironicendpoint
-      - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
-      - nmcli connection up enp1s0
+      - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
+      - nmcli connection up eth0
       - systemctl enable --now crio kubelet
       - sleep 120

--- a/test/e2e/data/infrastructure-metal3/v1.11/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.11/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KubeadmControlPlane
 metadata:
   name: ${CLUSTER_NAME}
@@ -86,22 +86,34 @@ spec:
       controlPlane: {}
       nodeRegistration:
         kubeletExtraArgs:
-          cgroup-driver: systemd
-          container-runtime-endpoint: unix:///var/run/crio/crio.sock
-          feature-gates: AllAlpha=false
-          node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
-          provider-id: ${PROVIDER_ID_FORMAT}
-          runtime-request-timeout: 5m
+        - name: cgroup-driver
+          value: systemd
+        - name: container-runtime-endpoint
+          value: unix:///var/run/crio/crio.sock
+        - name: feature-gates
+          value: AllAlpha=false
+        - name: node-labels
+          value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+        - name: provider-id
+          value: '${PROVIDER_ID_FORMAT}'
+        - name: runtime-request-timeout
+          value: '5m'
         name: '{{ ds.meta_data.name }}'
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          cgroup-driver: systemd
-          container-runtime-endpoint: unix:///var/run/crio/crio.sock
-          feature-gates: AllAlpha=false
-          node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
-          provider-id: ${PROVIDER_ID_FORMAT}
-          runtime-request-timeout: 5m
+        - name: cgroup-driver
+          value: systemd
+        - name: container-runtime-endpoint
+          value: unix:///var/run/crio/crio.sock
+        - name: feature-gates
+          value: AllAlpha=false
+        - name: node-labels
+          value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+        - name: provider-id
+          value: '${PROVIDER_ID_FORMAT}'
+        - name: runtime-request-timeout
+          value: '5m'
         name: '{{ ds.meta_data.name }}'
     postKubeadmCommands:
     - mkdir -p /home/${IMAGE_USERNAME}/.kube
@@ -116,7 +128,7 @@ spec:
     - if (curl -sk --max-time 10 https://${CLUSTER_APIENDPOINT_HOST}:${CLUSTER_APIENDPOINT_PORT}/healthz); then echo "keepalived already running";else systemctl start keepalived; fi
     - systemctl enable --now /lib/systemd/system/monitor.keepalived.service
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-workers

--- a/test/e2e/data/infrastructure-metal3/v1.11/cluster-template-centos-md-remediation/md.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.11/cluster-template-centos-md-remediation/md.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   labels:

--- a/test/e2e/data/infrastructure-metal3/v1.11/cluster-template-centos-md-remediation/mhc.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.11/cluster-template-centos-md-remediation/mhc.yaml
@@ -1,19 +1,22 @@
 ---
 # MachineHealthCheck object with
 # - a selector that targets all the machines with label e2e.remediation.label=""
-# - unhealthyConditions triggering remediation after 10s the condition is set
-apiVersion: cluster.x-k8s.io/v1beta1
+# - unhealthyNodeConditions triggering remediation after 10s the condition is set
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineHealthCheck
 metadata:
   name: "${CLUSTER_NAME}-mhc-0"
   namespace: ${NAMESPACE}
 spec:
   clusterName: "${CLUSTER_NAME}"
-  maxUnhealthy: 100%
+  remediation:
+    triggerIf:
+      unhealthyLessThanOrEqualTo: 100%
   selector:
     matchLabels:
       e2e.remediation.label: ""
-  unhealthyConditions:
-  - type: e2e.remediation.condition
-    status: "False"
-    timeout: 10s
+  checks:
+    unhealthyNodeConditions:
+    - type: e2e.remediation.condition
+      status: "False"
+      timeoutSeconds: 10

--- a/test/e2e/data/infrastructure-metal3/v1.11/cluster-template-opensuse-leap/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.11/cluster-template-opensuse-leap/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- ../bases/ippool
+- ../bases/opensuse-leap-kubeadm-config

--- a/test/e2e/data/infrastructure-metal3/v1.11/cluster-template-ubuntu-md-remediation/md.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.11/cluster-template-ubuntu-md-remediation/md.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   labels:

--- a/test/e2e/data/infrastructure-metal3/v1.11/cluster-template-ubuntu-md-remediation/mhc.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.11/cluster-template-ubuntu-md-remediation/mhc.yaml
@@ -1,19 +1,22 @@
 ---
 # MachineHealthCheck object with
 # - a selector that targets all the machines with label e2e.remediation.label=""
-# - unhealthyConditions triggering remediation after 10s the condition is set
-apiVersion: cluster.x-k8s.io/v1beta1
+# - unhealthyNodeConditions triggering remediation after 10s the condition is set
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineHealthCheck
 metadata:
   name: "${CLUSTER_NAME}-mhc-0"
   namespace: ${NAMESPACE}
 spec:
   clusterName: "${CLUSTER_NAME}"
-  maxUnhealthy: 100%
+  remediation:
+    triggerIf:
+      unhealthyLessThanOrEqualTo: "100%"
   selector:
     matchLabels:
       e2e.remediation.label: ""
-  unhealthyConditions:
-  - type: e2e.remediation.condition
-    status: "False"
-    timeout: 10s
+  checks:
+    unhealthyNodeConditions:
+    - type: e2e.remediation.condition
+      status: "False"
+      timeoutSeconds: 10

--- a/test/e2e/data/infrastructure-metal3/v1.11/clusterclass-metal3/clusterclass-metal3.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.11/clusterclass-metal3/clusterclass-metal3.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: ClusterClass
 metadata:
   name: metal3
@@ -10,17 +10,18 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
-        properties: 
-          host: 
+        properties:
+          host:
             type: string
           port:
             type: integer
   - name: image
+    required: false
     schema:
       openAPIV3Schema:
         type: object
-        properties: 
-          checksum: 
+        properties:
+          checksum:
             type: string
           checksumType:
             type: string
@@ -29,6 +30,7 @@ spec:
           url:
             type: string
   - name: controlPlaneDataTemplate
+    required: false
     schema:
       openAPIV3Schema:
         type: string
@@ -85,36 +87,35 @@ spec:
         valueFrom:
           variable: controlPlaneDataTemplate
   controlPlane:
-    ref:
-      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    templateRef:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
       kind: KubeadmControlPlaneTemplate
       name: metal3-control-plane
     machineInfrastructure:
-      ref:
+      templateRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: metal3-control-plane
   infrastructure:
-    ref:
+    templateRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: Metal3ClusterTemplate
       name: metal3-cluster
   workers:
     machineDeployments:
-    - class: worker
-      template:
+      - class: worker
         metadata:
           labels:
             cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
             nodepool: nodepool-0
         bootstrap:
-          ref:
-            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          templateRef:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
             kind: KubeadmConfigTemplate
             name: metal3-default-worker-bootstraptemplate
         infrastructure:
-          ref:
-            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+          templateRef:
+            apiVersion: infrastructure.cluster.x-k8s.io/${CAPM3_VERSION}
             kind: Metal3MachineTemplate
             name:  metal3-default-worker-machinetemplate
 ---
@@ -130,7 +131,7 @@ spec:
         port: ${CLUSTER_APIENDPOINT_PORT}
       cloudProviderEnabled: false
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KubeadmControlPlaneTemplate
 metadata:
   name: metal3-control-plane
@@ -138,27 +139,38 @@ spec:
   template:
     spec:
       kubeadmConfigSpec:
-        clusterConfiguration: {}
         initConfiguration:
           nodeRegistration:
             kubeletExtraArgs:
-              cgroup-driver: systemd
-              container-runtime-endpoint: unix:///var/run/crio/crio.sock
-              feature-gates: AllAlpha=false
-              node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
-              provider-id: ${PROVIDER_ID_FORMAT}
-              runtime-request-timeout: 5m
+            - name: cgroup-driver
+              value: systemd
+            - name: container-runtime-endpoint
+              value: unix:///var/run/crio/crio.sock
+            - name: feature-gates
+              value: AllAlpha=false
+            - name: node-labels
+              value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+            - name: provider-id
+              value: '${PROVIDER_ID_FORMAT}'
+            - name: runtime-request-timeout
+              value: '5m'
             name: '{{ ds.meta_data.name }}'
         joinConfiguration:
           controlPlane: {}
           nodeRegistration:
             kubeletExtraArgs:
-              cgroup-driver: systemd
-              container-runtime-endpoint: unix:///var/run/crio/crio.sock
-              feature-gates: AllAlpha=false
-              node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
-              provider-id: ${PROVIDER_ID_FORMAT}
-              runtime-request-timeout: 5m
+            - name: cgroup-driver
+              value: systemd
+            - name: container-runtime-endpoint
+              value: unix:///var/run/crio/crio.sock
+            - name: feature-gates
+              value: AllAlpha=false
+            - name: node-labels
+              value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+            - name: provider-id
+              value: '${PROVIDER_ID_FORMAT}'
+            - name: runtime-request-timeout
+              value: '5m'
             name: '{{ ds.meta_data.name }}'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/${CAPM3_VERSION}
@@ -176,7 +188,7 @@ spec:
         format: raw
         url: ${IMAGE_RAW_URL}
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
   name: metal3-default-worker-bootstraptemplate
@@ -186,12 +198,18 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            cgroup-driver: systemd
-            container-runtime-endpoint: unix:///var/run/crio/crio.sock
-            feature-gates: AllAlpha=false
-            node-labels: metal3.io/uuid={{ ds.meta_data.uuid }}
-            provider-id: ${PROVIDER_ID_FORMAT}
-            runtime-request-timeout: 5m
+          - name: cgroup-driver
+            value: systemd
+          - name: container-runtime-endpoint
+            value: unix:///var/run/crio/crio.sock
+          - name: feature-gates
+            value: AllAlpha=false
+          - name: node-labels
+            value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+          - name: provider-id
+            value: '${PROVIDER_ID_FORMAT}'
+          - name: runtime-request-timeout
+            value: '5m'
           name: '{{ ds.meta_data.name }}'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/${CAPM3_VERSION}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
1.11 templates were using v1beta1 CAPI, this PR is changing it to v1beta2

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
