### PR TITLE
🌱 E2E: Fix centos image prefix

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -204,7 +204,7 @@ func EnsureImage(k8sVersion string) (imageURL string, imageChecksum string) {
 	imageNamePrefix := ""
 	switch osType {
 	case osTypeCentos:
-		imageNamePrefix = "CENTOS_9_NODE_IMAGE_K8S"
+		imageNamePrefix = "CENTOS_10_NODE_IMAGE_K8S"
 	case osTypeUbuntu:
 		imageNamePrefix = "UBUNTU_24.04_NODE_IMAGE_K8S"
 	case osTypeLeap:


### PR DESCRIPTION
**What this PR does / why we need it**:

We are using centos 10 images now but this e2e function still had centos 9.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
