### PR TITLE
🐛  Fix clusterctl upgrade test to upgrade to right version and fix conditions after upgrade

### DIFF
--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -62,6 +62,10 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 	m.EXPECT().IsProvisioned().Return(tc.Provisioned)
 	if tc.Provisioned {
 		m.EXPECT().MachineHasNodeRef().Return(tc.Provisioned)
+		m.EXPECT().SetV1beta2Condition(
+			infrav1.AssociateMetal3MachineMetaDataV1Beta2Condition,
+			metav1.ConditionTrue,
+			infrav1.AssociateMetal3MachineMetaDataSuccessV1Beta2Reason, "")
 		m.EXPECT().Update(context.TODO()).Return(nil)
 		m.EXPECT().IsBootstrapReady().MaxTimes(0)
 		m.EXPECT().AssociateM3Metadata(context.TODO()).MaxTimes(0)

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -164,6 +164,16 @@ providers:
 - name: metal3
   type: IPAMProvider
   versions:
+  - name: "v1.12.99"
+    value: "https://github.com/metal3-io/ip-address-manager/releases/download/v1.12.0-beta.0/ipam-components.yaml"
+    type: "url"
+    contract: v1beta1
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+    files:
+    - sourcePath: "../data/shared/ipam-metal3/v1.12/metadata.yaml"
+      targetName: "metadata.yaml"
   - name: "{go://github.com/metal3-io/ip-address-manager@v1.11}"
     value: "https://github.com/metal3-io/ip-address-manager/releases/download/{go://github.com/metal3-io/ip-address-manager@v1.11}/ipam-components.yaml"
     type: "url"

--- a/test/e2e/data/shared/ipam-metal3/v1.12/metadata.yaml
+++ b/test/e2e/data/shared/ipam-metal3/v1.12/metadata.yaml
@@ -1,0 +1,42 @@
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+- major: 1
+  minor: 12
+  contract: v1beta1
+- major: 1
+  minor: 11
+  contract: v1beta1
+- major: 1
+  minor: 10
+  contract: v1beta1
+- major: 1
+  minor: 9
+  contract: v1beta1
+- major: 1
+  minor: 8
+  contract: v1beta1
+- major: 1
+  minor: 7
+  contract: v1beta1
+- major: 1
+  minor: 6
+  contract: v1beta1
+- major: 1
+  minor: 5
+  contract: v1beta1
+- major: 1
+  minor: 4
+  contract: v1beta1
+- major: 1
+  minor: 3
+  contract: v1beta1
+- major: 1
+  minor: 2
+  contract: v1beta1
+- major: 1
+  minor: 1
+  contract: v1beta1
+- major: 1
+  minor: 0
+  contract: v1beta1


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:
- Making sure capm3 it upgrade to latest commit and to pr commit in case of running on pr.
- ipam and capi are bumped to 1.12 pre releases, they are specified in e2e_conf.yaml
- if machine is provisioned and has NodeRef instead of just returning early and skipping other steps, this PR is setting AssociateMetal3MachineMetaDataV1Beta2Condition before returning. In normal flow this is done in the later part of the reconcile loop. But in case of clusterctl upgrade from 1.10 or 1.11 to newer version of CAPM3, the machine can be already provisioned, this condition might not be set. This can be removed in future once 1.10 and 1.11 are not supported.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
