### PR TITLE
:sparkles: enable container signing

### DIFF
--- a/.github/workflows/build-fkas-images-action.yml
+++ b/.github/workflows/build-fkas-images-action.yml
@@ -19,6 +19,7 @@ jobs:
       image-name: "metal3-fkas"
       pushImage: true
       dockerfile-directory: hack/fake-apiserver
+      sign-image: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -23,6 +23,7 @@ jobs:
       image-name: 'cluster-api-provider-metal3'
       pushImage: true
       generate-sbom: true
+      sign-image: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -134,6 +134,7 @@ jobs:
       pushImage: true
       ref: ${{ needs.push_release_tags.outputs.release_tag }}
       generate-sbom: true
+      sign-image: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
This commit enables container signing for all images build from this repository via build-images-action.yml and release.yml, both reusing container-image-build.yml from project-infra.

All container images will be built with keyless signing, utilizing short-lived Github Actions OIDC tokens (id-token: write) and the certificates and transparency logs are utilizing Sigstore's public Fulcio and Rekor services.

Manual cherry-pick of #2988 