### PR TITLE
🐛 Fix hardcoded restconfig user-agent value

### DIFF
--- a/main.go
+++ b/main.go
@@ -145,7 +145,7 @@ func main() {
 	restConfig := ctrl.GetConfigOrDie()
 	restConfig.QPS = restConfigQPS
 	restConfig.Burst = restConfigBurst
-	restConfig.UserAgent = "controllerName"
+	restConfig.UserAgent = controllerName
 
 	tlsOptions, metricsOptions, err := flags.GetManagerOptions(managerOptions)
 	if err != nil {


### PR DESCRIPTION
We now correctly use the controllerName variable instead of the hardcoded literal string 'controllerName ' as the restconfigs useragent value.

Main benefit: the mergepatch fieldowner name is now correctly set to the actual operators name instead of literally 'controllerName' as was before.