### PR TITLE
🌱 Document CAPM3 pod placement and add optional affinity example

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -216,6 +216,49 @@ WORKERS_KUBEADM_EXTRA_CONFIG="
 "
 ```
 
+## Pod Placement Configuration
+
+By default, CAPM3 controller pods are configured with **tolerations** so they
+can run on control-plane nodes (which are typically tainted), but there is **no
+default node affinity**. This means pods may still be scheduled on regular
+worker nodes unless additional scheduling constraints are applied by the admin.
+
+### Default Configuration
+
+The default deployment includes:
+
+- **Tolerations**: Allow pods to run on control-plane nodes (which typically
+   have taints)
+   - `node-role.kubernetes.io/master:NoSchedule`
+   - `node-role.kubernetes.io/control-plane:NoSchedule`
+
+- **Node Affinity**: Not set by default. Pods can run on any schedulable node
+   (control-plane or worker), depending on the cluster’s taints and labels.
+
+### Customizing Pod Placement
+
+If you want to ensure that CAPM3 pods do **not** run alongside regular
+workloads, you can:
+
+- Add node affinity and/or additional tolerations via your preferred deployment
+   mechanism (CAPI Operator, `clusterctl`, or kustomize), and
+- Use dedicated infrastructure nodes if your environment provides them.
+
+For more details on how to customize provider manifests, see the upstream
+Cluster API documentation:
+
+- **CAPI Operator provider configuration**:
+   [Provider spec configuration docs](https://cluster-api-operator.sigs.k8s.io/topics/configuration/provider-spec-configuration#provider-spec)
+- **`clusterctl` config overrides**:
+   [`clusterctl` configuration overrides](https://cluster-api.sigs.k8s.io/clusterctl/configuration#overrides-layer)
+- **`clusterctl generate provider`**:
+   [`clusterctl generate provider` command reference](https://cluster-api.sigs.k8s.io/clusterctl/commands/generate-provider)
+
+For kustomize-based workflows, you can use the CAPM3 example patches in
+[`examples/provider-components/`](https://github.com/metal3-io/cluster-api-provider-metal3/tree/main/examples/provider-components)
+as a starting point. The `manager_node_affinity_patch.yaml` example shows how
+to require control-plane or infra nodes and prefer infra nodes when available.
+
 ## Pivoting or updating Ironic
 
 Before running the `move` command of Clusterctl, elements such as Ironic if

--- a/examples/provider-components/manager_node_affinity_patch.yaml
+++ b/examples/provider-components/manager_node_affinity_patch.yaml
@@ -1,0 +1,41 @@
+---
+# This patch adds node affinity to require CAPM3 controller pods to run only on
+# control-plane or infra nodes instead of regular worker nodes.
+# Within those eligible nodes, it prefers dedicated infra nodes first, then
+# control-plane nodes.
+#
+# To use this patch, apply it after deploying CAPM3:
+# kubectl patch deployment capm3-controller-manager -n capm3-system --patch-file examples/provider-components/manager_node_affinity_patch.yaml
+#
+# Or use it with kustomize by adding it as a patch in your kustomization.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capm3-controller-manager
+  namespace: capm3-system
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          # Require pods to run on control-plane or infra nodes
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/infra
+                operator: Exists
+          # Prefer dedicated infra nodes first, then control-plane nodes
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/infra
+                operator: Exists
+          - weight: 50
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists

--- a/examples/provider-components/manager_tolerations_patch.yaml
+++ b/examples/provider-components/manager_tolerations_patch.yaml
@@ -1,4 +1,9 @@
 ---
+# This patch adds tolerations to allow CAPM3 controller pods to run on
+# control-plane nodes (which typically have taints).
+#
+# Note: The default deployment already includes tolerations for control-plane nodes.
+# This patch is provided for reference or if you need to add additional tolerations.
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

Clarifies and improves how CAPM3 controller pods can be scheduled away from regular
workloads without enforcing environment-specific defaults. The PR keeps the default
deployment aligned with upstream CAPI (tolerations only, no node affinity), and
documents how operators can optionally harden placement (for example to control-plane
or infra nodes) using their preferred deployment tooling

Changes:
- Add a new optional example patch
  `examples/provider-components/manager_node_affinity_patch.yaml` that shows how to:
  - Require scheduling on control-plane and/or infra nodes
  - Prefer infra nodes first, then control-plane nodes
- Add a “Pod Placement Configuration” section to `docs/getting-started.md` that:
  - Describes the default behavior (tolerations only, no affinity)
  - Explains how and why to harden placement if desired
  - Links to CAPI Operator and `clusterctl` documentation for provider customization
  - Points to `examples/provider-components/` as a starting point for kustomize-based
    workflows
- Update `examples/provider-components/manager_tolerations_patch.yaml` comments to
  reference the new affinity example and clarify usage.
  
<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #940

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
