### PR TITLE
✨: Add custom Prometheus metrics for controller observability

### DIFF
--- a/controllers/metal3cluster_controller.go
+++ b/controllers/metal3cluster_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-logr/logr"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta2"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
+	"github.com/metal3-io/cluster-api-provider-metal3/internal/metrics"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,7 +53,7 @@ import (
 )
 
 const (
-	clusterControllerName = "Metal3Cluster-controller"
+	clusterControllerName = metrics.ControllerMetal3Cluster
 	requeueAfter          = time.Second * 30
 )
 
@@ -72,10 +73,23 @@ type Metal3ClusterReconciler struct {
 
 // Reconcile reads that state of the cluster for a Metal3Cluster object and makes changes based on the state read
 // and what is in the Metal3Cluster.Spec.
-func (r *Metal3ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
+func (r *Metal3ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (rres ctrl.Result, rerr error) {
+	reconcileStart := time.Now()
 	clusterLog := log.Log.WithName(clusterControllerName).WithValues(
 		baremetal.LogFieldMetal3Cluster, req.NamespacedName,
 	)
+
+	// Track metrics for this reconciliation
+	defer func() {
+		hasError := rerr != nil
+		metrics.RecordMetal3ClusterReconcile(req.Namespace, req.Name, reconcileStart, hasError)
+		if rerr != nil {
+			var reconcileErr baremetal.ReconcileError
+			isTransient := errors.As(rerr, &reconcileErr) && reconcileErr.IsTransient()
+			metrics.RecordReconcileError(clusterControllerName, req.Namespace, isTransient)
+		}
+	}()
+
 	clusterLog.V(baremetal.VerbosityLevelTrace).Info("Reconcile: starting Metal3Cluster reconciliation")
 
 	// Fetch the Metal3Cluster instance

--- a/controllers/metal3data_controller.go
+++ b/controllers/metal3data_controller.go
@@ -18,11 +18,14 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta2"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
+	"github.com/metal3-io/cluster-api-provider-metal3/internal/metrics"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -42,7 +45,7 @@ import (
 )
 
 const (
-	dataControllerName = "Metal3Data-controller"
+	dataControllerName = metrics.ControllerMetal3Data
 )
 
 // Metal3DataReconciler reconciles a Metal3Data object.
@@ -61,10 +64,24 @@ type Metal3DataReconciler struct {
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile handles Metal3Data events.
-func (r *Metal3DataReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
+func (r *Metal3DataReconciler) Reconcile(ctx context.Context, req ctrl.Request) (rres ctrl.Result, rerr error) {
+	reconcileStart := time.Now()
 	metadataLog := r.Log.WithName(dataControllerName).WithValues(
 		baremetal.LogFieldData, req.NamespacedName,
 	)
+
+	// Track metrics for this reconciliation.
+	hasError := false
+	defer func() {
+		if rerr != nil {
+			hasError = true
+			var reconcileErr baremetal.ReconcileError
+			isTransient := errors.As(rerr, &reconcileErr) && reconcileErr.IsTransient()
+			metrics.RecordReconcileError(dataControllerName, req.Namespace, isTransient)
+		}
+		metrics.RecordMetal3DataReconcile(req.Namespace, reconcileStart, hasError)
+	}()
+
 	metadataLog.V(baremetal.VerbosityLevelTrace).Info("Reconcile: starting Metal3Data reconciliation")
 
 	// Fetch the Metal3Data instance.

--- a/controllers/metal3datatemplate_controller.go
+++ b/controllers/metal3datatemplate_controller.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta2"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
+	"github.com/metal3-io/cluster-api-provider-metal3/internal/metrics"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
@@ -38,7 +40,7 @@ import (
 )
 
 const (
-	dataTemplateControllerName = "Metal3DataTemplate-controller"
+	dataTemplateControllerName = metrics.ControllerMetal3DataTemplate
 )
 
 // Metal3DataTemplateReconciler reconciles a Metal3DataTemplate object.
@@ -69,10 +71,24 @@ type Metal3DataTemplateReconciler struct {
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile handles Metal3DataTemplate events.
-func (r *Metal3DataTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
+func (r *Metal3DataTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (rres ctrl.Result, rerr error) {
+	reconcileStart := time.Now()
 	log := r.Log.WithName(dataTemplateControllerName).WithValues(
 		baremetal.LogFieldDataTemplate, req.NamespacedName,
 	)
+
+	// Track metrics for this reconciliation.
+	hasError := false
+	defer func() {
+		if rerr != nil {
+			hasError = true
+			var reconcileErr baremetal.ReconcileError
+			isTransient := errors.As(rerr, &reconcileErr) && reconcileErr.IsTransient()
+			metrics.RecordReconcileError(dataTemplateControllerName, req.Namespace, isTransient)
+		}
+		metrics.RecordMetal3DataTemplateReconcile(req.Namespace, reconcileStart, hasError)
+	}()
+
 	log.V(baremetal.VerbosityLevelTrace).Info("Reconcile: starting Metal3DataTemplate reconciliation")
 
 	// Fetch the Metal3DataTemplate instance.

--- a/controllers/metal3datatemplate_controller.go
+++ b/controllers/metal3datatemplate_controller.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta2"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
+	"github.com/metal3-io/cluster-api-provider-metal3/internal/metrics"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
@@ -39,7 +41,7 @@ import (
 )
 
 const (
-	dataTemplateControllerName = "Metal3DataTemplate-controller"
+	dataTemplateControllerName = metrics.ControllerMetal3DataTemplate
 )
 
 // Metal3DataTemplateReconciler reconciles a Metal3DataTemplate object.
@@ -71,10 +73,24 @@ type Metal3DataTemplateReconciler struct {
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile handles Metal3DataTemplate events.
-func (r *Metal3DataTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
+func (r *Metal3DataTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (rres ctrl.Result, rerr error) {
+	reconcileStart := time.Now()
 	log := r.Log.WithName(dataTemplateControllerName).WithValues(
 		baremetal.LogFieldDataTemplate, req.NamespacedName,
 	)
+
+	// Track metrics for this reconciliation.
+	hasError := false
+	defer func() {
+		if rerr != nil {
+			hasError = true
+			var reconcileErr baremetal.ReconcileError
+			isTransient := errors.As(rerr, &reconcileErr) && reconcileErr.IsTransient()
+			metrics.RecordReconcileError(dataTemplateControllerName, req.Namespace, isTransient)
+		}
+		metrics.RecordMetal3DataTemplateReconcile(req.Namespace, reconcileStart, hasError)
+	}()
+
 	log.V(baremetal.VerbosityLevelTrace).Info("Reconcile: starting Metal3DataTemplate reconciliation")
 
 	// Fetch the Metal3DataTemplate instance.

--- a/controllers/metal3datatemplate_controller_test.go
+++ b/controllers/metal3datatemplate_controller_test.go
@@ -392,6 +392,10 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: requeueAfter}))
+
+		result, err = checkReconcileError(baremetal.WithTerminalError(errors.New("failed")), "abc")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}))
 	})
 
 })

--- a/controllers/metal3datatemplate_controller_test.go
+++ b/controllers/metal3datatemplate_controller_test.go
@@ -429,6 +429,10 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: requeueAfter}))
+
+		result, err = checkReconcileError(baremetal.WithTerminalError(errors.New("failed")), "abc")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}))
 	})
 
 })

