### PR TITLE
:seedling: Add SKIP_NODE_IMAGE_PREPULL var in ci-e2e.sh

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -33,6 +33,7 @@ export NUM_NODES=${NUM_NODES:-"4"}
 export KUBERNETES_VERSION=${KUBERNETES_VERSION}
 export IMAGE_OS=${IMAGE_OS}
 export FORCE_REPO_UPDATE="false"
+export SKIP_NODE_IMAGE_PREPULL="true"
 EOF
 # if running a scalability test skip apply bmhs in dev-env and run fakeIPA
 if [[ ${GINKGO_FOCUS:-} == "clusterctl-upgrade" ]]; then


### PR DESCRIPTION
This var informs dev-env not to prepull node image for e2e tests from dev-env. e2e test should take care of correct node image download from within the test

Manual cherry-pick of #2853  
