### PR TITLE
🌱 Rename ephemeral cluster name to bootstrap cluster

### DIFF
--- a/docs/e2e-test.md
+++ b/docs/e2e-test.md
@@ -114,7 +114,7 @@ order:
 - Node reuse
 - Re-pivoting
 
-However, in case we need to run them in the ephemeral cluster pivoting and
+However, in case we need to run them in the bootstrap cluster pivoting and
 re-pivoting should be ignored.
 
 ### Remediation based feature tests
@@ -129,10 +129,10 @@ Independent from the previous tests and can run independently includes:
 [in the middle of the remediation test](https://github.com/metal3-io/cluster-api-provider-metal3/blob/8d08f375de93a793f839b42b5ec40e6bebf98664/test/e2e/remediation_test.go#L108)
 for practical reasons at the moment.
 
-The ephemeral cluster is first launched using
+The bootstrap cluster is first launched using
 [metal3-dev-env](https://github.com/metal3-io/metal3-dev-env). The remediation,
 inspection and Metal3Remediation tests are then run with the controllers still
-in the ephemeral cluster either before pivoting or after re-pivoting.
+in the bootstrap cluster either before pivoting or after re-pivoting.
 
 ### clusterctl upgrade tests
 

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -39,7 +39,7 @@ M3_DEV_ENV_PATH="${M3_DEV_ENV_PATH:-${WORKING_DIR}/metal3-dev-env}"
 clone_repo "${M3_DEV_ENV_REPO}" "${M3_DEV_ENV_BRANCH}" "${M3_DEV_ENV_PATH}"
 
 # Config devenv
-# SKIP_NODE_IMAGE_PREPULL is set to true to avoid dev-env downloading the node 
+# SKIP_NODE_IMAGE_PREPULL is set to true to avoid dev-env downloading the node
 # image
 cat <<-EOF >"${M3_DEV_ENV_PATH}/config_${USER}.sh"
 export CAPI_VERSION="v1beta2"
@@ -84,7 +84,7 @@ case "${GINKGO_FOCUS:-}" in
     sed -i "s/^export NUM_NODES=.*/export NUM_NODES=${NUM_NODES:-50}/" "${M3_DEV_ENV_PATH}/config_${USER}.sh"
     mkdir -p "${CAPI_CONFIG_FOLDER}"
     echo 'CLUSTER_TOPOLOGY: true' >"${CAPI_CONFIG_FOLDER}/clusterctl.yaml"
-    echo 'export EPHEMERAL_CLUSTER="minikube"' >>"${M3_DEV_ENV_PATH}/config_${USER}.sh"
+    echo 'export BOOTSTRAP_CLUSTER="minikube"' >>"${M3_DEV_ENV_PATH}/config_${USER}.sh"
   ;;
 esac
 

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -46,9 +46,9 @@ elif [[ "${OS}" == "opensuse-leap" ]]; then
 fi
 
 if [ "${CONTAINER_RUNTIME}" == "docker" ]; then
-  export EPHEMERAL_CLUSTER="kind"
+  export BOOTSTRAP_CLUSTER="kind"
 else
-  export EPHEMERAL_CLUSTER="minikube"
+  export BOOTSTRAP_CLUSTER="minikube"
 fi
 
 export FROM_K8S_VERSION=${FROM_K8S_VERSION:-"v1.33.5"}

--- a/scripts/fetch_manifests.sh
+++ b/scripts/fetch_manifests.sh
@@ -10,7 +10,7 @@ DIR_NAME_AFTER_REPIVOT="/tmp/manifests/bootstrap-after-repivot"
 if [[ -d "${DIR_NAME}" ]] && [[ -d "${DIR_NAME_AFTER_PIVOT}" ]]; then
   DIR_NAME="${DIR_NAME_AFTER_REPIVOT}"
   mkdir -p "${DIR_NAME}"
-  # Ephemeral cluster kubeconfig
+  # Bootstrap cluster kubeconfig
   kconfig="${KUBECONFIG_BOOTSTRAP}"
 elif [[ -d "${DIR_NAME}" ]] && [[ ! -d "${DIR_NAME_AFTER_PIVOT}" ]]; then
   DIR_NAME="${DIR_NAME_AFTER_PIVOT}"
@@ -19,7 +19,7 @@ elif [[ -d "${DIR_NAME}" ]] && [[ ! -d "${DIR_NAME_AFTER_PIVOT}" ]]; then
   kconfig="${KUBECONFIG_WORKLOAD}"
 else
   mkdir -p "${DIR_NAME}"
-  # Ephemeral cluster kubeconfig
+  # Bootstrap cluster kubeconfig
   kconfig="${KUBECONFIG_BOOTSTRAP}"
 fi
 

--- a/test/e2e/pivoting.go
+++ b/test/e2e/pivoting.go
@@ -83,9 +83,9 @@ func pivoting(ctx context.Context, inputGetter func() PivotingInput) {
 	}
 
 	By("Fetch container logs")
-	ephemeralCluster := os.Getenv("EPHEMERAL_CLUSTER")
+	bootstrapCluster := os.Getenv("BOOTSTRAP_CLUSTER")
 	fetchContainerLogs(&generalContainers, input.ArtifactFolder, input.E2EConfig.MustGetVariable("CONTAINER_RUNTIME"))
-	if ephemeralCluster == Kind {
+	if bootstrapCluster == Kind {
 		fetchContainerLogs(&ironicContainers, input.ArtifactFolder, input.E2EConfig.MustGetVariable("CONTAINER_RUNTIME"))
 	}
 
@@ -109,7 +109,7 @@ func pivoting(ctx context.Context, inputGetter func() PivotingInput) {
 
 	By("Remove Ironic containers from the source cluster")
 	ironicDeploymentType := IronicDeploymentTypeBMO
-	if ephemeralCluster == Kind {
+	if bootstrapCluster == Kind {
 		ironicDeploymentType = IronicDeploymentTypeLocal
 	} else if GetBoolVariable(input.E2EConfig, "USE_IRSO") {
 		ironicDeploymentType = IronicDeploymentTypeIrSO
@@ -394,8 +394,8 @@ func rePivoting(ctx context.Context, inputGetter func() RePivotingInput) {
 	})
 
 	By("Reinstate Ironic containers and BMH")
-	ephemeralCluster := os.Getenv("EPHEMERAL_CLUSTER")
-	if ephemeralCluster == Kind {
+	bootstrapCluster := os.Getenv("BOOTSTRAP_CLUSTER")
+	if bootstrapCluster == Kind {
 		bmoPath := input.E2EConfig.MustGetVariable("BMOPATH")
 		ironicCommand := bmoPath + "/tools/run_local_ironic.sh"
 		//#nosec G204:gosec

--- a/test/e2e/upgrade_clusterctl_test.go
+++ b/test/e2e/upgrade_clusterctl_test.go
@@ -315,9 +315,9 @@ func preInitFunc(clusterProxy framework.ClusterProxy, bmoRelease string, ironicR
 	installCertManager(clusterProxy)
 	// Remove ironic
 	By("Remove Ironic containers from the source cluster")
-	ephemeralCluster := os.Getenv("EPHEMERAL_CLUSTER")
+	bootstrapCluster := os.Getenv("BOOTSTRAP_CLUSTER")
 	ironicDeploymentType := IronicDeploymentTypeBMO
-	if ephemeralCluster == Kind {
+	if bootstrapCluster == Kind {
 		ironicDeploymentType = IronicDeploymentTypeLocal
 	} else if GetBoolVariable(e2eConfig, "USE_IRSO") {
 		ironicDeploymentType = IronicDeploymentTypeIrSO
@@ -461,8 +461,8 @@ func preCleanupManagementCluster(clusterProxy framework.ClusterProxy, ironicRele
 	// Reinstall ironic
 	reInstallIronic := func() {
 		By("Reinstate Ironic containers and BMH")
-		ephemeralCluster := os.Getenv("EPHEMERAL_CLUSTER")
-		if ephemeralCluster == Kind {
+		bootstrapCluster := os.Getenv("BOOTSTRAP_CLUSTER")
+		if bootstrapCluster == Kind {
 			By("Install Ironic in the source cluster as containers")
 			bmoPath := e2eConfig.MustGetVariable("BMOPATH")
 			ironicCommand := bmoPath + "/tools/run_local_ironic.sh"


### PR DESCRIPTION
We have been discussing to update  Ephemeral cluster name to  Bootstrap cluster instances. This PR will unify all the variables from `EPHEMERAL_CLUSTER` to `BOOTSTRAP_CLUSTER`.
