### PR TITLE
🌱 Add k8s in-place upgrade test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ IMAGE_NAME ?= cluster-api-provider-metal3
 CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
 BMO_IMAGE_NAME ?= baremetal-operator
 BMO_CONTROLLER_IMG ?= $(REGISTRY)/$(BMO_IMAGE_NAME)
+TEST_EXTENSION_IMG ?= $(REGISTRY)/test-extension:$(TAG)
 TAG ?= v1beta1
 BMO_TAG ?= capm3-$(TAG)
 ARCH ?= $(shell go env GOARCH)
@@ -567,6 +568,13 @@ generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
 		output:webhook:dir=$(WEBHOOK_ROOT) \
 		webhook
 
+.PHONY: generate-manifests-test-extension
+generate-manifests-test-extension: $(CONTROLLER_GEN) ## Generate manifests e.g. RBAC for test-extension provider
+	$(CONTROLLER_GEN) \
+		paths=./test/extension/... \
+		output:rbac:dir=./test/extension/config/rbac \
+		rbac:roleName=manager-role
+
 .PHONY: generate-examples
 generate-examples: $(KUSTOMIZE) clean-examples ## Generate examples configurations to run a cluster.
 	./examples/generate.sh
@@ -609,6 +617,14 @@ docker-build-fkas:
 	$(CONTAINER_RUNTIME) build --build-arg ARCH=$(ARCH) -t "quay.io/metal3-io/metal3-fkas:latest" . || true
 	rm -rf /tmp/fake-apiserver
 
+.PHONY: docker-build-test-extension
+docker-build-test-extension: ## Build the docker image for test extension
+	$(CONTAINER_RUNTIME) build --network=host --pull \
+	--build-arg TARGETOS=linux \
+	--build-arg TARGETARCH=$(ARCH) \
+	-f test/extension/Dockerfile \
+	-t $(TEST_EXTENSION_IMG) .
+
 ## --------------------------------------
 ## Docker — All ARCH
 ## --------------------------------------
@@ -623,6 +639,11 @@ docker-build-%:
 set-manifest-image:
 	$(info Updating kustomize image patch file for manager resource)
 	sed -i'' -e 's@image: .*@image: \"'"${MANIFEST_IMG}:$(MANIFEST_TAG)"'\"@' ./config/default/capm3/manager_image_patch.yaml
+
+.PHONY: set-manifest-image-test-extension
+set-manifest-image-test-extension:
+	$(info Updating kustomize image patch file for test extension)
+	sed -i'' -e 's@image: .*@image: \"'"${TEST_EXTENSION_IMG}"'\"@' ./test/extension/config/default/manager_image_patch.yaml
 
 .PHONY: set-manifest-pull-policy
 set-manifest-pull-policy:
@@ -693,6 +714,7 @@ endif
 PREVIOUS_TAG ?= $(shell git tag -l | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" | sort -V | grep -B1 $(RELEASE_TAG) | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$$" | head -n 1 2>/dev/null)
 RELEASE_DIR := out
 RELEASE_NOTES_DIR := releasenotes
+TEST_EXTENSION_MANIFESTS_DIR := out/runtime-extension-test-extension
 
 $(RELEASE_DIR):
 	mkdir -p $(RELEASE_DIR)/
@@ -706,6 +728,12 @@ release-manifests: $(KUSTOMIZE) $(RELEASE_DIR) ## Builds the manifests to publis
 	cp metadata.yaml $(RELEASE_DIR)/metadata.yaml
 	cp examples/clusterctl-templates/clusterctl-cluster.yaml $(RELEASE_DIR)/cluster-template.yaml
 	cp examples/clusterctl-templates/example_variables.rc $(RELEASE_DIR)/example_variables.rc
+
+.PHONY: test-extension-manifests
+test-extension-manifests: $(KUSTOMIZE) $(RELEASE_DIR) ## Builds the runtime extension manifests for development
+	mkdir -p $(TEST_EXTENSION_MANIFESTS_DIR)
+	$(KUSTOMIZE) build test/extension/config/default > $(TEST_EXTENSION_MANIFESTS_DIR)/components.yaml
+	cp metadata.yaml $(TEST_EXTENSION_MANIFESTS_DIR)/metadata.yaml
 
 .PHONY: release-notes
 release-notes: $(RELEASE_NOTES_DIR) $(RELEASE_NOTES)

--- a/docs/e2e-test.md
+++ b/docs/e2e-test.md
@@ -61,6 +61,7 @@ Below are the tests that you can use with `GINKGO_FOCUS` and `GINKGO_SKIP`
 - integration
 - basic
 - capi-md-tests
+- in-place-upgrade
 
 You can combine both `GINKGO_FOCUS` and `GINKGO_SKIP` to run multiple tests
 according to your requirements. For example following will run ip-reuse and
@@ -118,7 +119,7 @@ In short it is to make the test bit more efficient.
 
 ## Included tests
 
-The e2e tests currently include six different sets:
+The e2e tests currently include seven different sets:
 
 1. Pivoting based feature tests
 1. Remediation based feature tests
@@ -126,6 +127,7 @@ The e2e tests currently include six different sets:
 1. K8s upgrade tests
 1. K8s conformance tests
 1. CAPI MachineDeployment tests
+1. In place upgrade test
 
 ### Pivoting based feature tests
 
@@ -248,6 +250,35 @@ e2e tests:
 
 - [MachineDeployment rolling upgrades](https://github.com/kubernetes-sigs/cluster-api/blob/main/test/e2e/kcp_md_rollout.go)
 - [MachineDeployment scale](https://github.com/kubernetes-sigs/cluster-api/blob/main/test/e2e/md_scale.go)
+
+### In place upgrade test
+
+The in-place upgrade test upgrades Kubernetes on existing cluster nodes
+(control plane) without reprovisioning or restarting machines. This approach
+upgrades the Kubernetes components directly on running nodes via SSH, avoiding
+the time and resource overhead of machine replacement.
+
+The test leverages CAPI's Runtime SDK and the experimental
+`EXP_IN_PLACE_UPDATES` feature gate to intercept machine update operations.
+A runtime extension server implements the necessary hooks
+(`DoCanUpdateMachine`, `DoCanUpdateMachineSet`, `DoUpdateMachine`) to perform
+the actual upgrade via SSH.
+See [test/extension/handlers/inplaceupdate/handlers.go](../test/extension/handlers/inplaceupdate/handlers.go)
+for the detailed implementation.
+
+**Test flow:**
+
+1. Test starts 5 bmh, 3 CP nodes and 0 worker node
+1. Get uids of machines before upgrade
+1. Upgrades Kubernetes
+1. Waits for control plane nodes to upgrade
+1. Check uids of upgraded CP machines with before upgrade uids to check
+   in-place upgrade
+1. Scales CP machines from 3→5 to validate new node uses the new image.
+1. Verifies all machines are running with the new version
+
+**Note:** Currently, the SSH-based upgrade implementation is only available
+for CentOS. The test runs exclusively with the CentOS flavor.
 
 ## Guidelines to follow when adding new E2E tests
 

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -91,8 +91,16 @@ case "${GINKGO_FOCUS:-}" in
     echo 'export SKIP_APPLY_BMH="true"' >>"${M3_DEV_ENV_PATH}/config_${USER}.sh"
     echo 'export USE_IRSO="false"' >>"${M3_DEV_ENV_PATH}/config_${USER}.sh"
     sed -i "s/^export NUM_NODES=.*/export NUM_NODES=30/" "${M3_DEV_ENV_PATH}/config_${USER}.sh"
-    echo 'CLUSTER_TOPOLOGY: true' >"${CAPI_CONFIG_FOLDER}/clusterctl.yaml"
+    echo 'CLUSTER_TOPOLOGY: true' >>"${CAPI_CONFIG_FOLDER}/clusterctl.yaml"
     echo 'export BOOTSTRAP_CLUSTER="minikube"' >>"${M3_DEV_ENV_PATH}/config_${USER}.sh"
+  ;;
+
+  in-place-upgrade)
+    # Enable Cluster Topology and in-place updates features
+    echo 'CLUSTER_TOPOLOGY: true' >>"${CAPI_CONFIG_FOLDER}/clusterctl.yaml"
+    echo 'EXP_RUNTIME_SDK: true' >>"${CAPI_CONFIG_FOLDER}/clusterctl.yaml"
+    echo 'EXP_IN_PLACE_UPDATES: true' >>"${CAPI_CONFIG_FOLDER}/clusterctl.yaml"
+    echo 'export SKIP_APPLY_BMH="true"' >>"${M3_DEV_ENV_PATH}/config_${USER}.sh"
   ;;
 esac
 
@@ -119,6 +127,16 @@ source "${REPO_ROOT}/hack/ensure-go.sh"
 source "${REPO_ROOT}/hack/ensure-kind.sh"
 # shellcheck source=./hack/ensure-kubectl.sh
 source "${REPO_ROOT}/hack/ensure-kubectl.sh"
+
+# If running in-place-upgrade tests, ensure extension namespace and ssh key secret exist
+if [[ "${GINKGO_FOCUS:-}" == "in-place-upgrade" ]]; then
+  EXT_NS="test-extension-system"
+  kubectl get ns "${EXT_NS}" >/dev/null 2>&1 || kubectl create ns "${EXT_NS}"
+  # Recreate the secret to ensure freshest key is used
+  kubectl -n "${EXT_NS}" delete secret ssh-key >/dev/null 2>&1 || true
+  kubectl -n "${EXT_NS}" create secret generic ssh-key \
+    --from-file=id_rsa="${HOME}/.ssh/id_rsa"
+fi
 # Ensure kustomize
 make kustomize
 

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -132,6 +132,12 @@ case "${GINKGO_FOCUS:-}" in
     export WORKER_MACHINE_COUNT=${WORKER_MACHINE_COUNT:-"5"}
   ;;
 
+  in-place-upgrade)
+    export NUM_NODES="5"
+    export CONTROL_PLANE_MACHINE_COUNT=3
+    export WORKER_MACHINE_COUNT=0
+  ;;
+
   *)
     # unknown GINKGO_FOCUS, let's print out the crucial env and continue
     echo "WARNING: unrecognized GINKGO_FOCUS='${GINKGO_FOCUS:-}'"

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -477,6 +477,7 @@ func CreateNewM3MachineTemplate(ctx context.Context, namespace string, newM3Mach
 	newM3MachineTemplate.Spec.Template.Spec.Image.DiskFormat = &imageFormat
 	newM3MachineTemplate.Spec.Template.Spec.Image.ChecksumType = &checksumType
 	newM3MachineTemplate.ObjectMeta.Name = newM3MachineTemplateName
+	newM3MachineTemplate.Spec.Template.Spec.DataTemplate.Namespace = newM3MachineTemplate.ObjectMeta.Namespace
 
 	Expect(clusterClient.Create(ctx, newM3MachineTemplate)).To(Succeed(), "Failed to create new Metal3MachineTemplate")
 }

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -246,6 +246,7 @@ variables:
   DOCKER_HUB_PROXY: "${DOCKER_HUB_PROXY:-docker.io}"
   IRONIC_IMAGE_TAG: "${IRONIC_IMAGE_TAG:-main}"
   UPGRADED_BMO_IMAGE_TAG: "${UPGRADED_BMO_IMAGE_TAG:-main}"
