### PR TITLE
🐛 Fix nil pointer issue while checking bootstrapReadyCondition

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -203,6 +203,9 @@ func (m *MachineManager) IsBaremetalHostProvisioned(ctx context.Context) bool {
 func (m *MachineManager) IsBootstrapReady() bool {
 	if m.Machine.Spec.Bootstrap.ConfigRef.IsDefined() {
 		bootstrapReadyCondition := deprecatedv1beta1conditions.Get(m.Machine, clusterv1.BootstrapReadyV1Beta1Condition)
+		if bootstrapReadyCondition == nil {
+			return false
+		}
 		return bootstrapReadyCondition.Status == corev1.ConditionTrue
 	}
 

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -469,6 +469,19 @@ var _ = Describe("Metal3Machine manager", func() {
 			Machine:    clusterv1.Machine{},
 			ExpectTrue: false,
 		}),
+		Entry("ConfigRef defined but condition not set", testCaseBootstrapReady{
+			Machine: clusterv1.Machine{
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: clusterv1.ContractVersionedObjectReference{
+							Name: "abc",
+						},
+					},
+				},
+				// No Status.Deprecated.V1Beta1.Conditions set - should return nil from Get()
+			},
+			ExpectTrue: false,
+		}),
 		Entry("ready data secret", testCaseBootstrapReady{
 			Machine: clusterv1.Machine{
 				Spec: clusterv1.MachineSpec{

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -144,7 +144,7 @@ func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Make sure infrastructure is ready
 	infrastructureReadyCondition := deprecatedv1beta1conditions.Get(cluster, clusterv1.InfrastructureReadyV1Beta1Condition)
-	if infrastructureReadyCondition.Status != corev1.ConditionTrue {
+	if infrastructureReadyCondition == nil || infrastructureReadyCondition.Status != corev1.ConditionTrue {
 		machineLog.Info("Waiting for Metal3Cluster Controller to create cluster infrastructure")
 		v1beta1conditions.MarkFalse(capm3Machine, infrav1.AssociateBMHCondition, infrav1.WaitingForClusterInfrastructureReason, clusterv1beta1.ConditionSeverityInfo, "")
 		v1beta2conditions.Set(capm3Machine, metav1.Condition{


### PR DESCRIPTION
We should check if bootstrapReadyCondition is nil or not before checking bootstrapReadyCondition.Status


**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #2956 

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
