### PR TITLE
:seedling: Add KUBERNETES_VERSION_UPGRADE_FROM in scalability test

### DIFF
--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -98,7 +98,7 @@ case "${GINKGO_FOCUS:-}" in
     export BMH_BATCH_SIZE=${BMH_BATCH_SIZE:-"2"}
     export CONTROL_PLANE_MACHINE_COUNT=${CONTROL_PLANE_MACHINE_COUNT:-"1"}
     export WORKER_MACHINE_COUNT=${WORKER_MACHINE_COUNT:-"0"}
-    # Note: Uses KUBERNETES_VERSION_FROM directly now (no duplication needed)
+    export KUBERNETES_VERSION_UPGRADE_FROM="${KUBERNETES_VERSION_FROM}"
   ;;
 
   # CAPI md-tests environment vars and config


### PR DESCRIPTION
This vas was removed in https://github.com/metal3-io/cluster-api-provider-metal3/pull/3153/ causing [periodics to fail](https://jenkins.nordix.org/view/Metal3%20periodic%20FAIL/job/metal3-periodic-centos-e2e-feature-test-main-scalability/). This variable is required by CAPI scale test https://github.com/kubernetes-sigs/cluster-api/blob/v1.12.3/test/e2e/scale.go#L333C62-L333C90 and defined here https://github.com/kubernetes-sigs/cluster-api/blob/main/test/e2e/common.go#L42

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