+  IN_PLACE_UPGRADE_EXTENSION_CONFIG_PATH: "../extension/handlers/inplaceupdate/extensionconfig.yaml"
 
   PROVIDER_ID_FORMAT: "metal3://{{ ds.meta_data.providerid }}"
   CNI_PROVIDER: "${CNI_PROVIDER:-calico}"

--- a/test/e2e/k8s_in_place_upgrade.go
+++ b/test/e2e/k8s_in_place_upgrade.go
@@ -1,0 +1,149 @@
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type InPlaceUpgradeInput struct {
+	E2EConfig             *clusterctl.E2EConfig
+	BootstrapClusterProxy framework.ClusterProxy
+	TargetCluster         framework.ClusterProxy
+	SpecName              string
+	ClusterName           string
+	Namespace             string
+}
+
+func InPlaceUpgrade(ctx context.Context, inputGetter func() InPlaceUpgradeInput) {
+	Logf("Starting in-place Kubernetes upgrade tests")
+	input := inputGetter()
+	managementClusterClient := input.BootstrapClusterProxy.GetClient()
+	targetClusterClient := input.TargetCluster.GetClient()
+	upgradedK8sVersion := input.E2EConfig.MustGetVariable("KUBERNETES_VERSION")
+	fromK8sVersion := input.E2EConfig.MustGetVariable("KUBERNETES_VERSION_UPGRADE_FROM")
+	numberOfControlplane := int(*input.E2EConfig.MustGetInt32PtrVariable("CONTROL_PLANE_MACHINE_COUNT"))
+
+	Logf("FROM K8S VERSION: %v", fromK8sVersion)
+	Logf("UPGRADED K8S VERSION: %v", upgradedK8sVersion)
+	Logf("NUMBER OF CONTROLPLANE: %v", numberOfControlplane)
+
+	ListBareMetalHosts(ctx, managementClusterClient, client.InNamespace(input.Namespace))
+	ListMetal3Machines(ctx, managementClusterClient, client.InNamespace(input.Namespace))
+	ListMachines(ctx, managementClusterClient, client.InNamespace(input.Namespace))
+	ListNodes(ctx, targetClusterClient)
+
+	// Get the initial machine UIDs before upgrade to verify in-place upgrade (no rollout)
+	By("Capture machine UIDs before upgrade to verify no rollout occurs")
+	machineList := &clusterv1.MachineList{}
+	Expect(managementClusterClient.List(ctx, machineList, client.InNamespace(input.Namespace))).To(Succeed())
+	initialMachineUIDs := make(map[string]string) // map[machineName]UID
+	for _, machine := range machineList.Items {
+		initialMachineUIDs[machine.Name] = string(machine.UID)
+		Logf("Tracking machine %s with UID %s", machine.Name, machine.UID)
+	}
+	Logf("Captured %d machine UIDs before upgrade", len(initialMachineUIDs))
+
+	// Download and ensure node image is available locally
+	By("Download and ensure image is available locally")
+	imageURL, imageChecksum := EnsureImage(upgradedK8sVersion)
+
+	Logf("Image URL: %s", imageURL)
+	Logf("Image Checksum: %s", imageChecksum)
+
+	// Get the cluster object
+	By("Get the Cluster object")
+	cluster := &clusterv1.Cluster{}
+	Expect(managementClusterClient.Get(ctx, client.ObjectKey{
+		Namespace: input.Namespace,
+		Name:      input.ClusterName,
+	}, cluster)).To(Succeed())
+
+	By("Create new KCP Metal3MachineTemplate with upgraded image to boot")
+	m3MachineTemplateName := input.ClusterName + "-controlplane"
+	newM3MachineTemplateName := input.ClusterName + "-new-controlplane"
+	CreateNewM3MachineTemplate(ctx, input.Namespace, newM3MachineTemplateName, m3MachineTemplateName, managementClusterClient, imageURL, imageChecksum)
+
+	Byf("Update KCP to upgrade k8s version and binaries from %s to %s", fromK8sVersion, upgradedK8sVersion)
+	kcpObj := framework.GetKubeadmControlPlaneByCluster(ctx, framework.GetKubeadmControlPlaneByClusterInput{
+		Lister:      managementClusterClient,
+		ClusterName: input.ClusterName,
+		Namespace:   input.Namespace,
+	})
+	helper, err := patch.NewHelper(kcpObj, managementClusterClient)
+	Expect(err).NotTo(HaveOccurred())
+	kcpObj.Spec.MachineTemplate.Spec.InfrastructureRef.Name = newM3MachineTemplateName
+	kcpObj.Spec.Version = upgradedK8sVersion
+	kcpObj.Spec.Rollout.Strategy.RollingUpdate.MaxSurge.IntVal = 0
+	Expect(helper.Patch(ctx, kcpObj)).To(Succeed())
+
+	// Wait for CP nodes to be upgraded
+	Byf("Wait for %d CP node(s) to be upgraded and running", numberOfControlplane)
+	runningAndUpgraded := func(machine clusterv1.Machine) bool {
+		running := machine.Status.GetTypedPhase() == clusterv1.MachinePhaseRunning
+		upgraded := machine.Spec.Version == upgradedK8sVersion
+		_, isControlPlane := machine.GetLabels()[clusterv1.MachineControlPlaneLabel]
+		return running && upgraded && isControlPlane
+	}
+	WaitForNumMachines(ctx, runningAndUpgraded, WaitForNumInput{
+		Client:    managementClusterClient,
+		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
+		Replicas:  numberOfControlplane,
+		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-machine-running"),
+	})
+
+	Logf("CP nodes upgraded successfully to %s", upgradedK8sVersion)
+
+	// Verify CP machines were not replaced (in-place upgrade)
+	By("Verify CP machines were not replaced (no rollout)")
+	cpMachineList := &clusterv1.MachineList{}
+	Expect(managementClusterClient.List(ctx, cpMachineList,
+		client.InNamespace(input.Namespace),
+		client.MatchingLabels{clusterv1.MachineControlPlaneLabel: ""})).To(Succeed())
+	for _, machine := range cpMachineList.Items {
+		initialUID, exists := initialMachineUIDs[machine.Name]
+		Expect(exists).To(BeTrue(), "CP machine %s should exist in initial machine list", machine.Name)
+		Expect(string(machine.UID)).To(Equal(initialUID),
+			"CP machine %s UID should not change (expected: %s, got: %s) - in-place upgrade should not replace machines",
+			machine.Name, initialUID, machine.UID)
+		Logf("✓ CP machine %s has same UID - confirmed in-place upgrade", machine.Name)
+	}
+
+	// Scale up control plane nodes to 5
+	By("Scale up control plane nodes to 5")
+
+	kcpObj = framework.GetKubeadmControlPlaneByCluster(ctx, framework.GetKubeadmControlPlaneByClusterInput{
+		Lister:      managementClusterClient,
+		ClusterName: input.ClusterName,
+		Namespace:   input.Namespace,
+	})
+	helper, err = patch.NewHelper(kcpObj, managementClusterClient)
+	Expect(err).NotTo(HaveOccurred())
+	kcpObj.Spec.Replicas = ptr.To[int32](5)
+	Expect(helper.Patch(ctx, kcpObj)).To(Succeed())
+
+	Logf("Control plane nodes scaled to 5 replicas")
+	// Wait for all 5 CP nodes to be running with new version
+	By("Wait for all 5 CP nodes to be running with new K8s version")
+	WaitForNumMachines(ctx, runningAndUpgraded, WaitForNumInput{
+		Client:    managementClusterClient,
+		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
+		Replicas:  5,
+		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-machine-running"),
+	})
+	Logf("All 5 control plane nodes running successfully with %s", upgradedK8sVersion)
+
+	ListBareMetalHosts(ctx, managementClusterClient, client.InNamespace(input.Namespace))
+	ListMetal3Machines(ctx, managementClusterClient, client.InNamespace(input.Namespace))
+	ListMachines(ctx, managementClusterClient, client.InNamespace(input.Namespace))
+	ListNodes(ctx, targetClusterClient)
+
+	By("IN-PLACE K8S UPGRADE TESTS PASSED!")
+}

