### PR TITLE
✨ Add `name` field to network links and make MAC address optional

### DIFF
--- a/api/v1beta1/metal3datatemplate_types.go
+++ b/api/v1beta1/metal3datatemplate_types.go
@@ -240,6 +240,14 @@ type NetworkDataLinkEthernet struct {
 	// Id is the ID of the interface (used for naming)
 	Id string `json:"id"` //nolint:stylecheck,revive
 
+	// Name is the interface name to be used by cloud-init. When combined with
+	// MACAddress, cloud-init will rename the interface matching the MAC to this name.
+	// When MACAddress is omitted, cloud-init will use this name directly.
+	// +kubebuilder:validation:MaxLength=15
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z][a-zA-Z0-9._-]*$`
+	// +optional
+	Name string `json:"name,omitempty"`
+
 	// +kubebuilder:default=1500
 	// +kubebuilder:validation:Maximum=9000
 	// MTU is the MTU of the interface
@@ -265,6 +273,14 @@ type NetworkDataLinkBond struct {
 
 	// Id is the ID of the interface (used for naming)
 	Id string `json:"id"` //nolint:stylecheck,revive
+
+	// Name is the interface name to be used by cloud-init. When combined with
+	// MACAddress, cloud-init will rename the interface matching the MAC to this name.
+	// When MACAddress is omitted, cloud-init will use this name directly.
+	// +kubebuilder:validation:MaxLength=15
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z][a-zA-Z0-9._-]*$`
+	// +optional
+	Name string `json:"name,omitempty"`
 
 	// +kubebuilder:default=1500
 	// +kubebuilder:validation:Maximum=9000
@@ -295,6 +311,14 @@ type NetworkDataLinkVlan struct {
 
 	// Id is the ID of the interface (used for naming)
 	Id string `json:"id"` //nolint:stylecheck,revive
+
+	// Name is the interface name to be used by cloud-init. When combined with
+	// MACAddress, cloud-init will rename the interface matching the MAC to this name.
+	// When MACAddress is omitted, cloud-init will use this name directly.
+	// +kubebuilder:validation:MaxLength=15
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z][a-zA-Z0-9._-]*$`
+	// +optional
+	Name string `json:"name,omitempty"`
 
 	// +kubebuilder:default=1500
 	// +kubebuilder:validation:Maximum=9000

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3datatemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3datatemplates.yaml
@@ -429,6 +429,14 @@ spec:
                               description: MTU is the MTU of the interface
                               maximum: 9000
                               type: integer
+                            name:
+                              description: |-
+                                Name is the interface name to be used by cloud-init. When combined with
+                                MACAddress, cloud-init will rename the interface matching the MAC to this name.
+                                When MACAddress is omitted, cloud-init will use this name directly.
+                              maxLength: 15
+                              pattern: ^[a-zA-Z][a-zA-Z0-9._-]*$
+                              type: string
                             parameters:
                               additionalProperties:
                                 x-kubernetes-preserve-unknown-fields: true
@@ -492,6 +500,14 @@ spec:
                               description: MTU is the MTU of the interface
                               maximum: 9000
                               type: integer
+                            name:
+                              description: |-
+                                Name is the interface name to be used by cloud-init. When combined with
+                                MACAddress, cloud-init will rename the interface matching the MAC to this name.
+                                When MACAddress is omitted, cloud-init will use this name directly.
+                              maxLength: 15
+                              pattern: ^[a-zA-Z][a-zA-Z0-9._-]*$
+                              type: string
                             type:
                               description: |-
                                 Type is the type of the ethernet link. It can be one of:
@@ -564,6 +580,14 @@ spec:
                               description: MTU is the MTU of the interface
                               maximum: 9000
                               type: integer
+                            name:
+                              description: |-
+                                Name is the interface name to be used by cloud-init. When combined with
+                                MACAddress, cloud-init will rename the interface matching the MAC to this name.
+                                When MACAddress is omitted, cloud-init will use this name directly.
+                              maxLength: 15
+                              pattern: ^[a-zA-Z][a-zA-Z0-9._-]*$
+                              type: string
                             vlanID:
                               description: VlanID is the Vlan ID
                               maximum: 4096


### PR DESCRIPTION
This change enables interface renaming, add 'name' field to network link output, set from the 'name' field. Cloud-init uses the 'name' field to rename interfaces when combined with MAC address matching.

```
   networkData:
     links:
       ethernets:
         - id: eth0
           name: enp1s0  # cloud-init will rename interface to enp1s0
           macAddress:
             fromHostInterface: eth0  # find by MAC, rename to enp1s0
```

(ref: cloudinit/sources/helpers/openstack.py)