### PR TITLE
🌱E2E: Fix scalability tests for release-1.12

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -82,10 +82,9 @@ case "${GINKGO_FOCUS:-}" in
 
   scalability)
     # if running a scalability tests, configure dev-env with fakeIPA
-    export NUM_NODES="${NUM_NODES:-50}"
     echo 'export NODES_PLATFORM="fake"' >>"${M3_DEV_ENV_PATH}/config_${USER}.sh"
     echo 'export SKIP_APPLY_BMH="true"' >>"${M3_DEV_ENV_PATH}/config_${USER}.sh"
-    sed -i "s/^export NUM_NODES=.*/export NUM_NODES=${NUM_NODES:-50}/" "${M3_DEV_ENV_PATH}/config_${USER}.sh"
+    sed -i "s/^export NUM_NODES=.*/export NUM_NODES=${NUM_NODES:-40}/" "${M3_DEV_ENV_PATH}/config_${USER}.sh"
     echo 'CLUSTER_TOPOLOGY: true' >"${CAPI_CONFIG_FOLDER}/clusterctl.yaml"
     echo 'export BOOTSTRAP_CLUSTER="minikube"' >>"${M3_DEV_ENV_PATH}/config_${USER}.sh"
   ;;

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -83,7 +83,7 @@ case "${GINKGO_FOCUS:-}" in
 
   # Scalability test environment vars and config
   scalability)
-    export NUM_NODES=${NUM_NODES:-"10"}
+    export NUM_NODES=${NUM_NODES:-"40"}
     export BMH_BATCH_SIZE=${BMH_BATCH_SIZE:-"2"}
     export CONTROL_PLANE_MACHINE_COUNT=${CONTROL_PLANE_MACHINE_COUNT:-"1"}
     export WORKER_MACHINE_COUNT=${WORKER_MACHINE_COUNT:-"0"}

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -339,6 +339,7 @@ intervals:
   #  Giving a bit more time during scale tests.
   scale/wait-cluster: [ "20m", "10s" ]
   scale/wait-control-plane: [ "40m", "10s" ]
+  scale/wait-delete-cluster: [ "90m", "10s" ]
   default/wait-worker-nodes: [ "60m", "10s" ]
   default/wait-delete-cluster: [ "40m", "10s" ]
   default/wait-machine-upgrade: [ "50m", "10s" ]


### PR DESCRIPTION
Scalability test was failing for creating 50 nodes and also was having timeout during the deletion of cluster. The CI Job was failed for long time and this PR will reduce the node size to 40 and same time will increase the timeout for cluster deletion.  