--- a/test/e2e/k8s_in_place_upgrade_test.go
+++ b/test/e2e/k8s_in_place_upgrade_test.go
@@ -1,0 +1,71 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("When testing in-place k8s upgrade", Label("in-place-upgrade", "features"), func() {
+
+	BeforeEach(func() {
+		osType = strings.ToLower(os.Getenv("OS"))
+		Expect(osType).ToNot(Equal(""))
+		validateGlobals(specName)
+
+		// We need to override clusterctl apply log folder to avoid getting our credentials exposed.
+		clusterctlLogFolder = filepath.Join(os.TempDir(), "target_cluster_logs", bootstrapClusterProxy.GetName())
+
+		// Apply ExtensionConfig for in-place upgrade test
+		By("Applying ExtensionConfig for test-extension")
+		extensionConfigPath := e2eConfig.MustGetVariable("IN_PLACE_UPGRADE_EXTENSION_CONFIG_PATH")
+		if extensionConfigPath == "" {
+			extensionConfigPath = filepath.Join("test", "extension", "handlers", "inplaceupdate", "extensionconfig.yaml")
+		}
+		extensionConfig, err := os.ReadFile(extensionConfigPath)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(CreateOrUpdateWithNamespace(ctx, bootstrapClusterProxy, extensionConfig, "")).ShouldNot(HaveOccurred())
+	})
+	It("Should create a workload cluster then upgrade k8s in-place", func() {
+		By("Apply BMH for workload cluster")
+		ApplyBmh(ctx, e2eConfig, bootstrapClusterProxy, namespace, specName)
+		By("Provision Workload cluster")
+		targetCluster, _ = CreateTargetCluster(ctx, func() CreateTargetClusterInput {
+			return CreateTargetClusterInput{
+				E2EConfig:             e2eConfig,
+				BootstrapClusterProxy: bootstrapClusterProxy,
+				SpecName:              specName,
+				ClusterName:           clusterName,
+				K8sVersion:            e2eConfig.MustGetVariable("KUBERNETES_VERSION_UPGRADE_FROM"),
+				KCPMachineCount:       int64(numberOfControlplane),
+				WorkerMachineCount:    int64(numberOfWorkers),
+				ClusterctlLogFolder:   clusterctlLogFolder,
+				ClusterctlConfigPath:  clusterctlConfigPath,
+				OSType:                osType,
+				Namespace:             namespace,
+			}
+		})
+		InPlaceUpgrade(ctx, func() InPlaceUpgradeInput {
+			return InPlaceUpgradeInput{
+				E2EConfig:             e2eConfig,
+				BootstrapClusterProxy: bootstrapClusterProxy,
+				TargetCluster:         targetCluster,
+				SpecName:              specName,
+				ClusterName:           clusterName,
+				Namespace:             namespace,
+			}
+		})
+	})
+
+	AfterEach(func() {
+		ListBareMetalHosts(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		ListMetal3Machines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		ListMachines(ctx, bootstrapClusterProxy.GetClient(), client.InNamespace(namespace))
+		ListNodes(ctx, targetCluster.GetClient())
+		DumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, targetCluster, artifactFolder, namespace, e2eConfig.GetIntervals, clusterName, clusterctlLogFolder, skipCleanup, clusterctlConfigPath)
+	})
+})

--- a/test/extension/Dockerfile
+++ b/test/extension/Dockerfile
@@ -1,0 +1,40 @@
+# Build the extension binary
+ARG BUILD_IMAGE=docker.io/golang:1.25.8@sha256:779b230b2508037a8095c9e2d223a6405f8426e12233b694dbae50197b9f6d04
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
+
+FROM $BUILD_IMAGE AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY api/ api/
+COPY test/go.mod test/go.mod
+COPY test/go.sum test/go.sum
+
+# Cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+RUN cd test && go mod download
+
+# Copy the go source
+COPY test/extension/ test/extension/
+
+# Build
+RUN cd test/extension && \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
+    go build -a -o /workspace/extension \
+    -ldflags '-extldflags "-static"' \
+    .
+
+
+FROM $BASE_IMAGE
+WORKDIR /
+COPY --from=builder /workspace/extension .
+USER 65532:65532
+
+ENTRYPOINT ["/extension"]

--- a/test/extension/config/certmanager/certificate.yaml
+++ b/test/extension/config/certmanager/certificate.yaml
@@ -1,0 +1,24 @@
+# The following manifests contain a self-signed issuer CR and a certificate CR.
+# More document can be found at https://docs.cert-manager.io
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: { }
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+spec:
+  # SERVICE_NAMESPACE will be substituted by kustomize
+  dnsNames:
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  # for local testing.
+  - localhost
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: test-extension-webhook-service-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/test/extension/config/certmanager/kustomization.yaml
+++ b/test/extension/config/certmanager/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- certificate.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/test/extension/config/certmanager/kustomizeconfig.yaml
+++ b/test/extension/config/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,8 @@
+# This configuration is for teaching kustomize how to update name ref and var substitution
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name

--- a/test/extension/config/default/kustomization.yaml
+++ b/test/extension/config/default/kustomization.yaml
@@ -1,0 +1,62 @@
+namespace: test-extension-system
+
+namePrefix: test-extension-
+
+labels:
+- includeSelectors: true
+  pairs:
+    # Label to identify all the providers objects; As per the clusterctl contract the value should be unique.
+    cluster.x-k8s.io/provider: runtime-extension-test-extension
+
+resources:
+- namespace.yaml
+- manager.yaml
+- service.yaml
+- ../certmanager
+- ../rbac
+
+patches:
+# Enable webhook with corresponding certificate mount.
+- path: manager_webhook_patch.yaml
+# Provide customizable hook for make targets.
+- path: manager_image_patch.yaml
+- path: manager_pull_policy.yaml
+# Mount SSH key for in-place upgrades
+- path: manager_ssh_patch.yaml
+
+
+replacements:
+- source: # Add cert-manager annotation to the webhook Service
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.name # namespace of the service
+  targets:
+  - select:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1
+    fieldPaths:
+    - .spec.dnsNames.0
+    - .spec.dnsNames.1
+    options:
+      delimiter: '.'
+      index: 0
+      create: true
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.namespace # namespace of the service
+  targets:
+  - select:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1
+    fieldPaths:
+    - .spec.dnsNames.0
+    - .spec.dnsNames.1
+    options:
+      delimiter: '.'
+      index: 1
+      create: true

--- a/test/extension/config/default/manager.yaml
+++ b/test/extension/config/default/manager.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+  labels:
+    app: test-extension-manager
+spec:
+  selector:
+    matchLabels:
+      app: test-extension-manager
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: test-extension-manager
+    spec:
+      containers:
+      - command:
+        - /extension
+        args:
+        - "--leader-elect"
+        - "--diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}"
+        - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
+        - "--feature-gates=PriorityQueue=${EXP_PRIORITY_QUEUE:=false}"
+        image: controller:latest
+        name: manager
+        ports:
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsUser: 65532
+          runAsGroup: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      terminationGracePeriodSeconds: 10
+      serviceAccountName: manager
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault

--- a/test/extension/config/default/manager_image_patch.yaml
+++ b/test/extension/config/default/manager_image_patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - image: quay.io/metal3-io/test-extension:latest
+        name: manager

--- a/test/extension/config/default/manager_pull_policy.yaml
+++ b/test/extension/config/default/manager_pull_policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        imagePullPolicy: Always

--- a/test/extension/config/default/manager_ssh_patch.yaml
+++ b/test/extension/config/default/manager_ssh_patch.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      securityContext:
+        fsGroup: 65532
+      containers:
+      - name: manager
+        volumeMounts:
+        - name: ssh-key
+          mountPath: /home/nonroot/.ssh
+          readOnly: true
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
+      volumes:
+      - name: ssh-key
+        secret:
+          secretName: ssh-key
+          defaultMode: 0400
+          items:
+          - key: id_rsa
+            path: id_rsa
+            mode: 0400

--- a/test/extension/config/default/manager_webhook_patch.yaml
+++ b/test/extension/config/default/manager_webhook_patch.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          secretName: test-extension-webhook-service-cert

--- a/test/extension/config/default/namespace.yaml
+++ b/test/extension/config/default/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-extension-system

--- a/test/extension/config/default/service.yaml
+++ b/test/extension/config/default/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    app: test-extension-manager

--- a/test/extension/config/rbac/kustomization.yaml
+++ b/test/extension/config/rbac/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- leader_election_role.yaml
+- leader_election_role_binding.yaml
+- role.yaml
+- role_binding.yaml
+- service_account.yaml

--- a/test/extension/config/rbac/leader_election_role.yaml
+++ b/test/extension/config/rbac/leader_election_role.yaml
@@ -1,0 +1,25 @@
+
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/test/extension/config/rbac/leader_election_role_binding.yaml
+++ b/test/extension/config/rbac/leader_election_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: manager
+  namespace: system

--- a/test/extension/config/rbac/role.yaml
+++ b/test/extension/config/rbac/role.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - metal3datas
+  - metal3machines
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - metal3datas/status
+  - metal3machines/status
+  verbs:
+  - get
+- apiGroups:
+  - ipam.metal3.io
+  resources:
+  - ipaddresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ipam.metal3.io
+  resources:
+  - ipaddresses/status
+  verbs:
+  - get

--- a/test/extension/config/rbac/role_binding.yaml
+++ b/test/extension/config/rbac/role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: manager
+  namespace: system

--- a/test/extension/config/rbac/service_account.yaml
+++ b/test/extension/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manager
+  namespace: system

--- a/test/extension/handlers/inplaceupdate/extensionconfig.yaml
+++ b/test/extension/handlers/inplaceupdate/extensionconfig.yaml
@@ -1,0 +1,20 @@
+apiVersion: runtime.cluster.x-k8s.io/v1beta2
+kind: ExtensionConfig
+metadata:
+  annotations:
+    runtime.cluster.x-k8s.io/inject-ca-from-secret: test-extension-system/test-extension-webhook-service-cert
+  name: test-extension
+spec:
+  settings:
+    extensionConfigName: test-extension
+  clientConfig:
+    service:
+      name: test-extension-webhook-service
+      namespace: test-extension-system # Note: this assumes the test extension get deployed in the same namespace defined in its own runtime-extensions-components.yaml
+      port: 443
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - metal3 # Note: this assumes the test extension is used by Cluster in the metal3 namespace only

