### PR TITLE
🌱 lint: allow long lines in tables and code fences

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -4,6 +4,9 @@ config:
   ul-indent:
     # Kramdown wanted us to have 3 earlier, tho this CLI recommends 2 or 4
     indent: 3
+  line-length:
+    tables: false
+    code_blocks: false
 
 # Don't autofix anything, we're linting here
 fix: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,14 +147,10 @@ is defined above.
 - The EOL date of each API Version is determined from the last release available
   once a new API version is published.
 
-<!-- markdownlint-disable MD013 -->
-
 | API Version  | Supported Until                                                              |
 | ------------ | ---------------------------------------------------------------------------- |
 | **v1beta1**  | TBD (current latest)                                                         |
 | **v1alpha5** | EOL since 2022-09-30 ([apiVersion removal](#removal-of-v1alpha5-apiversion)) |
-
-<!-- markdownlint-enable MD013 -->
 
 - For the current stable API version (v1beta1) we support the two most recent
   minor releases; older minor releases are immediately unsupported when a new
@@ -166,8 +162,6 @@ is defined above.
   emergency patch release. For example, if v1.7 and v1.6 are currently
   supported, we will also maintain test coverage for v1.5 for one additional
   release cycle. When v1.7 is released, tests for v1.4 will be removed.
-
-<!-- markdownlint-disable MD013 -->
 
 | Minor Release | API Version  | Supported Until                              |
 | ------------- | ------------ | -------------------------------------------- |
@@ -183,8 +177,6 @@ is defined above.
 | v1.1.x        | **v1beta1**  | EOL since 2023-05-17                         |
 | v0.5.x        | **v1alpha4** | EOL since 2022-09-30 - API version EOL       |
 | v0.4.x        | **v1alpha3** | EOL since 2022-02-23 - API version EOL       |
-
-<!-- markdownlint-enable MD013 -->
 
 (\*) Previous support policy applies, older minor releases were immediately
 unsupported when a new major/minor release was available

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -284,8 +284,6 @@ spec:
 
 BareMetalHost, after reconciliation
 
-<!-- markdownlint-disable MD013 -->
-
 ```yaml
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
@@ -331,8 +329,6 @@ status:
       namespace: metal3
     credentialsVersion: "1435"
 ```
-
-<!-- markdownlint-enable MD013 -->
 
 ### KubeadmConfig
 

--- a/docs/e2e-test.md
+++ b/docs/e2e-test.md
@@ -140,15 +140,11 @@ in the bootstrap cluster either before pivoting or after re-pivoting.
 - Upgrade Ironic
 - Upgrade CAPI/CAPM3
 
-<!-- markdownlint-disable MD013 -->
-
 | tests          | CAPM3 from             | CAPM3 to  | CAPI from             | CAPI to         |
 | ---------------| ---------------------- | --------- | --------------------- |---------------- |
 | v1.10=>current | v1.10 latest patch     | main      | v1.10 latest patch    | latest release  |
 | v1.9=>current  | v1.9 latest patch      | main      | v1.9 latest patch     | latest release  |
 | v1.8=>current  | v1.8 latest patch      | main      | v1.8 latest patch     | latest release  |
-
-<!-- markdownlint-disable MD013 -->
 
 ### K8s upgrade tests
 
@@ -189,7 +185,8 @@ for more information on which tests are required for each Kubernetes release.
 
 ### CAPI MachineDeployment tests
 
-Includes the following MachineDeployment tests adopted from the Cluster API's e2e tests:
+Includes the following MachineDeployment tests adopted from the Cluster API's
+e2e tests:
 
 - [MachineDeployment rolling upgrades](https://github.com/kubernetes-sigs/cluster-api/blob/main/test/e2e/md_rollout.go)
 - [MachineDeployment scale](https://github.com/kubernetes-sigs/cluster-api/blob/main/test/e2e/md_scale.go)
@@ -227,13 +224,9 @@ to the latest.
 Current e2e tests use the following Kubernetes versions for source and target
 clusters:
 
-<!-- markdownlint-disable MD013 -->
-
 | tests               | bootstrap cluster | metal3 cluster init | metal3 cluster final |
 | ------------------- | ----------------- | -------------------- | -------------------- |
 | integration         | v1.34.0           | v1.34.0              | x                    |
 | remediation         | v1.34.0           | v1.34.0              | x                    |
 | pivot based feature | v1.34.0           | v1.34.0              | v1.34.0              |
 | upgrade             | v1.34.0           | v1.34.0              | v1.34.0              |
-
-<!-- markdownlint-enable MD013 -->

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,8 +96,6 @@ critical to maintain the indentation. The allowed keys are :
 
 Here is an example for Ubuntu:
 
-<!-- markdownlint-disable MD013 -->
-
 ```bash
 CTLPLANE_KUBEADM_EXTRA_CONFIG="
     preKubeadmCommands:
@@ -171,8 +169,6 @@ CTLPLANE_KUBEADM_EXTRA_CONFIG="
 "
 ```
 
-<!-- markdownlint-enable MD013 -->
-
 #### WORKERS_KUBEADM_EXTRA_CONFIG
 
 This contains the extra configuration to pass in KubeadmConfig for workers. It
@@ -186,8 +182,6 @@ is critical to maintain the indentation. The allowed keys are :
 - format
 
 Here is an example for Ubuntu:
-
-<!-- markdownlint-disable MD013 -->
 
 ```bash
 WORKERS_KUBEADM_EXTRA_CONFIG="
@@ -221,8 +215,6 @@ WORKERS_KUBEADM_EXTRA_CONFIG="
                 version: 2
 "
 ```
-
-<!-- markdownlint-enable MD013 -->
 
 ## Pivoting or updating Ironic
 


### PR DESCRIPTION
Allow lines longer than 80 chars, if they're in tables or code fences. In those, long lines cannot often be avoided, and ignoring them one by one is painful and not pretty.

The same change is applied to all repos with markdownlint, but only on main. Documentation is 99% of the time maintained only in main, so it doesn't matter in release branches.
