### PR TITLE
:seedling: Bump golang for image build to v1.25.8

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,12 +26,12 @@ jobs:
       id: vars
       run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
     - name: Set up Go
-      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: ${{ steps.vars.outputs.go_version }}
     - name: golangci-lint-${{matrix.working-directory}}
       uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
       with:
-        version: v2.1.0
+        version: v2.4.0
         working-directory: ${{matrix.working-directory}}
         args: --timeout=15m

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.25.7@sha256:85c0ab0b73087fda36bf8692efe2cf67c54a06d7ca3b49c489bbff98c9954d64
+ARG BUILD_IMAGE=docker.io/golang:1.25.8@sha256:779b230b2508037a8095c9e2d223a6405f8426e12233b694dbae50197b9f6d04
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary on golang image

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SHELL:=/usr/bin/env bash
 
 .DEFAULT_GOAL:=help
 
-GO_VERSION ?= 1.25.7
+GO_VERSION ?= 1.25.8
 GO := $(shell type -P go)
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell $(GO) env GOPROXY)

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -32,7 +32,7 @@ EOF
     local go_version
     IFS=" " read -ra go_version <<< "$(go version)"
     local minimum_go_version
-    minimum_go_version=go1.25
+    minimum_go_version=go1.24
     if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]] && [[ "${go_version[2]}" != "devel" ]]; then
         cat << EOF
 Detected go version: ${go_version[*]}.

--- a/hack/ensure-golangci-lint.sh
+++ b/hack/ensure-golangci-lint.sh
@@ -60,11 +60,11 @@ download_and_install_golangci_lint()
     KERNEL_OS="$(uname | tr '[:upper:]' '[:lower:]')"
     ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')"
     GOLANGCI_LINT="golangci-lint"
-    GOLANGCI_VERSION="2.1.0"
+    GOLANGCI_VERSION="2.4.0"
     case "${KERNEL_OS}-${ARCH}" in
-        darwin-arm64) GOLANGCI_SHA256="88eb4d7d1761fc39e6cc4e90e12fa8167739354507a137cac678c8246a8f5888" ;;
-        linux-amd64) GOLANGCI_SHA256="ef8211a45a23c067f6ef4d9cf8cb4dd9db165c3586e2472b5f499177b6e784b1" ;;
-      *)
+        darwin-arm64) GOLANGCI_SHA256="cd4dd53fa09b6646baff5fd22b8c64d91db02c21c7496df27992d75d34feec59" ;;
+        linux-amd64) GOLANGCI_SHA256="fae792524c04424c0ac369f5b8076f04b45cf29fc945a370e55d369a8dc11840" ;;
+        *)
         echo >&2 "error:${KERNEL_OS}-${ARCH} not supported. Please obtain the binary and calculate sha256 manually."
         exit 1
         ;;