--- a/test/extension/handlers/inplaceupdate/handlers.go
+++ b/test/extension/handlers/inplaceupdate/handlers.go
@@ -1,0 +1,523 @@
+// Package inplaceupdate contains the handlers for the in-place update hooks.
+//
+// The implementation of the handlers is specifically designed for Cluster API Metal3 E2E test use cases.
+// When implementing custom RuntimeExtension, it is only required to expose HandlerFunc with the
+// signature defined in sigs.k8s.io/cluster-api/api/runtime/hooks/v1alpha1.
+package inplaceupdate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/go-logr/logr"
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta2"
+	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
+	"github.com/pkg/errors"
+	"gomodules.xyz/jsonpatch/v2"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
+	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	runtimehooksv1 "sigs.k8s.io/cluster-api/api/runtime/hooks/v1alpha1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=metal3machines,verbs=get;list;watch
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=metal3machines/status,verbs=get
+// +kubebuilder:rbac:groups=ipam.metal3.io,resources=ipaddresses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=ipam.metal3.io,resources=ipaddresses/status,verbs=get
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=metal3datas,verbs=get;list;watch
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=metal3datas/status,verbs=get
+
+const (
+	trueString                      = "true"
+	extensionUpdatingMachineMessage = "Extension is updating Machine"
+)
+
+// ExtensionHandlers provides a common struct shared across the in-place update hook handlers.
+type ExtensionHandlers struct {
+	decoder runtime.Decoder
+	client  client.Client
+	state   sync.Map
+}
+
+// NewExtensionHandlers returns a new ExtensionHandlers for the in-place update hook handlers.
+func NewExtensionHandlers(client client.Client) *ExtensionHandlers {
+	scheme := runtime.NewScheme()
+	_ = infrav1.AddToScheme(scheme)
+	_ = bootstrapv1.AddToScheme(scheme)
+	_ = controlplanev1.AddToScheme(scheme)
+	return &ExtensionHandlers{
+		client: client,
+		decoder: serializer.NewCodecFactory(scheme).UniversalDecoder(
+			infrav1.GroupVersion,
+			bootstrapv1.GroupVersion,
+			controlplanev1.GroupVersion,
+		),
+	}
+}
+
+// * MachineSpec.Version.
+func canUpdateMachineSpec(current, desired *clusterv1.MachineSpec) {
+	if current.Version != desired.Version {
+		current.Version = desired.Version
+	}
+}
+
+// canUpdateKubeadmConfigSpec declares that this extension can update.
+func canUpdateKubeadmConfigSpec(_, _ *bootstrapv1.KubeadmConfigSpec) {
+	// Todo: add more fields as needed.
+}
+
+// * Metal3MachineSpec.DataTemplate.
+func canUpdateMetal3MachineSpec(log logr.Logger, current, desired *infrav1.Metal3MachineSpec) {
+	log.Info("canUpdateMetal3MachineSpec", "currentImage", current.Image, "desiredImage", desired.Image, "currentDataTemplate", current.DataTemplate, "desiredDataTemplate", desired.DataTemplate)
+	if current.Image != desired.Image {
+		log.Info("Updating Metal3MachineSpec image", "from", current.Image, "to", desired.Image)
+		current.Image = desired.Image
+	}
+	if current.DataTemplate != nil && desired.DataTemplate != nil {
+		// Normalize: desired may omit namespace (defaults to object's namespace), so
+		// treat an empty desired namespace as equal to the current one to avoid a
+		// spurious patch that strips the namespace field.
+		normalizedDesired := *desired.DataTemplate
+		if normalizedDesired.Namespace == "" {
+			normalizedDesired.Namespace = current.DataTemplate.Namespace
+		}
+		if *current.DataTemplate != normalizedDesired {
+			log.Info("Updating Metal3MachineSpec dataTemplate", "from", current.DataTemplate, "to", normalizedDesired)
+			current.DataTemplate = &normalizedDesired
+		}
+	} else if current.DataTemplate != desired.DataTemplate {
+		// One or both are nil — direct assignment is safe.
+		log.Info("Updating Metal3MachineSpec dataTemplate (nil case)", "from", current.DataTemplate, "to", desired.DataTemplate)
+		current.DataTemplate = desired.DataTemplate
+	}
+}
+
+// DoCanUpdateMachine implements the CanUpdateMachine hook.
+// This function create the patches to allow in-place updates on certain fields
+// in Machine. If in-place update of the field is not supported, the field is
+// left unchanged, and empty patches will be returned, causing Cluster API to
+// perform roll-out updates.
+// This is for KCP in-place updates.
+func (h *ExtensionHandlers) DoCanUpdateMachine(ctx context.Context, req *runtimehooksv1.CanUpdateMachineRequest, resp *runtimehooksv1.CanUpdateMachineResponse) {
+	log := ctrl.LoggerFrom(ctx).WithValues("Machine", klog.KObj(&req.Desired.Machine))
+	log.Info("CanUpdateMachine is called")
+
+	if req.Settings["disableInPlaceUpdates"] == trueString {
+		resp.Status = runtimehooksv1.ResponseStatusSuccess
+		return
+	}
+
+	currentMachine, desiredMachine,
+		currentBootstrapConfig, desiredBootstrapConfig,
+		currentInfraMachine, desiredInfraMachine, err := h.getObjectsFromCanUpdateMachineRequest(req)
+	if err != nil {
+		resp.Status = runtimehooksv1.ResponseStatusFailure
+		resp.Message = err.Error()
+		log.Info("Failed to get objects from CanUpdateMachine request", "error", err)
+		return
+	}
+
+	log.Info("Current Machine", "machine", currentMachine)
+	log.Info("Desired Machine", "machine", desiredMachine)
+
+	log.Info("Current currentBootstrapConfig", "currentBootstrapConfig", currentBootstrapConfig)
+	log.Info("Desired desiredBootstrapConfig", "desiredBootstrapConfig", desiredBootstrapConfig)
+
+	log.Info("Current currentInfraMachine", "currentInfraMachine", currentInfraMachine)
+	log.Info("Desired desiredInfraMachine", "desiredInfraMachine", desiredInfraMachine)
+
+	// Declare changes that this Runtime Extension can update in-place.
+
+	// Machine
+	canUpdateMachineSpec(&currentMachine.Spec, &desiredMachine.Spec)
+
+	// BootstrapConfig (we can only update KubeadmConfigs)
+	currentKubeadmConfig, isCurrentKubeadmConfig := currentBootstrapConfig.(*bootstrapv1.KubeadmConfig)
+	desiredKubeadmConfig, isDesiredKubeadmConfig := desiredBootstrapConfig.(*bootstrapv1.KubeadmConfig)
+	if isCurrentKubeadmConfig && isDesiredKubeadmConfig {
+		canUpdateKubeadmConfigSpec(&currentKubeadmConfig.Spec, &desiredKubeadmConfig.Spec)
+	}
+
+	// InfraMachine (we can only update Metal3Machines)
+	currentMetal3Machine, isCurrentMetal3Machine := currentInfraMachine.(*infrav1.Metal3Machine)
+	desiredMetal3Machine, isDesiredMetal3Machine := desiredInfraMachine.(*infrav1.Metal3Machine)
+	log.Info("Metal3Machine type assertion", "isCurrentMetal3Machine", isCurrentMetal3Machine, "isDesiredMetal3Machine", isDesiredMetal3Machine, "currentInfraMachineType", fmt.Sprintf("%T", currentInfraMachine), "desiredInfraMachineType", fmt.Sprintf("%T", desiredInfraMachine))
+	if isCurrentMetal3Machine && isDesiredMetal3Machine {
+		canUpdateMetal3MachineSpec(log, &currentMetal3Machine.Spec, &desiredMetal3Machine.Spec)
+	}
+
+	if err := h.computeCanUpdateMachineResponse(req, resp, currentMachine, currentBootstrapConfig, currentInfraMachine); err != nil {
+		log.Info("Failed to compute CanUpdateMachine response", "error", err)
+		resp.Status = runtimehooksv1.ResponseStatusFailure
+		resp.Message = err.Error()
+		return
+	}
+
+	log.Info("Successfully computed CanUpdateMachine response")
+
+	resp.Status = runtimehooksv1.ResponseStatusSuccess
+}
+
+// DoCanUpdateMachineSet implements the CanUpdateMachineSet hook.
+// This function create the patches to allow in-place updates on certain fields
+// in MachineSet. If in-place update of the field is not supported, the field is
+// left unchanged, and empty patches will be returned, causing Cluster API to
+// perform roll-out updates.
+// This is for worker machines in-place updates.
+func (h *ExtensionHandlers) DoCanUpdateMachineSet(ctx context.Context, req *runtimehooksv1.CanUpdateMachineSetRequest, resp *runtimehooksv1.CanUpdateMachineSetResponse) {
+	log := ctrl.LoggerFrom(ctx).WithValues("MachineSet", klog.KObj(&req.Desired.MachineSet))
+	log.Info("CanUpdateMachineSet is called")
+
+	if req.Settings["disableInPlaceUpdates"] == trueString {
+		resp.Status = runtimehooksv1.ResponseStatusSuccess
+		return
+	}
+
+	currentMachineSet, desiredMachineSet,
+		currentBootstrapConfigTemplate, desiredBootstrapConfigTemplate,
+		currentInfraMachineTemplate, desiredInfraMachineTemplate, err := h.getObjectsFromCanUpdateMachineSetRequest(req)
+	if err != nil {
+		resp.Status = runtimehooksv1.ResponseStatusFailure
+		resp.Message = err.Error()
+		return
+	}
+
+	log.Info("Current MachineSet", "machineSet", currentMachineSet)
+	log.Info("Desired MachineSet", "machineSet", desiredMachineSet)
+
+	// Declare changes that this Runtime Extension can update in-place.
+
+	// Machine
+	canUpdateMachineSpec(&currentMachineSet.Spec.Template.Spec, &desiredMachineSet.Spec.Template.Spec)
+
+	// BootstrapConfig (we can only update KubeadmConfigs)
+	currentKubeadmConfigTemplate, isCurrentKubeadmConfigTemplate := currentBootstrapConfigTemplate.(*bootstrapv1.KubeadmConfigTemplate)
+	desiredKubeadmConfigTemplate, isDesiredKubeadmConfigTemplate := desiredBootstrapConfigTemplate.(*bootstrapv1.KubeadmConfigTemplate)
+	if isCurrentKubeadmConfigTemplate && isDesiredKubeadmConfigTemplate {
+		canUpdateKubeadmConfigSpec(&currentKubeadmConfigTemplate.Spec.Template.Spec, &desiredKubeadmConfigTemplate.Spec.Template.Spec)
+	}
+
+	// InfraMachine (we can only update Metal3Machines)
+	currentMetal3MachineTemplate, isCurrentMetal3MachineTemplate := currentInfraMachineTemplate.(*infrav1.Metal3MachineTemplate)
+	desiredMetal3MachineTemplate, isDesiredMetal3MachineTemplate := desiredInfraMachineTemplate.(*infrav1.Metal3MachineTemplate)
+	if isCurrentMetal3MachineTemplate && isDesiredMetal3MachineTemplate {
+		canUpdateMetal3MachineSpec(log, &currentMetal3MachineTemplate.Spec.Template.Spec, &desiredMetal3MachineTemplate.Spec.Template.Spec)
+	}
+
+	if err := h.computeCanUpdateMachineSetResponse(req, resp, currentMachineSet, currentBootstrapConfigTemplate, currentInfraMachineTemplate); err != nil {
+		resp.Status = runtimehooksv1.ResponseStatusFailure
+		resp.Message = err.Error()
+		return
+	}
+
+	resp.Status = runtimehooksv1.ResponseStatusSuccess
+}
+
+// DoUpdateMachine implements the UpdateMachine hook.
+// It performs an actual in-place Kubernetes upgrade by SSHing to the machine.
+func (h *ExtensionHandlers) DoUpdateMachine(ctx context.Context, req *runtimehooksv1.UpdateMachineRequest, resp *runtimehooksv1.UpdateMachineResponse) {
+	log := ctrl.LoggerFrom(ctx).WithValues("Machine", klog.KObj(&req.Desired.Machine))
+	log.Info("UpdateMachine is called")
+	defer func() {
+		log.Info("UpdateMachine response", "Machine", klog.KObj(&req.Desired.Machine), "status", resp.Status, "message", resp.Message, "retryAfterSeconds", resp.RetryAfterSeconds)
+	}()
+
+	if req.Settings["disableInPlaceUpdates"] == trueString {
+		resp.Status = runtimehooksv1.ResponseStatusFailure
+		resp.Message = "Unexpected call to UpdateMachine hook after CanUpdateMachine or CanUpdateMachineSet did not return any patches"
+		return
+	}
+
+	key := klog.KObj(&req.Desired.Machine).String()
+	errorKey := key + "errored"
+
+	// Get the machine IP address (pass empty string to match any IP pool)
+	machineIP, err := h.getMachineIP(ctx, &req.Desired.Machine, "baremetalv4-pool")
+	if err != nil {
+		log.Error(err, "Failed to get machine IP address")
+		resp.Status = runtimehooksv1.ResponseStatusFailure
+		resp.Message = fmt.Sprintf("Failed to get machine IP: %v", err)
+		return
+	}
+
+	// Get target version from the desired machine spec
+	targetVersion := ""
+	if req.Desired.Machine.Spec.Version != "" {
+		targetVersion = strings.TrimPrefix(req.Desired.Machine.Spec.Version, "v")
+	}
+
+	if targetVersion == "" {
+		resp.Status = runtimehooksv1.ResponseStatusFailure
+		resp.Message = "Target Kubernetes version not specified"
+		return
+	}
+
+	// If a previous async run failed, surface error and cleanup state
+	if _, failed := h.state.Load(errorKey); failed {
+		h.state.Delete(errorKey)
+		h.state.Delete(key)
+		resp.Status = runtimehooksv1.ResponseStatusFailure
+		resp.Message = "Failed to upgrade Kubernetes: background upgrade errored; check logs on target node"
+		return
+	}
+
+	user := "metal3"
+	desiredBootstrapConfig, _, err := h.decoder.Decode(req.Desired.BootstrapConfig.Raw, nil, req.Desired.BootstrapConfig.Object)
+	if err != nil {
+		log.Error(err, "Failed to get desired bootstrap config")
+		resp.Status = runtimehooksv1.ResponseStatusFailure
+		resp.Message = fmt.Sprintf("Failed to get desired bootstrap config: %v", err)
+		return
+	}
+	desiredKubeadmConfig, isDesiredKubeadmConfig := desiredBootstrapConfig.(*bootstrapv1.KubeadmConfig)
+
+	if isDesiredKubeadmConfig && len(desiredKubeadmConfig.Spec.Users) > 0 && desiredKubeadmConfig.Spec.Users[0].Name != "" {
+		user = desiredKubeadmConfig.Spec.Users[0].Name
+	}
+
+	// If upgrade already started, verify completion by checking the node version
+	if _, started := h.state.Load(key); started {
+		log.Info("Checking if Kubernetes is upgraded", "machineIP", machineIP, "targetVersion", targetVersion)
+		isUpgraded, err := isKubernetesUpgraded(machineIP, user, targetVersion)
+		if err != nil {
+			log.Error(err, "Failed to check if Kubernetes is upgraded")
+			resp.Status = runtimehooksv1.ResponseStatusSuccess
+			resp.Message = extensionUpdatingMachineMessage
+			resp.RetryAfterSeconds = 15
+			return
+		}
+		if isUpgraded {
+			h.state.Delete(key)
+			resp.Status = runtimehooksv1.ResponseStatusSuccess
+			resp.Message = "Extension completed updating Machine"
+			resp.RetryAfterSeconds = 0
+			return
+		}
+		// Still in progress
+		resp.Status = runtimehooksv1.ResponseStatusSuccess
+		resp.Message = extensionUpdatingMachineMessage
+		resp.RetryAfterSeconds = 15
+		return
+	}
+
+	// First time called - start the upgrade process in background
+	log.Info("Starting in-place Kubernetes upgrade", "machineIP", machineIP, "targetVersion", targetVersion)
+	h.state.Store(key, true)
+	go func(machineIP, user, targetVersion, errKey string) {
+		if err := upgradeKubernetesInPlace(machineIP, user, targetVersion); err != nil {
+			log.Error(err, "Background upgrade failed")
+			h.state.Store(errKey, true)
+		}
+	}(machineIP, user, targetVersion, errorKey)
+
+	resp.Status = runtimehooksv1.ResponseStatusSuccess
+	resp.Message = extensionUpdatingMachineMessage
+	resp.RetryAfterSeconds = 15
+}
+
+//nolint:dupl // Similar logic to getObjectsFromCanUpdateMachineSetRequest but operates on different types
+func (h *ExtensionHandlers) getObjectsFromCanUpdateMachineRequest(req *runtimehooksv1.CanUpdateMachineRequest) (*clusterv1.Machine, *clusterv1.Machine, runtime.Object, runtime.Object, runtime.Object, runtime.Object, error) { //nolint:gocritic // accepting high number of return parameters for now
+	currentMachine := req.Current.Machine.DeepCopy()
+	desiredMachine := req.Desired.Machine.DeepCopy()
+	currentBootstrapConfig, _, err := h.decoder.Decode(req.Current.BootstrapConfig.Raw, nil, req.Current.BootstrapConfig.Object)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+	desiredBootstrapConfig, _, err := h.decoder.Decode(req.Desired.BootstrapConfig.Raw, nil, req.Desired.BootstrapConfig.Object)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+	currentInfraMachine, _, err := h.decoder.Decode(req.Current.InfrastructureMachine.Raw, nil, req.Current.InfrastructureMachine.Object)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+	desiredInfraMachine, _, err := h.decoder.Decode(req.Desired.InfrastructureMachine.Raw, nil, req.Desired.InfrastructureMachine.Object)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+
+	return currentMachine, desiredMachine, currentBootstrapConfig, desiredBootstrapConfig, currentInfraMachine, desiredInfraMachine, nil
+}
+
+func (h *ExtensionHandlers) computeCanUpdateMachineResponse(req *runtimehooksv1.CanUpdateMachineRequest, resp *runtimehooksv1.CanUpdateMachineResponse, currentMachine *clusterv1.Machine, currentBootstrapConfig, currentInfraMachine runtime.Object) error {
+	marshalledCurrentMachine, err := json.Marshal(req.Current.Machine)
+	if err != nil {
+		return err
+	}
+	machinePatch, err := createJSONPatch(marshalledCurrentMachine, currentMachine)
+	if err != nil {
+		return err
+	}
+	bootstrapConfigPatch, err := createJSONPatch(req.Current.BootstrapConfig.Raw, currentBootstrapConfig)
+	if err != nil {
+		return err
+	}
+	infraMachinePatch, err := createJSONPatch(req.Current.InfrastructureMachine.Raw, currentInfraMachine)
+	if err != nil {
+		return err
+	}
+
+	resp.MachinePatch = runtimehooksv1.Patch{
+		PatchType: runtimehooksv1.JSONPatchType,
+		Patch:     machinePatch,
+	}
+	resp.BootstrapConfigPatch = runtimehooksv1.Patch{
+		PatchType: runtimehooksv1.JSONPatchType,
+		Patch:     bootstrapConfigPatch,
+	}
+	resp.InfrastructureMachinePatch = runtimehooksv1.Patch{
+		PatchType: runtimehooksv1.JSONPatchType,
+		Patch:     infraMachinePatch,
+	}
+	return nil
+}
+
+// getMachineIP retrieves the IP address of a machine using the chain: Machine -> Metal3Machine -> Metal3Data -> IPAddress.
+// This follows the same approach as MachineToIPAddress1beta1 from the e2e tests.
+func (h *ExtensionHandlers) getMachineIP(ctx context.Context, machine *clusterv1.Machine, ippoolName string) (string, error) {
+	// Get the Metal3Machine
+	metal3Machine := &infrav1.Metal3Machine{}
+	err := h.client.Get(ctx, types.NamespacedName{
+		Namespace: machine.Namespace,
+		Name:      machine.Spec.InfrastructureRef.Name,
+	}, metal3Machine)
+	if err != nil {
+		return "", fmt.Errorf("couldn't get Metal3Machine %s/%s: %w", machine.Namespace, machine.Spec.InfrastructureRef.Name, err)
+	}
+
+	// List Metal3Data objects and find the one owned by this Metal3Machine
+	m3DataList := &infrav1.Metal3DataList{}
+	err = h.client.List(ctx, m3DataList, client.InNamespace(machine.Namespace))
+	if err != nil {
+		return "", fmt.Errorf("couldn't list Metal3Data objects: %w", err)
+	}
+
+	var m3Data *infrav1.Metal3Data
+	for i, m3d := range m3DataList.Items {
+		for _, owner := range m3d.OwnerReferences {
+			if owner.Name == metal3Machine.Name {
+				m3Data = &m3DataList.Items[i]
+				break
+			}
+		}
+		if m3Data != nil {
+			break
+		}
+	}
+	if m3Data == nil {
+		return "", errors.New("couldn't find matching Metal3Data object")
+	}
+
+	// List IPAddress objects and find the one owned by this Metal3Data
+	IPAddresses := &ipamv1.IPAddressList{}
+	err = h.client.List(ctx, IPAddresses, client.InNamespace(machine.Namespace))
+	if err != nil {
+		return "", fmt.Errorf("couldn't list IPAddress objects: %w", err)
+	}
+
+	var IPAddress *ipamv1.IPAddress
+	for i, ip := range IPAddresses.Items {
+		for _, owner := range ip.OwnerReferences {
+			if owner.Name == m3Data.Name && (ippoolName == "" || ip.Spec.Pool.Name == ippoolName) {
+				IPAddress = &IPAddresses.Items[i]
+				break
+			}
+		}
+		if IPAddress != nil {
+			break
+		}
+	}
+	if IPAddress == nil {
+		return "", errors.Errorf("couldn't find IPAddress object with owner ref(Metal3Data) %s and pool name %s", m3Data.Name, ippoolName)
+	}
+
+	return string(IPAddress.Spec.Address), nil
+}
+
+//nolint:dupl // Similar logic to getObjectsFromCanUpdateMachineRequest but operates on different types
+func (h *ExtensionHandlers) getObjectsFromCanUpdateMachineSetRequest(req *runtimehooksv1.CanUpdateMachineSetRequest) (*clusterv1.MachineSet, *clusterv1.MachineSet, runtime.Object, runtime.Object, runtime.Object, runtime.Object, error) { //nolint:gocritic // accepting high number of return parameters for now
+	currentMachineSet := req.Current.MachineSet.DeepCopy()
+	desiredMachineSet := req.Desired.MachineSet.DeepCopy()
+	currentBootstrapConfigTemplate, _, err := h.decoder.Decode(req.Current.BootstrapConfigTemplate.Raw, nil, req.Current.BootstrapConfigTemplate.Object)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+	desiredBootstrapConfigTemplate, _, err := h.decoder.Decode(req.Desired.BootstrapConfigTemplate.Raw, nil, req.Desired.BootstrapConfigTemplate.Object)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+	currentInfraMachineTemplate, _, err := h.decoder.Decode(req.Current.InfrastructureMachineTemplate.Raw, nil, req.Current.InfrastructureMachineTemplate.Object)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+	desiredInfraMachineTemplate, _, err := h.decoder.Decode(req.Desired.InfrastructureMachineTemplate.Raw, nil, req.Desired.InfrastructureMachineTemplate.Object)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+
+	return currentMachineSet, desiredMachineSet, currentBootstrapConfigTemplate, desiredBootstrapConfigTemplate, currentInfraMachineTemplate, desiredInfraMachineTemplate, nil
+}
+
+func (h *ExtensionHandlers) computeCanUpdateMachineSetResponse(req *runtimehooksv1.CanUpdateMachineSetRequest, resp *runtimehooksv1.CanUpdateMachineSetResponse, currentMachineSet *clusterv1.MachineSet, currentBootstrapConfigTemplate, currentInfraMachineTemplate runtime.Object) error {
+	marshalledCurrentMachineSet, err := json.Marshal(req.Current.MachineSet)
+	if err != nil {
+		return err
+	}
+	machineSetPatch, err := createJSONPatch(marshalledCurrentMachineSet, currentMachineSet)
+	if err != nil {
+		return err
+	}
+	bootstrapConfigTemplatePatch, err := createJSONPatch(req.Current.BootstrapConfigTemplate.Raw, currentBootstrapConfigTemplate)
+	if err != nil {
+		return err
+	}
+	infraMachineTemplatePatch, err := createJSONPatch(req.Current.InfrastructureMachineTemplate.Raw, currentInfraMachineTemplate)
+	if err != nil {
+		return err
+	}
+
+	resp.MachineSetPatch = runtimehooksv1.Patch{
+		PatchType: runtimehooksv1.JSONPatchType,
+		Patch:     machineSetPatch,
+	}
+	resp.BootstrapConfigTemplatePatch = runtimehooksv1.Patch{
+		PatchType: runtimehooksv1.JSONPatchType,
+		Patch:     bootstrapConfigTemplatePatch,
+	}
+	resp.InfrastructureMachineTemplatePatch = runtimehooksv1.Patch{
+		PatchType: runtimehooksv1.JSONPatchType,
+		Patch:     infraMachineTemplatePatch,
+	}
+	return nil
+}
+
+// createJSONPatch creates a RFC 6902 JSON patch from the original and the modified object.
+func createJSONPatch(marshalledOriginal []byte, modified runtime.Object) ([]byte, error) {
+	// TODO: avoid producing patches for status (although they will be ignored by the KCP / MD controllers anyway)
+	marshalledModified, err := json.Marshal(modified)
+	if err != nil {
+		return nil, errors.Errorf("failed to marshal modified object: %v", err)
+	}
+
+	patch, err := jsonpatch.CreatePatch(marshalledOriginal, marshalledModified)
+	if err != nil {
+		return nil, errors.Errorf("failed to create patch: %v", err)
+	}
+
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return nil, errors.Errorf("failed to marshal patch: %v", err)
+	}
+
+	return patchBytes, nil
+}

