### PR TITLE
🐛 Fix Metal3Cluster webhook blocking cloudProvider toggle updates

### DIFF
--- a/internal/webhooks/v1beta1/metal3cluster_webhook.go
+++ b/internal/webhooks/v1beta1/metal3cluster_webhook.go
@@ -97,7 +97,7 @@ func (webhook *Metal3Cluster) ValidateDelete(_ context.Context, _ runtime.Object
 	return nil, nil
 }
 
-func (webhook *Metal3Cluster) validate(oldM3C, newM3C *infrav1.Metal3Cluster) error {
+func (webhook *Metal3Cluster) validate(_ *infrav1.Metal3Cluster, newM3C *infrav1.Metal3Cluster) error {
 	var allErrs field.ErrorList
 	if newM3C.Spec.ControlPlaneEndpoint.Host == "" {
 		allErrs = append(
@@ -120,36 +120,6 @@ func (webhook *Metal3Cluster) validate(oldM3C, newM3C *infrav1.Metal3Cluster) er
 					"cloudProviderEnabled conflicts the value of noCloudProvider",
 				),
 			)
-		}
-	}
-
-	if oldM3C != nil {
-		// Validate cloudProviderEnabled
-		if newM3C.Spec.CloudProviderEnabled != nil && oldM3C.Spec.NoCloudProvider != nil {
-			if *newM3C.Spec.CloudProviderEnabled == *oldM3C.Spec.NoCloudProvider {
-				allErrs = append(
-					allErrs,
-					field.Invalid(
-						field.NewPath("spec", "cloudProviderEnabled"),
-						newM3C.Spec.CloudProviderEnabled,
-						"ValidateUpdate failed, cloudProviderEnabled conflicts the value of noCloudProvider",
-					),
-				)
-			}
-		}
-
-		// Validate noCloudProvider
-		if newM3C.Spec.NoCloudProvider != nil && oldM3C.Spec.CloudProviderEnabled != nil {
-			if *newM3C.Spec.NoCloudProvider == *oldM3C.Spec.CloudProviderEnabled {
-				allErrs = append(
-					allErrs,
-					field.Invalid(
-						field.NewPath("spec", "noCloudProvider"),
-						newM3C.Spec.NoCloudProvider,
-						"ValidateUpdate failed, noCloudProvider conflicts the value of cloudProviderEnabled",
-					),
-				)
-			}
 		}
 	}
 

