### PR TITLE
🐛 Add missing RBAC permissions for metal3clustertemplates

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -85,6 +85,7 @@ rules:
   - infrastructure.cluster.x-k8s.io
   resources:
   - metal3clusters
+  - metal3clustertemplates
   - metal3dataclaims
   - metal3datas
   - metal3datatemplates

--- a/controllers/metal3cluster_controller.go
+++ b/controllers/metal3cluster_controller.go
@@ -66,6 +66,7 @@ type Metal3ClusterReconciler struct {
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=metal3clusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=metal3clusters/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=metal3clustertemplates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
 
 // Reconcile reads that state of the cluster for a Metal3Cluster object and makes changes based on the state read


### PR DESCRIPTION
Fixes RBAC permission error where capm3-manager service account could not list metal3clustertemplates resources.

Error fixed:
```
metal3clustertemplates.infrastructure.cluster.x-k8s.io is forbidden: User "system:serviceaccount:capm3-system:capm3-manager" cannot list resource "metal3clustertemplates"
```
probably something we missed during https://github.com/metal3-io/cluster-api-provider-metal3/pull/2909.
