### PR TITLE
:bug: Do not set BMC Secret label until BMH claimed

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -404,11 +404,6 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 		}
 	}
 
-	err = m.setBMCSecretLabel(ctx, host)
-	if err != nil {
-		return err
-	}
-
 	err = helper.Patch(ctx, host)
 	if err != nil {
 		var aggr kerrors.Aggregate
@@ -417,6 +412,11 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 				return WithTransientError(nil, requeueAfter)
 			}
 		}
+		return err
+	}
+
+	err = m.setBMCSecretLabel(ctx, host)
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
We should wait until we have successfully claimed the BMH (by setting the ConsumerRef field) before claiming the associated BMC Secret. If another consumer beat us to the BMH then we are potentially overwriting its labeling by doing this first.