--- a/controllers/metal3labelsync_controller.go
+++ b/controllers/metal3labelsync_controller.go
@@ -28,6 +28,7 @@ import (
 	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta2"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
+	"github.com/metal3-io/cluster-api-provider-metal3/internal/metrics"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,7 +52,7 @@ var (
 )
 
 const (
-	labelSyncControllerName = "metal3-label-sync-controller"
+	labelSyncControllerName = metrics.ControllerMetal3LabelSync
 	// PrefixAnnotationKey is prefix for annotation key.
 	PrefixAnnotationKey = "metal3.io/metal3-label-sync-prefixes"
 )
@@ -75,11 +76,21 @@ type Metal3LabelSyncReconciler struct {
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 
 // Reconcile handles label sync events.
-func (r *Metal3LabelSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
+func (r *Metal3LabelSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (rres ctrl.Result, rerr error) {
+	reconcileStart := time.Now()
 	controllerLog := r.Log.WithName(labelSyncControllerName).WithValues(
 		baremetal.LogFieldBMH, req.NamespacedName,
 	)
 	controllerLog.V(baremetal.VerbosityLevelTrace).Info("Reconcile: starting label sync reconciliation")
+
+	// Record metrics at the end of reconciliation
+	defer func() {
+		hasError := rerr != nil
+		metrics.RecordMetal3LabelSyncReconcile(req.Namespace, reconcileStart, hasError)
+		if rerr != nil {
+			metrics.RecordReconcileError(labelSyncControllerName, req.Namespace, false)
+		}
+	}()
 
 	// We need to get the NodeRef from the CAPI Machine object:
 	// BareMetalHost.ConsumerRef --> Metal3Machine.OwnerRef --> Machine.NodeRef

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -20,11 +20,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta2"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
+	"github.com/metal3-io/cluster-api-provider-metal3/internal/metrics"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,7 +50,7 @@ import (
 )
 
 const (
-	machineControllerName = "Metal3Machine-controller"
+	machineControllerName = metrics.ControllerMetal3Machine
 	// metal3MachineKind is the Kind of the Metal3Machine.
 	metal3MachineKind = "Metal3Machine"
 )
@@ -82,10 +84,24 @@ type Metal3MachineReconciler struct {
 // +kubebuilder:rbac:groups=metal3.io,resources=baremetalhosts/status,verbs=get;update;patch
 
 // Reconcile handles Metal3Machine events.
-func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
+func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (rres ctrl.Result, rerr error) {
+	reconcileStart := time.Now()
 	machineLog := r.Log.WithName(machineControllerName).WithValues(
 		baremetal.LogFieldMetal3Machine, req.NamespacedName,
 	)
+
+	// Track metrics for this reconciliation - will be recorded in defer.
+	clusterName := metrics.LabelValueUnknown
+	hasError := false
+	defer func() {
+		if rerr != nil {
+			hasError = true
+			var reconcileErr baremetal.ReconcileError
+			isTransient := errors.As(rerr, &reconcileErr) && reconcileErr.IsTransient()
+			metrics.RecordReconcileError(machineControllerName, req.Namespace, isTransient)
+		}
+		metrics.RecordMetal3MachineReconcile(req.Namespace, clusterName, reconcileStart, hasError)
+	}()
 
 	machineLog.V(baremetal.VerbosityLevelTrace).Info("Starting Metal3Machine reconciliation")
 
@@ -141,6 +157,9 @@ func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		})
 		return ctrl.Result{}, nil
 	}
+	if labelClusterName := capiMachine.Labels[clusterv1.ClusterNameLabel]; labelClusterName != "" {
+		clusterName = labelClusterName
+	}
 
 	// Add machine context for subsequent log messages
 	machineLog = machineLog.WithValues(baremetal.LogFieldMachine, capiMachine.Name)
@@ -172,6 +191,9 @@ func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	machineLog = machineLog.WithValues(baremetal.LogFieldCluster, cluster.Name)
 	machineLog.V(baremetal.VerbosityLevelDebug).Info("Found cluster",
 		"clusterPhase", cluster.Status.Phase)
+
+	// Capture cluster name for metrics deferred recording
+	clusterName = cluster.Name
 
 	// Make sure infrastructure is ready
 	infrastructureReadyCondition := deprecatedv1beta1conditions.Get(cluster, clusterv1.InfrastructureReadyV1Beta1Condition)
@@ -311,7 +333,7 @@ func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Handle non-deleted machines
 	machineLog.V(baremetal.VerbosityLevelTrace).Info("Running normal reconciliation")
-	return r.reconcileNormal(ctx, machineMgr, machineLog)
+	return r.reconcileNormal(ctx, machineMgr, machineLog, req.Namespace, clusterName, capm3Machine.ObjectMeta.CreationTimestamp.Time)
 }
 
 func patchMetal3Machine(ctx context.Context, patchHelper *patch.Helper, metal3Machine *infrav1.Metal3Machine, options ...patch.Option) error {
@@ -367,14 +389,25 @@ func patchMetal3Machine(ctx context.Context, patchHelper *patch.Helper, metal3Ma
 
 func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 	machineMgr baremetal.MachineManagerInterface, log logr.Logger,
+	namespace, clusterName string, creationTime time.Time,
 ) (ctrl.Result, error) {
 	log.V(baremetal.VerbosityLevelTrace).Info("reconcileNormal: starting")
+
+	// Track if machine was already ready at start of reconcile for metrics
+	wasReadyBeforeReconcile := machineMgr.IsProvisioned()
+
+	// Helper to record provisioning duration when machine becomes ready for the first time
+	recordProvisioningIfNewlyReady := func() {
+		if !wasReadyBeforeReconcile {
+			metrics.RecordMetal3MachineProvisioning(namespace, clusterName, creationTime)
+		}
+	}
 
 	// If the Metal3Machine doesn't have finalizer, add it.
 	machineMgr.SetFinalizer()
 
 	// if the machine is already provisioned, update and return
-	isProvisioned := machineMgr.IsProvisioned()
+	isProvisioned := wasReadyBeforeReconcile
 	log.V(baremetal.VerbosityLevelDebug).Info("Checking machine provisioning state",
 		"isProvisioned", isProvisioned)
 
@@ -421,12 +454,14 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 	if !hasAnnotation {
 		log.V(baremetal.VerbosityLevelTrace).Info("No BMH annotation, attempting to associate")
 		// Associate the baremetalhost hosting the machine
+		associationStart := time.Now()
 		var err error
 		chosenHostReason, err := machineMgr.Associate(ctx)
 		if err != nil {
 			log.V(baremetal.VerbosityLevelDebug).Info("Association failed",
 				baremetal.LogFieldError, err.Error())
 			machineMgr.SetV1Beta1ConditionToFalse(infrav1.AssociateBMHV1Beta1Condition, infrav1.AssociateBMHFailedV1Beta1Reason, clusterv1.ConditionSeverityError, "%s", err.Error())
+			metrics.RecordBMHAssociation(namespace, clusterName, associationStart, err)
 			return checkMachineError(machineMgr, err,
 				infrav1.AssociateBareMetalHostCondition, infrav1.AssociateBareMetalHostFailedReason,
 				"failed to associate the Metal3Machine to a BareMetalHost")
@@ -438,6 +473,7 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 			machineMgr.SetCondition(infrav1.AssociateBareMetalHostCondition, metav1.ConditionTrue, chosenHostReason, "")
 		}
 
+		metrics.RecordBMHAssociation(namespace, clusterName, associationStart, nil)
 		log.V(baremetal.VerbosityLevelTrace).Info("Association initiated successfully")
 		return ctrl.Result{}, nil
 	}
@@ -487,6 +523,7 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 		log.V(baremetal.VerbosityLevelDebug).Info("Node with matching ProviderID found, waiting for NodeRef")
 		// Nothing to be done but wait for Machine.Spec.NodeRef
 		machineMgr.SetReadyTrue()
+		recordProvisioningIfNewlyReady()
 		return ctrl.Result{}, nil
 	}
 
@@ -533,6 +570,7 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 		if dataReadyCond == nil || dataReadyCond.Status != metav1.ConditionTrue {
 			machineMgr.SetMetal3DataReadyConditionTrue(infrav1.SecretsSetExternallyReason)
 		}
+		recordProvisioningIfNewlyReady()
 		return ctrl.Result{}, nil
 	}
 
@@ -551,6 +589,7 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 				"Failed to set default ProviderID the Metal3Machine")
 		}
 		machineMgr.SetReadyTrue()
+		recordProvisioningIfNewlyReady()
 
 		log.V(baremetal.VerbosityLevelTrace).Info("Updating machine after setting default ProviderID")
 		err = machineMgr.Update(ctx)

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/go-logr/logr"
 	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
@@ -58,10 +59,11 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 ) *baremetal_mocks.MockMachineManagerInterface {
 	m := baremetal_mocks.NewMockMachineManagerInterface(ctrl)
 
+	// First call to IsProvisioned to check if machine was already ready (for metrics)
+	m.EXPECT().IsProvisioned().Return(tc.Provisioned)
+
 	m.EXPECT().SetFinalizer()
 
-	// provisioned, we should only call Update, nothing else
-	m.EXPECT().IsProvisioned().Return(tc.Provisioned)
 	if tc.Provisioned {
 		m.EXPECT().MachineHasNodeRef().Return(tc.Provisioned)
 		m.EXPECT().SetCondition(
@@ -234,7 +236,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		DescribeTable("ReconcileNormal tests",
 			func(tc reconcileNormalTestCase) {
 				m := setReconcileNormalExpectations(gomockCtrl, tc)
-				res, err := bmReconcile.reconcileNormal(context.TODO(), m, logr.Discard())
+				res, err := bmReconcile.reconcileNormal(context.TODO(), m, logr.Discard(), "test-ns", "test-cluster", time.Now())
 
 				if tc.ExpectError {
 					Expect(err).To(HaveOccurred())

--- a/controllers/metal3machinetemplate_controller.go
+++ b/controllers/metal3machinetemplate_controller.go
@@ -16,10 +16,12 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta2"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
+	"github.com/metal3-io/cluster-api-provider-metal3/internal/metrics"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
@@ -34,7 +36,7 @@ import (
 )
 
 const (
-	templateControllerName = "Metal3MachineTemplate-controller"
+	templateControllerName = metrics.ControllerMetal3MachineTemplate
 	clonedFromGroupKind    = clusterv1.TemplateClonedFromGroupKindAnnotation
 	clonedFromName         = clusterv1.TemplateClonedFromNameAnnotation
 )
@@ -53,10 +55,20 @@ type Metal3MachineTemplateReconciler struct {
 }
 
 // Reconcile handles Metal3MachineTemplate events.
-func (r *Metal3MachineTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
+func (r *Metal3MachineTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (rres ctrl.Result, rerr error) {
+	reconcileStart := time.Now()
 	m3templateLog := r.Log.WithName(templateControllerName).WithValues(
 		baremetal.LogFieldMetal3MachineTemplate, req.NamespacedName,
 	)
+
+	// Track metrics for this reconciliation
+	defer func() {
+		hasError := rerr != nil
+		metrics.RecordMetal3MachineTemplateReconcile(req.Namespace, reconcileStart, hasError)
+		if rerr != nil {
+			metrics.RecordReconcileError(templateControllerName, req.Namespace, false)
+		}
+	}()
 
 	m3templateLog.V(baremetal.VerbosityLevelTrace).Info("starting reconciliation",
 		baremetal.LogFieldController, templateControllerName,

--- a/controllers/metal3remediation_controller.go
+++ b/controllers/metal3remediation_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-logr/logr"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta2"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
+	"github.com/metal3-io/cluster-api-provider-metal3/internal/metrics"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +40,7 @@ import (
 )
 
 const (
+	metal3RemediationControllerName  = metrics.ControllerMetal3Remediation
 	defaultTimeout                   = 5 * time.Second
 	defaultRemediationTimeoutSeconds = 600
 )
@@ -60,10 +62,21 @@ type Metal3RemediationReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;update;patch;delete
 
 // Reconcile handles Metal3Remediation events.
-func (r *Metal3RemediationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
+func (r *Metal3RemediationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (rres ctrl.Result, rerr error) {
+	reconcileStart := time.Now()
 	remediationLog := r.Log.WithValues(
 		baremetal.LogFieldMetal3Remediation, req.NamespacedName,
 	)
+
+	// Track metrics for this reconciliation
+	defer func() {
+		hasError := rerr != nil
+		metrics.RecordMetal3RemediationReconcile(req.Namespace, reconcileStart, hasError)
+		if rerr != nil {
+			metrics.RecordReconcileError(metal3RemediationControllerName, req.Namespace, false)
+		}
+	}()
+
 	remediationLog.V(baremetal.VerbosityLevelTrace).Info("Reconcile: starting Metal3Remediation reconciliation")
 
 	// Fetch the Metal3Remediation instance.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,322 @@
+# CAPM3 Prometheus Metrics
+
+Cluster API Provider Metal3 (CAPM3) exposes custom Prometheus metrics to provide
+visibility into controller operations, provisioning workflows, and error rates.
+
+## Overview
+
+CAPM3 automatically registers custom metrics with the controller-runtime metrics
+server (default port: 8443). These metrics are exposed at the `/metrics` endpoint
+and can be scraped by Prometheus.
+
+All metrics use the `capm3_` prefix to distinguish them from controller-runtime
+and Kubernetes metrics.
+
+## Available Metrics
+
+### Controller Reconciliation Metrics
+
+These metrics track the performance and success rate of each controller's
+reconciliation loop.
+
+- `capm3_metal3machine_reconcile_total` (Counter)
+   - Labels: `namespace`, `cluster`, `result`
+   - Total number of Metal3Machine reconciliations
+- `capm3_metal3machine_reconcile_duration_seconds` (Histogram)
+   - Labels: `namespace`, `cluster`, `result`
+   - Duration of Metal3Machine reconciliations in seconds
+- `capm3_metal3cluster_reconcile_total` (Counter)
+   - Labels: `namespace`, `cluster`, `result`
+   - Total number of Metal3Cluster reconciliations
+- `capm3_metal3cluster_reconcile_duration_seconds` (Histogram)
+   - Labels: `namespace`, `cluster`, `result`
+   - Duration of Metal3Cluster reconciliations in seconds
+- `capm3_metal3data_reconcile_total` (Counter)
+   - Labels: `namespace`, `result`
+   - Total number of Metal3Data reconciliations
+- `capm3_metal3data_reconcile_duration_seconds` (Histogram)
+   - Labels: `namespace`, `result`
+   - Duration of Metal3Data reconciliations in seconds
+- `capm3_metal3datatemplate_reconcile_total` (Counter)
+   - Labels: `namespace`, `result`
+   - Total number of Metal3DataTemplate reconciliations
+- `capm3_metal3datatemplate_reconcile_duration_seconds` (Histogram)
+   - Labels: `namespace`, `result`
+   - Duration of Metal3DataTemplate reconciliations in seconds
+- `capm3_metal3remediation_reconcile_total` (Counter)
+   - Labels: `namespace`, `result`
+   - Total number of Metal3Remediation reconciliations
+- `capm3_metal3remediation_reconcile_duration_seconds` (Histogram)
+   - Labels: `namespace`, `result`
+   - Duration of Metal3Remediation reconciliations in seconds
+- `capm3_metal3machinetemplate_reconcile_total` (Counter)
+   - Labels: `namespace`, `result`
+   - Total number of Metal3MachineTemplate reconciliations
+- `capm3_metal3machinetemplate_reconcile_duration_seconds` (Histogram)
+   - Labels: `namespace`, `result`
+   - Duration of Metal3MachineTemplate reconciliations in seconds
+- `capm3_metal3labelsync_reconcile_total` (Counter)
+   - Labels: `namespace`, `result`
+   - Total number of Metal3LabelSync reconciliations
+- `capm3_metal3labelsync_reconcile_duration_seconds` (Histogram)
+   - Labels: `namespace`, `result`
+   - Duration of Metal3LabelSync reconciliations in seconds
+
+### BareMetalHost Association Metrics
+
+These metrics track the association between Metal3Machines and BareMetalHosts.
+
+- `capm3_bmh_association_total` (Counter)
+   - Labels: `namespace`, `cluster`, `result`
+   - Total number of BMH association attempts
+- `capm3_bmh_association_duration_seconds` (Histogram)
+   - Labels: `namespace`, `cluster`, `result`
+   - Duration of BMH association operations in seconds
+
+### Provisioning Metrics
+
+These metrics provide visibility into machine provisioning workflows.
+
+- `capm3_metal3machine_provisioning_duration_seconds` (Histogram)
+   - Labels: `namespace`, `cluster`
+   - Duration from machine creation to Ready state
+- `capm3_metal3machine_phase_transitions_total` (Counter)
+   - Labels: `namespace`, `cluster`, `phase`
+   - Total phase transitions for Metal3Machines
+
+### Remediation Metrics
+
+These metrics track machine remediation operations.
+
+- `capm3_metal3remediation_total` (Counter)
+   - Labels: `namespace`, `remediation_type`, `result`
+   - Total number of remediation operations
+- `capm3_metal3remediation_duration_seconds` (Histogram)
+   - Labels: `namespace`, `remediation_type`, `result`
+   - Duration of remediation operations in seconds
+
+### Error Metrics
+
+These metrics track reconciliation errors by controller type.
+
+- `capm3_reconcile_errors_total` (Counter)
+   - Labels: `controller`, `namespace`, `error_type`
+   - Total number of reconcile errors by controller and error type
+
+### Gauge Metrics
+
+These gauge metrics are available for tracking current state counts.
+Note: These require additional implementation to update values.
+
+- `capm3_metal3machines_count` (Gauge)
+   - Labels: `namespace`, `phase`
+   - Current count of Metal3Machines by phase
+- `capm3_metal3clusters_count` (Gauge)
+   - Labels: `namespace`
+   - Current count of Metal3Clusters
+
+## Label Values
+
+### Result Labels
+
+The `result` label indicates the outcome of an operation:
+
+- `success` - Operation completed successfully
+- `error` - Operation failed with a returned error or a translated
+   `baremetal.ReconcileError`
+
+Normal requeues are recorded as successful reconciliations unless they are caused
+by a translated `baremetal.ReconcileError`.
+
+### Error Type Labels
+
+The `error_type` label identifies whether the reconcile error was recoverable:
+
+- `transient` - Reconcile failed and requested another attempt
+- `terminal` - Reconcile failed without a transient retry classification
+
+### Phase Labels
+
+The `phase` label indicates the current phase of a Metal3Machine:
+
+- `provisioning` - Machine is being provisioned
+- `provisioned` - Machine has been provisioned
+- `deleting` - Machine is being deleted
+
+### Controller Labels
+
+The `controller` label identifies the source controller for error metrics:
+
+- `Metal3Machine-controller`
+- `Metal3Cluster-controller`
+- `Metal3Data-controller`
+- `Metal3DataTemplate-controller`
+- `Metal3Remediation-controller`
+- `Metal3MachineTemplate-controller`
+- `metal3-label-sync-controller`
+
+## Histogram Buckets
+
+Histogram bucket boundaries vary by metric family. For exact bucket values, refer
+to `internal/metrics/metrics.go`.
+
+## Example Prometheus Queries
+
+### Reconciliation Success Rate
+
+```promql
+# Metal3Machine reconciliation success rate (last 5 minutes)
+sum(rate(capm3_metal3machine_reconcile_total{result="success"}[5m]))
+/
+sum(rate(capm3_metal3machine_reconcile_total[5m]))
+```
+
+### Average Reconciliation Duration
+
+```promql
+# Average Metal3Machine reconciliation duration
+rate(capm3_metal3machine_reconcile_duration_seconds_sum[5m])
+/
+rate(capm3_metal3machine_reconcile_duration_seconds_count[5m])
+```
+
+### BMH Association Duration P99
+
+```promql
+# 99th percentile BMH association duration
+histogram_quantile(0.99, rate(capm3_bmh_association_duration_seconds_bucket[5m]))
+```
+
+### Provisioning Duration P50
+
+```promql
+# Median time from machine creation to Ready state
+histogram_quantile(0.50, rate(capm3_metal3machine_provisioning_duration_seconds_bucket[5m]))
+```
+
+### Error Rate by Controller
+
+```promql
+# Error rate by controller (last 5 minutes)
+sum by (controller) (rate(capm3_reconcile_errors_total[5m]))
+```
+
+### Phase Transition Rate
+
+```promql
+# Rate of machines entering provisioned state
+rate(capm3_metal3machine_phase_transitions_total{phase="provisioned"}[5m])
+```
+
+## Grafana Dashboard
+
+A sample Grafana dashboard configuration can be created using these metrics.
+Key panels to include:
+
+1. **Overview Panel** - Total machines, clusters, current error rate
+1. **Reconciliation Performance** - Duration histograms, success rates
+1. **Provisioning Workflow** - BMH association time, provisioning duration
+1. **Error Tracking** - Error counts by controller, error trends
+1. **Remediation** - Remediation counts by remediation type, success rate
+
+## Alerting Examples
+
+### High Error Rate Alert
+
+```yaml
+groups:
+- name: capm3-alerts
+  rules:
+  - alert: CAPM3HighMetal3MachineReconcileErrorRate
+    expr: |
+      sum(rate(capm3_reconcile_errors_total{controller="Metal3Machine-controller"}[5m]))
+      /
+      sum(rate(capm3_metal3machine_reconcile_total[5m])) > 0.1
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "High Metal3Machine reconcile error rate"
+      description: "More than 10% of Metal3Machine reconciliations are failing"
+```
+
+### Slow Provisioning Alert
+
+```yaml
+- alert: CAPM3SlowProvisioning
+  expr: |
+    histogram_quantile(0.95, rate(capm3_metal3machine_provisioning_duration_seconds_bucket[15m])) > 600
+  for: 10m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Slow Metal3Machine provisioning"
+    description: "95th percentile provisioning time exceeds 10 minutes"
+```
+
+## Integration with ServiceMonitor
+
+The default manifests expose metrics through the controller-manager Pod
+annotations and the container port named `metrics`; they do not create a metrics
+Service.
+
+If using the Prometheus Operator, create a Service and ServiceMonitor to scrape
+CAPM3 metrics:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: capm3-controller-manager-metrics
+  namespace: capm3-system
+  labels:
+    control-plane: controller-manager
+spec:
+  selector:
+    control-plane: controller-manager
+  ports:
+  - name: metrics
+    port: 8443
+    targetPort: metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: capm3-controller-manager
+  namespace: capm3-system
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  endpoints:
+  - port: metrics
+    scheme: https
+    path: /metrics
+    tlsConfig:
+      insecureSkipVerify: true
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+```
+
+## Troubleshooting
+
+### Metrics Not Appearing
+
+1. Verify the controller manager is running and healthy
+1. Check that port 8443 is accessible
+1. Ensure the `/metrics` endpoint returns data:
+
+   ```bash
+   kubectl port-forward -n capm3-system deployment/controller-manager 8443:8443
+   curl -k https://localhost:8443/metrics | grep capm3_
+   ```
+
+### High Cardinality Concerns
+
+The metrics are designed with low-cardinality labels. If you have many namespaces
+or clusters, consider using recording rules to aggregate metrics:
+
+```promql
+# Recording rule for aggregate error rate
+record: capm3:reconcile_errors:rate5m
+expr: sum(rate(capm3_reconcile_errors_total[5m]))
+```

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/metal3-io/ip-address-manager/api v1.14.0-rc.0
 	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.42.1
+	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/spf13/pflag v1.0.10
 	go.uber.org/mock v0.6.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -65,8 +67,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/metal3-io/ip-address-manager/api v1.14.0-beta.0
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
+	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/spf13/pflag v1.0.10
 	go.uber.org/mock v0.6.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -65,8 +67,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,460 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// revive:disable:var-naming
+// Package metrics provides custom Prometheus metrics for CAPM3.
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	// Subsystem is the metrics subsystem name for CAPM3.
+	Subsystem = "capm3"
+
+	// Labels used across metrics.
+	LabelNamespace   = "namespace"
+	LabelCluster     = "cluster"
+	LabelController  = "controller"
+	LabelResult      = "result"
+	LabelPhase       = "phase"
+	LabelErrorType   = "error_type"
+	LabelRemediation = "remediation_type"
+
+	// Controller label values used by capm3_reconcile_errors_total.
+	ControllerMetal3Machine         = "Metal3Machine-controller"
+	ControllerMetal3Cluster         = "Metal3Cluster-controller"
+	ControllerMetal3Data            = "Metal3Data-controller"
+	ControllerMetal3DataTemplate    = "Metal3DataTemplate-controller"
+	ControllerMetal3Remediation     = "Metal3Remediation-controller"
+	ControllerMetal3MachineTemplate = "Metal3MachineTemplate-controller"
+	ControllerMetal3LabelSync       = "metal3-label-sync-controller"
+
+	// LabelValueUnknown marks dimensions that cannot be derived for an early reconcile return.
+	LabelValueUnknown = "unknown"
+
+	// Result label values.
+	ResultSuccess = "success"
+	ResultError   = "error"
+
+	// Error type label values.
+	ErrorTypeTransient = "transient"
+	ErrorTypeTerminal  = "terminal"
+)
+
+var (
+	// Metal3MachineReconcileTotal counts the total number of Metal3Machine reconciliations.
+	Metal3MachineReconcileTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3machine_reconcile_total",
+			Help:      "Total number of Metal3Machine reconciliations.",
+		},
+		[]string{LabelNamespace, LabelCluster, LabelResult},
+	)
+
+	// Metal3MachineReconcileDuration measures the duration of Metal3Machine reconciliations.
+	Metal3MachineReconcileDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3machine_reconcile_duration_seconds",
+			Help:      "Duration of Metal3Machine reconciliation in seconds.",
+			Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300},
+		},
+		[]string{LabelNamespace, LabelCluster, LabelResult},
+	)
+
+	// Metal3MachineProvisioningDuration measures the time from machine creation to ready state.
+	Metal3MachineProvisioningDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3machine_provisioning_duration_seconds",
+			Help:      "Duration from Metal3Machine creation to ready state in seconds.",
+			Buckets:   []float64{30, 60, 120, 300, 600, 900, 1200, 1800, 3600},
+		},
+		[]string{LabelNamespace, LabelCluster},
+	)
+
+	// Metal3ClusterReconcileTotal counts the total number of Metal3Cluster reconciliations.
+	Metal3ClusterReconcileTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3cluster_reconcile_total",
+			Help:      "Total number of Metal3Cluster reconciliations.",
+		},
+		[]string{LabelNamespace, LabelCluster, LabelResult},
+	)
+
+	// Metal3ClusterReconcileDuration measures the duration of Metal3Cluster reconciliations.
+	Metal3ClusterReconcileDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3cluster_reconcile_duration_seconds",
+			Help:      "Duration of Metal3Cluster reconciliation in seconds.",
+			Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60},
+		},
+		[]string{LabelNamespace, LabelCluster, LabelResult},
+	)
+
+	// BMHAssociationTotal counts the total number of BareMetalHost associations.
+	BMHAssociationTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: Subsystem,
+			Name:      "bmh_association_total",
+			Help:      "Total number of BareMetalHost association attempts.",
+		},
+		[]string{LabelNamespace, LabelCluster, LabelResult},
+	)
+
+	// BMHAssociationDuration measures the time taken to associate a BMH.
+	BMHAssociationDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: Subsystem,
+			Name:      "bmh_association_duration_seconds",
+			Help:      "Duration of BareMetalHost association in seconds.",
+			Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10, 30},
+		},
+		[]string{LabelNamespace, LabelCluster, LabelResult},
+	)
+
+	// ReconcileErrorsTotal counts reconciliation errors by type.
+	ReconcileErrorsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: Subsystem,
+			Name:      "reconcile_errors_total",
+			Help:      "Total number of reconciliation errors by controller and error type.",
+		},
+		[]string{LabelController, LabelNamespace, LabelErrorType},
+	)
+
+	// Metal3DataReconcileTotal counts the total number of Metal3Data reconciliations.
+	Metal3DataReconcileTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3data_reconcile_total",
+			Help:      "Total number of Metal3Data reconciliations.",
+		},
+		[]string{LabelNamespace, LabelResult},
+	)
+
+	// Metal3DataReconcileDuration measures the duration of Metal3Data reconciliations.
+	Metal3DataReconcileDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3data_reconcile_duration_seconds",
+			Help:      "Duration of Metal3Data reconciliation in seconds.",
+			Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60},
+		},
+		[]string{LabelNamespace, LabelResult},
+	)
+
+	// Metal3DataTemplateReconcileTotal counts the total number of Metal3DataTemplate reconciliations.
+	Metal3DataTemplateReconcileTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3datatemplate_reconcile_total",
+			Help:      "Total number of Metal3DataTemplate reconciliations.",
+		},
+		[]string{LabelNamespace, LabelResult},
+	)
+
+	// Metal3DataTemplateReconcileDuration measures the duration of Metal3DataTemplate reconciliations.
+	Metal3DataTemplateReconcileDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3datatemplate_reconcile_duration_seconds",
+			Help:      "Duration of Metal3DataTemplate reconciliation in seconds.",
+			Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60},
+		},
+		[]string{LabelNamespace, LabelResult},
+	)
+
+	// Metal3RemediationReconcileDuration measures the duration of Metal3Remediation reconciliations.
+	Metal3RemediationReconcileDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3remediation_reconcile_duration_seconds",
+			Help:      "Duration of Metal3Remediation reconciliation in seconds.",
+			Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60},
+		},
+		[]string{LabelNamespace, LabelResult},
+	)
+
+	// Metal3RemediationReconcileTotal counts the total number of Metal3Remediation reconciliations.
+	Metal3RemediationReconcileTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3remediation_reconcile_total",
+			Help:      "Total number of Metal3Remediation reconciliations.",
+		},
+		[]string{LabelNamespace, LabelResult},
+	)
+
+	// Metal3RemediationTotal counts the total number of remediation operations.
+	Metal3RemediationTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3remediation_total",
+			Help:      "Total number of Metal3Remediation operations.",
+		},
+		[]string{LabelNamespace, LabelRemediation, LabelResult},
+	)
+
+	// Metal3RemediationDuration measures the duration of remediation operations.
+	Metal3RemediationDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3remediation_duration_seconds",
+			Help:      "Duration of Metal3Remediation operations in seconds.",
+			Buckets:   []float64{10, 30, 60, 120, 300, 600, 1200},
+		},
+		[]string{LabelNamespace, LabelRemediation, LabelResult},
+	)
+
+	// Metal3MachinePhaseTransitions tracks phase transitions for Metal3Machines.
+	Metal3MachinePhaseTransitions = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3machine_phase_transitions_total",
+			Help:      "Total number of Metal3Machine phase transitions.",
+		},
+		[]string{LabelNamespace, LabelCluster, LabelPhase},
+	)
+
+	// Metal3MachinesCount is a gauge showing current count of Metal3Machines by phase.
+	Metal3MachinesCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3machines_count",
+			Help:      "Current count of Metal3Machines by namespace and phase.",
+		},
+		[]string{LabelNamespace, LabelPhase},
+	)
+
+	// Metal3ClustersCount is a gauge showing current count of Metal3Clusters.
+	Metal3ClustersCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3clusters_count",
+			Help:      "Current count of Metal3Clusters by namespace.",
+		},
+		[]string{LabelNamespace},
+	)
+
+	// Metal3MachineTemplateReconcileTotal counts the total number of Metal3MachineTemplate reconciliations.
+	Metal3MachineTemplateReconcileTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3machinetemplate_reconcile_total",
+			Help:      "Total number of Metal3MachineTemplate reconciliations.",
+		},
+		[]string{LabelNamespace, LabelResult},
+	)
+
+	// Metal3MachineTemplateReconcileDuration measures the duration of Metal3MachineTemplate reconciliations.
+	Metal3MachineTemplateReconcileDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3machinetemplate_reconcile_duration_seconds",
+			Help:      "Duration of Metal3MachineTemplate reconciliation in seconds.",
+			Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60},
+		},
+		[]string{LabelNamespace, LabelResult},
+	)
+
+	// Metal3LabelSyncReconcileTotal counts the total number of Metal3LabelSync reconciliations.
+	Metal3LabelSyncReconcileTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3labelsync_reconcile_total",
+			Help:      "Total number of Metal3LabelSync reconciliations.",
+		},
+		[]string{LabelNamespace, LabelResult},
+	)
+
+	// Metal3LabelSyncReconcileDuration measures the duration of Metal3LabelSync reconciliations.
+	Metal3LabelSyncReconcileDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: Subsystem,
+			Name:      "metal3labelsync_reconcile_duration_seconds",
+			Help:      "Duration of Metal3LabelSync reconciliation in seconds.",
+			Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60},
+		},
+		[]string{LabelNamespace, LabelResult},
+	)
+)
+
+func init() {
+	// Register all metrics with the controller-runtime metrics registry.
+	metrics.Registry.MustRegister(
+		Metal3MachineReconcileTotal,
+		Metal3MachineReconcileDuration,
+		Metal3MachineProvisioningDuration,
+		Metal3ClusterReconcileTotal,
+		Metal3ClusterReconcileDuration,
+		BMHAssociationTotal,
+		BMHAssociationDuration,
+		ReconcileErrorsTotal,
+		Metal3DataReconcileTotal,
+		Metal3DataReconcileDuration,
+		Metal3DataTemplateReconcileTotal,
+		Metal3DataTemplateReconcileDuration,
+		Metal3RemediationReconcileTotal,
+		Metal3RemediationTotal,
+		Metal3RemediationDuration,
+		Metal3RemediationReconcileDuration,
+		Metal3MachinePhaseTransitions,
+		Metal3MachinesCount,
+		Metal3ClustersCount,
+		Metal3MachineTemplateReconcileTotal,
+		Metal3MachineTemplateReconcileDuration,
+		Metal3LabelSyncReconcileTotal,
+		Metal3LabelSyncReconcileDuration,
+	)
+}
+
+// RecordMetal3MachineReconcile records a Metal3Machine reconciliation metric.
+func RecordMetal3MachineReconcile(namespace, cluster string, startTime time.Time, hasError bool) {
+	result := ResultSuccess
+	if hasError {
+		result = ResultError
+	}
+	duration := time.Since(startTime).Seconds()
+	Metal3MachineReconcileTotal.WithLabelValues(namespace, cluster, result).Inc()
+	Metal3MachineReconcileDuration.WithLabelValues(namespace, cluster, result).Observe(duration)
+}
+
+// RecordMetal3ClusterReconcile records a Metal3Cluster reconciliation metric.
+func RecordMetal3ClusterReconcile(namespace, cluster string, startTime time.Time, hasError bool) {
+	result := ResultSuccess
+	if hasError {
+		result = ResultError
+	}
+	duration := time.Since(startTime).Seconds()
+	Metal3ClusterReconcileTotal.WithLabelValues(namespace, cluster, result).Inc()
+	Metal3ClusterReconcileDuration.WithLabelValues(namespace, cluster, result).Observe(duration)
+}
+
+// RecordBMHAssociation records a BareMetalHost association metric.
+func RecordBMHAssociation(namespace, cluster string, startTime time.Time, err error) {
+	result := ResultSuccess
+	if err != nil {
+		result = ResultError
+	}
+	duration := time.Since(startTime).Seconds()
+	BMHAssociationTotal.WithLabelValues(namespace, cluster, result).Inc()
+	BMHAssociationDuration.WithLabelValues(namespace, cluster, result).Observe(duration)
+}
+
+// RecordReconcileError records a reconciliation error metric.
+func RecordReconcileError(controller, namespace string, isTransient bool) {
+	errorType := ErrorTypeTerminal
+	if isTransient {
+		errorType = ErrorTypeTransient
+	}
+	ReconcileErrorsTotal.WithLabelValues(controller, namespace, errorType).Inc()
+}
+
+// RecordMetal3MachineProvisioning records the provisioning duration when a machine becomes ready.
+func RecordMetal3MachineProvisioning(namespace, cluster string, creationTime time.Time) {
+	duration := time.Since(creationTime).Seconds()
+	Metal3MachineProvisioningDuration.WithLabelValues(namespace, cluster).Observe(duration)
+}
+
+// RecordMetal3DataReconcile records a Metal3Data reconciliation metric.
+func RecordMetal3DataReconcile(namespace string, startTime time.Time, hasError bool) {
+	result := ResultSuccess
+	if hasError {
+		result = ResultError
+	}
+	duration := time.Since(startTime).Seconds()
+	Metal3DataReconcileTotal.WithLabelValues(namespace, result).Inc()
+	Metal3DataReconcileDuration.WithLabelValues(namespace, result).Observe(duration)
+}
+
+// RecordMetal3DataTemplateReconcile records a Metal3DataTemplate reconciliation metric.
+func RecordMetal3DataTemplateReconcile(namespace string, startTime time.Time, hasError bool) {
+	result := ResultSuccess
+	if hasError {
+		result = ResultError
+	}
+	duration := time.Since(startTime).Seconds()
+	Metal3DataTemplateReconcileTotal.WithLabelValues(namespace, result).Inc()
+	Metal3DataTemplateReconcileDuration.WithLabelValues(namespace, result).Observe(duration)
+}
+
+// RecordMetal3RemediationReconcile records a Metal3Remediation reconciliation metric.
+func RecordMetal3RemediationReconcile(namespace string, startTime time.Time, hasError bool) {
+	result := ResultSuccess
+	if hasError {
+		result = ResultError
+	}
+	duration := time.Since(startTime).Seconds()
+	Metal3RemediationReconcileTotal.WithLabelValues(namespace, result).Inc()
+	Metal3RemediationReconcileDuration.WithLabelValues(namespace, result).Observe(duration)
+}
+
+// RecordMetal3Remediation records a remediation metric.
+func RecordMetal3Remediation(namespace, remediationType string, startTime time.Time, err error) {
+	result := ResultSuccess
+	if err != nil {
+		result = ResultError
+	}
+	duration := time.Since(startTime).Seconds()
+	Metal3RemediationTotal.WithLabelValues(namespace, remediationType, result).Inc()
+	Metal3RemediationDuration.WithLabelValues(namespace, remediationType, result).Observe(duration)
+}
+
+// RecordMetal3MachinePhaseTransition records a phase transition for a Metal3Machine.
+func RecordMetal3MachinePhaseTransition(namespace, cluster, phase string) {
+	Metal3MachinePhaseTransitions.WithLabelValues(namespace, cluster, phase).Inc()
+}
+
+// SetMetal3MachinesCount sets the gauge for Metal3Machines count.
+func SetMetal3MachinesCount(namespace, phase string, count float64) {
+	Metal3MachinesCount.WithLabelValues(namespace, phase).Set(count)
+}
+
+// SetMetal3ClustersCount sets the gauge for Metal3Clusters count.
+func SetMetal3ClustersCount(namespace string, count float64) {
+	Metal3ClustersCount.WithLabelValues(namespace).Set(count)
+}
+
+// RecordMetal3MachineTemplateReconcile records a Metal3MachineTemplate reconciliation metric.
+func RecordMetal3MachineTemplateReconcile(namespace string, startTime time.Time, hasError bool) {
+	result := ResultSuccess
+	if hasError {
+		result = ResultError
+	}
+	duration := time.Since(startTime).Seconds()
+	Metal3MachineTemplateReconcileTotal.WithLabelValues(namespace, result).Inc()
+	Metal3MachineTemplateReconcileDuration.WithLabelValues(namespace, result).Observe(duration)
+}
+
+// RecordMetal3LabelSyncReconcile records a Metal3LabelSync reconciliation metric.
+func RecordMetal3LabelSyncReconcile(namespace string, startTime time.Time, hasError bool) {
+	result := ResultSuccess
+	if hasError {
+		result = ResultError
+	}
+	duration := time.Since(startTime).Seconds()
+	Metal3LabelSyncReconcileTotal.WithLabelValues(namespace, result).Inc()
+	Metal3LabelSyncReconcileDuration.WithLabelValues(namespace, result).Observe(duration)
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,275 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	metrics "github.com/metal3-io/cluster-api-provider-metal3/internal/metrics"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func uniqueLabel(t *testing.T, suffix string) string {
+	t.Helper()
+	return fmt.Sprintf("%s-%s", t.Name(), suffix)
+}
+
+func expectCounterIncrement(t *testing.T, counter prometheus.Counter, record func()) {
+	t.Helper()
+
+	before := testutil.ToFloat64(counter)
+	record()
+
+	NewWithT(t).Expect(testutil.ToFloat64(counter)).To(Equal(before + 1))
+}
+
+func expectHistogramObservation(t *testing.T, collector prometheus.Collector, labels prometheus.Labels, record func()) {
+	t.Helper()
+
+	before := histogramSampleCount(t, collector, labels)
+	record()
+
+	NewWithT(t).Expect(histogramSampleCount(t, collector, labels)).To(Equal(before + 1))
+}
+
+func histogramSampleCount(t *testing.T, collector prometheus.Collector, labels prometheus.Labels) uint64 {
+	t.Helper()
+
+	metricCh := make(chan prometheus.Metric)
+	go func() {
+		collector.Collect(metricCh)
+		close(metricCh)
+	}()
+
+	for metric := range metricCh {
+		dtoMetric := &dto.Metric{}
+		if err := metric.Write(dtoMetric); err != nil {
+			t.Fatalf("failed to read metric: %v", err)
+		}
+		if !hasLabels(dtoMetric, labels) || dtoMetric.GetHistogram() == nil {
+			continue
+		}
+		return dtoMetric.GetHistogram().GetSampleCount()
+	}
+	return 0
+}
+
+func hasLabels(metric *dto.Metric, labels prometheus.Labels) bool {
+	values := map[string]string{}
+	for _, label := range metric.GetLabel() {
+		values[label.GetName()] = label.GetValue()
+	}
+	for name, value := range labels {
+		if values[name] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func TestRecordMetal3MachineReconcile(t *testing.T) {
+	startTime := time.Now().Add(-time.Second)
+	namespace := uniqueLabel(t, "ns")
+	cluster := uniqueLabel(t, "cluster")
+	successMetric := metrics.Metal3MachineReconcileTotal.WithLabelValues(namespace, cluster, metrics.ResultSuccess)
+	errorMetric := metrics.Metal3MachineReconcileTotal.WithLabelValues(namespace, cluster, metrics.ResultError)
+
+	expectCounterIncrement(t, successMetric, func() {
+		metrics.RecordMetal3MachineReconcile(namespace, cluster, startTime, false)
+	})
+	expectCounterIncrement(t, errorMetric, func() {
+		metrics.RecordMetal3MachineReconcile(namespace, cluster, startTime, true)
+	})
+}
+
+func TestRecordMetal3ClusterReconcile(t *testing.T) {
+	startTime := time.Now().Add(-time.Second)
+	namespace := uniqueLabel(t, "ns")
+	cluster := uniqueLabel(t, "cluster")
+	successMetric := metrics.Metal3ClusterReconcileTotal.WithLabelValues(namespace, cluster, metrics.ResultSuccess)
+	errorMetric := metrics.Metal3ClusterReconcileTotal.WithLabelValues(namespace, cluster, metrics.ResultError)
+
+	expectCounterIncrement(t, successMetric, func() {
+		metrics.RecordMetal3ClusterReconcile(namespace, cluster, startTime, false)
+	})
+	expectCounterIncrement(t, errorMetric, func() {
+		metrics.RecordMetal3ClusterReconcile(namespace, cluster, startTime, true)
+	})
+}
+
+func TestRecordBMHAssociation(t *testing.T) {
+	startTime := time.Now().Add(-time.Second)
+	namespace := uniqueLabel(t, "ns")
+	cluster := uniqueLabel(t, "cluster")
+	successMetric := metrics.BMHAssociationTotal.WithLabelValues(namespace, cluster, metrics.ResultSuccess)
+	errorMetric := metrics.BMHAssociationTotal.WithLabelValues(namespace, cluster, metrics.ResultError)
+
+	expectCounterIncrement(t, successMetric, func() {
+		metrics.RecordBMHAssociation(namespace, cluster, startTime, nil)
+	})
+	expectCounterIncrement(t, errorMetric, func() {
+		metrics.RecordBMHAssociation(namespace, cluster, startTime, errors.New("test error"))
+	})
+}
+
+func TestRecordReconcileError(t *testing.T) {
+	namespace := uniqueLabel(t, "ns")
+	controller := uniqueLabel(t, "controller")
+	transientMetric := metrics.ReconcileErrorsTotal.WithLabelValues(controller, namespace, metrics.ErrorTypeTransient)
+	terminalMetric := metrics.ReconcileErrorsTotal.WithLabelValues(controller, namespace, metrics.ErrorTypeTerminal)
+
+	expectCounterIncrement(t, transientMetric, func() {
+		metrics.RecordReconcileError(controller, namespace, true)
+	})
+	expectCounterIncrement(t, terminalMetric, func() {
+		metrics.RecordReconcileError(controller, namespace, false)
+	})
+}
+
+func TestRecordMetal3MachineProvisioning(t *testing.T) {
+	creationTime := time.Now().Add(-5 * time.Minute)
+	namespace := uniqueLabel(t, "ns")
+	cluster := uniqueLabel(t, "cluster")
+
+	expectHistogramObservation(t, metrics.Metal3MachineProvisioningDuration, prometheus.Labels{
+		metrics.LabelNamespace: namespace,
+		metrics.LabelCluster:   cluster,
+	}, func() {
+		metrics.RecordMetal3MachineProvisioning(namespace, cluster, creationTime)
+	})
+}
+
+func TestRecordMetal3DataReconcile(t *testing.T) {
+	startTime := time.Now().Add(-time.Second)
+	namespace := uniqueLabel(t, "ns")
+	successMetric := metrics.Metal3DataReconcileTotal.WithLabelValues(namespace, metrics.ResultSuccess)
+	errorMetric := metrics.Metal3DataReconcileTotal.WithLabelValues(namespace, metrics.ResultError)
+
+	expectCounterIncrement(t, successMetric, func() {
+		metrics.RecordMetal3DataReconcile(namespace, startTime, false)
+	})
+	expectCounterIncrement(t, errorMetric, func() {
+		metrics.RecordMetal3DataReconcile(namespace, startTime, true)
+	})
+}
+
+func TestRecordMetal3DataTemplateReconcile(t *testing.T) {
+	startTime := time.Now().Add(-time.Second)
+	namespace := uniqueLabel(t, "ns")
+	successMetric := metrics.Metal3DataTemplateReconcileTotal.WithLabelValues(namespace, metrics.ResultSuccess)
+	errorMetric := metrics.Metal3DataTemplateReconcileTotal.WithLabelValues(namespace, metrics.ResultError)
+
+	expectCounterIncrement(t, successMetric, func() {
+		metrics.RecordMetal3DataTemplateReconcile(namespace, startTime, false)
+	})
+	expectCounterIncrement(t, errorMetric, func() {
+		metrics.RecordMetal3DataTemplateReconcile(namespace, startTime, true)
+	})
+}
+
+func TestRecordMetal3RemediationReconcile(t *testing.T) {
+	startTime := time.Now().Add(-time.Second)
+	namespace := uniqueLabel(t, "ns")
+	successMetric := metrics.Metal3RemediationReconcileTotal.WithLabelValues(namespace, metrics.ResultSuccess)
+	errorMetric := metrics.Metal3RemediationReconcileTotal.WithLabelValues(namespace, metrics.ResultError)
+
+	expectCounterIncrement(t, successMetric, func() {
+		metrics.RecordMetal3RemediationReconcile(namespace, startTime, false)
+	})
+	expectCounterIncrement(t, errorMetric, func() {
+		metrics.RecordMetal3RemediationReconcile(namespace, startTime, true)
+	})
+}
+
+func TestRecordMetal3Remediation(t *testing.T) {
+	startTime := time.Now().Add(-time.Second)
+	namespace := uniqueLabel(t, "ns")
+	remediationType := uniqueLabel(t, "reboot")
+	successMetric := metrics.Metal3RemediationTotal.WithLabelValues(namespace, remediationType, metrics.ResultSuccess)
+	errorMetric := metrics.Metal3RemediationTotal.WithLabelValues(namespace, remediationType, metrics.ResultError)
+
+	expectCounterIncrement(t, successMetric, func() {
+		metrics.RecordMetal3Remediation(namespace, remediationType, startTime, nil)
+	})
+	expectCounterIncrement(t, errorMetric, func() {
+		metrics.RecordMetal3Remediation(namespace, remediationType, startTime, errors.New("test error"))
+	})
+}
+
+func TestRecordMetal3MachinePhaseTransition(t *testing.T) {
+	namespace := uniqueLabel(t, "ns")
+	cluster := uniqueLabel(t, "cluster")
+	phase := uniqueLabel(t, "provisioning")
+	metric := metrics.Metal3MachinePhaseTransitions.WithLabelValues(namespace, cluster, phase)
+
+	expectCounterIncrement(t, metric, func() {
+		metrics.RecordMetal3MachinePhaseTransition(namespace, cluster, phase)
+	})
+}
+
+func TestSetMetal3MachinesCount(t *testing.T) {
+	g := NewWithT(t)
+	namespace := uniqueLabel(t, "ns")
+	phase := uniqueLabel(t, "running")
+
+	metrics.SetMetal3MachinesCount(namespace, phase, 5)
+
+	g.Expect(testutil.ToFloat64(metrics.Metal3MachinesCount.WithLabelValues(namespace, phase))).To(Equal(float64(5)))
+}
+
+func TestSetMetal3ClustersCount(t *testing.T) {
+	g := NewWithT(t)
+	namespace := uniqueLabel(t, "ns")
+
+	metrics.SetMetal3ClustersCount(namespace, 3)
+
+	g.Expect(testutil.ToFloat64(metrics.Metal3ClustersCount.WithLabelValues(namespace))).To(Equal(float64(3)))
+}
+
+func TestRecordMetal3MachineTemplateReconcile(t *testing.T) {
+	startTime := time.Now().Add(-time.Second)
+	namespace := uniqueLabel(t, "ns")
+	successMetric := metrics.Metal3MachineTemplateReconcileTotal.WithLabelValues(namespace, metrics.ResultSuccess)
+	errorMetric := metrics.Metal3MachineTemplateReconcileTotal.WithLabelValues(namespace, metrics.ResultError)
+
+	expectCounterIncrement(t, successMetric, func() {
+		metrics.RecordMetal3MachineTemplateReconcile(namespace, startTime, false)
+	})
+	expectCounterIncrement(t, errorMetric, func() {
+		metrics.RecordMetal3MachineTemplateReconcile(namespace, startTime, true)
+	})
+}
+
+func TestRecordMetal3LabelSyncReconcile(t *testing.T) {
+	startTime := time.Now().Add(-time.Second)
+	namespace := uniqueLabel(t, "ns")
+	successMetric := metrics.Metal3LabelSyncReconcileTotal.WithLabelValues(namespace, metrics.ResultSuccess)
+	errorMetric := metrics.Metal3LabelSyncReconcileTotal.WithLabelValues(namespace, metrics.ResultError)
+
+	expectCounterIncrement(t, successMetric, func() {
+		metrics.RecordMetal3LabelSyncReconcile(namespace, startTime, false)
+	})
+	expectCounterIncrement(t, errorMetric, func() {
+		metrics.RecordMetal3LabelSyncReconcile(namespace, startTime, true)
+	})
+}


### PR DESCRIPTION
## What this PR does

Adds custom Prometheus metrics to all CAPM3 controllers, addressing the lack of visibility into provisioning times, error rates, and controller performance.

## Why we need it

Previously, CAPM3 only exposed default controller-runtime metrics, making it difficult to:
- Monitor provisioning success rates and durations
- Debug slow BMH associations
- Track error rates by controller type
- Set up meaningful alerts for operational issues

## Changes

### New files
- `internal/metrics/metrics.go` - Central metrics package with 22 Prometheus metrics
- `internal/metrics/metrics_test.go` - Unit tests for all helper functions (14 tests)
- `docs/metrics.md` - Comprehensive documentation with PromQL examples

### Modified controllers
All controllers instrumented with reconcile metrics:
- `metal3machine_controller.go` - Also tracks BMH association and provisioning duration
- `metal3cluster_controller.go`
- `metal3data_controller.go`
- `metal3datatemplate_controller.go`
- `metal3remediation_controller.go`
- `metal3machinetemplate_controller.go`
- `metal3labelsync_controller.go`

## Metrics overview

| Category | Metrics |
|----------|---------|
| Reconcile performance | Counter + duration histogram per controller |
| BMH association | `capm3_bmh_association_total`, `capm3_bmh_association_duration_seconds` |
| Provisioning | `capm3_metal3machine_provisioning_duration_seconds` (creation → Ready) |
| Errors | `capm3_reconcile_errors_total` by controller |
| Phase tracking | `capm3_metal3machine_phase_transitions_total` |

## How to test

```bash
make test  # Runs generate + lint + unit tests