--- a/internal/webhooks/v1beta1/metal3cluster_webhook_test.go
+++ b/internal/webhooks/v1beta1/metal3cluster_webhook_test.go
@@ -124,6 +124,25 @@ func TestMetal3ClusterValidation(t *testing.T) {
 			oldCluster: valid,
 		},
 		{
+			name:              "should fail when cloudProviderEnabled and noCloudProvider have conflicting values in new object",
+			expectErrOnCreate: true,
+			expectErrOnUpdate: true,
+			newCluster: &infrav1.Metal3Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: infrav1.Metal3ClusterSpec{
+					ControlPlaneEndpoint: infrav1.APIEndpoint{
+						Host: "abc.com",
+						Port: 443,
+					},
+					CloudProviderEnabled: ptr.To(true),
+					NoCloudProvider:      ptr.To(true),
+				},
+			},
+			oldCluster: valid,
+		},
+		{
 			name:              "should succeed when cloudProviderEnabled and noCloudProvider do not conflict",
 			expectErrOnCreate: false,
 			expectErrOnUpdate: false,
@@ -153,9 +172,9 @@ func TestMetal3ClusterValidation(t *testing.T) {
 			},
 		},
 		{
-			name:              "should not succeed when cloudProviderEnabled and noCloudProvider do conflict on update",
+			name:              "should succeed when cloudProviderEnabled and noCloudProvider do not conflict on update",
 			expectErrOnCreate: false,
-			expectErrOnUpdate: true,
+			expectErrOnUpdate: false,
 			newCluster: &infrav1.Metal3Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "foo",
@@ -178,6 +197,128 @@ func TestMetal3ClusterValidation(t *testing.T) {
 						Port: 443,
 					},
 					NoCloudProvider: ptr.To(false),
+				},
+			},
+		},
+		{
+			name:              "should succeed when enabling cloudProvider from disabled state",
+			expectErrOnCreate: false,
+			expectErrOnUpdate: false,
+			newCluster: &infrav1.Metal3Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: infrav1.Metal3ClusterSpec{
+					ControlPlaneEndpoint: infrav1.APIEndpoint{
+						Host: "abc.com",
+						Port: 443,
+					},
+					CloudProviderEnabled: ptr.To(true),
+					NoCloudProvider:      ptr.To(false),
+				},
+			},
+			oldCluster: &infrav1.Metal3Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: infrav1.Metal3ClusterSpec{
+					ControlPlaneEndpoint: infrav1.APIEndpoint{
+						Host: "abc.com",
+						Port: 443,
+					},
+					CloudProviderEnabled: ptr.To(false),
+					NoCloudProvider:      ptr.To(true),
+				},
+			},
+		},
+		{
+			name:              "should succeed when disabling cloudProvider from enabled state",
+			expectErrOnCreate: false,
+			expectErrOnUpdate: false,
+			newCluster: &infrav1.Metal3Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: infrav1.Metal3ClusterSpec{
+					ControlPlaneEndpoint: infrav1.APIEndpoint{
+						Host: "abc.com",
+						Port: 443,
+					},
+					CloudProviderEnabled: ptr.To(false),
+					NoCloudProvider:      ptr.To(true),
+				},
+			},
+			oldCluster: &infrav1.Metal3Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: infrav1.Metal3ClusterSpec{
+					ControlPlaneEndpoint: infrav1.APIEndpoint{
+						Host: "abc.com",
+						Port: 443,
+					},
+					CloudProviderEnabled: ptr.To(true),
+					NoCloudProvider:      ptr.To(false),
+				},
+			},
+		},
+		{
+			name:              "should succeed when updating with only cloudProviderEnabled changing from false to true",
+			expectErrOnCreate: false,
+			expectErrOnUpdate: false,
+			newCluster: &infrav1.Metal3Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: infrav1.Metal3ClusterSpec{
+					ControlPlaneEndpoint: infrav1.APIEndpoint{
+						Host: "abc.com",
+						Port: 443,
+					},
+					CloudProviderEnabled: ptr.To(true),
+				},
+			},
+			oldCluster: &infrav1.Metal3Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: infrav1.Metal3ClusterSpec{
+					ControlPlaneEndpoint: infrav1.APIEndpoint{
+						Host: "abc.com",
+						Port: 443,
+					},
+					CloudProviderEnabled: ptr.To(false),
+					NoCloudProvider:      ptr.To(true),
+				},
+			},
+		},
+		{
+			name:              "should succeed when updating with only noCloudProvider changing from true to false",
+			expectErrOnCreate: false,
+			expectErrOnUpdate: false,
+			newCluster: &infrav1.Metal3Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: infrav1.Metal3ClusterSpec{
+					ControlPlaneEndpoint: infrav1.APIEndpoint{
+						Host: "abc.com",
+						Port: 443,
+					},
+					NoCloudProvider: ptr.To(false),
+				},
+			},
+			oldCluster: &infrav1.Metal3Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: infrav1.Metal3ClusterSpec{
+					ControlPlaneEndpoint: infrav1.APIEndpoint{
+						Host: "abc.com",
+						Port: 443,
+					},
+					CloudProviderEnabled: ptr.To(false),
+					NoCloudProvider:      ptr.To(true),
 				},
 			},
 		},


### PR DESCRIPTION
The validating webhook incorrectly rejected updates when toggling the cloudProviderEnabled field from true to false or vice versa. The cross-field validation was comparing new values against old values of the opposite field (e.g., newM3C.CloudProviderEnabled vs oldM3C.NoCloudProvider), which would always fail when legitimately changing the cloudProvider setting.

Remove the incorrect cross-field validation between old and new objects. The internal consistency check (ensuring cloudProviderEnabled and noCloudProvider are opposite values in the new object) is sufficient, especially since the defaulting webhook keeps both fields in sync.

Add test cases to verify:
- Enabling cloudProvider from disabled state works
- Disabling cloudProvider from enabled state works
- Partial updates with only one field changing work
- Internal conflicts (both fields set to same value) are still caught

