### PR TITLE
:seedling: Add SKIP_NODE_IMAGE_PREPULL var in ci-e2e.sh

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -36,6 +36,8 @@ M3_DEV_ENV_PATH="${M3_DEV_ENV_PATH:-${WORKING_DIR}/metal3-dev-env}"
 clone_repo "${M3_DEV_ENV_REPO}" "${M3_DEV_ENV_BRANCH}" "${M3_DEV_ENV_PATH}"
 
 # Config devenv
+# SKIP_NODE_IMAGE_PREPULL is set to true to avoid dev-env downloading the node 
+# image
 cat <<-EOF >"${M3_DEV_ENV_PATH}/config_${USER}.sh"
 export CAPI_VERSION=${CAPI_VERSION:-"v1beta1"}
 export CAPM3_VERSION=${CAPM3_VERSION:-"v1beta1"}
@@ -44,6 +46,7 @@ export KUBERNETES_VERSION=${KUBERNETES_VERSION}
 export IMAGE_OS=${IMAGE_OS}
 export FORCE_REPO_UPDATE="false"
 export USE_IRSO="${USE_IRSO:-false}"
+export SKIP_NODE_IMAGE_PREPULL="true"
 EOF
 # if running a scalability test skip apply bmhs in dev-env and run fakeIPA
 if [[ ${GINKGO_FOCUS:-} == "clusterctl-upgrade" ]]; then


### PR DESCRIPTION
This var informs dev-env not to prepull node image for e2e tests from dev-env. e2e test should take care of correct node image download from within the test

Manual cherry-pick of #2853 
