### PR TITLE
🌱 Add image pull for md remediation test

### DIFF
--- a/test/e2e/md_remediations_test.go
+++ b/test/e2e/md_remediations_test.go
@@ -21,6 +21,10 @@ var _ = Describe("When testing MachineDeployment remediation", Label("healthchec
 		osType = strings.ToLower(os.Getenv("OS"))
 		Expect(osType).ToNot(Equal(""))
 		validateGlobals(specName)
+		k8sVersion := e2eConfig.MustGetVariable("KUBERNETES_VERSION")
+		imageURL, imageChecksum := EnsureImage(k8sVersion)
+		os.Setenv("IMAGE_RAW_CHECKSUM", imageChecksum)
+		os.Setenv("IMAGE_RAW_URL", imageURL)
 		// We need to override clusterctl apply log folder to avoid getting our credentials exposed.
 		clusterctlLogFolder = filepath.Join(os.TempDir(), "target_cluster_logs", bootstrapClusterProxy.GetName())
 


### PR DESCRIPTION
We have seen failure in BMH creation during e2e tests because of missing image. md-remediation test usually do the test along with remediation test. In that scenario, it will pass the test. But if user wants to test it separately, I will fail because of the missing image.  This will help user to run this test separately. 