### PR TITLE
:warning: Restore TLS default to no configuration

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,7 +29,6 @@ spec:
         - "--enable-bmh-name-based-preallocation=${ENABLE_BMH_NAME_BASED_PREALLOCATION:=false}"
         - "--diagnostics-address=${CAPM3_DIAGNOSTICS_ADDRESS:=:8443}"
         - "--insecure-diagnostics=${CAPM3_INSECURE_DIAGNOSTICS:=false}"
-        - "--tls-min-version=${TLS_MIN_VERSION:=VersionTLS13}"
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -134,9 +134,8 @@ providers:
 - name: metal3
   type: IPAMProvider
   versions:
-  - name: "{go://github.com/metal3-io/ip-address-manager@v1.12}"
-    value: "https://github.com/metal3-io/ip-address-manager/releases/download/{go://github.com/metal3-io/ip-address-manager@v1.12}/ipam-components.yaml"
-    type: "url"
+  - name: v1.12.99
+    value: "${PWD}/test/e2e/data/ipamprovider-metal3/overlays/release-1.12/"
     contract: v1beta1
     replacements:
     - old: --metrics-addr=127.0.0.1:8080
@@ -144,9 +143,8 @@ providers:
     files:
     - sourcePath: "../data/shared/ipam-metal3/v1.12/metadata.yaml"
       targetName: "metadata.yaml"
-  - name: "{go://github.com/metal3-io/ip-address-manager@v1.11}"
-    value: "https://github.com/metal3-io/ip-address-manager/releases/download/{go://github.com/metal3-io/ip-address-manager@v1.11}/ipam-components.yaml"
-    type: "url"
+  - name: v1.11.99
+    value: "${PWD}/test/e2e/data/ipamprovider-metal3/overlays/release-1.11/"
     contract: v1beta1
     replacements:
     - old: --metrics-addr=127.0.0.1:8080
@@ -158,9 +156,8 @@ providers:
 - name: metal3
   type: InfrastructureProvider
   versions:
-  - name: "{go://github.com/metal3-io/cluster-api-provider-metal3@v1.12}"
-    value: "https://github.com/metal3-io/cluster-api-provider-metal3/releases/download/{go://github.com/metal3-io/cluster-api-provider-metal3@v1.12}/infrastructure-components.yaml"
-    type: "url"
+  - name: "v1.12.99"
+    value: "${PWD}/test/e2e/data/infrastructure-metal3/overlays/release-1.12/"
     contract: v1beta1
     files:
     - sourcePath: "../data/shared/infrastructure-metal3/v1.12/metadata.yaml"
@@ -169,9 +166,8 @@ providers:
       targetName: "cluster-template-ubuntu.yaml"
     - sourcePath: "../_out/v1.12/cluster-template-upgrade-workload.yaml"
       targetName: "cluster-template-upgrade-workload.yaml"
-  - name: "{go://github.com/metal3-io/cluster-api-provider-metal3@v1.11}"
-    value: "https://github.com/metal3-io/cluster-api-provider-metal3/releases/download/{go://github.com/metal3-io/cluster-api-provider-metal3@v1.11}/infrastructure-components.yaml"
-    type: "url"
+  - name: "v1.11.99"
+    value: "${PWD}/test/e2e/data/infrastructure-metal3/overlays/release-1.11/"
     contract: v1beta1
     files:
     - sourcePath: "../data/shared/infrastructure-metal3/v1.11/metadata.yaml"
@@ -181,7 +177,7 @@ providers:
     - sourcePath: "../_out/v1.11/cluster-template-upgrade-workload.yaml"
       targetName: "cluster-template-upgrade-workload.yaml"
   - name: v1.13.99
-    value: "${PWD}/config/default"
+    value: "${PWD}/test/e2e/data/infrastructure-metal3/overlays/main/"
     contract: v1beta2
     files:
     - sourcePath: "../data/shared/infrastructure-metal3/main/metadata.yaml"

--- a/test/e2e/data/bmo-deployment/overlays/pr-test/kustomization.yaml
+++ b/test/e2e/data/bmo-deployment/overlays/pr-test/kustomization.yaml
@@ -17,6 +17,14 @@ patches:
   target:
     kind: Deployment
     name: controller-manager
+- patch: |
+    # Extend default with TLS 1.3 hardening.
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-min-version=TLS13"
+  target:
+    kind: Deployment
+    name: controller-manager
 images:
 - name: quay.io/metal3-io/baremetal-operator
   newTag: main

--- a/test/e2e/data/bmo-deployment/overlays/release-main/kustomization.yaml
+++ b/test/e2e/data/bmo-deployment/overlays/release-main/kustomization.yaml
@@ -17,6 +17,14 @@ patches:
   target:
     kind: Deployment
     name: controller-manager
+- patch: |
+    # Extend default with TLS 1.3 hardening.
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-min-version=TLS13"
+  target:
+    kind: Deployment
+    name: controller-manager
 images:
 - name: quay.io/metal3-io/baremetal-operator
   newTag: main

--- a/test/e2e/data/infrastructure-metal3/overlays/main/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/overlays/main/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../../../../config/default
+
+patches:
+- patch: |
+    # Extend default with TLS 1.3 hardening.
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-min-version=VersionTLS13"
+  target:
+    kind: Deployment
+    name: controller-manager

--- a/test/e2e/data/infrastructure-metal3/overlays/release-1.11/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/overlays/release-1.11/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- https://github.com/metal3-io/cluster-api-provider-metal3/config/default?ref=release-1.11

--- a/test/e2e/data/infrastructure-metal3/overlays/release-1.12/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/overlays/release-1.12/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- https://github.com/metal3-io/cluster-api-provider-metal3/config/default?ref=release-1.12

--- a/test/e2e/data/ipamprovider-metal3/overlays/main/kustomization.yaml
+++ b/test/e2e/data/ipamprovider-metal3/overlays/main/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- github.com/metal3-io/ip-address-manager/config/default?ref=main
+
+patches:
+- patch: |
+    # Extend default with TLS 1.3 hardening.
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-min-version=VersionTLS13"
+  target:
+    kind: Deployment
+    name: controller-manager

--- a/test/e2e/data/ipamprovider-metal3/overlays/release-1.11/kustomization.yaml
+++ b/test/e2e/data/ipamprovider-metal3/overlays/release-1.11/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- https://github.com/metal3-io/ip-address-manager/config/default?ref=release-1.11

--- a/test/e2e/data/ipamprovider-metal3/overlays/release-1.12/kustomization.yaml
+++ b/test/e2e/data/ipamprovider-metal3/overlays/release-1.12/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- https://github.com/metal3-io/ip-address-manager/config/default?ref=release-1.12


### PR DESCRIPTION
Restore TLS default to no configuration and make TLS 1.3 hardening a kustomization applied in e2e tests

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