--- a/hack/fake-apiserver/Dockerfile
+++ b/hack/fake-apiserver/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.25.7@sha256:85c0ab0b73087fda36bf8692efe2cf67c54a06d7ca3b49c489bbff98c9954d64
+ARG BUILD_IMAGE=docker.io/golang:1.25.8@sha256:779b230b2508037a8095c9e2d223a6405f8426e12233b694dbae50197b9f6d04
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the fkas binary on golang image

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -224,7 +224,7 @@ func EnsureImage(k8sVersion string) (imageURL string, imageChecksum string) {
 		Logf("Local image %v is not found \nDownloading..", rawImagePath)
 		err = DownloadFile(imagePath, fmt.Sprintf("%s/%s", imageLocation, imageName))
 		Expect(err).ToNot(HaveOccurred())
-		cmd := exec.Command("qemu-img", "convert", "-O", "raw", imagePath, rawImagePath) // #nosec G204:gosec
+		cmd := exec.CommandContext(context.Background(), "qemu-img", "convert", "-O", "raw", imagePath, rawImagePath) // #nosec G204:gosec
 		err = cmd.Run()
 		Expect(err).ToNot(HaveOccurred())
 		var sha256sum []byte
@@ -245,7 +245,7 @@ func EnsureImage(k8sVersion string) (imageURL string, imageChecksum string) {
 func DownloadFile(filePath string, url string) error {
 	// TODO: Lets change the wget to use go's native http client when network
 	// more resilient
-	cmd := exec.Command("wget", "-O", filePath, url)
+	cmd := exec.CommandContext(context.Background(), "wget", "-O", filePath, url)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("wget failed: %w, output: %s", err, string(output))

--- a/test/e2e/logcollector.go
+++ b/test/e2e/logcollector.go
@@ -48,13 +48,13 @@ func (Metal3LogCollector) CollectMachineLog(ctx context.Context, cli client.Clie
 	}
 
 	copyCmd := fmt.Sprintf("sudo cp %s %s", serialLog, qemuFolder)
-	cmd := exec.Command("/bin/sh", "-c", copyCmd) // #nosec G204:gosec
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", copyCmd) // #nosec G204:gosec
 	var output []byte
 	if output, err = cmd.Output(); err != nil {
 		return fmt.Errorf("something went wrong when executing '%s': %w, output: %s", cmd.String(), err, output)
 	}
 	setPermsCmd := "sudo chmod -v 777 " + path.Join(qemuFolder, filepath.Base(serialLog))
-	cmd = exec.Command("/bin/sh", "-c", setPermsCmd) // #nosec G204:gosec
+	cmd = exec.CommandContext(ctx, "/bin/sh", "-c", setPermsCmd) // #nosec G204:gosec
 	output, err = cmd.Output()
 	if err != nil {
 		return fmt.Errorf("error changing file permissions after copying: %w, output: %s", err, output)

--- a/test/e2e/pivoting.go
+++ b/test/e2e/pivoting.go
@@ -102,7 +102,7 @@ func pivoting(ctx context.Context, inputGetter func() PivotingInput) {
 	// target log collection. There is possibility to handle the kubeconfig in better way.
 	// KubeconfigPathTemp will be used by project-infra target log collection only incase of failed e2e test
 	kubeconfigPathTemp := "/tmp/kubeconfig-test1.yaml"
-	cmd := exec.Command("cp", kconfigPathWorkload, kubeconfigPathTemp) // #nosec G204:gosec
+	cmd := exec.CommandContext(ctx, "cp", kconfigPathWorkload, kubeconfigPathTemp) // #nosec G204:gosec
 	stdoutStderr, er := cmd.CombinedOutput()
 	Logf("%s\n", stdoutStderr)
 	Expect(er).ToNot(HaveOccurred(), "Cannot fetch target cluster kubeconfig")
@@ -399,7 +399,7 @@ func rePivoting(ctx context.Context, inputGetter func() RePivotingInput) {
 		bmoPath := input.E2EConfig.MustGetVariable("BMOPATH")
 		ironicCommand := bmoPath + "/tools/run_local_ironic.sh"
 		//#nosec G204:gosec
-		cmd := exec.Command("sh", "-c", "export CONTAINER_RUNTIME=docker; "+ironicCommand)
+		cmd := exec.CommandContext(ctx, "sh", "-c", "export CONTAINER_RUNTIME=docker; "+ironicCommand)
 		var stdoutStderr []byte
 		stdoutStderr, err = cmd.CombinedOutput()
 		Logf("Output: %s", stdoutStderr)
@@ -521,7 +521,7 @@ func fetchContainerLogs(containerNames *[]string, folder string, containerComman
 		By(fmt.Sprintf("Create log directory for container %s at %s", name, logDir))
 		createDirIfNotExist(logDir)
 		By("Fetch logs for container " + name)
-		cmd := exec.Command("sudo", containerCommand, "logs", name) // #nosec G204:gosec
+		cmd := exec.CommandContext(context.Background(), "sudo", containerCommand, "logs", name) // #nosec G204:gosec
 		out, err := cmd.Output()
 		if err != nil {
 			writeErr := os.WriteFile(filepath.Join(logDir, "stderr.log"), []byte(err.Error()), 0400)

--- a/test/e2e/remediation.go
+++ b/test/e2e/remediation.go
@@ -390,13 +390,13 @@ func listVms(state vmState) []string {
 	var cmd *exec.Cmd // gosec Subprocess launched with variable
 	switch state {
 	case running:
-		cmd = exec.Command("sudo", "virsh", "list", "--name", "--state-running")
+		cmd = exec.CommandContext(context.Background(), "sudo", "virsh", "list", "--name", "--state-running")
 	case shutoff:
-		cmd = exec.Command("sudo", "virsh", "list", "--name", "--state-shutoff")
+		cmd = exec.CommandContext(context.Background(), "sudo", "virsh", "list", "--name", "--state-shutoff")
 	case paused:
-		cmd = exec.Command("sudo", "virsh", "list", "--name", "--state-paused")
+		cmd = exec.CommandContext(context.Background(), "sudo", "virsh", "list", "--name", "--state-paused")
 	case other:
-		cmd = exec.Command("sudo", "virsh", "list", "--name", "--state-other")
+		cmd = exec.CommandContext(context.Background(), "sudo", "virsh", "list", "--name", "--state-other")
 	}
 
 	result, err := cmd.Output()

--- a/test/e2e/upgrade_clusterctl_test.go
+++ b/test/e2e/upgrade_clusterctl_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -280,7 +281,7 @@ func preInitFunc(clusterProxy framework.ClusterProxy, bmoRelease string, ironicR
 	os.Setenv("KUBECONFIG_WORKLOAD", kconfigPathWorkload)
 	Logf("Save kubeconfig in temp folder for project-infra target log collection")
 	kubeconfigPathTemp := "/tmp/kubeconfig-test1.yaml"
-	cmd := exec.Command("cp", kconfigPathWorkload, kubeconfigPathTemp) // #nosec G204:gosec
+	cmd := exec.CommandContext(context.Background(), "cp", kconfigPathWorkload, kubeconfigPathTemp) // #nosec G204:gosec
 	stdoutStderr, er := cmd.CombinedOutput()
 	Expect(er).ToNot(HaveOccurred(), "Cannot fetch target cluster kubeconfig: %s", stdoutStderr)
 	// install certmanager
@@ -433,7 +434,7 @@ func preCleanupManagementCluster(clusterProxy framework.ClusterProxy, ironicRele
 			bmoPath := e2eConfig.MustGetVariable("BMOPATH")
 			ironicCommand := bmoPath + "/tools/run_local_ironic.sh"
 			//#nosec G204 -- We take the BMOPATH from a variable.
-			cmd := exec.Command("sh", "-c", "export CONTAINER_RUNTIME=docker; "+ironicCommand)
+			cmd := exec.CommandContext(context.Background(), "sh", "-c", "export CONTAINER_RUNTIME=docker; "+ironicCommand)
 			stdoutStderr, err := cmd.CombinedOutput()
 			Logf("Output: %s", stdoutStderr)
 			Expect(err).ToNot(HaveOccurred(), "Cannot run local ironic")


### PR DESCRIPTION
- Bumps golang for image build to v1.25.8
- bump osv-scanner to v2.3.3
- golangci-lint older than v2.4.0 was compiled with Go 1.24.4. When linting the
test/ module with Go 1.25.8 installed, golangci-lint panics:

  panic: file requires newer Go version go1.25 (application built with go1.24)

This is triggered because golang.org/x/crypto@v0.45.0 (pulled in via
helm/v3 and docker/docker in test/go.mod) contains files with
//go:build go1.25 constraints. With Go 1.25 installed these files are
included in the build graph, but golangci-lint's embedded go/types
checker (compiled with Go 1.24) cannot handle them.

v2.4.0 is the minimum version compiled with Go 1.25.0, so it handles
these files correctly.

- Also fix 13 noctx violations


Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
