### PR TITLE
🌱 Fix capi-md-e2e test to support taint propagation feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,8 @@ cluster-templates-main: $(KUSTOMIZE) ## Generate cluster templates
 	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/main/cluster-template-upgrade-workload > $(E2E_OUT_DIR)/main/cluster-template-upgrade-workload.yaml
 	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/main/cluster-template-centos-md-remediation > $(E2E_OUT_DIR)/main/cluster-template-centos-md-remediation.yaml
 	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/main/cluster-template-ubuntu-md-remediation > $(E2E_OUT_DIR)/main/cluster-template-ubuntu-md-remediation.yaml
+	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/main/cluster-template-ubuntu-md-taints > $(E2E_OUT_DIR)/main/cluster-template-ubuntu-md-taints.yaml
+	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/main/cluster-template-centos-md-taints > $(E2E_OUT_DIR)/main/cluster-template-centos-md-taints.yaml
 	touch $(E2E_OUT_DIR)/main/clusterclass.yaml
 
 .PHONY: clusterclass-templates-main

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -18,7 +18,8 @@ providers:
   type: CoreProvider
   versions:
   - name: "v1.12.99"
-    value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_${DATE}/core-components.yaml"
+    # Switch back to nightly builds once 1.12 stable is out. ("https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_${DATE}/core-components.yaml"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.0-rc.0/core-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:
@@ -66,7 +67,8 @@ providers:
   type: BootstrapProvider
   versions:
   - name: "v1.12.99"
-    value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_${DATE}/bootstrap-components.yaml"
+    # Switch back to nightly builds once 1.12 stable is out. ("https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_${DATE}/bootstrap-components.yaml"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.0-rc.0/bootstrap-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:
@@ -114,7 +116,8 @@ providers:
   type: ControlPlaneProvider
   versions:
   - name: "v1.12.99"
-    value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_${DATE}/control-plane-components.yaml"
+    # Switch back to nightly builds once 1.12 stable is out. ("https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_${DATE}/control-plane-components.yaml"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.0-rc.0/control-plane-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:
@@ -241,6 +244,10 @@ providers:
       targetName: "cluster-template-ubuntu-md-remediation.yaml"
     - sourcePath: "../_out/main/cluster-template-opensuse-leap.yaml"
       targetName: "cluster-template-opensuse-leap.yaml"
+    - sourcePath: "../_out/main/cluster-template-ubuntu-md-taints.yaml"
+      targetName: "cluster-template-ubuntu-md-taints.yaml"
+    - sourcePath: "../_out/main/cluster-template-centos-md-taints.yaml"
+      targetName: "cluster-template-centos-md-taints.yaml"
 
 variables:
   CNI: "/tmp/cni.yaml"
@@ -313,6 +320,7 @@ variables:
   BMO_RELEASE_LATEST: "data/bmo-deployment/overlays/release-latest"
   FKAS_RELEASE_LATEST: "data/fkas"
   REPO_NAME: "${REPO_NAME:cluster-api-provider-metal3}"
+  EXP_MACHINE_TAINT_PROPAGATION: "true"
 
 intervals:
   default/wait-controllers: [ "10m", "10s" ]

--- a/test/e2e/data/infrastructure-metal3/main/cluster-template-centos-md-taints/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/main/cluster-template-centos-md-taints/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- ../bases/ippool
+- ../bases/centos-kubeadm-config
+
+patches:
+- path: md-taints.yaml

--- a/test/e2e/data/infrastructure-metal3/main/cluster-template-centos-md-taints/md-taints.yaml
+++ b/test/e2e/data/infrastructure-metal3/main/cluster-template-centos-md-taints/md-taints.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+    nodepool: nodepool-0
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      taints:
+      - key: "pre-existing-on-initialization-taint"
+        value: "on-initialization-value"
+        effect: PreferNoSchedule
+        propagation: OnInitialization
+      - key: "pre-existing-always-taint"
+        value: "always-value"
+        effect: PreferNoSchedule
+        propagation: Always

--- a/test/e2e/data/infrastructure-metal3/main/cluster-template-ubuntu-md-taints/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/main/cluster-template-ubuntu-md-taints/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- ../bases/ippool
+- ../bases/ubuntu-kubeadm-config
+
+patches:
+- path: md-taints.yaml

--- a/test/e2e/data/infrastructure-metal3/main/cluster-template-ubuntu-md-taints/md-taints.yaml
+++ b/test/e2e/data/infrastructure-metal3/main/cluster-template-ubuntu-md-taints/md-taints.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+    nodepool: nodepool-0
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      taints:
+      - key: "pre-existing-on-initialization-taint"
+        value: "on-initialization-value"
+        effect: PreferNoSchedule
+        propagation: OnInitialization
+      - key: "pre-existing-always-taint"
+        value: "always-value"
+        effect: PreferNoSchedule
+        propagation: Always

--- a/test/e2e/md_rollout_test.go
+++ b/test/e2e/md_rollout_test.go
@@ -29,7 +29,7 @@ var _ = Describe("When testing MachineDeployment rolling upgrades", Label("capi-
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,
-			Flavor:                osType,
+			Flavor:                osType + "-md-taints",
 			PostNamespaceCreated:  createBMHsInNamespace,
 		}
 	})


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:
CAPI added taint propagation feature and updated their e2e test to test it. 
We are running same capi test on our side so we also have to update our yamls.
This pr is enabling EXP_MACHINE_TAINT_PROPAGATION and updating md yaml so it can be tested.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
