### PR TITLE
✨ Add comprehensive trace/debug logging across controllers and managers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ GitHub pull requests. Those guidelines are the same as the
       - [Support and guarantees](#support-and-guarantees)
       - [Removal of v1alpha5 apiVersion](#removal-of-v1alpha5-apiversion)
    - [Contributing a Patch](#contributing-a-patch)
+      - [Logging Guidelines](#logging-guidelines)
    - [Backporting a Patch](#backporting-a-patch)
    - [Breaking Changes](#breaking-changes)
       - [Merge Approval](#merge-approval)
@@ -220,6 +221,45 @@ explained in the official
 Expect reviewers to request that you avoid common
 [go style mistakes](https://github.com/golang/go/wiki/CodeReviewComments) in
 your PRs.
+
+### Logging Guidelines
+
+This project uses structured logging with defined verbosity levels. When adding
+or modifying log statements, follow these conventions:
+
+#### Verbosity Levels
+
+| Level | Constant | Usage |
+|-------|----------|-------|
+| Error | `.Error()` | Actual errors requiring attention |
+| Info | `.Info()` | Important operational events, major state changes |
+| Debug | `.V(4)` / `VerbosityLevelDebug` | Internal state, fetched objects, intermediate results |
+| Trace | `.V(5)` / `VerbosityLevelTrace` | Function entry/exit, detailed flow tracing |
+
+#### Structured Logging Fields
+
+Use the predefined `LogField*` constants from `baremetal/utils.go` for
+consistent field names:
+
+```go
+log.V(baremetal.VerbosityLevelDebug).Info("Processing machine",
+    baremetal.LogFieldMachine, machine.Name,
+    baremetal.LogFieldNamespace, machine.Namespace)
+```
+
+Common fields include: `LogFieldMachine`, `LogFieldMetal3Machine`,
+`LogFieldCluster`, `LogFieldBMH`, `LogFieldError`, `LogFieldPhase`, etc.
+
+#### Best Practices
+
+- **Trace level**: Use for entering/exiting functions and processing individual
+  items
+- **Debug level**: Use for state checks, configuration values, and successful
+  operations
+- **Info level**: Use sparingly for user-facing operational events
+- **Error level**: Always include the error and relevant context
+- **Context**: Populate logger with NamespacedName at the start of Reconcile
+  functions
 
 ## Backporting a Patch
 

--- a/baremetal/metal3cluster_manager.go
+++ b/baremetal/metal3cluster_manager.go
@@ -77,6 +77,7 @@ func NewClusterManager(client client.Client, cluster *clusterv1.Cluster,
 func (s *ClusterManager) SetFinalizer() {
 	// If the Metal3Cluster doesn't have finalizer, add it.
 	if !controllerutil.ContainsFinalizer(s.Metal3Cluster, infrav1.ClusterFinalizer) {
+		s.Log.V(VerbosityLevelTrace).Info("Adding finalizer to Metal3Cluster")
 		controllerutil.AddFinalizer(s.Metal3Cluster, infrav1.ClusterFinalizer)
 	}
 }
@@ -84,33 +85,44 @@ func (s *ClusterManager) SetFinalizer() {
 // UnsetFinalizer unsets finalizer.
 func (s *ClusterManager) UnsetFinalizer() {
 	// Cluster is deleted so remove the finalizer.
+	s.Log.V(VerbosityLevelTrace).Info("Removing finalizer from Metal3Cluster")
 	controllerutil.RemoveFinalizer(s.Metal3Cluster, infrav1.ClusterFinalizer)
 }
 
 // Create creates a cluster manager for the cluster.
 func (s *ClusterManager) Create(_ context.Context) error {
+	s.Log.V(VerbosityLevelTrace).Info("Validating Metal3Cluster configuration")
 	config := s.Metal3Cluster.Spec
 	err := config.IsValid()
 	if err != nil {
 		// Should have been picked earlier. Do not requeue.
+		s.Log.V(VerbosityLevelDebug).Info("Invalid Metal3Cluster configuration",
+			LogFieldError, err.Error())
 		s.setError("Invalid Metal3Cluster provided", capierrors.InvalidConfigurationClusterError)
 		return err
 	}
+	s.Log.V(VerbosityLevelDebug).Info("Metal3Cluster configuration is valid")
 	return nil
 }
 
 // ControlPlaneEndpoint returns cluster controlplane endpoint.
 func (s *ClusterManager) ControlPlaneEndpoint() ([]infrav1.APIEndpoint, error) {
+	s.Log.V(VerbosityLevelTrace).Info("Getting ControlPlaneEndpoint")
 	// Get IP address from spec, which gets it from posted cr yaml.
 	endPoint := s.Metal3Cluster.Spec.ControlPlaneEndpoint
 	var err error
 
 	if endPoint.Host == "" || endPoint.Port == 0 {
 		err = errors.New("invalid field ControlPlaneEndpoint")
-		s.Log.Error(err, "Host IP or PORT not set")
+		s.Log.V(VerbosityLevelDebug).Info("ControlPlaneEndpoint validation failed",
+			"host", endPoint.Host,
+			"port", endPoint.Port)
 		return nil, err
 	}
 
+	s.Log.V(VerbosityLevelDebug).Info("ControlPlaneEndpoint is valid",
+		"host", endPoint.Host,
+		"port", endPoint.Port)
 	return []infrav1.APIEndpoint{
 		{
 			Host: endPoint.Host,
@@ -121,15 +133,19 @@ func (s *ClusterManager) ControlPlaneEndpoint() ([]infrav1.APIEndpoint, error) {
 
 // Delete function, no-op for now.
 func (s *ClusterManager) Delete() error {
+	s.Log.V(VerbosityLevelTrace).Info("Delete called on Metal3Cluster (no-op)")
 	return nil
 }
 
 // UpdateClusterStatus updates a metal3Cluster object's status.
 func (s *ClusterManager) UpdateClusterStatus() error {
+	s.Log.V(VerbosityLevelTrace).Info("Updating Metal3Cluster status")
 	// Get APIEndpoints from  metal3Cluster Spec
 	_, err := s.ControlPlaneEndpoint()
 
 	if err != nil {
+		s.Log.V(VerbosityLevelDebug).Info("ControlPlaneEndpoint validation failed",
+			LogFieldError, err.Error())
 		s.Metal3Cluster.Status.Ready = false
 		s.setError("Invalid ControlPlaneEndpoint values", capierrors.InvalidConfigurationClusterError)
 		v1beta1conditions.MarkFalse(s.Metal3Cluster, infrav1.BaremetalInfrastructureReadyCondition, infrav1.ControlPlaneEndpointFailedReason, clusterv1beta1.ConditionSeverityError, "%s", err.Error())
@@ -142,6 +158,7 @@ func (s *ClusterManager) UpdateClusterStatus() error {
 	}
 
 	// Mark the metal3Cluster ready.
+	s.Log.V(VerbosityLevelDebug).Info("Metal3Cluster is ready")
 	s.Metal3Cluster.Status.Ready = true
 	v1beta1conditions.MarkTrue(s.Metal3Cluster, infrav1.BaremetalInfrastructureReadyCondition)
 	v1beta2conditions.Set(s.Metal3Cluster, metav1.Condition{
@@ -158,6 +175,9 @@ func (s *ClusterManager) UpdateClusterStatus() error {
 // the message. It assumes the reason is invalid configuration, since that is
 // currently the only relevant Metal3ClusterStatusError choice.
 func (s *ClusterManager) setError(message string, reason capierrors.ClusterStatusError) {
+	s.Log.V(VerbosityLevelDebug).Info("Setting error on Metal3Cluster status",
+		LogFieldError, message,
+		"reason", reason)
 	s.Metal3Cluster.Status.FailureMessage = &message
 	s.Metal3Cluster.Status.FailureReason = &reason
 }
@@ -165,6 +185,7 @@ func (s *ClusterManager) setError(message string, reason capierrors.ClusterStatu
 // CountDescendants will return the number of descendants objects of the
 // metal3Cluster.
 func (s *ClusterManager) CountDescendants(ctx context.Context) (int, error) {
+	s.Log.V(VerbosityLevelTrace).Info("Counting Metal3Cluster descendants")
 	// Verify that no metal3machine depend on the metal3cluster
 	descendants, err := s.listDescendants(ctx)
 	if err != nil {
@@ -174,6 +195,8 @@ func (s *ClusterManager) CountDescendants(ctx context.Context) (int, error) {
 	}
 
 	nbDescendants := len(descendants.Items)
+	s.Log.V(VerbosityLevelDebug).Info("Found descendants",
+		LogFieldCount, nbDescendants)
 
 	if nbDescendants > 0 {
 		s.Log.Info(
@@ -187,6 +210,7 @@ func (s *ClusterManager) CountDescendants(ctx context.Context) (int, error) {
 // listDescendants returns a list of all Machines, for the cluster owning the
 // metal3Cluster.
 func (s *ClusterManager) listDescendants(ctx context.Context) (clusterv1.MachineList, error) {
+	s.Log.V(VerbosityLevelTrace).Info("Listing cluster descendants")
 	machines := clusterv1.MachineList{}
 	cluster, err := util.GetOwnerCluster(ctx, s.client,
 		s.Metal3Cluster.ObjectMeta,
@@ -194,6 +218,9 @@ func (s *ClusterManager) listDescendants(ctx context.Context) (clusterv1.Machine
 	if err != nil {
 		return machines, err
 	}
+	s.Log.V(VerbosityLevelDebug).Info("Found owner cluster",
+		LogFieldCluster, cluster.Name,
+		LogFieldNamespace, cluster.Namespace)
 
 	listOptions := []client.ListOption{
 		client.InNamespace(cluster.Namespace),
@@ -207,5 +234,8 @@ func (s *ClusterManager) listDescendants(ctx context.Context) (clusterv1.Machine
 		return machines, fmt.Errorf("%s: %w", errMsg, err)
 	}
 
+	s.Log.V(VerbosityLevelDebug).Info("Listed machines for cluster",
+		LogFieldCluster, cluster.Name,
+		LogFieldCount, len(machines.Items))
 	return machines, nil
 }

--- a/baremetal/utils.go
+++ b/baremetal/utils.go
@@ -43,9 +43,78 @@ const (
 	// metal3SecretType defines the type of secret created by metal3.
 	metal3SecretType corev1.SecretType = "infrastructure.cluster.x-k8s.io/secret"
 	// metal3MachineKind is the Kind of the Metal3Machine.
-	metal3MachineKind   = "Metal3Machine"
+	metal3MachineKind = "Metal3Machine"
+
+	// Logging verbosity levels follow the Kubernetes logging conventions:
+	// - Level 0 (Info): Always logged - errors, warnings, important state changes
+	// - Level 1-3: Progressively more detailed operational information
+	// - Level 4 (Debug): Detailed debugging information for developers
+	// - Level 5 (Trace): Very verbose tracing information
+	//
+	// Use VerbosityLevelDebug for internal state checks, fetched objects, and
+	// intermediate processing steps that are useful for debugging but too
+	// verbose for normal operation.
+	//
+	// Use VerbosityLevelTrace for very detailed flow tracing, such as entering/
+	// exiting functions or processing individual list items.
 	VerbosityLevelDebug = 4
 	VerbosityLevelTrace = 5
+
+	// Standard log field keys for consistent structured logging.
+	// Use these constants when adding context to log statements to ensure
+	// consistency across the codebase.
+	LogFieldController            = "controller"
+	LogFieldName                  = "name"
+	LogFieldMachine               = "machine"
+	LogFieldMetal3Machine         = "metal3Machine"
+	LogFieldHost                  = "host"
+	LogFieldHostNamespace         = "hostNamespace"
+	LogFieldCluster               = "cluster"
+	LogFieldMetal3Cluster         = "metal3Cluster"
+	LogFieldMetal3Remediation     = "metal3Remediation"
+	LogFieldNamespace             = "namespace"
+	LogFieldNode                  = "node"
+	LogFieldRemediation           = "remediation"
+	LogFieldProviderID            = "providerID"
+	LogFieldBMH                   = "bareMetalHost"
+	LogFieldError                 = "error"
+	LogFieldState                 = "state"
+	LogFieldPhase                 = "phase"
+	LogFieldDataTemplate          = "dataTemplate"
+	LogFieldData                  = "data"
+	LogFieldDataClaim             = "dataClaim"
+	LogFieldStep                  = "step"
+	LogFieldResult                = "result"
+	LogFieldCount                 = "count"
+	LogFieldDuration              = "duration"
+	LogFieldSecretName            = "secret"
+	LogFieldAnnotation            = "annotation"
+	LogFieldLabel                 = "label"
+	LogFieldCondition             = "condition"
+	LogFieldOwner                 = "owner"
+	LogFieldImage                 = "image"
+	LogFieldOnline                = "online"
+	LogFieldPoweredOn             = "poweredOn"
+	LogFieldRetryCount            = "retryCount"
+	LogFieldTimeout               = "timeout"
+	LogFieldFailureDomain         = "failureDomain"
+	LogFieldMachineSet            = "machineSet"
+	LogFieldMachineDeployment     = "machineDeployment"
+	LogFieldControlPlane          = "controlPlane"
+	LogFieldPod                   = "pod"
+	LogFieldVolumeAttachment      = "volumeAttachment"
+	LogFieldMetal3Data            = "metal3Data"
+	LogFieldMetal3DataTemplate    = "metal3DataTemplate"
+	LogFieldMetal3DataClaim       = "metal3DataClaim"
+	LogFieldMetal3MachineTemplate = "metal3MachineTemplate"
+	LogFieldIPClaim               = "ipClaim"
+	LogFieldIPAddress             = "ipAddress"
+	LogFieldPoolRef               = "poolRef"
+	LogFieldPool                  = "pool"
+	LogFieldIndex                 = "index"
+	LogFieldReason                = "reason"
+	LogFieldMessage               = "message"
+	LogFieldAPIEndpoint           = "apiEndpoint"
 )
 
 var (

--- a/controllers/metal3cluster_controller_test.go
+++ b/controllers/metal3cluster_controller_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	baremetal_mocks "github.com/metal3-io/cluster-api-provider-metal3/baremetal/mocks"
 	. "github.com/onsi/ginkgo/v2"
@@ -73,7 +74,7 @@ var _ = Describe("Metal3Cluster controller", func() {
 			m.EXPECT().
 				Create(context.TODO()).Return(returnedError)
 
-			res, err := reconcileNormal(context.TODO(), m)
+			res, err := reconcileClusterNormal(context.TODO(), m, logr.Discard())
 
 			if tc.ExpectError {
 				Expect(err).To(HaveOccurred())
@@ -139,7 +140,7 @@ var _ = Describe("Metal3Cluster controller", func() {
 				returnedError,
 			)
 
-			res, err := reconcileDelete(context.TODO(), m)
+			res, err := reconcileClusterDelete(context.TODO(), m, logr.Discard())
 
 			if tc.ExpectError {
 				Expect(err).To(HaveOccurred())

--- a/controllers/metal3data_controller_test.go
+++ b/controllers/metal3data_controller_test.go
@@ -303,7 +303,7 @@ var _ = Describe("Metal3Data manager", func() {
 					m.EXPECT().Reconcile(context.TODO()).Return(nil)
 				}
 
-				res, err := dataReconcile.reconcileNormal(context.TODO(), m)
+				res, err := dataReconcile.reconcileNormal(context.TODO(), m, logr.Discard())
 				gomockCtrl.Finish()
 
 				if tc.ExpectError {
@@ -364,7 +364,7 @@ var _ = Describe("Metal3Data manager", func() {
 				m.EXPECT().UnsetFinalizer()
 			}
 
-			res, err := dataReconcile.reconcileDelete(context.TODO(), m)
+			res, err := dataReconcile.reconcileDelete(context.TODO(), m, logr.Discard())
 			gomockCtrl.Finish()
 
 			if tc.ExpectError {

--- a/controllers/metal3datatemplate_controller_test.go
+++ b/controllers/metal3datatemplate_controller_test.go
@@ -238,7 +238,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				m.EXPECT().UpdateDatas(context.TODO()).Return(false, false, errors.New(""))
 			}
 
-			res, err := r.reconcileNormal(context.TODO(), m)
+			res, err := r.reconcileNormal(context.TODO(), m, logr.Discard())
 			gomockCtrl.Finish()
 
 			if tc.ExpectError {
@@ -293,7 +293,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				m.EXPECT().UpdateDatas(context.TODO()).Return(false, false, errors.New(""))
 			}
 
-			res, err := r.reconcileDelete(context.TODO(), m)
+			res, err := r.reconcileDelete(context.TODO(), m, logr.Discard())
 			gomockCtrl.Finish()
 
 			if tc.ExpectError {

--- a/controllers/metal3labelsync_controller.go
+++ b/controllers/metal3labelsync_controller.go
@@ -76,18 +76,29 @@ type Metal3LabelSyncReconciler struct {
 
 // Reconcile handles label sync events.
 func (r *Metal3LabelSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
-	controllerLog := r.Log.WithName(labelSyncControllerName).WithValues("metal3-label-sync", req.NamespacedName)
+	controllerLog := r.Log.WithName(labelSyncControllerName).WithValues(
+		baremetal.LogFieldBMH, req.NamespacedName,
+	)
+	controllerLog.V(baremetal.VerbosityLevelTrace).Info("Reconcile: starting label sync reconciliation")
 
 	// We need to get the NodeRef from the CAPI Machine object:
 	// BareMetalHost.ConsumerRef --> Metal3Machine.OwnerRef --> Machine.NodeRef
 
+	controllerLog.V(baremetal.VerbosityLevelTrace).Info("Fetching BareMetalHost")
 	host := &bmov1alpha1.BareMetalHost{}
 	if err := r.Client.Get(ctx, req.NamespacedName, host); err != nil {
 		if apierrors.IsNotFound(err) {
+			controllerLog.V(baremetal.VerbosityLevelDebug).Info("BareMetalHost not found, may have been deleted")
 			return ctrl.Result{}, nil
 		}
+		controllerLog.V(baremetal.VerbosityLevelDebug).Info("Failed to fetch BareMetalHost",
+			baremetal.LogFieldError, err.Error())
 		return ctrl.Result{}, err
 	}
+	controllerLog.V(baremetal.VerbosityLevelDebug).Info("BareMetalHost fetched",
+		"provisioningState", host.Status.Provisioning.State,
+		baremetal.LogFieldPoweredOn, host.Status.PoweredOn)
+
 	if host.Annotations != nil {
 		if _, ok := host.Annotations[bmov1alpha1.PausedAnnotation]; ok {
 			controllerLog.Info("BaremetalHost is currently paused. Remove pause to continue reconciliation.")
@@ -95,11 +106,13 @@ func (r *Metal3LabelSyncReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
+	controllerLog.V(baremetal.VerbosityLevelTrace).Info("Creating patch helper")
 	helper, err := v1beta1patch.NewHelper(host, r.Client)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to init patch helper: %w", err)
 	}
 	defer func() {
+		controllerLog.V(baremetal.VerbosityLevelTrace).Info("Patching BareMetalHost on exit")
 		err = helper.Patch(ctx, host)
 		if err != nil {
 			controllerLog.Info("Failed to Patch BareMetalHost")
@@ -108,7 +121,9 @@ func (r *Metal3LabelSyncReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}()
 
 	// Fetch the Metal3Machine instance.
+	controllerLog.V(baremetal.VerbosityLevelTrace).Info("Checking ConsumerRef")
 	if host.Spec.ConsumerRef == nil {
+		controllerLog.V(baremetal.VerbosityLevelDebug).Info("No ConsumerRef, skipping")
 		// ignore BMH with no ConsumerRef
 		return ctrl.Result{}, nil
 	}
@@ -117,6 +132,8 @@ func (r *Metal3LabelSyncReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		controllerLog.Info("Unknown GroupVersionKind in BareMetalHost Consumer Ref", "groupversion", host.Spec.ConsumerRef.GroupVersionKind())
 		return ctrl.Result{}, nil
 	}
+
+	controllerLog.V(baremetal.VerbosityLevelTrace).Info("Fetching Metal3Machine from ConsumerRef")
 	capm3Machine := &infrav1.Metal3Machine{}
 	capm3MachineKey := client.ObjectKey{
 		Name:      host.Spec.ConsumerRef.Name,
@@ -125,16 +142,18 @@ func (r *Metal3LabelSyncReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if err = r.Client.Get(ctx, capm3MachineKey, capm3Machine); err != nil {
 		if apierrors.IsNotFound(err) {
 			controllerLog.Info("Could not find associated Metal3Machine for BareMetalHost, will retry",
-				"machinekey", capm3MachineKey,
-				"hostnamespace", host.Namespace,
-				"host", host.Name)
+				baremetal.LogFieldMetal3Machine, capm3MachineKey,
+				baremetal.LogFieldHostNamespace, host.Namespace,
+				baremetal.LogFieldHost, host.Name)
 			return ctrl.Result{RequeueAfter: requeueAfter}, nil
 		}
 		return ctrl.Result{}, err
 	}
-	controllerLog.V(baremetal.VerbosityLevelTrace).Info(fmt.Sprintf("Found Metal3Machine %v", capm3MachineKey))
+	controllerLog = controllerLog.WithValues(baremetal.LogFieldMetal3Machine, capm3MachineKey.Name)
+	controllerLog.V(baremetal.VerbosityLevelTrace).Info("Found Metal3Machine")
 
 	// Fetch the Machine.
+	controllerLog.V(baremetal.VerbosityLevelTrace).Info("Fetching owner Machine")
 	capiMachine, err := util.GetOwnerMachine(ctx, r.Client, capm3Machine.ObjectMeta)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("metal3Machine's owner Machine could not be retrieved: %w", err)
@@ -143,13 +162,18 @@ func (r *Metal3LabelSyncReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		controllerLog.Info("Could not find Machine object, will retry")
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
-	controllerLog.V(baremetal.VerbosityLevelTrace).Info(fmt.Sprintf("Found Machine %v/%v", capiMachine.Name, capiMachine.Namespace))
+	controllerLog = controllerLog.WithValues(baremetal.LogFieldMachine, capiMachine.Name)
+	controllerLog.V(baremetal.VerbosityLevelTrace).Info("Found Machine")
+
 	if !capiMachine.Status.NodeRef.IsDefined() {
 		controllerLog.Info("Could not find Node Ref on Machine object, will retry")
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
+	controllerLog.V(baremetal.VerbosityLevelDebug).Info("NodeRef found",
+		baremetal.LogFieldNode, capiMachine.Status.NodeRef.Name)
 
 	// Fetch the Cluster
+	controllerLog.V(baremetal.VerbosityLevelTrace).Info("Fetching Cluster")
 	cluster := &clusterv1.Cluster{}
 	clusterKey := client.ObjectKey{
 		Name:      capiMachine.Spec.ClusterName,
@@ -157,70 +181,115 @@ func (r *Metal3LabelSyncReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 	err = r.Client.Get(ctx, clusterKey, cluster)
 	if err != nil {
+		controllerLog.V(baremetal.VerbosityLevelDebug).Info("Failed to fetch Cluster",
+			baremetal.LogFieldError, err.Error())
 		controllerLog.Info("Error fetching cluster, will retry")
 		return ctrl.Result{RequeueAfter: requeueAfter}, err
 	}
-	controllerLog.V(baremetal.VerbosityLevelTrace).Info(fmt.Sprintf("Found Cluster %v/%v", cluster.Name, cluster.Namespace))
+	controllerLog = controllerLog.WithValues(baremetal.LogFieldCluster, cluster.Name)
+	controllerLog.V(baremetal.VerbosityLevelTrace).Info("Found Cluster")
 
 	// Fetch the Metal3 cluster.
+	controllerLog.V(baremetal.VerbosityLevelTrace).Info("Fetching Metal3Cluster")
 	metal3Cluster := &infrav1.Metal3Cluster{}
 	metal3ClusterName := types.NamespacedName{
 		Namespace: capm3Machine.Namespace,
 		Name:      cluster.Spec.InfrastructureRef.Name,
 	}
 	if err = r.Client.Get(ctx, metal3ClusterName, metal3Cluster); err != nil {
+		controllerLog.V(baremetal.VerbosityLevelDebug).Info("Failed to fetch Metal3Cluster",
+			baremetal.LogFieldError, err.Error())
 		controllerLog.Info("Error fetching Metal3Cluster, will retry")
 		return ctrl.Result{RequeueAfter: requeueAfter}, err
 	}
-	controllerLog.V(baremetal.VerbosityLevelTrace).Info(fmt.Sprintf("Found Metal3Cluster %v/%v", metal3Cluster.Name, metal3Cluster.Namespace))
+	controllerLog = controllerLog.WithValues(baremetal.LogFieldMetal3Cluster, metal3Cluster.Name)
+	controllerLog.V(baremetal.VerbosityLevelTrace).Info("Found Metal3Cluster")
 
+	controllerLog.V(baremetal.VerbosityLevelTrace).Info("Checking pause status")
 	if annotations.IsPaused(cluster, metal3Cluster) {
+		controllerLog.V(baremetal.VerbosityLevelDebug).Info("Cluster or Metal3Cluster is paused")
 		controllerLog.Info("Cluster and/or Metal3Cluster are currently paused. Remove pause to continue reconciliation.")
 		return ctrl.Result{RequeueAfter: bmhSyncInterval}, nil
 	}
 
 	// Get prefix set
+	controllerLog.V(baremetal.VerbosityLevelTrace).Info("Getting prefix annotations from Metal3Cluster")
 	annotations := metal3Cluster.ObjectMeta.GetAnnotations()
 	if annotations == nil {
+		controllerLog.V(baremetal.VerbosityLevelDebug).Info("No annotations on Metal3Cluster")
 		return ctrl.Result{}, nil
 	}
 	prefixStr, ok := annotations[PrefixAnnotationKey]
 	if !ok {
-		controllerLog.V(baremetal.VerbosityLevelTrace).Info("No annotation for prefixes found on Metal3Cluster")
+		controllerLog.V(baremetal.VerbosityLevelDebug).Info("No prefix annotation found on Metal3Cluster")
 		return ctrl.Result{}, nil
 	}
+	controllerLog.V(baremetal.VerbosityLevelDebug).Info("Found prefix annotation",
+		"prefixes", prefixStr)
 
+	controllerLog.V(baremetal.VerbosityLevelTrace).Info("Parsing prefix annotation")
 	prefixSet, err := parsePrefixAnnotation(prefixStr)
 	if err != nil {
+		controllerLog.V(baremetal.VerbosityLevelDebug).Info("Failed to parse prefix annotation",
+			baremetal.LogFieldError, err.Error())
 		return ctrl.Result{}, err
 	}
-	err = r.reconcileBMHLabels(ctx, host, capiMachine, cluster, prefixSet)
+	controllerLog.V(baremetal.VerbosityLevelDebug).Info("Prefix set parsed",
+		baremetal.LogFieldCount, len(prefixSet))
+
+	controllerLog.V(baremetal.VerbosityLevelTrace).Info("Reconciling BMH labels to Node")
+	err = r.reconcileBMHLabels(ctx, host, capiMachine, cluster, prefixSet, controllerLog)
 	if err != nil {
+		controllerLog.V(baremetal.VerbosityLevelDebug).Info("Failed to reconcile labels",
+			baremetal.LogFieldError, err.Error())
 		controllerLog.Info(fmt.Sprintf("Error reconciling BMH labels to Node, will retry: %v", err))
 		return ctrl.Result{RequeueAfter: requeueAfter}, err
 	}
 	controllerLog.Info("Finished synchronizing labels between BaremetalHost and Node")
+	controllerLog.V(baremetal.VerbosityLevelTrace).Info("Reconcile: completed successfully")
 	// Always requeue to ensure label sync runs periodically for each BareMetalHost. This is necessary to catch any label updates to the Node that are synchronized through the BareMetalHost.
 	return ctrl.Result{RequeueAfter: bmhSyncInterval}, nil
 }
 
-func (r *Metal3LabelSyncReconciler) reconcileBMHLabels(ctx context.Context, host *bmov1alpha1.BareMetalHost, machine *clusterv1.Machine, cluster *clusterv1.Cluster, prefixSet map[string]struct{}) error {
+func (r *Metal3LabelSyncReconciler) reconcileBMHLabels(ctx context.Context, host *bmov1alpha1.BareMetalHost, machine *clusterv1.Machine, cluster *clusterv1.Cluster, prefixSet map[string]struct{}, log logr.Logger) error {
+	log.V(baremetal.VerbosityLevelTrace).Info("reconcileBMHLabels: starting label synchronization")
+
+	log.V(baremetal.VerbosityLevelTrace).Info("Building host label sync set")
 	hostLabelSyncSet := buildLabelSyncSet(prefixSet, host.Labels)
+	log.V(baremetal.VerbosityLevelDebug).Info("Host label sync set built",
+		baremetal.LogFieldCount, len(hostLabelSyncSet))
+
 	// Get the Node from the workload cluster
+	log.V(baremetal.VerbosityLevelTrace).Info("Getting remote client for workload cluster")
 	corev1Remote, err := r.CapiClientGetter(ctx, r.Client, cluster)
 	if err != nil {
 		return fmt.Errorf("error creating a remote client: %w", err)
 	}
+
+	log.V(baremetal.VerbosityLevelTrace).Info("Fetching Node from workload cluster",
+		baremetal.LogFieldNode, machine.Status.NodeRef.Name)
 	node, err := corev1Remote.Nodes().Get(ctx, machine.Status.NodeRef.Name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
+	log.V(baremetal.VerbosityLevelDebug).Info("Node fetched from workload cluster",
+		baremetal.LogFieldNode, node.Name)
+
+	log.V(baremetal.VerbosityLevelTrace).Info("Building node label sync set")
 	nodeLabelSyncSet := buildLabelSyncSet(prefixSet, node.Labels)
+	log.V(baremetal.VerbosityLevelDebug).Info("Node label sync set built",
+		baremetal.LogFieldCount, len(nodeLabelSyncSet))
+
+	log.V(baremetal.VerbosityLevelTrace).Info("Synchronizing labels on node")
 	synchronizeLabelSyncSetsOnNode(hostLabelSyncSet, nodeLabelSyncSet, node)
+
+	log.V(baremetal.VerbosityLevelTrace).Info("Updating node with synchronized labels")
 	_, err = corev1Remote.Nodes().Update(ctx, node, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to update the target node: %w", err)
 	}
+	log.V(baremetal.VerbosityLevelDebug).Info("Node updated successfully")
+	log.V(baremetal.VerbosityLevelTrace).Info("reconcileBMHLabels: completed successfully")
 	return nil
 }
 
@@ -281,7 +350,10 @@ func (r *Metal3LabelSyncReconciler) Metal3ClusterToBareMetalHosts(ctx context.Co
 		)
 		return nil
 	}
-	log := r.Log.WithValues("Metal3ClusterToBareMetalHosts", c.Name, "Namespace", c.Namespace)
+	log := r.Log.WithValues(
+		baremetal.LogFieldMetal3Cluster, c.Name,
+		baremetal.LogFieldNamespace, c.Namespace,
+	)
 	cluster, err := util.GetOwnerCluster(ctx, r.Client, c.ObjectMeta)
 	switch {
 	case apierrors.IsNotFound(err) || cluster == nil:

--- a/controllers/metal3labelsync_controller_test.go
+++ b/controllers/metal3labelsync_controller_test.go
@@ -548,7 +548,7 @@ var _ = Describe("Metal3LabelSync controller", func() {
 					WatchFilterValue: "",
 				}
 				err := r.reconcileBMHLabels(context.TODO(),
-					tc.Host, tc.Machine, tc.Cluster, tc.PrefixSet)
+					tc.Host, tc.Machine, tc.Cluster, tc.PrefixSet, logr.Discard())
 
 				if tc.ExpectError {
 					Expect(err).To(HaveOccurred())

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -85,17 +85,28 @@ type Metal3MachineReconciler struct {
 
 // Reconcile handles Metal3Machine events.
 func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
-	machineLog := r.Log.WithName(machineControllerName).WithValues("metal3-machine", req.NamespacedName)
+	machineLog := r.Log.WithName(machineControllerName).WithValues(
+		baremetal.LogFieldMetal3Machine, req.NamespacedName,
+	)
+
+	machineLog.V(baremetal.VerbosityLevelTrace).Info("Starting Metal3Machine reconciliation")
 
 	// Fetch the Metal3Machine instance.
 	capm3Machine := &infrav1.Metal3Machine{}
 
 	if err := r.Client.Get(ctx, req.NamespacedName, capm3Machine); err != nil {
 		if apierrors.IsNotFound(err) {
+			machineLog.V(baremetal.VerbosityLevelDebug).Info("Metal3Machine not found, likely deleted")
 			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to get Metal3Machine: %w", err)
 	}
+
+	machineLog.V(baremetal.VerbosityLevelDebug).Info("Fetched Metal3Machine",
+		"resourceVersion", capm3Machine.ResourceVersion,
+		"generation", capm3Machine.Generation,
+		"deletionTimestamp", capm3Machine.DeletionTimestamp)
+
 	// Always patch capm3Machine exiting this function so we can persist any Metal3Machine changes.
 	patchHelper, err := v1beta1patch.NewHelper(capm3Machine, r.Client)
 	if err != nil {
@@ -115,6 +126,7 @@ func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, fmt.Errorf("metal3Machine's owner Machine could not be retrieved: %w", err)
 	}
 	if capiMachine == nil {
+		machineLog.V(baremetal.VerbosityLevelDebug).Info("Owner Machine not found, waiting for OwnerRef to be set")
 		machineLog.Info("Waiting for Machine Controller to set OwnerRef on Metal3Machine")
 		v1beta1conditions.MarkFalse(capm3Machine, infrav1.AssociateBMHCondition, infrav1.WaitingForMetal3MachineOwnerRefReason, clusterv1beta1.ConditionSeverityInfo, "")
 		v1beta2conditions.Set(capm3Machine, metav1.Condition{
@@ -126,10 +138,15 @@ func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
-	machineLog = machineLog.WithValues("machine", capiMachine.Name)
+	// Add machine context for subsequent log messages
+	machineLog = machineLog.WithValues(baremetal.LogFieldMachine, capiMachine.Name)
+	machineLog.V(baremetal.VerbosityLevelDebug).Info("Found owner Machine",
+		"machinePhase", capiMachine.Status.Phase)
 
 	// Set Failuredomain from machine to metal3Machine
 	if capm3Machine.Spec.FailureDomain != capiMachine.Spec.FailureDomain {
+		machineLog.V(baremetal.VerbosityLevelDebug).Info("Updating failure domain",
+			baremetal.LogFieldFailureDomain, capiMachine.Spec.FailureDomain)
 		capm3Machine.Spec.FailureDomain = capiMachine.Spec.FailureDomain
 	}
 
@@ -141,11 +158,17 @@ func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
-	machineLog = machineLog.WithValues("cluster", cluster.Name)
+	// Add cluster context for subsequent log messages
+	machineLog = machineLog.WithValues(baremetal.LogFieldCluster, cluster.Name)
+	machineLog.V(baremetal.VerbosityLevelDebug).Info("Found cluster",
+		"clusterPhase", cluster.Status.Phase)
 
 	// Make sure infrastructure is ready
 	infrastructureReadyCondition := deprecatedv1beta1conditions.Get(cluster, clusterv1.InfrastructureReadyV1Beta1Condition)
 	if infrastructureReadyCondition == nil || infrastructureReadyCondition.Status != corev1.ConditionTrue {
+		machineLog.V(baremetal.VerbosityLevelDebug).Info("Cluster infrastructure not ready yet",
+			baremetal.LogFieldCondition, "InfrastructureReady",
+			baremetal.LogFieldState, infrastructureReadyCondition)
 		machineLog.Info("Waiting for Metal3Cluster Controller to create cluster infrastructure")
 		v1beta1conditions.MarkFalse(capm3Machine, infrav1.AssociateBMHCondition, infrav1.WaitingForClusterInfrastructureReason, clusterv1beta1.ConditionSeverityInfo, "")
 		v1beta2conditions.Set(capm3Machine, metav1.Condition{
@@ -164,6 +187,8 @@ func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		Name:      cluster.Spec.InfrastructureRef.Name,
 	}
 	if err = r.Client.Get(ctx, metal3ClusterName, metal3Cluster); err != nil {
+		machineLog.V(baremetal.VerbosityLevelDebug).Info("Metal3Cluster not found yet",
+			baremetal.LogFieldMetal3Cluster, metal3ClusterName.Name)
 		machineLog.Info("Waiting for Metal3Cluster Controller to create the Metal3Cluster")
 		v1beta1conditions.MarkFalse(capm3Machine, infrav1.AssociateBMHCondition, infrav1.WaitingforMetal3ClusterReason, clusterv1beta1.ConditionSeverityInfo, "")
 		v1beta2conditions.Set(capm3Machine, metav1.Condition{
@@ -175,7 +200,9 @@ func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
-	machineLog = machineLog.WithValues("metal3-cluster", metal3Cluster.Name)
+	machineLog = machineLog.WithValues(baremetal.LogFieldMetal3Cluster, metal3Cluster.Name)
+	machineLog.V(baremetal.VerbosityLevelDebug).Info("Found Metal3Cluster",
+		"metal3ClusterReady", metal3Cluster.Status.Ready)
 
 	// Create a helper for managing the baremetal container hosting the machine.
 	machineMgr, err := r.ManagerFactory.NewMachineManager(cluster, metal3Cluster, capiMachine, capm3Machine, machineLog)
@@ -183,13 +210,20 @@ func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, fmt.Errorf("failed to create helper for managing the machineMgr: %w", err)
 	}
 
+	machineLog.V(baremetal.VerbosityLevelTrace).Info("Created MachineManager, checking pause state")
+
 	// Check pause annotation on associated bmh (if any)
 	setPause := cluster.Spec.Paused != nil && *cluster.Spec.Paused
+	machineLog.V(baremetal.VerbosityLevelDebug).Info("Cluster pause check",
+		"clusterPaused", setPause)
+
 	if setPause {
+		machineLog.V(baremetal.VerbosityLevelTrace).Info("Cluster is paused, setting pause annotation on BMH")
 		// set pause annotation on associated bmh (if any)
 		err := machineMgr.SetPauseAnnotation(ctx)
 		if err != nil {
-			machineLog.Info("failed to set pause annotation on associated bmh")
+			machineLog.Info("failed to set pause annotation on associated bmh",
+				baremetal.LogFieldError, err.Error())
 			v1beta1conditions.MarkFalse(capm3Machine, infrav1.AssociateBMHCondition, infrav1.PauseAnnotationSetFailedReason, clusterv1beta1.ConditionSeverityInfo, "")
 			message := "Failed to set pause annotation on associated BareMetalHost. Error: " + err.Error()
 			v1beta2conditions.Set(capm3Machine, metav1.Condition{
@@ -201,9 +235,11 @@ func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, nil
 		}
 	} else {
+		machineLog.V(baremetal.VerbosityLevelTrace).Info("Cluster not paused, removing pause annotation from BMH if present")
 		err := machineMgr.RemovePauseAnnotation(ctx)
 		if err != nil {
-			machineLog.Info("failed to check pause annotation on associated bmh")
+			machineLog.Info("failed to check pause annotation on associated bmh",
+				baremetal.LogFieldError, err.Error())
 			v1beta1conditions.MarkFalse(capm3Machine, infrav1.AssociateBMHCondition, infrav1.PauseAnnotationRemoveFailedReason, clusterv1beta1.ConditionSeverityInfo, "")
 			message := "Failed to remove pause annotation on associated BareMetalHost. Error: " + err.Error()
 			v1beta2conditions.Set(capm3Machine, metav1.Condition{
@@ -223,6 +259,7 @@ func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Return early if the M3Machine or Cluster is paused.
 	if annotations.IsPaused(cluster, capm3Machine) {
+		machineLog.V(baremetal.VerbosityLevelDebug).Info("Metal3Machine or Cluster has pause annotation, skipping reconciliation")
 		machineLog.Info("reconciliation is paused for this object")
 		v1beta1conditions.MarkFalse(capm3Machine, infrav1.AssociateBMHCondition, infrav1.Metal3MachinePausedReason, clusterv1beta1.ConditionSeverityInfo, "")
 		v1beta2conditions.Set(capm3Machine, metav1.Condition{
@@ -235,11 +272,13 @@ func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Handle deleted machines
 	if !capm3Machine.ObjectMeta.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, machineMgr)
+		machineLog.V(baremetal.VerbosityLevelDebug).Info("Metal3Machine is being deleted, running delete reconciliation")
+		return r.reconcileDelete(ctx, machineMgr, machineLog)
 	}
 
 	// Handle non-deleted machines
-	return r.reconcileNormal(ctx, machineMgr)
+	machineLog.V(baremetal.VerbosityLevelTrace).Info("Running normal reconciliation")
+	return r.reconcileNormal(ctx, machineMgr, machineLog)
 }
 
 func patchMetal3Machine(ctx context.Context, patchHelper *v1beta1patch.Helper, metal3Machine *infrav1.Metal3Machine, options ...v1beta1patch.Option) error {
@@ -294,12 +333,21 @@ func patchMetal3Machine(ctx context.Context, patchHelper *v1beta1patch.Helper, m
 }
 
 func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
-	machineMgr baremetal.MachineManagerInterface,
+	machineMgr baremetal.MachineManagerInterface, log logr.Logger,
 ) (ctrl.Result, error) {
+	log.V(baremetal.VerbosityLevelTrace).Info("reconcileNormal: starting")
+
 	// If the Metal3Machine doesn't have finalizer, add it.
 	machineMgr.SetFinalizer()
+
 	// if the machine is already provisioned, update and return
-	if machineMgr.IsProvisioned() && machineMgr.MachineHasNodeRef() {
+	isProvisioned := machineMgr.IsProvisioned()
+	log.V(baremetal.VerbosityLevelDebug).Info("Checking machine provisioning state",
+		"isProvisioned", isProvisioned)
+
+	if isProvisioned && machineMgr.MachineHasNodeRef() {
+		log.V(baremetal.VerbosityLevelDebug).Info("Machine is provisioned with NodeRef")
+		log.V(baremetal.VerbosityLevelTrace).Info("Updating provisioned machine")
 		// If machine is provisioned and has NodeRef we should set that means metal3metadata
 		// is also associated. In normal flow this is done in the later part of this function.
 		// But in case of clusterctl upgrade from 1.10 or 1.11 to newer version of CAPM3,
@@ -309,16 +357,24 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 
 		err := machineMgr.Update(ctx)
 		if err != nil {
+			log.V(baremetal.VerbosityLevelDebug).Info("Failed to update provisioned machine",
+				baremetal.LogFieldError, err.Error())
 			errType := capierrors.UpdateMachineError
 			return checkMachineError(machineMgr, err,
 				"Failed to update the Metal3Machine", errType)
 		}
+		log.V(baremetal.VerbosityLevelTrace).Info("reconcileNormal: provisioned machine updated successfully")
 		return ctrl.Result{}, nil
 	}
 
 	// Make sure bootstrap data is available and populated. If not, return, we
 	// will get an event from the machine update when the flag is set to true.
-	if !machineMgr.IsBootstrapReady() {
+	bootstrapReady := machineMgr.IsBootstrapReady()
+	log.V(baremetal.VerbosityLevelDebug).Info("Checking bootstrap readiness",
+		"bootstrapReady", bootstrapReady)
+
+	if !bootstrapReady {
+		log.V(baremetal.VerbosityLevelTrace).Info("Bootstrap not ready, waiting")
 		machineMgr.SetConditionMetal3MachineToFalse(infrav1.AssociateBMHCondition, infrav1.WaitingForBootstrapReadyReason, clusterv1beta1.ConditionSeverityInfo, "")
 		machineMgr.SetV1beta2Condition(infrav1.AssociateBareMetalHostV1Beta2Condition, metav1.ConditionFalse, infrav1.WaitingForBootstrapDataV1Beta2Reason, "Waiting for bootstrap data to be ready before proceeding")
 		return ctrl.Result{}, nil
@@ -327,25 +383,38 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 	errType := capierrors.CreateMachineError
 
 	// Check if the metal3machine was associated with a baremetalhost
-	if !machineMgr.HasAnnotation() {
+	hasAnnotation := machineMgr.HasAnnotation()
+	log.V(baremetal.VerbosityLevelDebug).Info("Checking BMH association",
+		"hasBMHAnnotation", hasAnnotation)
+
+	if !hasAnnotation {
+		log.V(baremetal.VerbosityLevelTrace).Info("No BMH annotation, attempting to associate")
 		// Associate the baremetalhost hosting the machine
 		err := machineMgr.Associate(ctx)
 		if err != nil {
+			log.V(baremetal.VerbosityLevelDebug).Info("Association failed",
+				baremetal.LogFieldError, err.Error())
 			machineMgr.SetConditionMetal3MachineToFalse(infrav1.AssociateBMHCondition, infrav1.AssociateBMHFailedReason, clusterv1beta1.ConditionSeverityError, err.Error())
 			machineMgr.SetV1beta2Condition(infrav1.AssociateBareMetalHostV1Beta2Condition, metav1.ConditionFalse, infrav1.AssociateBareMetalHostFailedV1Beta2Reason, err.Error())
 			return checkMachineError(machineMgr, err,
 				"failed to associate the Metal3Machine to a BareMetalHost", errType)
 		}
 
+		log.V(baremetal.VerbosityLevelTrace).Info("Association initiated successfully")
 		return ctrl.Result{}, nil
 	}
+
+	log.V(baremetal.VerbosityLevelTrace).Info("BMH already associated, updating conditions")
 	// Update Condition to reflect that we have an associated BMH
 	machineMgr.SetConditionMetal3MachineToTrue(infrav1.AssociateBMHCondition)
 	machineMgr.SetV1beta2Condition(infrav1.AssociateBareMetalHostV1Beta2Condition, metav1.ConditionTrue, infrav1.AssociateBareMetalHostSuccessV1Beta2Reason, "")
 
 	// Make sure that the metadata is ready if any
+	log.V(baremetal.VerbosityLevelTrace).Info("Associating Metal3 metadata")
 	err := machineMgr.AssociateM3Metadata(ctx)
 	if err != nil {
+		log.V(baremetal.VerbosityLevelDebug).Info("Metadata association failed",
+			baremetal.LogFieldError, err.Error())
 		machineMgr.SetConditionMetal3MachineToFalse(infrav1.KubernetesNodeReadyCondition, infrav1.AssociateM3MetaDataFailedReason, clusterv1beta1.ConditionSeverityWarning, err.Error())
 		machineMgr.SetV1beta2Condition(infrav1.AssociateMetal3MachineMetaDataV1Beta2Condition, metav1.ConditionFalse, infrav1.AssociateMetal3MachineMetaDataFailedV1Beta2Reason, err.Error())
 		return checkMachineError(machineMgr, err,
@@ -353,26 +422,40 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 	}
 	machineMgr.SetV1beta2Condition(infrav1.AssociateMetal3MachineMetaDataV1Beta2Condition, metav1.ConditionTrue, infrav1.AssociateMetal3MachineMetaDataSuccessV1Beta2Reason, "")
 
+	log.V(baremetal.VerbosityLevelTrace).Info("Updating machine after metadata association")
 	err = machineMgr.Update(ctx)
 	if err != nil {
+		log.V(baremetal.VerbosityLevelDebug).Info("Failed to update BareMetalHost",
+			baremetal.LogFieldError, err.Error())
 		return checkMachineError(machineMgr, err,
 			"failed to update BareMetalHost", errType)
 	}
 
+	log.V(baremetal.VerbosityLevelTrace).Info("Checking if BMH is provisioned")
 	if !machineMgr.IsBaremetalHostProvisioned(ctx) {
-		r.Log.Info("IsBaremetalHostProvisioned check failed")
+		log.Info("BareMetalHost not yet provisioned, waiting")
 		return ctrl.Result{}, nil
 	}
+	log.V(baremetal.VerbosityLevelDebug).Info("BareMetalHost is provisioned")
 
+	log.V(baremetal.VerbosityLevelTrace).Info("Checking if Node with matching ProviderID exists")
 	if machineMgr.NodeWithMatchingProviderIDExists(ctx, r.CapiClientGetter) {
+		log.V(baremetal.VerbosityLevelDebug).Info("Node with matching ProviderID found, waiting for NodeRef")
 		// Nothing to be done but wait for Machine.Spec.NodeRef
 		machineMgr.SetReadyTrue()
 		return ctrl.Result{}, nil
 	}
 
-	if machineMgr.CloudProviderEnabled() {
+	cloudProviderEnabled := machineMgr.CloudProviderEnabled()
+	log.V(baremetal.VerbosityLevelDebug).Info("Checking cloud provider status",
+		"cloudProviderEnabled", cloudProviderEnabled)
+
+	if cloudProviderEnabled {
+		log.V(baremetal.VerbosityLevelTrace).Info("Cloud provider enabled, setting ProviderID from cloud provider node")
 		err = machineMgr.SetProviderIDFromCloudProviderNode(ctx, r.CapiClientGetter)
 		if err != nil {
+			log.V(baremetal.VerbosityLevelDebug).Info("Failed to set ProviderID from cloud provider",
+				baremetal.LogFieldError, err.Error())
 			return checkMachineError(machineMgr, err, "failed to set ProviderID on Metal3Machine based on Cloud Provider Node ProviderID", errType)
 		}
 		return ctrl.Result{}, nil
@@ -381,79 +464,119 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 	// If we have "moved", the Node label will not match the baremetalhost.  However,
 	// The Node should have a matching ProviderID already set and we will have
 	// caught it above.
+	log.V(baremetal.VerbosityLevelTrace).Info("Attempting to set ProviderID from node label")
 	success, err := machineMgr.SetProviderIDFromNodeLabel(ctx, r.CapiClientGetter)
 	if err != nil {
+		log.V(baremetal.VerbosityLevelDebug).Info("Failed to set ProviderID from node label",
+			baremetal.LogFieldError, err.Error())
 		return checkMachineError(machineMgr, err, "failed to set ProviderID on Metal3Machine based on Node label", errType)
 	}
 
+	log.V(baremetal.VerbosityLevelDebug).Info("SetProviderIDFromNodeLabel result",
+		baremetal.LogFieldResult, success)
+
 	if success {
+		log.V(baremetal.VerbosityLevelTrace).Info("ProviderID set from node label, marking ready")
 		machineMgr.SetReadyTrue()
 		return ctrl.Result{}, nil
 	}
 
-	if !machineMgr.Metal3MachineHasProviderID() {
+	hasProviderID := machineMgr.Metal3MachineHasProviderID()
+	log.V(baremetal.VerbosityLevelDebug).Info("Checking if Metal3Machine has ProviderID",
+		"hasProviderID", hasProviderID)
+
+	if !hasProviderID {
+		log.V(baremetal.VerbosityLevelTrace).Info("Setting default ProviderID")
 		err = machineMgr.SetDefaultProviderID()
 		if err != nil {
+			log.V(baremetal.VerbosityLevelDebug).Info("Failed to set default ProviderID",
+				baremetal.LogFieldError, err.Error())
 			return checkMachineError(machineMgr, err,
 				"Failed to set default ProviderID the Metal3Machine", errType)
 		}
 		machineMgr.SetReadyTrue()
 
 		errType = capierrors.UpdateMachineError
+		log.V(baremetal.VerbosityLevelTrace).Info("Updating machine after setting default ProviderID")
 		err = machineMgr.Update(ctx)
 		if err != nil {
+			log.V(baremetal.VerbosityLevelDebug).Info("Failed to update Metal3Machine",
+				baremetal.LogFieldError, err.Error())
 			return checkMachineError(machineMgr, err,
 				"Failed to update the Metal3Machine", errType)
 		}
 	}
 
+	log.V(baremetal.VerbosityLevelTrace).Info("Setting node ProviderID by hostname")
 	err = machineMgr.SetNodeProviderIDByHostname(ctx, r.CapiClientGetter)
 	if err != nil {
+		log.V(baremetal.VerbosityLevelDebug).Info("Failed to set node ProviderID by hostname",
+			baremetal.LogFieldError, err.Error())
 		errType = capierrors.UpdateMachineError
 		return checkMachineError(machineMgr, err, "unable to find Node by hostname, it may not be ready yet", errType)
 	}
 
 	errType = capierrors.UpdateMachineError
+	log.V(baremetal.VerbosityLevelTrace).Info("Final machine update")
 	err = machineMgr.Update(ctx)
 	if err != nil {
+		log.V(baremetal.VerbosityLevelDebug).Info("Final update failed",
+			baremetal.LogFieldError, err.Error())
 		return checkMachineError(machineMgr, err,
 			"Failed to update the Metal3Machine", errType)
 	}
 
+	log.V(baremetal.VerbosityLevelTrace).Info("reconcileNormal: completed successfully")
 	return ctrl.Result{}, nil
 }
 
 func (r *Metal3MachineReconciler) reconcileDelete(ctx context.Context,
-	machineMgr baremetal.MachineManagerInterface,
+	machineMgr baremetal.MachineManagerInterface, log logr.Logger,
 ) (ctrl.Result, error) {
+	log.V(baremetal.VerbosityLevelTrace).Info("reconcileDelete: starting deletion workflow")
+
 	// set machine condition to Deleting
+	log.V(baremetal.VerbosityLevelTrace).Info("Setting deletion conditions on Metal3Machine")
 	machineMgr.SetConditionMetal3MachineToFalse(infrav1.KubernetesNodeReadyCondition, infrav1.DeletingReason, clusterv1beta1.ConditionSeverityInfo, "")
 	machineMgr.SetV1beta2Condition(infrav1.AssociateMetal3MachineMetaDataV1Beta2Condition, metav1.ConditionFalse, infrav1.Metal3MachineDeletingV1Beta2Reason, "")
+	log.V(baremetal.VerbosityLevelDebug).Info("Deletion conditions set",
+		baremetal.LogFieldCondition, infrav1.KubernetesNodeReadyCondition)
 
 	errType := capierrors.DeleteMachineError
 
 	// dissociate metadata if any
+	log.V(baremetal.VerbosityLevelTrace).Info("Dissociating M3Metadata from machine")
 	if err := machineMgr.DissociateM3Metadata(ctx); err != nil {
+		log.V(baremetal.VerbosityLevelDebug).Info("Failed to dissociate M3Metadata",
+			baremetal.LogFieldError, err.Error())
 		machineMgr.SetConditionMetal3MachineToFalse(infrav1.KubernetesNodeReadyCondition, infrav1.DisassociateM3MetaDataFailedReason, clusterv1beta1.ConditionSeverityWarning, err.Error())
 		machineMgr.SetV1beta2Condition(infrav1.AssociateMetal3MachineMetaDataV1Beta2Condition, metav1.ConditionFalse, infrav1.DisassociateM3MetaDataFailedV1Beta2Reason, err.Error())
 
 		return checkMachineError(machineMgr, err,
 			"failed to dissociate Metadata", errType)
 	}
+	log.V(baremetal.VerbosityLevelDebug).Info("M3Metadata dissociated successfully")
 
 	// delete the machine
+	log.V(baremetal.VerbosityLevelTrace).Info("Deleting Metal3Machine resources (BMH dissociation)")
 	if err := machineMgr.Delete(ctx); err != nil {
+		log.V(baremetal.VerbosityLevelDebug).Info("Failed to delete Metal3Machine resources",
+			baremetal.LogFieldError, err.Error())
 		machineMgr.SetConditionMetal3MachineToFalse(infrav1.KubernetesNodeReadyCondition, infrav1.DeletionFailedReason, clusterv1beta1.ConditionSeverityWarning, err.Error())
 		machineMgr.SetV1beta2Condition(infrav1.AssociateMetal3MachineMetaDataV1Beta2Condition, metav1.ConditionFalse, infrav1.Metal3MachineDeletingFailedV1Beta2Reason, err.Error())
 
 		return checkMachineError(machineMgr, err,
 			"failed to delete Metal3Machine", errType)
 	}
+	log.V(baremetal.VerbosityLevelDebug).Info("Metal3Machine resources deleted successfully")
 
 	// metal3machine is marked for deletion and ready to be deleted,
 	// so remove the finalizer.
+	log.V(baremetal.VerbosityLevelTrace).Info("Removing finalizer from Metal3Machine")
 	machineMgr.UnsetFinalizer()
+	log.V(baremetal.VerbosityLevelDebug).Info("Finalizer removed")
 
+	log.V(baremetal.VerbosityLevelTrace).Info("reconcileDelete: completed successfully")
 	return ctrl.Result{}, nil
 }
 
@@ -536,7 +659,10 @@ func (r *Metal3MachineReconciler) Metal3ClusterToMetal3Machines(ctx context.Cont
 		)
 		return nil
 	}
-	log := r.Log.WithValues("Metal3Cluster", c.Name, "Namespace", c.Namespace)
+	log := r.Log.WithValues(
+		baremetal.LogFieldCluster, c.Name,
+		baremetal.LogFieldNamespace, c.Namespace,
+	)
 
 	cluster, err := util.GetOwnerCluster(ctx, r.Client, c.ObjectMeta)
 	switch {

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -213,7 +213,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		DescribeTable("ReconcileNormal tests",
 			func(tc reconcileNormalTestCase) {
 				m := setReconcileNormalExpectations(gomockCtrl, tc)
-				res, err := bmReconcile.reconcileNormal(context.TODO(), m)
+				res, err := bmReconcile.reconcileNormal(context.TODO(), m, logr.Discard())
 
 				if tc.ExpectError {
 					Expect(err).To(HaveOccurred())
@@ -303,7 +303,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		DescribeTable("Deletion tests",
 			func(tc reconcileDeleteTestCase) {
 				m := setReconcileDeleteExpectations(gomockCtrl, tc)
-				res, err := bmReconcile.reconcileDelete(context.TODO(), m)
+				res, err := bmReconcile.reconcileDelete(context.TODO(), m, logr.Discard())
 				if tc.ExpectError {
 					Expect(err).To(HaveOccurred())
 				} else {

--- a/controllers/metal3machinetemplate_controller_test.go
+++ b/controllers/metal3machinetemplate_controller_test.go
@@ -284,7 +284,7 @@ var _ = Describe("Metal3MachineTemplate controller", func() {
 				WatchFilterValue: "",
 			}
 
-			result, err := testReconciler.reconcileNormal(context.TODO(), m)
+			result, err := testReconciler.reconcileNormal(context.TODO(), m, logr.Discard())
 			Expect(result).To(Equal(tc.common.expectedResult))
 			evaluateTestError(tc.common.expectedError, err)
 			mockController.Finish()

--- a/controllers/metal3remediation_controller.go
+++ b/controllers/metal3remediation_controller.go
@@ -60,27 +60,35 @@ type Metal3RemediationReconciler struct {
 
 // Reconcile handles Metal3Remediation events.
 func (r *Metal3RemediationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
-	remediationLog := r.Log.WithValues("metal3remediation", req.NamespacedName)
+	remediationLog := r.Log.WithValues(
+		baremetal.LogFieldMetal3Remediation, req.NamespacedName,
+	)
+	remediationLog.V(baremetal.VerbosityLevelTrace).Info("Reconcile: starting Metal3Remediation reconciliation")
 
 	// Fetch the Metal3Remediation instance.
+	remediationLog.V(baremetal.VerbosityLevelTrace).Info("Fetching Metal3Remediation")
 	metal3Remediation := &infrav1.Metal3Remediation{}
 	if err := r.Client.Get(ctx, req.NamespacedName, metal3Remediation); err != nil {
 		if apierrors.IsNotFound(err) {
+			remediationLog.V(baremetal.VerbosityLevelDebug).Info("Metal3Remediation not found, may have been deleted")
 			return ctrl.Result{}, nil
 		}
-		remediationLog.Error(err, "unable to get metal3Remediation")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("unable to get metal3Remediation: %w", err)
 	}
+	remediationLog.V(baremetal.VerbosityLevelDebug).Info("Metal3Remediation fetched",
+		"phase", metal3Remediation.Status.Phase,
+		"retryCount", metal3Remediation.Status.RetryCount)
 
+	remediationLog.V(baremetal.VerbosityLevelTrace).Info("Creating patch helper")
 	helper, err := v1beta1patch.NewHelper(metal3Remediation, r.Client)
 	if err != nil {
-		remediationLog.Error(err, "failed to init patch helper")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to init patch helper: %w", err)
 	}
 
 	defer func() {
 		// Always attempt to Patch the Remediation object and status after each reconciliation.
 		// Patch ObservedGeneration only if the reconciliation completed successfully
+		remediationLog.V(baremetal.VerbosityLevelTrace).Info("Patching Metal3Remediation on exit")
 		patchOpts := make([]v1beta1patch.Option, 0, 1)
 		patchOpts = append(patchOpts, v1beta1patch.WithStatusObservedGeneration{})
 
@@ -93,18 +101,23 @@ func (r *Metal3RemediationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}()
 
 	// Fetch the Machine.
+	remediationLog.V(baremetal.VerbosityLevelTrace).Info("Fetching owner Machine")
 	capiMachine, err := util.GetOwnerMachine(ctx, r.Client, metal3Remediation.ObjectMeta)
 	if err != nil {
-		remediationLog.Error(err, "metal3Remediation's owner Machine could not be retrieved")
 		return ctrl.Result{}, fmt.Errorf("metal3Remediation's owner Machine could not be retrieved: %w", err)
 	}
 	if capiMachine == nil {
 		remediationLog.Info("metal3Remediation's owner Machine not set")
 		return ctrl.Result{}, errors.New("metal3Remediation's owner Machine not set")
 	}
-	remediationLog = remediationLog.WithValues("unhealthy machine detected", capiMachine.Name)
+	remediationLog = remediationLog.WithValues(
+		baremetal.LogFieldMachine, capiMachine.Name,
+	)
+	remediationLog.V(baremetal.VerbosityLevelDebug).Info("Owner Machine found",
+		"machinePhase", capiMachine.Status.Phase)
 
 	// Fetch Metal3Machine
+	remediationLog.V(baremetal.VerbosityLevelTrace).Info("Fetching Metal3Machine")
 	metal3Machine := infrav1.Metal3Machine{}
 	key := client.ObjectKey{
 		Name:      capiMachine.Spec.InfrastructureRef.Name,
@@ -112,194 +125,261 @@ func (r *Metal3RemediationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 	err = r.Get(ctx, key, &metal3Machine)
 	if err != nil {
-		remediationLog.Error(err, "metal3machine not found")
 		return ctrl.Result{}, fmt.Errorf("metal3machine not found: %w", err)
 	}
 
-	remediationLog = remediationLog.WithValues("metal3machine", metal3Machine.Name)
+	remediationLog = remediationLog.WithValues(baremetal.LogFieldMetal3Machine, metal3Machine.Name)
+	remediationLog.V(baremetal.VerbosityLevelDebug).Info("Metal3Machine fetched",
+		baremetal.LogFieldBMH, metal3Machine.Annotations[baremetal.HostAnnotation])
 
 	// Create a helper for managing the remediation object.
+	remediationLog.V(baremetal.VerbosityLevelTrace).Info("Creating RemediationManager")
 	remediationMgr, err := r.ManagerFactory.NewRemediationManager(metal3Remediation, &metal3Machine, capiMachine, remediationLog)
 	if err != nil {
-		remediationLog.Error(err, "failed to create helper for managing the metal3remediation")
 		return ctrl.Result{}, fmt.Errorf("failed to create helper for managing the metal3remediation: %w", err)
 	}
+	remediationLog.V(baremetal.VerbosityLevelDebug).Info("RemediationManager created")
 
 	// Handle both deleted and non-deleted remediations
-	return r.reconcileNormal(ctx, remediationMgr)
+	remediationLog.V(baremetal.VerbosityLevelTrace).Info("Proceeding with remediation")
+	return r.reconcileNormal(ctx, remediationMgr, remediationLog)
 }
 
 func (r *Metal3RemediationReconciler) reconcileNormal(ctx context.Context,
-	remediationMgr baremetal.RemediationManagerInterface,
+	remediationMgr baremetal.RemediationManagerInterface, log logr.Logger,
 ) (ctrl.Result, error) {
+	log.V(baremetal.VerbosityLevelTrace).Info("reconcileNormal: starting remediation workflow")
+
 	// If host is gone, exit early
+	log.V(baremetal.VerbosityLevelTrace).Info("Getting unhealthy host")
 	host, _, err := remediationMgr.GetUnhealthyHost(ctx)
 	if err != nil {
-		r.Log.Error(err, "unable to find a host for unhealthy machine")
 		return ctrl.Result{}, fmt.Errorf("unable to find a host for unhealthy machine: %w", err)
+	}
+	if host != nil {
+		log.V(baremetal.VerbosityLevelDebug).Info("Unhealthy host found",
+			baremetal.LogFieldBMH, host.Name,
+			baremetal.LogFieldPoweredOn, host.Status.PoweredOn)
 	}
 
 	// If user has set bmh.Spec.Online to false
 	// do not try to remediate the host
+	log.V(baremetal.VerbosityLevelTrace).Info("Checking host online status")
 	if !remediationMgr.OnlineStatus(host) {
-		r.Log.Info("Unable to remediate, Host is powered off (spec.Online is false)")
+		log.Info("Unable to remediate, Host is powered off (spec.Online is false)")
+		log.V(baremetal.VerbosityLevelDebug).Info("Setting remediation phase to Failed",
+			baremetal.LogFieldOnline, false)
 		remediationMgr.SetRemediationPhase(infrav1.PhaseFailed)
 		return ctrl.Result{}, nil
 	}
 
 	remediationType := remediationMgr.GetRemediationType()
+	log.V(baremetal.VerbosityLevelDebug).Info("Remediation type determined",
+		"remediationType", remediationType)
 
 	if remediationType != infrav1.RebootRemediationStrategy {
-		r.Log.Info("unsupported remediation strategy")
+		log.Info("unsupported remediation strategy")
 		return ctrl.Result{}, nil
 	}
 
 	if remediationType == infrav1.RebootRemediationStrategy {
+		currentPhase := remediationMgr.GetRemediationPhase()
+		log.V(baremetal.VerbosityLevelDebug).Info("Current remediation phase",
+			"phase", currentPhase)
+
 		// If no phase set, default to running and set time and retry count
-		if remediationMgr.GetRemediationPhase() == "" {
+		if currentPhase == "" {
+			log.V(baremetal.VerbosityLevelTrace).Info("No phase set, initializing to PhaseRunning")
 			remediationMgr.SetRemediationPhase(infrav1.PhaseRunning)
 			now := metav1.Now()
 			remediationMgr.SetLastRemediationTime(&now)
+			log.V(baremetal.VerbosityLevelDebug).Info("Remediation initialized",
+				"phase", infrav1.PhaseRunning,
+				"lastRemediationTime", now.String())
 			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 		}
 
 		// try to get node
+		log.V(baremetal.VerbosityLevelTrace).Info("Getting cluster client for node access")
 		clusterClient, err := remediationMgr.GetClusterClient(ctx)
 		if err != nil {
-			r.Log.Error(err, "error getting cluster client")
 			return ctrl.Result{}, fmt.Errorf("error getting cluster client: %w", err)
 		}
 
 		// handle old clusters which were not setup with RBAC for accessing nodes
 		isNodeForbidden := false
+		log.V(baremetal.VerbosityLevelTrace).Info("Getting node for remediation")
 		node, err := remediationMgr.GetNode(ctx, clusterClient)
 		if err != nil {
 			if apierrors.IsForbidden(err) {
-				r.Log.Info("Node access is forbidden, will skip node deletion")
+				log.Info("Node access is forbidden, will skip node deletion")
 				isNodeForbidden = true
 			} else if !apierrors.IsNotFound(err) {
-				r.Log.Error(err, "error getting node for remediation")
 				return ctrl.Result{}, fmt.Errorf("error getting node for remediation: %w", err)
+			} else {
+				log.V(baremetal.VerbosityLevelDebug).Info("Node not found, may have been deleted")
 			}
+		} else if node != nil {
+			log.V(baremetal.VerbosityLevelDebug).Info("Node found for remediation",
+				baremetal.LogFieldNode, node.Name)
 		}
+
+		log.V(baremetal.VerbosityLevelTrace).Info("Processing remediation phase",
+			"phase", remediationMgr.GetRemediationPhase())
 
 		switch remediationMgr.GetRemediationPhase() {
 		case infrav1.PhaseRunning:
-
-			return r.remediateRebootStrategy(ctx, remediationMgr, clusterClient, node)
+			log.V(baremetal.VerbosityLevelTrace).Info("Phase: Running - executing reboot strategy")
+			return r.remediateRebootStrategy(ctx, remediationMgr, clusterClient, node, log)
 
 		case infrav1.PhaseWaiting:
+			log.V(baremetal.VerbosityLevelTrace).Info("Phase: Waiting - waiting for power on and node restore")
 
 			// Node is deleted: remove power off annotation
+			log.V(baremetal.VerbosityLevelTrace).Info("Checking power off annotation status")
 			ok, err := remediationMgr.IsPowerOffRequested(ctx)
 			if err != nil {
-				r.Log.Error(err, "error getting poweroff annotation status")
 				return ctrl.Result{}, fmt.Errorf("error getting poweroff annotation status: %w", err)
 			} else if ok {
-				r.Log.Info("Powering on the host")
+				log.Info("Powering on the host")
 				err = remediationMgr.RemovePowerOffAnnotation(ctx)
 				if err != nil {
-					r.Log.Error(err, "error removing poweroff annotation")
 					return ctrl.Result{}, fmt.Errorf("error removing poweroff annotation: %w", err)
 				}
+				log.V(baremetal.VerbosityLevelDebug).Info("Power off annotation removed")
 			}
 
 			// Wait until powered on
+			log.V(baremetal.VerbosityLevelTrace).Info("Checking power status")
 			var on bool
 			if on, err = remediationMgr.IsPoweredOn(ctx); err != nil {
-				r.Log.Error(err, "error getting power status")
 				return ctrl.Result{}, fmt.Errorf("error getting power status: %w", err)
 			} else if !on {
+				log.V(baremetal.VerbosityLevelDebug).Info("Host not yet powered on, requeuing")
 				// wait a bit before checking again if we are powered on
 				return ctrl.Result{RequeueAfter: defaultTimeout}, nil
 			}
+			log.V(baremetal.VerbosityLevelDebug).Info("Host is powered on")
 
 			// Restore node if available and not done yet
+			log.V(baremetal.VerbosityLevelTrace).Info("Checking finalizer and node status")
 			if remediationMgr.HasFinalizer() {
+				log.V(baremetal.VerbosityLevelDebug).Info("Remediation has finalizer",
+					"hasNode", node != nil,
+					"outOfServiceTaintEnabled", r.IsOutOfServiceTaintEnabled)
+
 				if node != nil {
 					if r.IsOutOfServiceTaintEnabled {
 						if remediationMgr.HasOutOfServiceTaint(node) {
+							log.V(baremetal.VerbosityLevelTrace).Info("Removing out-of-service taint from node",
+								baremetal.LogFieldNode, node.Name)
 							if err = remediationMgr.RemoveOutOfServiceTaint(ctx, clusterClient, node); err != nil {
 								return ctrl.Result{}, fmt.Errorf("error removing out-of-service taint from node %s: %w", node.Name, err)
 							}
+							log.V(baremetal.VerbosityLevelDebug).Info("Out-of-service taint removed")
 						}
 					} else {
 						// Node was recreated, restore annotations and labels
-						r.Log.Info("Restoring the node")
-						if err = r.restoreNode(ctx, remediationMgr, clusterClient, node); err != nil {
+						log.Info("Restoring node annotations and labels", baremetal.LogFieldNode, node.Name)
+						if err = r.restoreNode(ctx, remediationMgr, clusterClient, node, log); err != nil {
 							return ctrl.Result{}, err
 						}
+						log.V(baremetal.VerbosityLevelDebug).Info("Node restored successfully")
 					}
 
 					// clean up
-					r.Log.Info("Remediation done, cleaning up remediation CR")
+
+					log.Info("Remediation done, cleaning up remediation CR")
 					if !r.IsOutOfServiceTaintEnabled {
+						log.V(baremetal.VerbosityLevelDebug).Info("Removing node backup annotations")
 						remediationMgr.RemoveNodeBackupAnnotations()
 					}
+					log.V(baremetal.VerbosityLevelDebug).Info("Removing finalizer")
 					remediationMgr.UnsetFinalizer()
+					log.V(baremetal.VerbosityLevelTrace).Info("reconcileNormal: completed successfully (node restored)")
 					return ctrl.Result{RequeueAfter: defaultTimeout}, nil
 				} else if isNodeForbidden {
 					// we don't have a node, just remove finalizer
+					log.V(baremetal.VerbosityLevelDebug).Info("Node access forbidden, removing finalizer without restore")
 					remediationMgr.UnsetFinalizer()
 
-					r.Log.Info("Skipping node restore, remediation done, CR should be deleted soon")
+					log.Info("Skipping node restore, remediation done, CR should be deleted soon")
 					return ctrl.Result{RequeueAfter: defaultTimeout}, nil
 				}
 			}
 
 			// Check timeout, either node wasn't recreated yet, or CR is not deleted because of still unhealthy node
-			timedOut, _ := remediationMgr.TimeToRemediate(remediationMgr.GetTimeout().Duration)
+			log.V(baremetal.VerbosityLevelTrace).Info("Checking remediation timeout")
+			timeout := remediationMgr.GetTimeout().Duration
+			timedOut, _ := remediationMgr.TimeToRemediate(timeout)
+			log.V(baremetal.VerbosityLevelDebug).Info("Timeout check result",
+				"timedOut", timedOut,
+				baremetal.LogFieldTimeout, timeout.String())
+
 			if !timedOut {
 				// Not yet time to retry or stop remediation, requeue
-				r.Log.Info("Waiting for node to get healthy and CR being deleted")
+				log.Info("Waiting for node to get healthy and CR being deleted")
 				return ctrl.Result{RequeueAfter: defaultTimeout}, nil
 			}
 
 			// Try again if limit not reached
-			if remediationMgr.RetryLimitIsSet() && !remediationMgr.HasReachRetryLimit() {
-				r.Log.Info("Remediation timed out, will retry")
+			log.V(baremetal.VerbosityLevelTrace).Info("Checking retry limit")
+			retryLimitSet := remediationMgr.RetryLimitIsSet()
+			hasReachedLimit := remediationMgr.HasReachRetryLimit()
+			log.V(baremetal.VerbosityLevelDebug).Info("Retry limit status",
+				"retryLimitSet", retryLimitSet,
+				"hasReachedLimit", hasReachedLimit)
+
+			if retryLimitSet && !hasReachedLimit {
+				log.Info("Remediation timed out, will retry")
 				remediationMgr.SetRemediationPhase(infrav1.PhaseRunning)
 				now := metav1.Now()
 				remediationMgr.SetLastRemediationTime(&now)
 				remediationMgr.IncreaseRetryCount()
+				log.V(baremetal.VerbosityLevelDebug).Info("Retrying remediation")
 				return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 			}
 
-			r.Log.Info("Remediation timed out and retry limit reached")
+			log.Info("Remediation timed out and retry limit reached")
+			log.V(baremetal.VerbosityLevelTrace).Info("Setting owner remediated condition")
 
 			// When machine is still unhealthy after remediation, setting of OwnerRemediatedCondition
 			// moves control to CAPI machine controller. The owning controller will do
 			// preflight checks and handles the Machine deletion
 			err = remediationMgr.SetOwnerRemediatedConditionNew(ctx)
 			if err != nil {
-				r.Log.Error(err, "error setting cluster api conditions")
 				return ctrl.Result{}, fmt.Errorf("error setting cluster api conditions: %w", err)
 			}
+			log.V(baremetal.VerbosityLevelDebug).Info("Owner remediated condition set")
 
 			// Remediation failed, so set unhealthy annotation on BMH
 			// This prevents BMH to be selected as a host.
+			log.V(baremetal.VerbosityLevelTrace).Info("Setting unhealthy annotation on BMH")
 			err = remediationMgr.SetUnhealthyAnnotation(ctx)
 			if err != nil {
-				r.Log.Error(err, "error setting unhealthy annotation")
 				return ctrl.Result{}, fmt.Errorf("error setting unhealthy annotation: %w", err)
 			}
+			log.V(baremetal.VerbosityLevelDebug).Info("Unhealthy annotation set")
 
+			log.V(baremetal.VerbosityLevelTrace).Info("Setting phase to Deleting")
 			remediationMgr.SetRemediationPhase(infrav1.PhaseDeleting)
 			// no requeue, we are done
+			log.V(baremetal.VerbosityLevelTrace).Info("reconcileNormal: completed (remediation failed)")
 			return ctrl.Result{}, nil
 
 		case infrav1.PhaseDeleting:
+			log.V(baremetal.VerbosityLevelDebug).Info("Phase: Deleting - nothing to do")
 			// nothing to do anymore
-			break
 
 		case infrav1.PhaseFailed:
+			log.V(baremetal.VerbosityLevelDebug).Info("Phase: Failed - nothing to do")
 			// nothing to do anymore
-			break
 
 		default:
-			r.Log.Error(nil, "unknown phase!", "phase", remediationMgr.GetRemediationPhase())
+			log.Error(nil, "unknown phase!", "phase", remediationMgr.GetRemediationPhase())
 		}
 	}
+	log.V(baremetal.VerbosityLevelTrace).Info("reconcileNormal: completed")
 	return ctrl.Result{}, nil
 }
 
@@ -308,53 +388,73 @@ func (r *Metal3RemediationReconciler) reconcileNormal(ctx context.Context,
 // Return a Result and optionally an error when reconcile should return.
 func (r *Metal3RemediationReconciler) remediateRebootStrategy(ctx context.Context,
 	remediationMgr baremetal.RemediationManagerInterface, clusterClient v1.CoreV1Interface,
-	node *corev1.Node) (ctrl.Result, error) {
+	node *corev1.Node, log logr.Logger) (ctrl.Result, error) {
+	log.V(baremetal.VerbosityLevelTrace).Info("remediateRebootStrategy: starting")
+
 	// add finalizer
+	log.V(baremetal.VerbosityLevelTrace).Info("Checking finalizer")
 	if !remediationMgr.HasFinalizer() {
+		log.V(baremetal.VerbosityLevelDebug).Info("Setting finalizer on remediation")
 		remediationMgr.SetFinalizer()
 		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
+	log.V(baremetal.VerbosityLevelDebug).Info("Finalizer already set")
 
 	// power off if needed
+	log.V(baremetal.VerbosityLevelTrace).Info("Checking power off status")
 	if ok, err := remediationMgr.IsPowerOffRequested(ctx); err != nil {
-		r.Log.Error(err, "error getting poweroff annotation status")
 		return ctrl.Result{}, fmt.Errorf("error getting poweroff annotation status: %w", err)
 	} else if !ok {
-		r.Log.Info("Powering off the host")
+		log.Info("Powering off the host")
 		err = remediationMgr.SetPowerOffAnnotation(ctx)
 		if err != nil {
-			r.Log.Error(err, "error setting poweroff annotation")
 			return ctrl.Result{}, fmt.Errorf("error setting poweroff annotation: %w", err)
 		}
+		log.V(baremetal.VerbosityLevelDebug).Info("Power off annotation set")
 
 		// done for now, wait a bit before checking if we are powered off already
 		return ctrl.Result{RequeueAfter: defaultTimeout}, nil
 	}
+	log.V(baremetal.VerbosityLevelDebug).Info("Power off already requested")
 
 	// wait until powered off
+	log.V(baremetal.VerbosityLevelTrace).Info("Checking if host is powered off")
 	if on, err := remediationMgr.IsPoweredOn(ctx); err != nil {
-		r.Log.Error(err, "error getting power status")
 		return ctrl.Result{}, fmt.Errorf("error getting power status: %w", err)
 	} else if on {
+		log.V(baremetal.VerbosityLevelDebug).Info("Host still powered on, waiting")
 		// wait a bit before checking again if we are powered off already
 		return ctrl.Result{RequeueAfter: defaultTimeout}, nil
 	}
+	log.V(baremetal.VerbosityLevelDebug).Info("Host is powered off")
+
+	log.V(baremetal.VerbosityLevelTrace).Info("Processing node for remediation",
+		"hasNode", node != nil,
+		"outOfServiceTaintEnabled", r.IsOutOfServiceTaintEnabled)
 
 	if node != nil {
 		if r.IsOutOfServiceTaintEnabled {
+			log.V(baremetal.VerbosityLevelTrace).Info("Out-of-service taint mode enabled")
 			if !remediationMgr.HasOutOfServiceTaint(node) {
+				log.V(baremetal.VerbosityLevelDebug).Info("Adding out-of-service taint to node",
+					baremetal.LogFieldNode, node.Name)
 				if err := remediationMgr.AddOutOfServiceTaint(ctx, clusterClient, node); err != nil {
 					return ctrl.Result{}, err
 				}
+				log.V(baremetal.VerbosityLevelDebug).Info("Out-of-service taint added")
 				// If we immediately check if the node is drained, we might find no pods with
 				// Deletion timestamp set yet and assume the node is drained.
 				return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 			}
 
+			log.V(baremetal.VerbosityLevelTrace).Info("Checking if node is drained")
 			if !remediationMgr.IsNodeDrained(ctx, clusterClient, node) {
+				log.V(baremetal.VerbosityLevelDebug).Info("Node not yet drained, waiting")
 				return ctrl.Result{RequeueAfter: defaultTimeout}, nil
 			}
+			log.V(baremetal.VerbosityLevelDebug).Info("Node is drained")
 		} else {
+			log.V(baremetal.VerbosityLevelTrace).Info("Using node deletion mode")
 			/*
 				Delete the node only after the host is powered off. Otherwise, if we would delete the node
 				when the host is powered on, the scheduler would assign the workload to other nodes, with the
@@ -362,83 +462,107 @@ func (r *Metal3RemediationReconciler) remediateRebootStrategy(ctx context.Contex
 				in corruption or other issues for applications with singleton requirement. After the host is powered
 				off we know for sure that it is safe to re-assign that workload to other nodes.
 			*/
-			modified := r.backupNode(remediationMgr, node)
+			modified := r.backupNode(remediationMgr, node, log)
 			if modified {
-				r.Log.Info("Backing up node")
+				log.Info("Backing up node before deletion", baremetal.LogFieldNode, node.Name)
 				// save annotations before deleting node
 				return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 			}
-			r.Log.Info("Deleting node")
+			log.Info("Deleting node", baremetal.LogFieldNode, node.Name)
 			err := remediationMgr.DeleteNode(ctx, clusterClient, node)
 			if err != nil {
-				r.Log.Error(err, "error deleting node")
 				return ctrl.Result{}, fmt.Errorf("error deleting node: %w", err)
 			}
+			log.V(baremetal.VerbosityLevelDebug).Info("Node deletion initiated")
 			// wait until node is gone
 			return ctrl.Result{RequeueAfter: defaultTimeout}, nil
 		}
 	}
 
 	// we are done for this phase, switch to waiting for power on and the node restore
+	log.V(baremetal.VerbosityLevelTrace).Info("Switching to waiting phase")
 	remediationMgr.SetRemediationPhase(infrav1.PhaseWaiting)
-	r.Log.Info("Switch to waiting phase for power on and node restore")
+	log.Info("Switch to waiting phase for power on and node restore")
+	log.V(baremetal.VerbosityLevelTrace).Info("remediateRebootStrategy: completed")
 	return ctrl.Result{RequeueAfter: defaultTimeout}, nil
 }
 
 // Returns whether annotations or labels were set / updated.
 func (r *Metal3RemediationReconciler) backupNode(remediationMgr baremetal.RemediationManagerInterface,
-	node *corev1.Node) bool {
+	node *corev1.Node, log logr.Logger) bool {
+	log.V(baremetal.VerbosityLevelTrace).Info("backupNode: backing up node annotations and labels",
+		baremetal.LogFieldNode, node.Name)
+
 	marshaledAnnotations, err := marshal(node.Annotations)
 	if err != nil {
-		r.Log.Error(err, "failed to marshal node annotations", "node", node.Name)
+		log.Error(err, "failed to marshal node annotations", "node", node.Name)
 		// if marshal fails we want to continue without blocking on this, as this error
 		// not likely to be resolved in the next run
 	}
 
 	marshaledLabels, err := marshal(node.Labels)
 	if err != nil {
-		r.Log.Error(err, "failed to marshal node labels", "node", node.Name)
+		log.Error(err, "failed to marshal node labels", "node", node.Name)
 	}
 
-	return remediationMgr.SetNodeBackupAnnotations(marshaledAnnotations, marshaledLabels)
+	modified := remediationMgr.SetNodeBackupAnnotations(marshaledAnnotations, marshaledLabels)
+	log.V(baremetal.VerbosityLevelDebug).Info("Node backup result",
+		"modified", modified)
+	return modified
 }
 
 func (r *Metal3RemediationReconciler) restoreNode(ctx context.Context, remediationMgr baremetal.RemediationManagerInterface,
-	clusterClient v1.CoreV1Interface, node *corev1.Node) error { //nolint:unparam
+	clusterClient v1.CoreV1Interface, node *corev1.Node, log logr.Logger) error { //nolint:unparam
+	log.V(baremetal.VerbosityLevelTrace).Info("restoreNode: restoring node annotations and labels",
+		baremetal.LogFieldNode, node.Name)
+
 	annotations, labels := remediationMgr.GetNodeBackupAnnotations()
+	log.V(baremetal.VerbosityLevelDebug).Info("Retrieved backup annotations",
+		"hasAnnotations", annotations != "",
+		"hasLabels", labels != "")
+
 	if annotations == "" && labels == "" {
+		log.V(baremetal.VerbosityLevelDebug).Info("No backup data to restore")
 		return nil
 	}
 
 	// set annotations
 	if annotations != "" {
+		log.V(baremetal.VerbosityLevelTrace).Info("Restoring node annotations")
 		nodeAnnotations, err := unmarshal(annotations)
 		if err != nil {
-			r.Log.Error(err, "failed to unmarshal node annotations", "node", node.Name, "annotations", annotations)
+			log.Error(err, "failed to unmarshal node annotations", "node", node.Name, "annotations", annotations)
 			// if unmarshal fails we want to continue without blocking on this, as this error
 			// is not likely to be resolved in the next run
 		}
 		if len(nodeAnnotations) > 0 {
 			node.Annotations = mergeMaps(node.Annotations, nodeAnnotations)
+			log.V(baremetal.VerbosityLevelDebug).Info("Node annotations restored",
+				baremetal.LogFieldCount, len(nodeAnnotations))
 		}
 	}
 
 	// set labels
 	if labels != "" {
+		log.V(baremetal.VerbosityLevelTrace).Info("Restoring node labels")
 		nodeLabels, err := unmarshal(labels)
 		if err != nil {
-			r.Log.Error(err, "failed to unmarshal node labels", "node", node.Name, "labels", labels)
+			log.Error(err, "failed to unmarshal node labels", "node", node.Name, "labels", labels)
 			// if unmarshal fails we want to continue without blocking on this, as this error
 			// is not likely to be resolved in the next run
 		}
 		if len(nodeLabels) > 0 {
 			node.Labels = mergeMaps(node.Labels, nodeLabels)
+			log.V(baremetal.VerbosityLevelDebug).Info("Node labels restored",
+				baremetal.LogFieldCount, len(nodeLabels))
 		}
 	}
 
+	log.V(baremetal.VerbosityLevelTrace).Info("Updating node with restored data")
 	if err := remediationMgr.UpdateNode(ctx, clusterClient, node); err != nil {
-		r.Log.Error(err, "failed to update node", "node", node.Name)
+		log.Error(err, "failed to update node", "node", node.Name)
 	}
+	log.V(baremetal.VerbosityLevelDebug).Info("Node updated successfully")
 
 	return nil
 }

--- a/controllers/metal3remediation_controller_test.go
+++ b/controllers/metal3remediation_controller_test.go
@@ -359,7 +359,7 @@ var _ = Describe("Metal3Remediation controller", func() {
 			IsOutOfServiceTaintEnabled: tc.IsOutOfServiceTaintSupported,
 		}
 		m := setReconcileNormalRemediationExpectations(goMockCtrl, tc)
-		res, err := testReconciler.reconcileNormal(context.TODO(), m)
+		res, err := testReconciler.reconcileNormal(context.TODO(), m, logr.Discard())
 
 		if tc.ExpectError {
 			Expect(err).To(HaveOccurred())


### PR DESCRIPTION
## What this PR does / why we need it

- Add `VerbosityLevelDebug` (4) and `VerbosityLevelTrace` (5) constants for consistent verbosity separation
- Add 20+ `LogField*` constants for structured logging keys (e.g., `LogFieldController`, `LogFieldNamespace`, `LogFieldCluster`, `LogFieldBMHName`)
- Instrument all controllers with trace-level (V=5) logging for function entry/exit and detailed flow tracing
- Add debug-level (V=4) logging for intermediate state, fetched objects, and decision points
- Extend logging to baremetal managers: `metal3cluster`, `metal3data`, `metal3datatemplate`, `metal3machinetemplate`, `metal3remediation`
- Update controller unit tests to pass explicit loggers after signature changes
- Document logging guidelines in CONTRIBUTING.md

## Why this matters

Before this change, many reconcile paths emitted no structured output—delete helpers only logged fatal errors while success paths were silent, and other branches used ad-hoc `Info`/`Error` calls without consistent context. Debugging required adding temporary log statements to trace execution flow.

Now, every controller and manager uses a two-tier approach:

- **Trace (V=5):** Step-by-step execution flow—function entry/exit, loop iterations, early returns
- **Debug (V=4):** Key decision points, fetched object state, intermediate results

All logs use structured fields (`LogFieldController`, `LogFieldNamespace`, etc.) for consistent, parseable output. Operators can enable trace logging with `-v=5` for deep debugging without code changes.

## Fixes

Fixes #

## Checklist

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