--- a/test/extension/handlers/inplaceupdate/ssh.go
+++ b/test/extension/handlers/inplaceupdate/ssh.go
@@ -1,0 +1,160 @@
+package inplaceupdate
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	sshTimeoutSeconds = 60
+	sshKeySetupHint   = "Ensure the ssh-key secret exists: kubectl -n test-extension-system create secret generic ssh-key --from-file=id_rsa=~/.ssh/id_rsa (key is mounted at /home/nonroot/.ssh/id_rsa)"
+)
+
+// versionRe matches a valid semver-like Kubernetes version (digits and dots only).
+var versionRe = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+
+// runCommand executes a command on a remote machine via SSH.
+// It uses the SSH key from /home/nonroot/.ssh/id_rsa.
+func runCommand(machineIP, user, command string) (string, error) {
+	// Use the mounted SSH key path directly
+	keyPath := "/home/nonroot/.ssh/id_rsa"
+
+	// Check if key exists first
+	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
+		return "", fmt.Errorf("SSH private key not found at %s. %s", keyPath, sshKeySetupHint)
+	}
+
+	privkey, err := os.ReadFile(keyPath) //#nosec G304:gosec
+	if err != nil {
+		return "", fmt.Errorf("couldn't read private key from %s: %w", keyPath, err)
+	}
+	signer, err := ssh.ParsePrivateKey(privkey)
+	if err != nil {
+		return "", fmt.Errorf("couldn't form a signer from ssh key: %w", err)
+	}
+	cfg := &ssh.ClientConfig{
+		User: user,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(signer),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec // test environment only; host key verification intentionally disabled
+		Timeout:         sshTimeoutSeconds * time.Second,
+	}
+	client, err := ssh.Dial("tcp", machineIP+":22", cfg)
+	if err != nil {
+		return "", fmt.Errorf("couldn't dial the machine host at %s : %w", machineIP, err)
+	}
+	defer client.Close()
+	session, err := client.NewSession()
+	if err != nil {
+		return "", fmt.Errorf("couldn't open a new session: %w", err)
+	}
+	defer session.Close()
+	var stdoutBuf bytes.Buffer
+	var stderrBuf bytes.Buffer
+	session.Stdout = &stdoutBuf
+	session.Stderr = &stderrBuf
+
+	fullCommand := "sudo " + command
+	if err := session.Run(fullCommand); err != nil {
+		return "", fmt.Errorf("unable to send command %q: %w, stderr: %s", fullCommand, err, stderrBuf.String())
+	}
+
+	result := strings.TrimSuffix(stdoutBuf.String(), "\n")
+	if stderrBuf.Len() > 0 {
+		result += "\n" + strings.TrimSuffix(stderrBuf.String(), "\n")
+	}
+	return result, nil
+}
+
+// upgradeKubernetesInPlace performs an in-place Kubernetes upgrade on the specified machine.
+func upgradeKubernetesInPlace(machineIP, user, targetVersion string) error {
+	// Strip 'v' prefix if present (e.g., v1.32.0 -> 1.32.0)
+	version := strings.TrimPrefix(targetVersion, "v")
+
+	// Validate version contains only digits and dots to prevent shell injection.
+	if !versionRe.MatchString(version) {
+		return fmt.Errorf("invalid version format: %q, expected format like '1.32.0'", version)
+	}
+
+	// Extract major.minor version for repository setup (e.g., 1.32.0 -> 1.32)
+	versionParts := strings.Split(version, ".")
+	majorMinor := versionParts[0] + "." + versionParts[1]
+
+	// Setup Kubernetes repository for the target version
+	setupRepoCmd := fmt.Sprintf(`sh -c 'cat <<EOF > /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/v%s/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/v%s/rpm/repodata/repomd.xml.key
+exclude=kubelet kubeadm kubectl cri-tools kubernetes-cni
+EOF'`, majorMinor, majorMinor)
+
+	if _, err := runCommand(machineIP, user, setupRepoCmd); err != nil {
+		return fmt.Errorf("failed to configure Kubernetes repository: %w", err)
+	}
+
+	// Clean yum cache
+	if _, err := runCommand(machineIP, user, "yum clean all"); err != nil {
+		return fmt.Errorf("failed to clean yum cache: %w", err)
+	}
+
+	// Refresh yum cache
+	if _, err := runCommand(machineIP, user, "yum makecache"); err != nil {
+		return fmt.Errorf("failed to refresh yum cache: %w", err)
+	}
+
+	// Upgrade kubeadm first
+	upgradeCmd := fmt.Sprintf("yum install -y kubeadm-%s-* --disableexcludes=kubernetes", version)
+	if _, err := runCommand(machineIP, user, upgradeCmd); err != nil {
+		return fmt.Errorf("failed to upgrade kubeadm: %w", err)
+	}
+
+	// Apply the upgrade to the node (for control plane nodes)
+	if _, err := runCommand(machineIP, user, "kubeadm upgrade node"); err != nil {
+		return fmt.Errorf("failed to run kubeadm upgrade node: %w", err)
+	}
+
+	// Upgrade kubelet and kubectl
+	upgradeKubeletCmd := fmt.Sprintf("yum install -y kubelet-%s-* kubectl-%s-* --disableexcludes=kubernetes", version, version)
+	if _, err := runCommand(machineIP, user, upgradeKubeletCmd); err != nil {
+		return fmt.Errorf("failed to upgrade kubelet/kubectl: %w", err)
+	}
+
+	// Reload systemd daemon
+	if _, err := runCommand(machineIP, user, "systemctl daemon-reload"); err != nil {
+		return fmt.Errorf("failed to reload systemd daemon: %w", err)
+	}
+
+	// Restart kubelet to apply the new version
+	if _, err := runCommand(machineIP, user, "systemctl restart kubelet"); err != nil {
+		return fmt.Errorf("failed to restart kubelet: %w", err)
+	}
+
+	return nil
+}
+
+// isKubernetesUpgraded checks if the Kubernetes version on the machine matches the target version.
+func isKubernetesUpgraded(machineIP, user, targetVersion string) (bool, error) {
+	// Get the kubelet version
+	getVersionCmd := "kubelet --version"
+	output, err := runCommand(machineIP, user, getVersionCmd)
+	if err != nil {
+		return false, fmt.Errorf("failed to get kubelet version: %w", err)
+	}
+
+	// Parse the version from output
+	if strings.Contains(output, targetVersion) {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/test/extension/main.go
+++ b/test/extension/main.go
@@ -1,0 +1,332 @@
+// Borrowed and adapted from sigs.k8s.io/cluster-api/test/extension/main.go
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	goruntime "runtime"
+	"time"
+
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta2"
+	"github.com/metal3-io/cluster-api-provider-metal3/test/extension/handlers/inplaceupdate"
+	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
+	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/component-base/logs"
+	logsv1 "k8s.io/component-base/logs/api/v1"
+	_ "k8s.io/component-base/logs/json/register"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
+	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	runtimehooksv1 "sigs.k8s.io/cluster-api/api/runtime/hooks/v1alpha1"
+	"sigs.k8s.io/cluster-api/controllers/remote"
+	runtimecatalog "sigs.k8s.io/cluster-api/exp/runtime/catalog"
+	"sigs.k8s.io/cluster-api/exp/runtime/server"
+	"sigs.k8s.io/cluster-api/feature"
+	"sigs.k8s.io/cluster-api/util/flags"
+	"sigs.k8s.io/cluster-api/version"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+)
+
+const (
+	// Leader election defaults.
+	defaultLeaderElectionLeaseDuration = 15 * time.Second
+	defaultLeaderElectionRenewDeadline = 10 * time.Second
+	defaultLeaderElectionRetryPeriod   = 2 * time.Second
+	defaultSyncPeriod                  = 10 * time.Minute
+	defaultKubeAPIQPS                  = float32(20)
+	defaultKubeAPIBurst                = 30
+	defaultWebhookPort                 = 9443
+)
+
+var (
+	// catalog contains all information about RuntimeHooks.
+	catalog = runtimecatalog.New()
+
+	// scheme is a Kubernetes runtime scheme containing all the information about API types used by the test extension.
+	// NOTE: it is not mandatory to use scheme in custom RuntimeExtension, but working with typed API objects makes code
+	// easier to read and less error-prone than using unstructured or working with raw json/yaml.
+	scheme = runtime.NewScheme()
+	// Creates a logger to be used during the main func using controller runtime utilities
+	// NOTE: it is not mandatory to use controller runtime utilities in custom RuntimeExtension, but it is recommended
+	// because it makes log from those components similar to log from controllers.
+	setupLog       = ctrl.Log.WithName("setup")
+	controllerName = "capm3-test-extension-manager"
+
+	// flags.
+	enableLeaderElection        bool
+	leaderElectionLeaseDuration time.Duration
+	leaderElectionRenewDeadline time.Duration
+	leaderElectionRetryPeriod   time.Duration
+	profilerAddress             string
+	enableContentionProfiling   bool
+	syncPeriod                  time.Duration
+	restConfigQPS               float32
+	restConfigBurst             int
+	webhookPort                 int
+	webhookCertDir              string
+	webhookCertName             string
+	webhookKeyName              string
+	healthAddr                  string
+	managerOptions              = flags.ManagerOptions{}
+	logOptions                  = logs.NewOptions()
+)
+
+func init() {
+	// Adds to the scheme all the API types used by the test extension.
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = apiextensionsv1.AddToScheme(scheme)
+	_ = infrav1.AddToScheme(scheme)
+	_ = ipamv1.AddToScheme(scheme)
+	_ = bootstrapv1.AddToScheme(scheme)
+	_ = controlplanev1.AddToScheme(scheme)
+	_ = clusterv1.AddToScheme(scheme)
+
+	// Register the RuntimeHook types into the catalog.
+	_ = runtimehooksv1.AddToCatalog(catalog)
+}
+
+// InitFlags initializes the flags.
+func InitFlags(fs *pflag.FlagSet) {
+	// Initialize logs flags using Kubernetes component-base machinery.
+	// NOTE: it is not mandatory to use Kubernetes component-base machinery in custom RuntimeExtension, but it is
+	// recommended because it helps in ensuring consistency across different components in the cluster.
+	logsv1.AddFlags(logOptions, fs)
+
+	fs.BoolVar(&enableLeaderElection, "leader-elect", false,
+		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+
+	fs.DurationVar(&leaderElectionLeaseDuration, "leader-elect-lease-duration", defaultLeaderElectionLeaseDuration,
+		"Interval at which non-leader candidates will wait to force acquire leadership (duration string)")
+
+	fs.DurationVar(&leaderElectionRenewDeadline, "leader-elect-renew-deadline", defaultLeaderElectionRenewDeadline,
+		"Duration that the leading controller manager will retry refreshing leadership before giving up (duration string)")
+
+	fs.DurationVar(&leaderElectionRetryPeriod, "leader-elect-retry-period", defaultLeaderElectionRetryPeriod,
+		"Duration the LeaderElector clients should wait between tries of actions (duration string)")
+
+	fs.StringVar(&profilerAddress, "profiler-address", "",
+		"Bind address to expose the pprof profiler (e.g. localhost:6060)")
+
+	fs.BoolVar(&enableContentionProfiling, "contention-profiling", false,
+		"Enable block profiling")
+
+	fs.DurationVar(&syncPeriod, "sync-period", defaultSyncPeriod,
+		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
+
+	fs.Float32Var(&restConfigQPS, "kube-api-qps", defaultKubeAPIQPS,
+		"Maximum queries per second from the controller client to the Kubernetes API server.")
+
+	fs.IntVar(&restConfigBurst, "kube-api-burst", defaultKubeAPIBurst,
+		"Maximum number of queries that should be allowed in one burst from the controller client to the Kubernetes API server.")
+
+	fs.IntVar(&webhookPort, "webhook-port", defaultWebhookPort,
+		"Webhook Server port")
+
+	fs.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs/",
+		"Webhook cert dir.")
+
+	fs.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt",
+		"Webhook cert name.")
+
+	fs.StringVar(&webhookKeyName, "webhook-key-name", "tls.key",
+		"Webhook key name.")
+
+	fs.StringVar(&healthAddr, "health-addr", ":9440",
+		"The address the health endpoint binds to.")
+
+	flags.AddManagerOptions(fs, &managerOptions)
+
+	feature.MutableGates.AddFlag(fs)
+
+	// Add test-extension specific flags
+	// NOTE: it is not mandatory to use the same flag names in all RuntimeExtension, but it is recommended when
+	// addressing common concerns like profiler-address, webhook-port, webhook-cert-dir etc. because it helps in ensuring
+	// consistency across different components in the cluster.
+}
+
+// Add RBAC for the authorized diagnostics endpoint.
+// +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
+// +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
+
+func main() {
+	InitFlags(pflag.CommandLine)
+	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	// Set log level 2 as default.
+	if err := pflag.CommandLine.Set("v", "2"); err != nil {
+		klog.Errorf("Failed to set default log level: %v", err)
+		os.Exit(1)
+	}
+	pflag.Parse()
+
+	// Validates logs flags using Kubernetes component-base machinery and apply them
+	// so klog will automatically use the right logger.
+	// NOTE: klog is the log of choice of component-base machinery.
+	if err := logsv1.ValidateAndApply(logOptions, nil); err != nil {
+		klog.Errorf("Unable to start manager: %v", err)
+		os.Exit(1)
+	}
+
+	// Add the klog logger in the context.
+	// NOTE: it is not mandatory to use contextual logging in custom RuntimeExtension, but it is recommended
+	// because it allows to use a log stored in the context across the entire chain of calls (without
+	// requiring an addition log parameter in all the functions).
+	ctrl.SetLogger(klog.Background())
+
+	// Note: setupLog can only be used after ctrl.SetLogger was called
+	setupLog.Info(fmt.Sprintf("Version: %s (git commit: %s)", version.Get().String(), version.Get().GitCommit))
+
+	restConfig := ctrl.GetConfigOrDie()
+	restConfig.QPS = restConfigQPS
+	restConfig.Burst = restConfigBurst
+	restConfig.UserAgent = remote.DefaultClusterAPIUserAgent(controllerName)
+
+	tlsOptions, metricsOptions, err := flags.GetManagerOptions(managerOptions)
+	if err != nil {
+		setupLog.Error(err, "Unable to start manager: invalid flags")
+		os.Exit(1)
+	}
+
+	if enableContentionProfiling {
+		goruntime.SetBlockProfileRate(1)
+	}
+
+	// Create an HTTP server for serving Runtime Extensions.
+	runtimeExtensionWebhookServer, err := server.New(server.Options{
+		Port:     webhookPort,
+		CertDir:  webhookCertDir,
+		CertName: webhookCertName,
+		KeyName:  webhookKeyName,
+		TLSOpts:  tlsOptions,
+		Catalog:  catalog,
+	})
+	if err != nil {
+		setupLog.Error(err, "Error creating runtime extension webhook server")
+		os.Exit(1)
+	}
+
+	ctrlOptions := ctrl.Options{
+		Controller: config.Controller{
+			UsePriorityQueue: ptr.To[bool](feature.Gates.Enabled(feature.PriorityQueue)),
+		},
+		Scheme:                     scheme,
+		LeaderElection:             enableLeaderElection,
+		LeaderElectionID:           "controller-leader-election-capm3-test-extension",
+		LeaseDuration:              &leaderElectionLeaseDuration,
+		RenewDeadline:              &leaderElectionRenewDeadline,
+		RetryPeriod:                &leaderElectionRetryPeriod,
+		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
+		HealthProbeBindAddress:     healthAddr,
+		PprofBindAddress:           profilerAddress,
+		Metrics:                    *metricsOptions,
+		Cache: cache.Options{
+			SyncPeriod: &syncPeriod,
+		},
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{
+					&corev1.ConfigMap{},
+					&corev1.Secret{},
+				},
+				// Use the cache for all Unstructured get/list calls.
+				Unstructured: true,
+			},
+		},
+		WebhookServer: runtimeExtensionWebhookServer,
+	}
+
+	// Start the manager
+	mgr, err := ctrl.NewManager(restConfig, ctrlOptions)
+	if err != nil {
+		setupLog.Error(err, "Unable to start manager")
+		os.Exit(1)
+	}
+
+	// Set up a context listening for SIGINT.
+	ctx := ctrl.SetupSignalHandler()
+
+	// Setup Runtime Extensions.
+	setupInPlaceUpdateHookHandlers(mgr, runtimeExtensionWebhookServer)
+
+	// Setup checks, indexes, reconcilers and webhooks.
+	setupChecks(mgr)
+	setupIndexes(ctx, mgr)
+	setupReconcilers(ctx, mgr)
+	setupWebhooks(mgr)
+
+	setupLog.Info("Starting manager", "version", version.Get().String())
+	if err := mgr.Start(ctx); err != nil {
+		setupLog.Error(err, "Problem running manager")
+		os.Exit(1)
+	}
+}
+
+// setupInPlaceUpdateHookHandlers sets up In-Place Update Hooks.
+func setupInPlaceUpdateHookHandlers(mgr ctrl.Manager, runtimeExtensionWebhookServer *server.Server) {
+	// Create the ExtensionHandlers for the in-place update hooks
+	// NOTE: it is not mandatory to group all the ExtensionHandlers using a struct, what is important
+	// is to have HandlerFunc with the signature defined in sigs.k8s.io/cluster-api/api/runtime/hooks/v1alpha1.
+	inPlaceUpdateExtensionHandlers := inplaceupdate.NewExtensionHandlers(mgr.GetClient())
+
+	if err := runtimeExtensionWebhookServer.AddExtensionHandler(server.ExtensionHandler{
+		Hook:        runtimehooksv1.CanUpdateMachine,
+		Name:        "can-update-machine",
+		HandlerFunc: inPlaceUpdateExtensionHandlers.DoCanUpdateMachine,
+	}); err != nil {
+		setupLog.Error(err, "Error adding CanUpdateMachine handler")
+		os.Exit(1)
+	}
+
+	if err := runtimeExtensionWebhookServer.AddExtensionHandler(server.ExtensionHandler{
+		Hook:        runtimehooksv1.CanUpdateMachineSet,
+		Name:        "can-update-machineset",
+		HandlerFunc: inPlaceUpdateExtensionHandlers.DoCanUpdateMachineSet,
+	}); err != nil {
+		setupLog.Error(err, "Error adding CanUpdateMachineSet handler")
+		os.Exit(1)
+	}
+
+	if err := runtimeExtensionWebhookServer.AddExtensionHandler(server.ExtensionHandler{
+		Hook:        runtimehooksv1.UpdateMachine,
+		Name:        "update-machine",
+		HandlerFunc: inPlaceUpdateExtensionHandlers.DoUpdateMachine,
+	}); err != nil {
+		setupLog.Error(err, "Error adding UpdateMachine handler")
+		os.Exit(1)
+	}
+}
+
+func setupChecks(mgr ctrl.Manager) {
+	if err := mgr.AddReadyzCheck("webhook", mgr.GetWebhookServer().StartedChecker()); err != nil {
+		setupLog.Error(err, "Unable to create ready check")
+		os.Exit(1)
+	}
+
+	if err := mgr.AddHealthzCheck("webhook", mgr.GetWebhookServer().StartedChecker()); err != nil {
+		setupLog.Error(err, "Unable to create health check")
+		os.Exit(1)
+	}
+}
+
+func setupIndexes(_ context.Context, _ ctrl.Manager) {
+}
+
+func setupReconcilers(_ context.Context, _ ctrl.Manager) {
+}
+
+func setupWebhooks(_ ctrl.Manager) {
+}

