### PR TITLE
:warning: Remove NoCloudProvider from v1beta2

### DIFF
--- a/api/v1beta1/conversion.go
+++ b/api/v1beta1/conversion.go
@@ -198,6 +198,10 @@ func Convert_v1beta2_Metal3ClusterSpec_To_v1beta1_Metal3ClusterSpec(in *infrav1.
 	if err := autoConvert_v1beta2_Metal3ClusterSpec_To_v1beta1_Metal3ClusterSpec(in, out, s); err != nil {
 		return err
 	}
+	if in.CloudProviderEnabled != nil {
+		out.CloudProviderEnabled = ptr.To(*in.CloudProviderEnabled)
+		out.NoCloudProvider = ptr.To(!*in.CloudProviderEnabled)
+	}
 	// Move FailureDomains
 	if in.FailureDomains != nil {
 		out.FailureDomains = FailureDomains{}
@@ -214,6 +218,9 @@ func Convert_v1beta2_Metal3ClusterSpec_To_v1beta1_Metal3ClusterSpec(in *infrav1.
 func Convert_v1beta1_Metal3ClusterSpec_To_v1beta2_Metal3ClusterSpec(in *Metal3ClusterSpec, out *infrav1.Metal3ClusterSpec, s apimachineryconversion.Scope) error {
 	if err := autoConvert_v1beta1_Metal3ClusterSpec_To_v1beta2_Metal3ClusterSpec(in, out, s); err != nil {
 		return err
+	}
+	if in.CloudProviderEnabled != nil {
+		out.CloudProviderEnabled = ptr.To(*in.CloudProviderEnabled)
 	}
 	// Move FailureDomains
 	if in.FailureDomains != nil {

--- a/api/v1beta1/conversion_test.go
+++ b/api/v1beta1/conversion_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 	"sigs.k8s.io/randfill"
@@ -97,6 +98,8 @@ func Metal3ClusterFuzzFuncs(_ runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		hubMetal3ClusterStatus,
 		hubMetal3FailureDomain,
+		hubMetal3ClusterSpec,
+		spokeMetal3ClusterSpec,
 		spokeMetal3ClusterStatus,
 	}
 }
@@ -148,7 +151,6 @@ func hubMetal3MachineStatus(in *infrav1.Metal3MachineStatus, c randfill.Continue
 	}
 }
 
-
 func spokeMetal3MachineSpec(in *Metal3MachineSpec, c randfill.Continue) {
 	c.FillNoCustom(in)
 
@@ -171,5 +173,35 @@ func spokeMetal3MachineStatus(in *Metal3MachineStatus, c randfill.Continue) {
 func Metal3ClusterTemplateFuzzFuncs(_ runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		hubMetal3FailureDomain,
+		hubMetal3ClusterSpec,
+		spokeMetal3ClusterSpec,
+	}
+}
+
+func hubMetal3ClusterSpec(in *infrav1.Metal3ClusterSpec, c randfill.Continue) {
+	c.FillNoCustom(in)
+
+	// Normalize: &false → nil (omitempty semantic)
+	if in.CloudProviderEnabled == nil {
+		in.CloudProviderEnabled = ptr.To(true)
+	}
+}
+
+func spokeMetal3ClusterSpec(in *Metal3ClusterSpec, c randfill.Continue) {
+	c.FillNoCustom(in)
+
+	// Normalize: &false → nil (omitempty semantic)
+	if in.CloudProviderEnabled == nil && in.NoCloudProvider == nil {
+		in.NoCloudProvider = ptr.To(true)
+		in.CloudProviderEnabled = ptr.To(false)
+	}
+	if in.CloudProviderEnabled == nil && in.NoCloudProvider != nil {
+		in.CloudProviderEnabled = ptr.To(!*in.NoCloudProvider)
+	}
+	if in.CloudProviderEnabled != nil && in.NoCloudProvider == nil {
+		in.NoCloudProvider = ptr.To(!*in.CloudProviderEnabled)
+	}
+	if in.CloudProviderEnabled != nil && in.NoCloudProvider != nil {
+		in.CloudProviderEnabled = ptr.To(!*in.NoCloudProvider)
 	}
 }

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -1255,7 +1255,6 @@ func autoConvert_v1beta1_Metal3ClusterSpec_To_v1beta2_Metal3ClusterSpec(in *Meta
 	if err := Convert_v1beta1_APIEndpoint_To_v1beta2_APIEndpoint(&in.ControlPlaneEndpoint, &out.ControlPlaneEndpoint, s); err != nil {
 		return err
 	}
-	out.NoCloudProvider = (*bool)(unsafe.Pointer(in.NoCloudProvider))
 	out.CloudProviderEnabled = (*bool)(unsafe.Pointer(in.CloudProviderEnabled))
 	// WARNING: in.FailureDomains requires manual conversion: inconvertible types (github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1.FailureDomains vs []sigs.k8s.io/cluster-api/api/core/v1beta2.FailureDomain)
 	return nil
@@ -1265,7 +1264,6 @@ func autoConvert_v1beta2_Metal3ClusterSpec_To_v1beta1_Metal3ClusterSpec(in *v1be
 	if err := Convert_v1beta2_APIEndpoint_To_v1beta1_APIEndpoint(&in.ControlPlaneEndpoint, &out.ControlPlaneEndpoint, s); err != nil {
 		return err
 	}
-	out.NoCloudProvider = (*bool)(unsafe.Pointer(in.NoCloudProvider))
 	out.CloudProviderEnabled = (*bool)(unsafe.Pointer(in.CloudProviderEnabled))
 	// WARNING: in.FailureDomains requires manual conversion: inconvertible types ([]sigs.k8s.io/cluster-api/api/core/v1beta2.FailureDomain vs github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1.FailureDomains)
 	return nil

--- a/api/v1beta2/metal3cluster_types.go
+++ b/api/v1beta2/metal3cluster_types.go
@@ -51,20 +51,9 @@ type Metal3ClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
 	ControlPlaneEndpoint APIEndpoint `json:"controlPlaneEndpoint,omitempty"`
-	// Determines if the cluster is not to be deployed with an external cloud provider.
-	// If set to true, CAPM3 will use node labels to set providerID on the kubernetes nodes.
-	// If set to false, providerID is set on nodes by other entities and CAPM3 uses the value of the providerID on the m3m resource.
-	// TODO: Remove this field in release 1.11. Ref: https://github.com/metal3-io/cluster-api-provider-metal3/issues/2255
-	//
-	// Deprecated: This field is deprecated, use cloudProviderEnabled instead
-	//
-	// +optional
-	NoCloudProvider *bool `json:"noCloudProvider,omitempty"`
 	// Determines if the cluster is to be deployed with an external cloud provider.
 	// If set to false, CAPM3 will use node labels to set providerID on the kubernetes nodes.
 	// If set to true, providerID is set on nodes by other entities and CAPM3 uses the value of the providerID on the m3m resource.
-	// TODO: Change the default value to false in release 1.12. Ref: https://github.com/metal3-io/cluster-api-provider-metal3/issues/2255
-	// Default value is true, it is set in the webhook.
 	// +optional
 	CloudProviderEnabled *bool `json:"cloudProviderEnabled,omitempty"`
 

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -451,11 +451,6 @@ func (in *Metal3ClusterList) DeepCopyObject() runtime.Object {
 func (in *Metal3ClusterSpec) DeepCopyInto(out *Metal3ClusterSpec) {
 	*out = *in
 	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
-	if in.NoCloudProvider != nil {
-		in, out := &in.NoCloudProvider, &out.NoCloudProvider
-		*out = new(bool)
-		**out = **in
-	}
 	if in.CloudProviderEnabled != nil {
 		in, out := &in.CloudProviderEnabled, &out.CloudProviderEnabled
 		*out = new(bool)

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -1267,9 +1267,6 @@ func (m *MachineManager) SetConditionMetal3MachineToTrue(t clusterv1.ConditionTy
 }
 
 func (m *MachineManager) CloudProviderEnabled() bool {
-	if m.Metal3Cluster.Spec.NoCloudProvider != nil && !*m.Metal3Cluster.Spec.NoCloudProvider {
-		return true
-	}
 	if m.Metal3Cluster.Spec.CloudProviderEnabled != nil && *m.Metal3Cluster.Spec.CloudProviderEnabled {
 		return true
 	}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3clusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3clusters.yaml
@@ -342,7 +342,6 @@ spec:
                   Determines if the cluster is to be deployed with an external cloud provider.
                   If set to false, CAPM3 will use node labels to set providerID on the kubernetes nodes.
                   If set to true, providerID is set on nodes by other entities and CAPM3 uses the value of the providerID on the m3m resource.
-                  Default value is true, it is set in the webhook.
                 type: boolean
               controlPlaneEndpoint:
                 description: ControlPlaneEndpoint represents the endpoint used to
@@ -385,14 +384,6 @@ spec:
                   - name
                   type: object
                 type: array
-              noCloudProvider:
-                description: |-
-                  Determines if the cluster is not to be deployed with an external cloud provider.
-                  If set to true, CAPM3 will use node labels to set providerID on the kubernetes nodes.
-                  If set to false, providerID is set on nodes by other entities and CAPM3 uses the value of the providerID on the m3m resource.
-
-                  Deprecated: This field is deprecated, use cloudProviderEnabled instead
-                type: boolean
             type: object
           status:
             description: Metal3ClusterStatus defines the observed state of Metal3Cluster.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3clustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3clustertemplates.yaml
@@ -151,7 +151,6 @@ spec:
                           Determines if the cluster is to be deployed with an external cloud provider.
                           If set to false, CAPM3 will use node labels to set providerID on the kubernetes nodes.
                           If set to true, providerID is set on nodes by other entities and CAPM3 uses the value of the providerID on the m3m resource.
-                          Default value is true, it is set in the webhook.
                         type: boolean
                       controlPlaneEndpoint:
                         description: ControlPlaneEndpoint represents the endpoint
@@ -196,14 +195,6 @@ spec:
                           - name
                           type: object
                         type: array
-                      noCloudProvider:
-                        description: |-
-                          Determines if the cluster is not to be deployed with an external cloud provider.
-                          If set to true, CAPM3 will use node labels to set providerID on the kubernetes nodes.
-                          If set to false, providerID is set on nodes by other entities and CAPM3 uses the value of the providerID on the m3m resource.
-
-                          Deprecated: This field is deprecated, use cloudProviderEnabled instead
-                        type: boolean
                     type: object
                 required:
                 - spec

--- a/controllers/metal3cluster_controller.go
+++ b/controllers/metal3cluster_controller.go
@@ -95,28 +95,6 @@ func (r *Metal3ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		"generation", metal3Cluster.Generation,
 		"resourceVersion", metal3Cluster.ResourceVersion)
 
-	// This is checking if default values are changed or not if the default
-	// value of CloudProviderEnabled or NoCloudProvider is changed then update
-	// the other value too to avoid conflicts.
-	// TODO: Remove this code after v1.10 when NoCloudProvider is completely
-	// removed. Ref: https://github.com/metal3-io/cluster-api-provider-metal3/issues/2255
-	clusterLog.V(baremetal.VerbosityLevelTrace).Info("Checking CloudProviderEnabled/NoCloudProvider deprecation handling")
-	if metal3Cluster.Spec.CloudProviderEnabled != nil {
-		clusterLog.V(baremetal.VerbosityLevelDebug).Info("CloudProviderEnabled is set",
-			"cloudProviderEnabled", *metal3Cluster.Spec.CloudProviderEnabled)
-		if !*metal3Cluster.Spec.CloudProviderEnabled {
-			metal3Cluster.Spec.NoCloudProvider = ptr.To(true)
-			clusterLog.V(baremetal.VerbosityLevelDebug).Info("Setting NoCloudProvider=true for compatibility")
-		}
-	} else if metal3Cluster.Spec.NoCloudProvider != nil {
-		clusterLog.V(baremetal.VerbosityLevelDebug).Info("NoCloudProvider is set (deprecated)",
-			"noCloudProvider", *metal3Cluster.Spec.NoCloudProvider)
-		if *metal3Cluster.Spec.NoCloudProvider {
-			metal3Cluster.Spec.CloudProviderEnabled = ptr.To(false)
-			clusterLog.V(baremetal.VerbosityLevelDebug).Info("Setting CloudProviderEnabled=false for compatibility")
-		}
-	}
-
 	clusterLog.V(baremetal.VerbosityLevelTrace).Info("Creating patch helper")
 	patchHelper, err := patch.NewHelper(metal3Cluster, r.Client)
 	if err != nil {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -169,7 +169,6 @@ func bmcSpec() *infrav1.Metal3ClusterSpec {
 			Host: "192.168.111.249",
 			Port: 6443,
 		},
-		NoCloudProvider:      ptr.To(true),
 		CloudProviderEnabled: ptr.To(false),
 	}
 }

--- a/internal/webhooks/v1beta2/metal3cluster_webhook.go
+++ b/internal/webhooks/v1beta2/metal3cluster_webhook.go
@@ -54,15 +54,8 @@ func (webhook *Metal3Cluster) Default(_ context.Context, obj runtime.Object) err
 		m3c.Spec.ControlPlaneEndpoint.Port = 6443
 	}
 
-	if m3c.Spec.CloudProviderEnabled != nil && m3c.Spec.NoCloudProvider == nil {
-		m3c.Spec.NoCloudProvider = ptr.To(!*m3c.Spec.CloudProviderEnabled)
-	}
-	if m3c.Spec.CloudProviderEnabled == nil && m3c.Spec.NoCloudProvider != nil {
-		m3c.Spec.CloudProviderEnabled = ptr.To(!*m3c.Spec.NoCloudProvider)
-	}
-	if m3c.Spec.CloudProviderEnabled == nil && m3c.Spec.NoCloudProvider == nil {
-		m3c.Spec.CloudProviderEnabled = ptr.To(true)
-		m3c.Spec.NoCloudProvider = ptr.To(false)
+	if m3c.Spec.CloudProviderEnabled == nil {
+		m3c.Spec.CloudProviderEnabled = ptr.To(false)
 	}
 	return nil
 }
@@ -108,19 +101,6 @@ func (webhook *Metal3Cluster) validate(_ *infrav1.Metal3Cluster, newM3C *infrav1
 				"is required",
 			),
 		)
-	}
-
-	if newM3C.Spec.CloudProviderEnabled != nil && newM3C.Spec.NoCloudProvider != nil {
-		if *newM3C.Spec.CloudProviderEnabled == *newM3C.Spec.NoCloudProvider {
-			allErrs = append(
-				allErrs,
-				field.Invalid(
-					field.NewPath("spec", "cloudProviderEnabled"),
-					newM3C.Spec.CloudProviderEnabled,
-					"cloudProviderEnabled conflicts the value of noCloudProvider",
-				),
-			)
-		}
 	}
 
 	if len(allErrs) == 0 {

--- a/internal/webhooks/v1beta2/metal3cluster_webhook_test.go
+++ b/internal/webhooks/v1beta2/metal3cluster_webhook_test.go
@@ -81,14 +81,14 @@ func TestMetal3ClusterValidation(t *testing.T) {
 			oldCluster:        valid,
 		},
 		{
-			name:              "should succeed when cloudProviderEnabled and noCloudProvider are not set",
+			name:              "should succeed when cloudProviderEnabled is not set",
 			expectErrOnCreate: false,
 			expectErrOnUpdate: false,
 			newCluster:        valid,
 			oldCluster:        valid,
 		},
 		{
-			name:              "should succeed when cloudProviderEnabled is set and noCloudProvider not set",
+			name:              "should succeed when cloudProviderEnabled is set",
 			expectErrOnCreate: false,
 			expectErrOnUpdate: false,
 			newCluster: &infrav1.Metal3Cluster{
@@ -104,101 +104,6 @@ func TestMetal3ClusterValidation(t *testing.T) {
 				},
 			},
 			oldCluster: valid,
-		},
-		{
-			name:              "should succeed when noCloudProvider is set and cloudProviderEnabled not set",
-			expectErrOnCreate: false,
-			expectErrOnUpdate: false,
-			newCluster: &infrav1.Metal3Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-				},
-				Spec: infrav1.Metal3ClusterSpec{
-					ControlPlaneEndpoint: infrav1.APIEndpoint{
-						Host: "abc.com",
-						Port: 443,
-					},
-					NoCloudProvider: ptr.To(true),
-				},
-			},
-			oldCluster: valid,
-		},
-		{
-			name:              "should fail when cloudProviderEnabled and noCloudProvider have conflicting values in new object",
-			expectErrOnCreate: true,
-			expectErrOnUpdate: true,
-			newCluster: &infrav1.Metal3Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-				},
-				Spec: infrav1.Metal3ClusterSpec{
-					ControlPlaneEndpoint: infrav1.APIEndpoint{
-						Host: "abc.com",
-						Port: 443,
-					},
-					CloudProviderEnabled: ptr.To(true),
-					NoCloudProvider:      ptr.To(true),
-				},
-			},
-			oldCluster: valid,
-		},
-		{
-			name:              "should succeed when cloudProviderEnabled and noCloudProvider do not conflict",
-			expectErrOnCreate: false,
-			expectErrOnUpdate: false,
-			newCluster: &infrav1.Metal3Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-				},
-				Spec: infrav1.Metal3ClusterSpec{
-					ControlPlaneEndpoint: infrav1.APIEndpoint{
-						Host: "abc.com",
-						Port: 443,
-					},
-					CloudProviderEnabled: ptr.To(true),
-				},
-			},
-			oldCluster: &infrav1.Metal3Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-				},
-				Spec: infrav1.Metal3ClusterSpec{
-					ControlPlaneEndpoint: infrav1.APIEndpoint{
-						Host: "abc.com",
-						Port: 443,
-					},
-					NoCloudProvider: ptr.To(false),
-				},
-			},
-		},
-		{
-			name:              "should succeed when cloudProviderEnabled and noCloudProvider do not conflict on update",
-			expectErrOnCreate: false,
-			expectErrOnUpdate: false,
-			newCluster: &infrav1.Metal3Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-				},
-				Spec: infrav1.Metal3ClusterSpec{
-					ControlPlaneEndpoint: infrav1.APIEndpoint{
-						Host: "abc.com",
-						Port: 443,
-					},
-					CloudProviderEnabled: ptr.To(false),
-				},
-			},
-			oldCluster: &infrav1.Metal3Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-				},
-				Spec: infrav1.Metal3ClusterSpec{
-					ControlPlaneEndpoint: infrav1.APIEndpoint{
-						Host: "abc.com",
-						Port: 443,
-					},
-					NoCloudProvider: ptr.To(false),
-				},
-			},
 		},
 		{
 			name:              "should succeed when enabling cloudProvider from disabled state",
@@ -214,7 +119,6 @@ func TestMetal3ClusterValidation(t *testing.T) {
 						Port: 443,
 					},
 					CloudProviderEnabled: ptr.To(true),
-					NoCloudProvider:      ptr.To(false),
 				},
 			},
 			oldCluster: &infrav1.Metal3Cluster{
@@ -227,7 +131,6 @@ func TestMetal3ClusterValidation(t *testing.T) {
 						Port: 443,
 					},
 					CloudProviderEnabled: ptr.To(false),
-					NoCloudProvider:      ptr.To(true),
 				},
 			},
 		},
