### PR TITLE
🌱 Refactor E2E tests: improve input handling and machine filtering logic

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -352,7 +352,7 @@ func updateCilium(config *clusterctl.E2EConfig, cniPath string) {
 		},
 	}
 
-	manifest, err := generateTemplateFromHelmChart(ctx, opts, manifestOverwriteValues, e2eConfig)
+	manifest, err := GenerateTemplateFromHelmChart(ctx, opts, manifestOverwriteValues, e2eConfig)
 	Expect(err).ToNot(HaveOccurred(), "failed to generate template: %v", err)
 
 	// Replace ${BIN_PATH} with /opt/cni/bin. This is done to prevent

--- a/test/e2e/healthcheck.go
+++ b/test/e2e/healthcheck.go
@@ -33,7 +33,7 @@ type HealthCheckInput struct {
 	SpecName              string
 }
 
-func healthcheck(ctx context.Context, inputGetter func() HealthCheckInput) {
+func HealthCheck(ctx context.Context, inputGetter func() HealthCheckInput) {
 	input := inputGetter()
 	bootstrapClusterClient := input.BootstrapClusterProxy.GetClient()
 	namespace := input.Namespace

--- a/test/e2e/helm_helper.go
+++ b/test/e2e/helm_helper.go
@@ -25,7 +25,7 @@ type HelmOpts struct {
 	Driver         string
 }
 
-func generateTemplateFromHelmChart(ctx context.Context, opts HelmOpts, manifestOverwriteValues map[string]interface{}, e2econfig *clusterctl.E2EConfig) (string, error) {
+func GenerateTemplateFromHelmChart(ctx context.Context, opts HelmOpts, manifestOverwriteValues map[string]interface{}, e2econfig *clusterctl.E2EConfig) (string, error) {
 	actionConfig, err := initActionConfig(opts)
 	if err != nil {
 		return "", fmt.Errorf("failed to init action config: %w", err)

--- a/test/e2e/integration_test.go
+++ b/test/e2e/integration_test.go
@@ -44,7 +44,7 @@ var _ = Describe("When testing integration", Label("integration"), func() {
 			}
 		})
 		By("Pivot objects to target cluster")
-		pivoting(ctx, func() PivotingInput {
+		Pivoting(ctx, func() PivotingInput {
 			return PivotingInput{
 				E2EConfig:             e2eConfig,
 				BootstrapClusterProxy: bootstrapClusterProxy,
@@ -66,7 +66,7 @@ var _ = Describe("When testing integration", Label("integration"), func() {
 			ClusterctlConfigPath: clusterctlConfigPath,
 		})
 		By("Repivot objects to the source cluster")
-		rePivoting(ctx, func() RePivotingInput {
+		RePivoting(ctx, func() RePivotingInput {
 			return RePivotingInput{
 				E2EConfig:             e2eConfig,
 				BootstrapClusterProxy: bootstrapClusterProxy,

--- a/test/e2e/node_deletion_remediation.go
+++ b/test/e2e/node_deletion_remediation.go
@@ -20,7 +20,7 @@ import (
 
 const minK8sVersionOutOfServiceTaint = "1.28"
 
-type NodeRemediation struct {
+type NodeRemediationInput struct {
 	E2EConfig             *clusterctl.E2EConfig
 	BootstrapClusterProxy framework.ClusterProxy
 	TargetCluster         framework.ClusterProxy
@@ -63,7 +63,7 @@ type NodeRemediation struct {
  * resiliency of the cluster by allowing workloads to be seamlessly migrated from unhealthy nodes to healthy node
  */
 
-func nodeRemediation(ctx context.Context, inputGetter func() NodeRemediation) {
+func NodeRemediation(ctx context.Context, inputGetter func() NodeRemediationInput) {
 	Logf("Starting node remediation tests")
 	input := inputGetter()
 	bootstrapClient := input.BootstrapClusterProxy.GetClient()

--- a/test/e2e/node_reuse.go
+++ b/test/e2e/node_reuse.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"path/filepath"
 	"reflect"
 	"time"
 
@@ -21,21 +22,20 @@ import (
 )
 
 type NodeReuseInput struct {
-	E2EConfig         *clusterctl.E2EConfig
-	ManagementCluster framework.ClusterProxy
-	TargetCluster     framework.ClusterProxy
-	SpecName          string
-	ClusterName       string
-	Namespace         string
+	E2EConfig      *clusterctl.E2EConfig
+	ClusterProxy   framework.ClusterProxy
+	SpecName       string
+	ClusterName    string
+	Namespace      string
+	ArtifactFolder string
 }
 
 // NodeReuse verifies the feature of reusing the same node after upgrading kcp/md nodes.
-func nodeReuse(ctx context.Context, inputGetter func() NodeReuseInput) {
+func NodeReuse(ctx context.Context, inputGetter func() NodeReuseInput) {
 	Logf("Starting node reuse tests [node_reuse]")
 	input := inputGetter()
-	targetClusterClient := input.TargetCluster.GetClient()
-	managementClusterClient := input.ManagementCluster.GetClient()
-	clientSet := input.TargetCluster.GetClientSet()
+	clusterClient := input.ClusterProxy.GetClient()
+	clientSet := input.ClusterProxy.GetClientSet()
 	fromK8sVersion := input.E2EConfig.MustGetVariable("KUBERNETES_PATCH_FROM_VERSION")
 	toK8sVersion := input.E2EConfig.MustGetVariable("KUBERNETES_PATCH_TO_VERSION")
 	numberOfWorkers := int(*input.E2EConfig.MustGetInt32PtrVariable("WORKER_MACHINE_COUNT"))
@@ -60,60 +60,61 @@ func nodeReuse(ctx context.Context, inputGetter func() NodeReuseInput) {
 	Logf("NUMBER OF CONTROLPLANE BMH: %v", numberOfControlplane)
 	Logf("NUMBER OF WORKER BMH: %v", numberOfWorkers)
 
-	ListBareMetalHosts(ctx, managementClusterClient, client.InNamespace(input.Namespace))
-	ListMetal3Machines(ctx, managementClusterClient, client.InNamespace(input.Namespace))
-	ListMachines(ctx, managementClusterClient, client.InNamespace(input.Namespace))
-	ListNodes(ctx, targetClusterClient)
+	ListBareMetalHosts(ctx, clusterClient, client.InNamespace(input.Namespace))
+	ListMetal3Machines(ctx, clusterClient, client.InNamespace(input.Namespace))
+	ListMachines(ctx, clusterClient, client.InNamespace(input.Namespace))
+	ListNodes(ctx, clusterClient)
 
 	By("Untaint all CP nodes before scaling down machinedeployment [node_reuse]")
 	for controlplaneNodesPresent := 0; controlplaneNodesPresent < numberOfControlplane; {
 		for untaintedNodeCount := 1; untaintedNodeCount > 0; {
 			controlplaneNodes := getControlplaneNodes(ctx, clientSet)
 			controlplaneNodesPresent = len(controlplaneNodes.Items)
-			untaintedNodeCount = untaintNodes(ctx, targetClusterClient, controlplaneNodes, controlplaneTaints)
+			untaintedNodeCount = untaintNodes(ctx, clusterClient, controlplaneNodes, controlplaneTaints)
 			time.Sleep(10 * time.Second)
 		}
 	}
 
 	By("Scale down MachineDeployment to 0 [node_reuse]")
 	// this removes the worker node(s)
-	ScaleMachineDeployment(ctx, managementClusterClient, input.ClusterName, input.Namespace, 0)
+	ScaleMachineDeployment(ctx, clusterClient, input.ClusterName, input.Namespace, 0)
+	numberOfWorkers = 0
 
-	Byf("Wait until the worker is scaled down and %d BMH(s) Available [node_reuse]", 1)
+	Byf("Wait until the worker is scaled down and %d BMH(s) Available [node_reuse]", numberOfAllBmh-numberOfControlplane-numberOfWorkers)
 	WaitForNumBmhInState(ctx, bmov1alpha1.StateAvailable, WaitForNumInput{
-		Client:    managementClusterClient,
+		Client:    clusterClient,
 		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
-		Replicas:  1,
+		Replicas:  numberOfAllBmh - numberOfControlplane - numberOfWorkers,
 		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-bmh-available"),
 	})
 
 	By("Wait for all pods to be running after workers were scaled down to 0 [node_reuse]")
 	// Give time for the pods to settle before starting the upgrade process
 	framework.WaitForPodListCondition(ctx, framework.WaitForPodListConditionInput{
-		Lister:      targetClusterClient,
+		Lister:      clusterClient,
 		ListOptions: &client.ListOptions{LabelSelector: labels.Everything(), Namespace: "kube-system"},
 		Condition:   framework.PhasePodCondition(corev1.PodRunning),
 	}, input.E2EConfig.GetIntervals(input.SpecName, "wait-all-pod-to-be-running-on-target-cluster")...)
 
 	By("Get the provisioned BMH names and UUIDs [node_reuse]")
-	kcpBmhBeforeUpgrade := getProvisionedBmhNamesUuids(ctx, input.Namespace, managementClusterClient)
+	kcpBmhBeforeUpgrade := getProvisionedBmhNamesUuids(ctx, input.Namespace, clusterClient)
 
 	By("Download image [node_reuse]")
 	imageURL, imageChecksum := EnsureImage(toK8sVersion)
 
 	By("Set nodeReuse field to 'True' and create new KCP Metal3MachineTemplate with upgraded image to boot [node_reuse]")
 	m3MachineTemplateName := input.ClusterName + "-controlplane"
-	updateNodeReuse(ctx, input.Namespace, true, m3MachineTemplateName, managementClusterClient)
+	updateNodeReuse(ctx, input.Namespace, true, m3MachineTemplateName, clusterClient)
 	newM3MachineTemplateName := input.ClusterName + "-new-controlplane"
-	CreateNewM3MachineTemplate(ctx, input.Namespace, newM3MachineTemplateName, m3MachineTemplateName, managementClusterClient, imageURL, imageChecksum)
+	CreateNewM3MachineTemplate(ctx, input.Namespace, newM3MachineTemplateName, m3MachineTemplateName, clusterClient, imageURL, imageChecksum)
 
 	Byf("Update KCP to upgrade k8s version and binaries from %s to %s [node_reuse]", fromK8sVersion, toK8sVersion)
 	kcpObj := framework.GetKubeadmControlPlaneByCluster(ctx, framework.GetKubeadmControlPlaneByClusterInput{
-		Lister:      managementClusterClient,
+		Lister:      clusterClient,
 		ClusterName: input.ClusterName,
 		Namespace:   input.Namespace,
 	})
-	helper, err := patch.NewHelper(kcpObj, managementClusterClient)
+	helper, err := patch.NewHelper(kcpObj, clusterClient)
 	Expect(err).NotTo(HaveOccurred())
 	kcpObj.Spec.MachineTemplate.Spec.InfrastructureRef.Name = newM3MachineTemplateName
 	kcpObj.Spec.Version = toK8sVersion
@@ -121,6 +122,18 @@ func nodeReuse(ctx context.Context, inputGetter func() NodeReuseInput) {
 	Logf("Disable tainting of CP nodes during the remainder of the node reuse test [node_reuse]")
 	kcpObj.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.Taints = ptr.To(emptyTaint)
 	kcpObj.Spec.KubeadmConfigSpec.InitConfiguration.NodeRegistration.Taints = ptr.To(emptyTaint)
+
+	By("Fetch cluster logs and manifests before patching KCP [node_reuse]")
+	err = FetchClusterLogs(input.ClusterProxy, filepath.Join(input.ArtifactFolder, "node_reuse", "preUpgrade-kcp", "logs"))
+	if err != nil {
+		Logf("Error: %v", err)
+	}
+
+	err = FetchManifests(input.ClusterProxy, filepath.Join(input.ArtifactFolder, "node_reuse", "preUpgrade-kcp", "manifests"))
+	if err != nil {
+		Logf("Error fetching manifests: %v", err)
+	}
+
 	patchRequestError := helper.Patch(ctx, kcpObj)
 	if patchRequestError != nil {
 		Logf("Error while patching KCP: %s [node_reuse]", patchRequestError.Error())
@@ -130,19 +143,19 @@ func nodeReuse(ctx context.Context, inputGetter func() NodeReuseInput) {
 
 	By("Check if only a single machine is in Deleting state and no other new machines are in Provisioning state [node_reuse]")
 	WaitForNumMachinesInState(ctx, clusterv1.MachinePhaseDeleting, WaitForNumInput{
-		Client:    managementClusterClient,
+		Client:    clusterClient,
 		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
 		Replicas:  1,
 		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-machine-deleting"),
 	})
 	// Since we do scale in, no Machine should start provisioning yet (the old must be deleted first)
 	machineList := &clusterv1.MachineList{}
-	Expect(managementClusterClient.List(ctx, machineList, client.InNamespace(input.Namespace))).To(Succeed())
+	Expect(clusterClient.List(ctx, machineList, client.InNamespace(input.Namespace))).To(Succeed())
 	Expect(FilterMachinesByPhase(machineList.Items, clusterv1.MachinePhaseProvisioning)).To(BeEmpty())
 
 	Byf("Wait until 1 BMH is in deprovisioning state [node_reuse]")
 	WaitForNumBmhInState(ctx, bmov1alpha1.StateDeprovisioning, WaitForNumInput{
-		Client:    managementClusterClient,
+		Client:    clusterClient,
 		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
 		Replicas:  1,
 		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-bmh-deprovisioning"),
@@ -150,7 +163,7 @@ func nodeReuse(ctx context.Context, inputGetter func() NodeReuseInput) {
 
 	Logf("Find the deprovisioning BMH [node_reuse]")
 	bmhList := bmov1alpha1.BareMetalHostList{}
-	Expect(managementClusterClient.List(ctx, &bmhList, client.InNamespace(input.Namespace))).To(Succeed())
+	Expect(clusterClient.List(ctx, &bmhList, client.InNamespace(input.Namespace))).To(Succeed())
 	deprovisioningBmhs := FilterBmhsByProvisioningState(bmhList.Items, bmov1alpha1.StateDeprovisioning)
 	Expect(deprovisioningBmhs).To(HaveLen(1))
 	key := types.NamespacedName{Name: deprovisioningBmhs[0].Name, Namespace: input.Namespace}
@@ -159,63 +172,58 @@ func nodeReuse(ctx context.Context, inputGetter func() NodeReuseInput) {
 	Eventually(
 		func(g Gomega) {
 			bmh := bmov1alpha1.BareMetalHost{}
-			g.Expect(managementClusterClient.Get(ctx, key, &bmh)).To(Succeed())
+			g.Expect(clusterClient.Get(ctx, key, &bmh)).To(Succeed())
 			g.Expect(bmh.Status.Provisioning.State).To(Equal(bmov1alpha1.StateAvailable))
 		}, input.E2EConfig.GetIntervals(input.SpecName, "wait-bmh-deprovisioning-available")...,
 	).Should(Succeed())
 
+	By("Fetch cluster logs and manifests after patching KCP [node_reuse]")
+	err = FetchClusterLogs(input.ClusterProxy, filepath.Join(input.ArtifactFolder, "node_reuse", "postUpgrade-kcp", "logs"))
+	if err != nil {
+		Logf("Error: %v", err)
+	}
+	err = FetchManifests(input.ClusterProxy, filepath.Join(input.ArtifactFolder, "node_reuse", "postUpgrade-kcp", "manifests"))
+	if err != nil {
+		Logf("Error fetching manifests: %v", err)
+	}
 	By("Check if just deprovisioned BMH re-used for the next provisioning [node_reuse]")
 	Eventually(
 		func(g Gomega) {
 			bmh := bmov1alpha1.BareMetalHost{}
-			g.Expect(managementClusterClient.Get(ctx, key, &bmh)).To(Succeed())
+			g.Expect(clusterClient.Get(ctx, key, &bmh)).To(Succeed())
 			g.Expect(bmh.Status.Provisioning.State).To(Equal(bmov1alpha1.StateProvisioning))
 		}, input.E2EConfig.GetIntervals(input.SpecName, "wait-bmh-available-provisioning")...,
 	).Should(Succeed())
 
-	Byf("Wait until two machines become running and updated with the new %s k8s version [node_reuse]", toK8sVersion)
-	runningAndUpgraded := func(machine clusterv1.Machine) bool {
+	Byf("Wait until all %v KCP machines become running and updated with new %s k8s version [node_reuse]", numberOfControlplane, toK8sVersion)
+	runningAndUpgradedKCPMachines := func(machine clusterv1.Machine) bool {
 		running := machine.Status.GetTypedPhase() == clusterv1.MachinePhaseRunning
 		upgraded := machine.Spec.Version == toK8sVersion
-		return (running && upgraded)
+		_, isControlPlane := machine.GetLabels()[clusterv1.MachineControlPlaneLabel]
+		return running && upgraded && isControlPlane
 	}
-	WaitForNumMachines(ctx, runningAndUpgraded, WaitForNumInput{
-		Client:    managementClusterClient,
-		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
-		Replicas:  2,
-		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-machine-running"),
-	})
-
-	ListBareMetalHosts(ctx, managementClusterClient, client.InNamespace(input.Namespace))
-	ListMetal3Machines(ctx, managementClusterClient, client.InNamespace(input.Namespace))
-	ListMachines(ctx, managementClusterClient, client.InNamespace(input.Namespace))
-	ListNodes(ctx, targetClusterClient)
-
-	Byf("Wait until all %v KCP machines become running and updated with new %s k8s version [node_reuse]", numberOfControlplane, toK8sVersion)
-	WaitForNumMachines(ctx, runningAndUpgraded, WaitForNumInput{
-		Client:    managementClusterClient,
+	WaitForNumMachines(ctx, runningAndUpgradedKCPMachines, WaitForNumInput{
+		Client:    clusterClient,
 		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
 		Replicas:  numberOfControlplane,
 		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-machine-running"),
 	})
 
-	By("Wait for all CP nodes to be present after the CP upgrade has ended [node_reuse]")
-	for controlplaneNodesPresent := 0; controlplaneNodesPresent < numberOfControlplane; {
-		controlplaneNodes := getControlplaneNodes(ctx, clientSet)
-		controlplaneNodesPresent = len(controlplaneNodes.Items)
-		time.Sleep(5 * time.Second)
-	}
+	ListBareMetalHosts(ctx, clusterClient, client.InNamespace(input.Namespace))
+	ListMetal3Machines(ctx, clusterClient, client.InNamespace(input.Namespace))
+	ListMachines(ctx, clusterClient, client.InNamespace(input.Namespace))
+	ListNodes(ctx, clusterClient)
 
 	By("Wait for all the pods to be running on the cluster after the upgrade process has ended [node_reuse]")
 	framework.WaitForPodListCondition(ctx, framework.WaitForPodListConditionInput{
-		Lister:      targetClusterClient,
+		Lister:      clusterClient,
 		ListOptions: &client.ListOptions{LabelSelector: labels.Everything(), Namespace: "kube-system"},
 		Condition:   framework.PhasePodCondition(corev1.PodRunning),
 	}, input.E2EConfig.GetIntervals(input.SpecName, "wait-all-pod-to-be-running-on-target-cluster")...)
-	Logf("The CP upgrade process has endend [node_reuse]")
+	Logf("The CP upgrade process has ended [node_reuse]")
 
 	By("Get the provisioned BMH names and UUIDs after upgrade [node_reuse]")
-	kcpBmhAfterUpgrade := getProvisionedBmhNamesUuids(ctx, input.Namespace, managementClusterClient)
+	kcpBmhAfterUpgrade := getProvisionedBmhNamesUuids(ctx, input.Namespace, clusterClient)
 
 	By("Check difference between before and after upgrade mappings")
 	equal := reflect.DeepEqual(kcpBmhBeforeUpgrade, kcpBmhAfterUpgrade)
@@ -223,11 +231,11 @@ func nodeReuse(ctx context.Context, inputGetter func() NodeReuseInput) {
 
 	By("Put maxSurge field in KubeadmControlPlane back to default value(1) [node_reuse]")
 	kcpObj = framework.GetKubeadmControlPlaneByCluster(ctx, framework.GetKubeadmControlPlaneByClusterInput{
-		Lister:      managementClusterClient,
+		Lister:      clusterClient,
 		ClusterName: input.ClusterName,
 		Namespace:   input.Namespace,
 	})
-	helper, err = patch.NewHelper(kcpObj, managementClusterClient)
+	helper, err = patch.NewHelper(kcpObj, clusterClient)
 	Expect(err).NotTo(HaveOccurred())
 	kcpObj.Spec.Rollout.Strategy.RollingUpdate.MaxSurge.IntVal = 1
 	for range 3 {
@@ -239,18 +247,18 @@ func nodeReuse(ctx context.Context, inputGetter func() NodeReuseInput) {
 	}
 
 	By("Scale the controlplane down to 1 [node_reuse]")
-	ScaleKubeadmControlPlane(ctx, managementClusterClient, client.ObjectKey{Namespace: input.Namespace, Name: input.ClusterName}, 1)
-
-	Byf("Wait until controlplane is scaled down and %d BMHs are Available [node_reuse]", (numberOfControlplane - 1 + numberOfWorkers))
+	ScaleKubeadmControlPlane(ctx, clusterClient, client.ObjectKey{Namespace: input.Namespace, Name: input.ClusterName}, 1)
+	numberOfControlplane = 1
+	Byf("Wait until controlplane is scaled down and %d BMHs are Available [node_reuse]", (numberOfAllBmh - numberOfControlplane - numberOfWorkers))
 	WaitForNumBmhInState(ctx, bmov1alpha1.StateAvailable, WaitForNumInput{
-		Client:    managementClusterClient,
+		Client:    clusterClient,
 		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
-		Replicas:  numberOfControlplane,
+		Replicas:  numberOfAllBmh - numberOfControlplane - numberOfWorkers,
 		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-cp-available"),
 	})
 
 	By("Wait for 1 CP nodes to be present after CP was scaled to 1 [node_reuse]")
-	for controlplaneNodesPresent := 0; controlplaneNodesPresent != 1; {
+	for controlplaneNodesPresent := 0; controlplaneNodesPresent != numberOfControlplane; {
 		controlplaneNodes := getControlplaneNodes(ctx, clientSet)
 		controlplaneNodesPresent = len(controlplaneNodes.Items)
 		time.Sleep(5 * time.Second)
@@ -258,20 +266,20 @@ func nodeReuse(ctx context.Context, inputGetter func() NodeReuseInput) {
 
 	By("Wait for all the pods to be running on the cluster after CP was scaled to 1 [node_reuse]")
 	framework.WaitForPodListCondition(ctx, framework.WaitForPodListConditionInput{
-		Lister:      targetClusterClient,
+		Lister:      clusterClient,
 		ListOptions: &client.ListOptions{LabelSelector: labels.Everything(), Namespace: "kube-system"},
 		Condition:   framework.PhasePodCondition(corev1.PodRunning),
 	}, input.E2EConfig.GetIntervals(input.SpecName, "wait-all-pod-to-be-running-on-target-cluster")...)
 
 	By("Cluster components listed after CP was scaled to 1 [node_reuse]")
-	ListBareMetalHosts(ctx, managementClusterClient, client.InNamespace(input.Namespace))
-	ListMetal3Machines(ctx, managementClusterClient, client.InNamespace(input.Namespace))
-	ListMachines(ctx, managementClusterClient, client.InNamespace(input.Namespace))
-	ListNodes(ctx, targetClusterClient)
+	ListBareMetalHosts(ctx, clusterClient, client.InNamespace(input.Namespace))
+	ListMetal3Machines(ctx, clusterClient, client.InNamespace(input.Namespace))
+	ListMachines(ctx, clusterClient, client.InNamespace(input.Namespace))
+	ListNodes(ctx, clusterClient)
 
 	By("Get MachineDeployment")
 	machineDeployments := framework.GetMachineDeploymentsByCluster(ctx, framework.GetMachineDeploymentsByClusterInput{
-		Lister:      managementClusterClient,
+		Lister:      clusterClient,
 		ClusterName: input.ClusterName,
 		Namespace:   input.Namespace,
 	})
@@ -281,68 +289,95 @@ func nodeReuse(ctx context.Context, inputGetter func() NodeReuseInput) {
 	By("Get Metal3MachineTemplate name for MachineDeployment [node_reuse]")
 	m3MachineTemplateName = input.ClusterName + "-workers"
 
-	By("Point to proper Metal3MachineTemplate in MachineDeployment [node_reuse]")
-	pointMDtoM3mt(ctx, input.Namespace, input.ClusterName, m3MachineTemplateName, machineDeploy.Name, managementClusterClient)
-
 	By("Scale the worker up to 1 to start testing MachineDeployment [node_reuse]")
-	ScaleMachineDeployment(ctx, managementClusterClient, input.ClusterName, input.Namespace, 1)
+	ScaleMachineDeployment(ctx, clusterClient, input.ClusterName, input.Namespace, 1)
+	numberOfWorkers = 1
 
 	Byf("Wait until the worker BMH becomes provisioned [node_reuse]")
 	WaitForNumBmhInState(ctx, bmov1alpha1.StateProvisioned, WaitForNumInput{
-		Client:    managementClusterClient,
+		Client:    clusterClient,
 		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
-		Replicas:  2,
+		Replicas:  numberOfControlplane + numberOfWorkers,
 		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-bmh-provisioned"),
 	})
 
+	Byf("Wait until worker machine becomes running with %s k8s version [node_reuse]", fromK8sVersion)
+	runningWorkerMachines := func(machine clusterv1.Machine) bool {
+		running := machine.Status.GetTypedPhase() == clusterv1.MachinePhaseRunning
+		upgraded := machine.Spec.Version == fromK8sVersion
+		_, isControlPlane := machine.GetLabels()[clusterv1.MachineControlPlaneLabel]
+		return running && upgraded && !isControlPlane
+	}
 	Byf("Wait until the worker machine becomes running [node_reuse]")
-	WaitForNumMachinesInState(ctx, clusterv1.MachinePhaseRunning, WaitForNumInput{
-		Client:    managementClusterClient,
+	WaitForNumMachines(ctx, runningWorkerMachines, WaitForNumInput{
+		Client:    clusterClient,
 		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
-		Replicas:  2,
+		Replicas:  numberOfWorkers,
 		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-machine-running"),
 	})
 
 	By("Wait for all the pods to be running on the cluster after worker node was scaled up to 1 [node_reuse]")
 	framework.WaitForPodListCondition(ctx, framework.WaitForPodListConditionInput{
-		Lister:      targetClusterClient,
+		Lister:      clusterClient,
 		ListOptions: &client.ListOptions{LabelSelector: labels.Everything(), Namespace: "kube-system"},
 		Condition:   framework.PhasePodCondition(corev1.PodRunning),
 	}, input.E2EConfig.GetIntervals(input.SpecName, "wait-all-pod-to-be-running-on-target-cluster")...)
 
 	By("Get the provisioned BMH names and UUIDs before starting upgrade in MachineDeployment [node_reuse]")
-	mdBmhBeforeUpgrade := getProvisionedBmhNamesUuids(ctx, input.Namespace, managementClusterClient)
+	mdBmhBeforeUpgrade := getProvisionedBmhNamesUuids(ctx, input.Namespace, clusterClient)
 
 	By("List all available BMHs, remove nodeReuse label from them if any [node_reuse]")
 	bmhs := bmov1alpha1.BareMetalHostList{}
-	Expect(managementClusterClient.List(ctx, &bmhs, client.InNamespace(input.Namespace))).To(Succeed())
+	Expect(clusterClient.List(ctx, &bmhs, client.InNamespace(input.Namespace))).To(Succeed())
 	for _, item := range bmhs.Items {
 		if item.Status.Provisioning.State == bmov1alpha1.StateAvailable {
 			// We make sure that all available BMHs are choosable by removing nodeReuse label
 			// set on them while testing KCP node reuse scenario previously.
-			DeleteNodeReuseLabelFromHost(ctx, managementClusterClient, item, nodeReuseLabel)
+			DeleteNodeReuseLabelFromHost(ctx, clusterClient, item, nodeReuseLabel)
 		}
 	}
 
+	// Verify labels were removed
+	Eventually(func(g Gomega) {
+		bmhs := bmov1alpha1.BareMetalHostList{}
+		g.Expect(clusterClient.List(ctx, &bmhs, client.InNamespace(input.Namespace))).To(Succeed())
+		for _, item := range bmhs.Items {
+			if item.Status.Provisioning.State == bmov1alpha1.StateAvailable {
+				g.Expect(item.Labels).NotTo(HaveKey(nodeReuseLabel))
+			}
+		}
+	}, 30*time.Second, 5*time.Second).Should(Succeed())
+
 	By("Set nodeReuse field to 'True' and create new Metal3MachineTemplate for MD with upgraded image to boot [node_reuse]")
-	updateNodeReuse(ctx, input.Namespace, true, m3MachineTemplateName, managementClusterClient)
+	updateNodeReuse(ctx, input.Namespace, true, m3MachineTemplateName, clusterClient)
 	newM3MachineTemplateName = input.ClusterName + "-new-workers"
-	CreateNewM3MachineTemplate(ctx, input.Namespace, newM3MachineTemplateName, m3MachineTemplateName, managementClusterClient, imageURL, imageChecksum)
+	CreateNewM3MachineTemplate(ctx, input.Namespace, newM3MachineTemplateName, m3MachineTemplateName, clusterClient, imageURL, imageChecksum)
 
 	Byf("Update MD to upgrade k8s version and binaries from %s to %s", fromK8sVersion, toK8sVersion)
 	// Note: We have only 4 nodes (3 control-plane and 1 worker) so we
 	// must allow maxUnavailable 1 here or it will get stuck.
-	helper, err = patch.NewHelper(machineDeploy, managementClusterClient)
+	helper, err = patch.NewHelper(machineDeploy, clusterClient)
 	Expect(err).NotTo(HaveOccurred())
 	machineDeploy.Spec.Rollout.Strategy.RollingUpdate.MaxSurge.IntVal = 0
 	machineDeploy.Spec.Rollout.Strategy.RollingUpdate.MaxUnavailable.IntVal = 1
 	machineDeploy.Spec.Template.Spec.InfrastructureRef.Name = newM3MachineTemplateName
 	machineDeploy.Spec.Template.Spec.Version = toK8sVersion
+
+	By("Fetch cluster logs and manifests before patching worker [node_reuse]")
+	err = FetchClusterLogs(input.ClusterProxy, filepath.Join(input.ArtifactFolder, "node_reuse", "preUpgrade-worker", "logs"))
+	if err != nil {
+		Logf("Error: %v", err)
+	}
+	err = FetchManifests(input.ClusterProxy, filepath.Join(input.ArtifactFolder, "node_reuse", "preUpgrade-worker", "manifests"))
+	if err != nil {
+		Logf("Error fetching manifests: %v", err)
+	}
+
 	Expect(helper.Patch(ctx, machineDeploy)).To(Succeed())
 
 	Byf("Wait until %d BMH(s) in deprovisioning state [node_reuse]", 1)
 	WaitForNumBmhInState(ctx, bmov1alpha1.StateDeprovisioning, WaitForNumInput{
-		Client:    managementClusterClient,
+		Client:    clusterClient,
 		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
 		Replicas:  1,
 		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-bmh-deprovisioning"),
@@ -350,7 +385,7 @@ func nodeReuse(ctx context.Context, inputGetter func() NodeReuseInput) {
 
 	Logf("Find the deprovisioning BMH [node_reuse]")
 	bmhList = bmov1alpha1.BareMetalHostList{}
-	Expect(managementClusterClient.List(ctx, &bmhList, client.InNamespace(input.Namespace))).To(Succeed())
+	Expect(clusterClient.List(ctx, &bmhList, client.InNamespace(input.Namespace))).To(Succeed())
 	deprovisioningBmhs = FilterBmhsByProvisioningState(bmhList.Items, bmov1alpha1.StateDeprovisioning)
 	Expect(deprovisioningBmhs).To(HaveLen(1))
 	key = types.NamespacedName{Name: deprovisioningBmhs[0].Name, Namespace: input.Namespace}
@@ -359,63 +394,80 @@ func nodeReuse(ctx context.Context, inputGetter func() NodeReuseInput) {
 	Eventually(
 		func(g Gomega) {
 			bmh := bmov1alpha1.BareMetalHost{}
-			g.Expect(managementClusterClient.Get(ctx, key, &bmh)).To(Succeed())
+			g.Expect(clusterClient.Get(ctx, key, &bmh)).To(Succeed())
 			g.Expect(bmh.Status.Provisioning.State).To(Equal(bmov1alpha1.StateAvailable))
 		},
 		input.E2EConfig.GetIntervals(input.SpecName, "wait-bmh-deprovisioning-available")...,
 	).Should(Succeed())
+
+	By("Fetch cluster logs and manifests after patching worker [node_reuse]")
+	err = FetchClusterLogs(input.ClusterProxy, filepath.Join(input.ArtifactFolder, "node_reuse", "postUpgrade-worker", "logs"))
+	if err != nil {
+		Logf("Error: %v", err)
+	}
+	err = FetchManifests(input.ClusterProxy, filepath.Join(input.ArtifactFolder, "node_reuse", "postUpgrade-worker", "manifests"))
+	if err != nil {
+		Logf("Error fetching manifests: %v", err)
+	}
 
 	By("Check if just deprovisioned BMH re-used for next provisioning [node_reuse]")
 	Eventually(
 		func(g Gomega) {
 			bmh := bmov1alpha1.BareMetalHost{}
 			key := types.NamespacedName{Name: deprovisioningBmhs[0].Name, Namespace: input.Namespace}
-			g.Expect(managementClusterClient.Get(ctx, key, &bmh)).To(Succeed())
+			g.Expect(clusterClient.Get(ctx, key, &bmh)).To(Succeed())
 			g.Expect(bmh.Status.Provisioning.State).To(Equal(bmov1alpha1.StateProvisioning))
 		},
 		input.E2EConfig.GetIntervals(input.SpecName, "wait-bmh-available-provisioning")...,
 	).Should(Succeed())
 
 	Byf("Wait until worker machine becomes running and updated with new %s k8s version [node_reuse]", toK8sVersion)
-	WaitForNumMachines(ctx, runningAndUpgraded, WaitForNumInput{
-		Client:    managementClusterClient,
+	runningAndUpgradedWorkerMachines := func(machine clusterv1.Machine) bool {
+		running := machine.Status.GetTypedPhase() == clusterv1.MachinePhaseRunning
+		upgraded := machine.Spec.Version == toK8sVersion
+		_, isControlPlane := machine.GetLabels()[clusterv1.MachineControlPlaneLabel]
+		return running && upgraded && !isControlPlane
+	}
+	WaitForNumMachines(ctx, runningAndUpgradedWorkerMachines, WaitForNumInput{
+		Client:    clusterClient,
 		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
-		Replicas:  2,
+		Replicas:  numberOfWorkers,
 		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-machine-running"),
 	})
 
 	By("Get provisioned BMH names and UUIDs after upgrade in MachineDeployment [node_reuse]")
-	mdBmhAfterUpgrade := getProvisionedBmhNamesUuids(ctx, input.Namespace, managementClusterClient)
+	mdBmhAfterUpgrade := getProvisionedBmhNamesUuids(ctx, input.Namespace, clusterClient)
 
 	By("Check difference between before and after upgrade mappings in MachineDeployment [node_reuse]")
 	equal = reflect.DeepEqual(mdBmhBeforeUpgrade, mdBmhAfterUpgrade)
 	Expect(equal).To(BeTrue(), "The same BMHs were not reused in MachineDeployment")
 
-	ListBareMetalHosts(ctx, managementClusterClient, client.InNamespace(input.Namespace))
-	ListMetal3Machines(ctx, managementClusterClient, client.InNamespace(input.Namespace))
-	ListMachines(ctx, managementClusterClient, client.InNamespace(input.Namespace))
-	ListNodes(ctx, targetClusterClient)
+	ListBareMetalHosts(ctx, clusterClient, client.InNamespace(input.Namespace))
+	ListMetal3Machines(ctx, clusterClient, client.InNamespace(input.Namespace))
+	ListMachines(ctx, clusterClient, client.InNamespace(input.Namespace))
+	ListNodes(ctx, clusterClient)
 
 	By("Scale controlplane up to 3 [node_reuse]")
-	ScaleKubeadmControlPlane(ctx, managementClusterClient, client.ObjectKey{Namespace: input.Namespace, Name: input.ClusterName}, 3)
+	ScaleKubeadmControlPlane(ctx, clusterClient, client.ObjectKey{Namespace: input.Namespace, Name: input.ClusterName}, 3)
+	numberOfControlplane = 3
 	WaitForNumBmhInState(ctx, bmov1alpha1.StateProvisioned, WaitForNumInput{
-		Client:    managementClusterClient,
+		Client:    clusterClient,
 		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
-		Replicas:  numberOfAllBmh,
+		Replicas:  numberOfControlplane + numberOfWorkers,
 		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-bmh-provisioned"),
 	})
 
-	Byf("Wait until all %d machine(s) become(s) running [node_reuse]", numberOfAllBmh)
+	Byf("Wait until all %d machine(s) become(s) running [node_reuse]", numberOfControlplane+numberOfWorkers)
 	WaitForNumMachinesInState(ctx, clusterv1.MachinePhaseRunning, WaitForNumInput{
-		Client:    managementClusterClient,
+		Client:    clusterClient,
 		Options:   []client.ListOption{client.InNamespace(input.Namespace)},
-		Replicas:  numberOfAllBmh,
+		Replicas:  numberOfControlplane + numberOfWorkers,
 		Intervals: input.E2EConfig.GetIntervals(input.SpecName, "wait-machine-running"),
 	})
 
 	By("Wait for all the pods to be running at the end of the node_reuse [node_reuse]")
 	framework.WaitForPodListCondition(ctx, framework.WaitForPodListConditionInput{
-		Lister:      targetClusterClient,
+		Lister:      clusterClient,
 		ListOptions: &client.ListOptions{LabelSelector: labels.Everything(), Namespace: "kube-system"},
 		Condition:   framework.PhasePodCondition(corev1.PodRunning),
 	}, input.E2EConfig.GetIntervals(input.SpecName, "wait-all-pod-to-be-running-on-target-cluster")...)
@@ -424,10 +476,10 @@ func nodeReuse(ctx context.Context, inputGetter func() NodeReuseInput) {
 	By("NODE REUSE TESTS PASSED!")
 }
 
-func getProvisionedBmhNamesUuids(ctx context.Context, namespace string, managementClusterClient client.Client) []string {
+func getProvisionedBmhNamesUuids(ctx context.Context, namespace string, clusterClient client.Client) []string {
 	bmhs := bmov1alpha1.BareMetalHostList{}
 	var nameUUIDList []string
-	Expect(managementClusterClient.List(ctx, &bmhs, client.InNamespace(namespace))).To(Succeed())
+	Expect(clusterClient.List(ctx, &bmhs, client.InNamespace(namespace))).To(Succeed())
 	for _, item := range bmhs.Items {
 		if item.WasProvisioned() {
 			concat := "metal3/" + item.Name + "=metal3://" + (string)(item.UID)
@@ -437,28 +489,15 @@ func getProvisionedBmhNamesUuids(ctx context.Context, namespace string, manageme
 	return nameUUIDList
 }
 
-func updateNodeReuse(ctx context.Context, namespace string, nodeReuse bool, m3MachineTemplateName string, managementClusterClient client.Client) {
+func updateNodeReuse(ctx context.Context, namespace string, nodeReuse bool, m3MachineTemplateName string, clusterClient client.Client) {
 	m3machineTemplate := infrav1beta1.Metal3MachineTemplate{}
-	Expect(managementClusterClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: m3MachineTemplateName}, &m3machineTemplate)).To(Succeed())
-	helper, err := patch.NewHelper(&m3machineTemplate, managementClusterClient)
+	Expect(clusterClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: m3MachineTemplateName}, &m3machineTemplate)).To(Succeed())
+	helper, err := patch.NewHelper(&m3machineTemplate, clusterClient)
 	Expect(err).NotTo(HaveOccurred())
 	m3machineTemplate.Spec.NodeReuse = nodeReuse
 	Expect(helper.Patch(ctx, &m3machineTemplate)).To(Succeed())
 
 	// verify that nodeReuse field is updated
-	Expect(managementClusterClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: m3MachineTemplateName}, &m3machineTemplate)).To(Succeed())
+	Expect(clusterClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: m3MachineTemplateName}, &m3machineTemplate)).To(Succeed())
 	Expect(m3machineTemplate.Spec.NodeReuse).To(BeEquivalentTo(nodeReuse))
-}
-
-func pointMDtoM3mt(ctx context.Context, namespace string, clusterName string, m3mtname, mdName string, managementClusterClient client.Client) {
-	md := clusterv1.MachineDeployment{}
-	Expect(managementClusterClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: mdName}, &md)).To(Succeed())
-	helper, err := patch.NewHelper(&md, managementClusterClient)
-	Expect(err).NotTo(HaveOccurred())
-	md.Spec.Template.Spec.InfrastructureRef.Name = m3mtname
-	Expect(helper.Patch(ctx, &md)).To(Succeed())
-
-	// verify that MachineDeployment is pointing to exact m3mt where nodeReuse is set to 'True'
-	Expect(managementClusterClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: mdName}, &md)).To(Succeed())
-	Expect(md.Spec.Template.Spec.InfrastructureRef.Name).To(BeEquivalentTo(clusterName + "-workers"))
 }

--- a/test/e2e/pivoting.go
+++ b/test/e2e/pivoting.go
@@ -53,7 +53,7 @@ type PivotingInput struct {
 }
 
 // Pivoting implements a test that verifies successful moving of management resources (CRs, BMO, Ironic) to a target cluster after initializing it with Provider components.
-func pivoting(ctx context.Context, inputGetter func() PivotingInput) {
+func Pivoting(ctx context.Context, inputGetter func() PivotingInput) {
 	Logf("Starting pivoting tests")
 	input := inputGetter()
 	numberOfWorkers := int(*input.E2EConfig.MustGetInt32PtrVariable("WORKER_MACHINE_COUNT"))
@@ -346,7 +346,7 @@ type RePivotingInput struct {
 	ClusterctlConfigPath  string
 }
 
-func rePivoting(ctx context.Context, inputGetter func() RePivotingInput) {
+func RePivoting(ctx context.Context, inputGetter func() RePivotingInput) {
 	Logf("Start the re-pivoting test")
 	input := inputGetter()
 	numberOfWorkers := int(*input.E2EConfig.MustGetInt32PtrVariable("WORKER_MACHINE_COUNT"))

--- a/test/e2e/pivoting_based_feature_test.go
+++ b/test/e2e/pivoting_based_feature_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Testing features in target cluster", Label("pivoting", "featur
 				}
 			})
 			managementCluster := targetCluster
-			pivoting(ctx, func() PivotingInput {
+			Pivoting(ctx, func() PivotingInput {
 				return PivotingInput{
 					E2EConfig:             e2eConfig,
 					BootstrapClusterProxy: bootstrapClusterProxy,
@@ -126,14 +126,14 @@ var _ = Describe("Testing features in target cluster", Label("pivoting", "featur
 				}
 			})
 
-			nodeReuse(ctx, func() NodeReuseInput {
+			NodeReuse(ctx, func() NodeReuseInput {
 				return NodeReuseInput{
-					E2EConfig:         e2eConfig,
-					ManagementCluster: managementCluster,
-					TargetCluster:     targetCluster,
-					SpecName:          specName,
-					ClusterName:       clusterName,
-					Namespace:         namespace,
+					E2EConfig:      e2eConfig,
+					ClusterProxy:   managementCluster,
+					SpecName:       specName,
+					ClusterName:    clusterName,
+					Namespace:      namespace,
+					ArtifactFolder: artifactFolder,
 				}
 			})
 		})
@@ -159,7 +159,7 @@ var _ = Describe("Testing features in target cluster", Label("pivoting", "featur
 				ClusterctlConfigPath: clusterctlConfigPath,
 			})
 
-			rePivoting(ctx, func() RePivotingInput {
+			RePivoting(ctx, func() RePivotingInput {
 				return RePivotingInput{
 					E2EConfig:             e2eConfig,
 					BootstrapClusterProxy: bootstrapClusterProxy,

--- a/test/e2e/remediation.go
+++ b/test/e2e/remediation.go
@@ -70,9 +70,9 @@ type RemediationInput struct {
  * 		Logf("REMEDIATION TESTS PASSED!")
  * 	}
  *
- * The remediation test ensures that the CAPM3 can effectively remediate worker nodes by performing necessary actions and annotations. It helps ensure the stability and resiliency of the cluster by allowing the cluster to recover from failure scenarios and successfully restore nodes to the desired state.
+ * The Remediation test ensures that the CAPM3 can effectively remediate worker nodes by performing necessary actions and annotations. It helps ensure the stability and resiliency of the cluster by allowing the cluster to recover from failure scenarios and successfully restore nodes to the desired state.
  */
-func remediation(ctx context.Context, inputGetter func() RemediationInput) {
+func Remediation(ctx context.Context, inputGetter func() RemediationInput) {
 	Logf("Starting remediation tests")
 	input := inputGetter()
 	numberOfWorkers := int(*input.E2EConfig.MustGetInt32PtrVariable("WORKER_MACHINE_COUNT"))
@@ -150,13 +150,13 @@ func remediation(ctx context.Context, inputGetter func() RemediationInput) {
 	ListNodes(ctx, targetClient)
 
 	// Calling an inspection tests here for now until we have a parallelism enabled in e2e framework.
-	inspection(ctx, func() InspectionInput {
+	Inspection(ctx, func() InspectionInput {
 		return InspectionInput{
-			E2EConfig:             input.E2EConfig,
-			BootstrapClusterProxy: input.BootstrapClusterProxy,
-			SpecName:              input.SpecName,
-			Namespace:             input.Namespace,
-			ClusterctlConfigPath:  input.ClusterctlConfigPath,
+			E2EConfig:            input.E2EConfig,
+			ClusterProxy:         input.BootstrapClusterProxy,
+			SpecName:             input.SpecName,
+			Namespace:            input.Namespace,
+			ClusterctlConfigPath: input.ClusterctlConfigPath,
 		}
 	})
 

--- a/test/e2e/remediation_based_feature_test.go
+++ b/test/e2e/remediation_based_feature_test.go
@@ -82,8 +82,8 @@ var _ = Describe("Testing nodes remediation", Label("remediation", "features"), 
 		})
 		// Run Metal3Remediation test first, doesn't work after remediation...
 		By("Running node remediation tests")
-		nodeRemediation(ctx, func() NodeRemediation {
-			return NodeRemediation{
+		NodeRemediation(ctx, func() NodeRemediationInput {
+			return NodeRemediationInput{
 				E2EConfig:             e2eConfig,
 				BootstrapClusterProxy: bootstrapClusterProxy,
 				TargetCluster:         targetCluster,
@@ -94,7 +94,7 @@ var _ = Describe("Testing nodes remediation", Label("remediation", "features"), 
 		})
 
 		By("Running healthcheck tests")
-		healthcheck(ctx, func() HealthCheckInput {
+		HealthCheck(ctx, func() HealthCheckInput {
 			return HealthCheckInput{
 				E2EConfig:             e2eConfig,
 				BootstrapClusterProxy: bootstrapClusterProxy,
@@ -105,7 +105,7 @@ var _ = Describe("Testing nodes remediation", Label("remediation", "features"), 
 		})
 
 		By("Running annotated powercycle remediation tests")
-		remediation(ctx, func() RemediationInput {
+		Remediation(ctx, func() RemediationInput {
 			return RemediationInput{
 				E2EConfig:             e2eConfig,
 				BootstrapClusterProxy: bootstrapClusterProxy,


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:
Addressing the refactoring that was discussed here: https://github.com/metal3-io/cluster-api-provider-metal3/pull/2776#discussion_r2707830042 , plus some other minor cleanup.

* Renamed the input parameter for the **CertRotation**, **Inspection**, and **NodeReuse** functions to **ClusterProxy** instead of **ManagementClusterProxy** or **TargetClusterProxy** to make it more generic. This change affects only the parameter name; the passed cluster remains the same.
* Refined the **runningAndUpgraded** filters to be more precise when evaluating worker and control plane nodes, and removed some unnecessary waits for machines.
* Capitalized the names of globally scoped functions for consistency and clarity.
* Fixed flakiness of node reuse test by adding eventually block after kcp upgrade that make sure that node reuse labels are removed from bmh before starting upgrade on worker machines


<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->



**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
