### PR TITLE
:sparkles: add image SBOM attestation to image builds

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -15,10 +15,14 @@ jobs:
   build_CAPM3:
     name: Build CAPM3 image
     if: github.repository == 'metal3-io/cluster-api-provider-metal3'
+    permissions:
+      contents: read
+      id-token: write
     uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
     with:
       image-name: 'cluster-api-provider-metal3'
       pushImage: true
+      generate-sbom: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -124,6 +124,7 @@ jobs:
   build_CAPM3:
     permissions:
       contents: read
+      id-token: write
     needs: push_release_tags
     name: Build CAPM3 image
     if: github.repository == 'metal3-io/cluster-api-provider-metal3'
@@ -132,6 +133,7 @@ jobs:
       image-name: 'cluster-api-provider-metal3'
       pushImage: true
       ref: ${{ needs.push_release_tags.outputs.release_tag }}
+      generate-sbom: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
Use reusable container build workflow from project-infra to enable image SBOM attestations to be attached to the image digest when any IPAM image is built.

For this, we need id-token permission for keyless signing and enabling the SBOM generation via flag.
