### PR TITLE
🌱  Remove checking m3Data from Associate function

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -380,41 +380,6 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 		return err
 	}
 
-	if m.Metal3Machine.Spec.DataTemplate != nil {
-		// Requeue to get the DataTemplate output. We need to requeue to trigger the
-		// wait on the Metal3DataTemplate
-		if err = m.WaitForM3Metadata(ctx); err != nil {
-			return err
-		}
-
-		// If the requeue is not needed, then get the updated host and set the host
-		// specs
-		host, helper, err = m.getHost(ctx)
-		if err != nil {
-			errMessage := "Failed to get BaremetalHost while setting Host Spec, requeuing"
-			m.Log.Info(errMessage)
-			return WithTransientError(errors.New(errMessage), requeueAfter)
-		}
-
-		if err = m.setHostSpec(ctx, host); err != nil {
-			return err
-		}
-
-		// Update the BMH object.
-		err = helper.Patch(ctx, host)
-		if err != nil {
-			var aggr kerrors.Aggregate
-			if ok := errors.As(err, &aggr); ok {
-				for _, kerr := range aggr.Errors() {
-					if apierrors.IsConflict(kerr) {
-						return WithTransientError(kerr, requeueAfter)
-					}
-				}
-			}
-			return err
-		}
-	}
-
 	m.Log.Info("Finished associating machine")
 	return nil
 }

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -2886,7 +2886,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Host:               newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
 				BMCSecret:          newBMCSecret("mycredentials", false),
 				ExpectClusterLabel: true,
-				ExpectRequeue:      true,
+				ExpectRequeue:      false,
 				ExpectOwnerRef:     true,
 			},
 		),


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
From what we understand this part of the code is never reached. Because  when we reprovision for upgrade(node reuse), metal3Machine name will change and consequently the name of the DataClaim and the rest changes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
