### PR TITLE
🌱 Hide generated files in GH diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Hide generated CRD yamls by default in the Github diff UX
+**/config/crd/bases/*.yaml linguist-generated=true
+
+# Hide generated Go files (deepcopy, mocks)
+**/zz_generated*.go linguist-generated=true


### PR DESCRIPTION
**What this PR does / why we need it**:

Hide generated files in the diff view on GitHub by default.
Similar to how [CAPI has it configured](https://github.com/kubernetes-sigs/cluster-api/blob/main/.gitattributes)

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #2436

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
