### PR TITLE
🌱Add Kubernetes N+3 upgrade test in e2e

### DIFF
--- a/docs/e2e-test.md
+++ b/docs/e2e-test.md
@@ -54,6 +54,7 @@ Below are the tests that you can use with `GINKGO_FOCUS` and `GINKGO_SKIP`
    - remediation
    - pivoting
 - k8s-upgrade
+- k8s-upgrade-n3
 - k8s-conformance
 - clusterctl-upgrade
 - scalability
@@ -179,6 +180,41 @@ Release 1.8 branch k8s-upgrade test:
 When Kubernetes 1.35 is released, k8s-upgrade `v1.33` => `v1.34` will be
 supported in v1.11.x (but not in v1.10.x)
 
+### K8s N+3 upgrade tests
+
+Kubernetes N+3(v1.34) version upgrade in target control plane nodes.
+We start the test with version N(v1.31) and gradually upgrade the
+target cluster control plane one by one for main branch. We are
+excluding the worker node upgrade and keep it to initial N version.
+When a new Kubernetes minor release is available, we will try to support
+it in main branch. This will have a check on weekly basis.
+
+```sh
+export GINKGO_FOCUS=k8s-upgrade-n3
+```
+
+Main branch k8s-upgrade-n3 tests:
+
+- `v1.31` => `v1.32`
+
+- `v1.32` => `v1.33`
+
+- `v1.33` => `v1.34`
+
+When Kubernetes 1.35 is released, k8s-upgrade-n3 test will be updated accordingly.
+
+### Test matrix for n+3 k8s upgrade version
+
+Kubernetes n+3 e2e test uses the following Kubernetes versions for n+3 upgrade control
+planes:
+
+<!-- markdownlint-disable MD013 -->
+| KUBERNETES_N0_VERSION | KUBERNETES_N1_VERSION | KUBERNETES_N2_VERSION | KUBERNETES_N3_VERSION |
+| ********************* | ********************* | ********************* | ********************* |
+|       v1.31.13        |        v1.32.9        |       v1.33.5         |        v1.34.1        |
+| ********************* | ********************* | ********************* | ********************* |
+<!-- markdownlint-enable MD013 -->
+
 ### K8s conformance tests
 
 The conformance tests are a subset of Kubernetes' E2E test set. The standard set
@@ -189,7 +225,8 @@ for more information on which tests are required for each Kubernetes release.
 
 ### CAPI MachineDeployment tests
 
-Includes the following MachineDeployment tests adopted from the Cluster API's e2e tests:
+Includes the following MachineDeployment tests adopted from the Cluster API's
+e2e tests:
 
 - [MachineDeployment rolling upgrades](https://github.com/kubernetes-sigs/cluster-api/blob/main/test/e2e/md_rollout.go)
 - [MachineDeployment scale](https://github.com/kubernetes-sigs/cluster-api/blob/main/test/e2e/md_scale.go)

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -65,8 +65,8 @@ if [[ "${CAPI_NIGHTLY_BUILD:-false}" == "true" ]]; then
 fi
 
 case "${GINKGO_FOCUS:-}" in
-  clusterctl-upgrade|k8s-upgrade|basic|integration|remediation|k8s-conformance|capi-md-tests)
-    # if running basic, integration, k8s upgrade, clusterctl-upgrade, remediation, k8s conformance or capi-md tests, skip apply bmhs in dev-env
+  clusterctl-upgrade|k8s-upgrade|k8s-upgrade-n3|basic|integration|remediation|k8s-conformance|capi-md-tests)
+    # if running basic, integration, k8s upgrade, k8s n+3 upgrade, clusterctl-upgrade, remediation, k8s conformance or capi-md tests, skip apply bmhs in dev-env
     echo 'export SKIP_APPLY_BMH="true"' >>"${M3_DEV_ENV_PATH}/config_${USER}.sh"
   ;;
 

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -81,6 +81,17 @@ case "${GINKGO_FOCUS:-}" in
     export WORKER_MACHINE_COUNT=${WORKER_MACHINE_COUNT:-"1"}
   ;;
 