--- a/test/go.mod
+++ b/test/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/blang/semver/v4 v4.0.0
 	github.com/docker/docker v28.5.2+incompatible
+	github.com/go-logr/logr v1.4.3
 	github.com/jinzhu/copier v0.4.0
 	github.com/metal3-io/baremetal-operator/apis v0.12.3
 	github.com/metal3-io/cluster-api-provider-metal3/api v0.0.0
@@ -13,14 +14,18 @@ require (
 	github.com/metal3-io/ironic-standalone-operator/api v0.8.1
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
+	github.com/pkg/errors v0.9.1
+	github.com/spf13/pflag v1.0.10
 	golang.org/x/crypto v0.49.0
 	golang.org/x/mod v0.34.0
+	gomodules.xyz/jsonpatch/v2 v2.5.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.19.4
 	k8s.io/api v0.34.6
 	k8s.io/apiextensions-apiserver v0.34.6
 	k8s.io/apimachinery v0.34.6
 	k8s.io/client-go v0.34.6
+	k8s.io/component-base v0.34.6
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kubectl v0.34.6
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
@@ -45,6 +50,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
 	github.com/adrg/xdg v0.5.3 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
@@ -76,8 +82,8 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
@@ -106,6 +112,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/lib/pq v1.10.9 // indirect
@@ -135,7 +142,6 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
@@ -152,7 +158,6 @@ require (
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/cobra v1.10.1 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spf13/viper v1.21.0 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
@@ -168,6 +173,8 @@ require (
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
@@ -179,7 +186,6 @@ require (
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.42.0 // indirect
-	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/grpc v1.79.3 // indirect
@@ -190,7 +196,6 @@ require (
 	k8s.io/apiserver v0.34.6 // indirect
 	k8s.io/cli-runtime v0.34.6 // indirect
 	k8s.io/cluster-bootstrap v0.34.2 // indirect
-	k8s.io/component-base v0.34.6 // indirect
 	k8s.io/component-helpers v0.34.6 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
 	oras.land/oras-go/v2 v2.6.0 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -26,6 +26,8 @@ github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
+github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 h1:wPbRQzjjwFc0ih8puEVAOFGELsn1zoIIYdxvML7mDxA=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
 github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:
Implements a full E2E test suite for upgrading Kubernetes versions on existing nodes without replacing machines, leveraging CAPI's cluster topology and Runtime Extension hooks.

E2E test flow:

- Test starts 5 bmh, 3 CP nodes and 0 worker node
- Get uids of machines before upgrade
- Upgrades Kubernetes
- Waits for control plane nodes to upgrade
- Check uids of upgraded CP machines with before upgrade uids to check in-place upgrade
- Scales CP machines from 3→5 to validate new node uses the new image.
- Verifies all machines are running with the new version

Runtime Extension Server
- Implements Runtime SDK hooks: `DoCanUpdateMachine`, `DoCanUpdateMachineSet`, `DoUpdateMachine`
- SSH-based remote upgrade execution on nodes
- Version validation before and after upgrades

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
