### PR TITLE
🐛 add capipamv1 to myscheme instead of scheme.Scheme

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func init() {
 	// metal3Ipam and capipam schemes
 	_ = ipamv1.AddToScheme(myscheme)
 	_ = capipamv1beta1.AddToScheme(myscheme)
-	_ = capipamv1.AddToScheme(scheme.Scheme)
+	_ = capipamv1.AddToScheme(myscheme)
 
 	// infra provider schemes
 	_ = infrav1.AddToScheme(myscheme)


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:
Correctly add capi ipam v1beta2 to `myscheme` instead of `scheme.Scheme`.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #3061 

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