+  # k8s N+3 upgrade vars and config
+  k8s-upgrade-n3)
+    export NUM_NODES="4"
+    export CONTROL_PLANE_MACHINE_COUNT=${CONTROL_PLANE_MACHINE_COUNT:-"3"}
+    export WORKER_MACHINE_COUNT=${WORKER_MACHINE_COUNT:-"1"}
+    export KUBERNETES_N0_VERSION=${KUBERNETES_N0_VERSION:-"v1.31.13"}
+    export KUBERNETES_N1_VERSION=${KUBERNETES_N1_VERSION:-"v1.32.9"}
+    export KUBERNETES_N2_VERSION=${KUBERNETES_N2_VERSION:-"v1.33.5"}
+    export KUBERNETES_N3_VERSION=${KUBERNETES_N3_VERSION:-"v1.34.1"}
+  ;;
+
   # Scalability test environment vars and config
   scalability)
     export NUM_NODES=${NUM_NODES:-"10"}

--- a/test/e2e/upgrade_kubernetes_n3_test.go
+++ b/test/e2e/upgrade_kubernetes_n3_test.go
@@ -1,0 +1,154 @@
+package e2e
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Kubernetes version upgrade through three consecutive minor versions (N+3) in target nodes", Label("k8s-upgrade-n3"), func() {
+
+	var (
+		ctx                 = context.TODO()
+		clusterctlLogFolder string
+	)
+
+	BeforeEach(func() {
+		osType = strings.ToLower(os.Getenv("OS"))
+		Expect(osType).ToNot(Equal(""))
+		validateGlobals(specName)
+
+		// We need to override clusterctl apply log folder to avoid getting our credentials exposed.
+		clusterctlLogFolder = filepath.Join(os.TempDir(), "target_cluster_logs", bootstrapClusterProxy.GetName())
+	})
+
+	It("Should create a cluster and run kubernetes N+3 tests", func() {
+		By("Apply BMH for workload cluster")
+		ApplyBmh(ctx, e2eConfig, bootstrapClusterProxy, namespace, specName)
+		By("Creating target cluster")
+		targetCluster, _ = CreateTargetCluster(ctx, func() CreateTargetClusterInput {
+			return CreateTargetClusterInput{
+				E2EConfig:             e2eConfig,
+				BootstrapClusterProxy: bootstrapClusterProxy,
+				SpecName:              specName,
+				ClusterName:           clusterName,
+				K8sVersion:            e2eConfig.MustGetVariable("KUBERNETES_N0_VERSION"),
+				KCPMachineCount:       int64(numberOfControlplane),
+				WorkerMachineCount:    int64(numberOfWorkers),
+				ClusterctlLogFolder:   clusterctlLogFolder,
+				ClusterctlConfigPath:  clusterctlConfigPath,
+				OSType:                osType,
+				Namespace:             namespace,
+			}
+		})
+
+		By("Running Kubernetes Upgrade tests")
+		upgradeKubernetesN3(ctx, func() upgradeKubernetesN3Input {
+			return upgradeKubernetesN3Input{
+				E2EConfig:             e2eConfig,
+				BootstrapClusterProxy: bootstrapClusterProxy,
+				TargetCluster:         targetCluster,
+				SpecName:              specName,
+				ClusterName:           clusterName,
+				Namespace:             namespace,
+			}
+		})
+	})
+
+	AfterEach(func() {
+		ListBareMetalHosts(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		ListMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		ListMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		ListNodes(ctx, targetCluster.GetClient())
+		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, targetCluster, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup, clusterctlConfigPath)
+	})
+
+})
+
+type upgradeKubernetesN3Input struct {
+	E2EConfig             *clusterctl.E2EConfig
+	BootstrapClusterProxy framework.ClusterProxy
+	TargetCluster         framework.ClusterProxy
+	SpecName              string
+	ClusterName           string
+	Namespace             string
+}
+
+// upgradeKubernetesN3 implements a test upgrading the control plane through three consecutive Kubernetes minor versions (N+3 upgrade path).
+func upgradeKubernetesN3(ctx context.Context, inputGetter func() upgradeKubernetesN3Input) {
+	Logf("Starting Kubernetes upgrade tests")
+	input := inputGetter()
+	clusterClient := input.BootstrapClusterProxy.GetClient()
+	targetClusterClient := input.TargetCluster.GetClient()
+	kubernetesVersion := input.E2EConfig.MustGetVariable("KUBERNETES_N0_VERSION")
+	upgradedK8sVersion1 := input.E2EConfig.MustGetVariable("KUBERNETES_N1_VERSION")
+	upgradedK8sVersion2 := input.E2EConfig.MustGetVariable("KUBERNETES_N2_VERSION")
+	upgradedK8sVersion3 := input.E2EConfig.MustGetVariable("KUBERNETES_N3_VERSION")
+
+	Logf("Kubernetes upgrade N+1: %s to %s", kubernetesVersion, upgradedK8sVersion1)
+	Logf("KUBERNETES VERSION: %v", kubernetesVersion)
+	Logf("UPGRADED K8S VERSION: %v", upgradedK8sVersion1)
+
+	ListBareMetalHosts(ctx, clusterClient, client.InNamespace(input.Namespace))
+	ListMetal3Machines(ctx, clusterClient, client.InNamespace(input.Namespace))
+	ListMachines(ctx, clusterClient, client.InNamespace(input.Namespace))
+	ListNodes(ctx, targetClusterClient)
+
+	By("Running Kubernetes N+1 Upgrade tests")
+	UpgradeControlPlane(ctx, func() UpgradeControlPlaneInput {
+		return UpgradeControlPlaneInput{
+			E2EConfig:             input.E2EConfig,
+			BootstrapClusterProxy: input.BootstrapClusterProxy,
+			TargetCluster:         input.TargetCluster,
+			SpecName:              input.SpecName,
+			ClusterName:           input.ClusterName,
+			Namespace:             input.Namespace,
+			K8sFromVersion:        kubernetesVersion,
+			K8sToVersion:          upgradedK8sVersion1,
+		}
+	})
+	By("KUBERNETES UPGRADE N+1 TESTS PASSED!")
+	Logf("Kubernetes upgrade N+2: %s to %s", upgradedK8sVersion1, upgradedK8sVersion2)
+	Logf("KUBERNETES VERSION: %v", upgradedK8sVersion1)
+	Logf("UPGRADED K8S VERSION: %v", upgradedK8sVersion2)
+
+	By("Running Kubernetes N+2 Upgrade tests")
+	UpgradeControlPlane(ctx, func() UpgradeControlPlaneInput {
+		return UpgradeControlPlaneInput{
+			E2EConfig:             input.E2EConfig,
+			BootstrapClusterProxy: input.BootstrapClusterProxy,
+			TargetCluster:         input.TargetCluster,
+			SpecName:              input.SpecName,
+			ClusterName:           input.ClusterName,
+			Namespace:             input.Namespace,
+			K8sFromVersion:        upgradedK8sVersion1,
+			K8sToVersion:          upgradedK8sVersion2,
+		}
+	})
+	By("KUBERNETES UPGRADE N+2 TESTS PASSED!")
+	Logf("Kubernetes upgrade N+3: %s to %s", upgradedK8sVersion2, upgradedK8sVersion3)
+	Logf("KUBERNETES VERSION: %v", upgradedK8sVersion2)
+	Logf("UPGRADED K8S VERSION: %v", upgradedK8sVersion3)
+
+	By("Running Kubernetes N+3 Upgrade tests")
+	UpgradeControlPlane(ctx, func() UpgradeControlPlaneInput {
+		return UpgradeControlPlaneInput{
+			E2EConfig:             input.E2EConfig,
+			BootstrapClusterProxy: input.BootstrapClusterProxy,
+			TargetCluster:         input.TargetCluster,
+			SpecName:              input.SpecName,
+			ClusterName:           input.ClusterName,
+			Namespace:             input.Namespace,
+			K8sFromVersion:        upgradedK8sVersion2,
+			K8sToVersion:          upgradedK8sVersion3,
+		}
+	})
+	By("KUBERNETES UPGRADE N+3 TESTS PASSED!")
+}


### PR DESCRIPTION
PR to have upgrade scenario to do control plane upgrade to three consecutive minor versions and we will keep the worker in the initial Kubernetes version.
```
Main branch k8s-upgrade N+3 tests:

- `v1.31` => `v1.32`

- `v1.32` => `v1.33`

- `v1.33` => `v1.34`
```

Documentation is also updated accordingly