### PR TITLE
🐛 remove limits from client.List calls

### DIFF
--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -1645,7 +1645,7 @@ func fetchM3IPClaim(ctx context.Context, cl client.Client, mLog logr.Logger,
 func (m *DataManager) fetchIPClaimsWithLabels(ctx context.Context, pool string) ([]ipamv1.IPClaim, error) {
 	allIPClaims := ipamv1.IPClaimList{}
 	opts := []client.ListOption{
-		&client.ListOptions{Namespace: m.Data.Namespace, Limit: DefaultListLimit},
+		&client.ListOptions{Namespace: m.Data.Namespace},
 		client.MatchingLabels{
 			DataLabelName: m.Data.Name,
 			PoolLabelName: pool,

--- a/baremetal/metal3datatemplate_manager.go
+++ b/baremetal/metal3datatemplate_manager.go
@@ -164,7 +164,6 @@ func (m *DataTemplateManager) UpdateDatas(ctx context.Context) (bool, bool, erro
 	// without this ListOption, all namespaces would be including in the listing
 	opts := &client.ListOptions{
 		Namespace: m.DataTemplate.Namespace,
-		Limit:     DefaultListLimit,
 	}
 
 	err = m.client.List(ctx, &dataClaimObjects, opts)

--- a/baremetal/metal3machinetemplate_manager.go
+++ b/baremetal/metal3machinetemplate_manager.go
@@ -68,7 +68,6 @@ func (m *MachineTemplateManager) UpdateAutomatedCleaningMode(ctx context.Context
 	// without this ListOption, all namespaces would be included in the listing
 	opts := &client.ListOptions{
 		Namespace: m.Metal3MachineTemplate.Namespace,
-		Limit:     DefaultListLimit,
 	}
 
 	if err := m.client.List(ctx, m3ms, opts); err != nil {

--- a/baremetal/utils.go
+++ b/baremetal/utils.go
@@ -46,7 +46,6 @@ const (
 	metal3MachineKind   = "Metal3Machine"
 	VerbosityLevelDebug = 4
 	VerbosityLevelTrace = 5
-	DefaultListLimit    = 200
 )
 
 var (


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

**What this PR does / why we need it**:
Essentially reverts https://github.com/metal3-io/cluster-api-provider-metal3/pull/2646, but excluding Metal3Machine since I've fixed it there in an earlier PR.

While the `Limit` option [works](https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/cache/internal/cache_reader.go#L150) by limiting (as the name suggests) the amount of items that are returned, it cannot be used to implement pagination since controller-runtimes cache [does not support](https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/cache/internal/cache_reader.go#L119) the `Continue` option, which would need to be set to receive the next batch.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Related to https://github.com/metal3-io/cluster-api-provider-metal3/issues/2924

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