@@ -245,7 +148,6 @@ func TestMetal3ClusterValidation(t *testing.T) {
 						Port: 443,
 					},
 					CloudProviderEnabled: ptr.To(false),
-					NoCloudProvider:      ptr.To(true),
 				},
 			},
 			oldCluster: &infrav1.Metal3Cluster{
@@ -258,67 +160,6 @@ func TestMetal3ClusterValidation(t *testing.T) {
 						Port: 443,
 					},
 					CloudProviderEnabled: ptr.To(true),
-					NoCloudProvider:      ptr.To(false),
-				},
-			},
-		},
-		{
-			name:              "should succeed when updating with only cloudProviderEnabled changing from false to true",
-			expectErrOnCreate: false,
-			expectErrOnUpdate: false,
-			newCluster: &infrav1.Metal3Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-				},
-				Spec: infrav1.Metal3ClusterSpec{
-					ControlPlaneEndpoint: infrav1.APIEndpoint{
-						Host: "abc.com",
-						Port: 443,
-					},
-					CloudProviderEnabled: ptr.To(true),
-				},
-			},
-			oldCluster: &infrav1.Metal3Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-				},
-				Spec: infrav1.Metal3ClusterSpec{
-					ControlPlaneEndpoint: infrav1.APIEndpoint{
-						Host: "abc.com",
-						Port: 443,
-					},
-					CloudProviderEnabled: ptr.To(false),
-					NoCloudProvider:      ptr.To(true),
-				},
-			},
-		},
-		{
-			name:              "should succeed when updating with only noCloudProvider changing from true to false",
-			expectErrOnCreate: false,
-			expectErrOnUpdate: false,
-			newCluster: &infrav1.Metal3Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-				},
-				Spec: infrav1.Metal3ClusterSpec{
-					ControlPlaneEndpoint: infrav1.APIEndpoint{
-						Host: "abc.com",
-						Port: 443,
-					},
-					NoCloudProvider: ptr.To(false),
-				},
-			},
-			oldCluster: &infrav1.Metal3Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-				},
-				Spec: infrav1.Metal3ClusterSpec{
-					ControlPlaneEndpoint: infrav1.APIEndpoint{
-						Host: "abc.com",
-						Port: 443,
-					},
-					CloudProviderEnabled: ptr.To(false),
-					NoCloudProvider:      ptr.To(true),
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:
Removes deprecated `NoCloudProvider` field from `MetalCluster` and fixes the tests accordingly.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #2255
Part of #2671

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] E2E tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
