### PR TITLE
:seedling: Enable Kube-API-linter

### DIFF
--- a/.github/workflows/kube-api-lint.yml
+++ b/.github/workflows/kube-api-lint.yml
@@ -1,0 +1,32 @@
+name: kube-api-lint
+
+on:
+  pull_request:
+    types: [ opened, edited, reopened, synchronize, ready_for_review ]
+
+permissions: {}
+
+jobs:
+  kubeapilint:
+    name: api-lint
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        working-directory:
+        - api
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Calculate go version
+      id: vars
+      run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
+    - name: Set up Go
+      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+      with:
+        go-version: ${{ steps.vars.outputs.go_version }}
+    - name: Run kube-api-linter
+      run: make kube-api-lint

--- a/.golangci-kal.yaml
+++ b/.golangci-kal.yaml
@@ -1,0 +1,68 @@
+version: "2"
+run:
+  go: "1.24"
+  allow-parallel-runners: true
+linters:
+  default: none
+  enable:
+  - kubeapilinter # linter for Kube API conventions
+  settings:
+    custom:
+      kubeapilinter:
+        type: module
+        description: KAL is the Kube-API-Linter and lints Kube like APIs based on API conventions and best practices.
+        settings:
+          linters:
+            disable:
+            - "commentstart"
+            - "optionalfields"
+            - "optionalorrequired"
+            - "nonpointerstructs"
+            - "nophase"
+            - "nodurations"
+            - "nomaps"
+            - "conditions"
+            - "integers"
+            - "arrayofstruct"
+            - "ssatags"
+            - "defaults"
+          lintersConfig:
+            conflictingmarkers:
+              conflicts:
+              - name: "default_vs_required"
+                sets:
+                - [ "default", "kubebuilder:default" ]
+                - [ "required", "kubebuilder:validation:Required", "k8s:required" ]
+                description: "A field with a default value cannot be required"
+            forbiddenmarkers:
+              markers:
+              # We don't want to do any defaulting (including OpenAPI) anymore on API fields because we prefer
+              # to have a clear signal on user intent. This also allows us to easily change the default behavior if necessary.
+              - identifier: "kubebuilder:default"
+              - identifier: "default"
+            conditions:
+              isFirstField: Warn # Require conditions to be the first field in the status struct.
+              usePatchStrategy: Forbid # Forbid patchStrategy markers on the Conditions field.
+              useProtobuf: Forbid # We don't use protobuf, so protobuf tags are not required.
+            optionalfields:
+              pointers:
+                preference: WhenRequired # Always | WhenRequired # Whether to always require pointers, or only when required. Defaults to `Always`.
+                policy: SuggestFix # SuggestFix | Warn # The policy for pointers in optional fields. Defaults to `SuggestFix`.
+              omitempty:
+                policy: SuggestFix # SuggestFix | Warn | Ignore # The policy for omitempty in optional fields. Defaults to `SuggestFix`.
+
+  exclusions:
+    generated: strict
+    paths:
+    - zz_generated.*\.go$
+    - ".*_test.go"
+    - "api/v1beta1/.*"
+    rules:
+    ## KAL should only run on API folders.
+    - path: "api/v1beta1//*"
+      linters:
+      - kubeapilinter
+
+issues:
+  max-same-issues: 0
+  max-issues-per-linter: 0

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ endif
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN)
+GOLANGCI_LINT_KAL_BIN := golangci-lint-kube-api-linter
+GOLANGCI_LINT_KAL := $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_KAL_BIN)
 MOCKGEN := $(TOOLS_BIN_DIR)/mockgen
 CONVERSION_GEN := $(TOOLS_BIN_DIR)/conversion-gen
 KUBEBUILDER := $(TOOLS_BIN_DIR)/kubebuilder
@@ -375,6 +377,12 @@ $(GOLANGCI_LINT):
 .PHONY: $(GOLANGCI_LINT_BIN)
 $(GOLANGCI_LINT_BIN): $(GOLANGCI_LINT) ## Build a local copy of golangci-lint.
 
+$(GOLANGCI_LINT_KAL):
+	cd $(TOOLS_DIR) && ${GOLANGCI_LINT} custom
+
+.PHONY: $(GOLANGCI_LINT_KAL_BIN)
+$(GOLANGCI_LINT_KAL_BIN): $(GOLANGCI_LINT_KAL) # Build golangci-lint-kal from custom configuration.
+
 $(MOCKGEN): $(TOOLS_DIR)/go.mod
 	cd $(TOOLS_DIR) && $(GO) build -tags=tools -o $(BIN_DIR)/mockgen go.uber.org/mock/mockgen
 
@@ -415,11 +423,15 @@ $(ENVSUBST_BIN): $(ENVSUBST) ## Build envsubst from tools folder.
 ##@ linters:
 
 .PHONY: lint
-lint: $(GOLANGCI_LINT) ## Lint codebase
+lint: $(GOLANGCI_LINT) $(GOLANGCI_LINT_KAL) ## Lint codebase
 	$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=15m
 	cd $(APIS_DIR) && $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=15m
 	cd $(TEST_DIR) && $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=15m
 	cd $(FAKE_APISERVER_DIR) && $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=15m
+	cd $(APIS_DIR) && $(GOLANGCI_LINT_KAL) run -v --config $(ROOT_DIR)/.golangci-kal.yaml $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=15m
+
+kube-api-lint: $(GOLANGCI_LINT) $(GOLANGCI_LINT_KAL) ## Run kube-api-linter on the codebase
+	cd $(APIS_DIR) && $(GOLANGCI_LINT_KAL) run -v --config $(ROOT_DIR)/.golangci-kal.yaml $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=15m
 
 .PHONY: lint-fix
 lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter

--- a/hack/tools/.custom-gcl.yml
+++ b/hack/tools/.custom-gcl.yml
@@ -1,0 +1,12 @@
+# Custom golangci-lint configuration for kube-api-linter plugin
+# This file is used by `golangci-lint custom` to build a custom binary
+# that includes the kube-api-linter module.
+#
+# See: https://github.com/kubernetes-sigs/kube-api-linter
+version: v2.8.0
+name: golangci-lint-kube-api-linter
+destination: ./bin
+plugins:
+- module: 'sigs.k8s.io/kube-api-linter'
+  # Check latest module version at: https://pkg.go.dev/sigs.k8s.io/kube-api-linter?tab=versions
+  version: 'v0.0.0-20260206102632-39e3d06a2850'


### PR DESCRIPTION
Enable Kube-API-linter to lint contents of api directory. I've disabled most of the linters and I will create separate PRs enabling each. Some fixes will be breaking or so large there is no point in having them in one PR. 

I've set similar rules as for linting as is set in CAPI project. Check CAPI config [here](https://github.com/kubernetes-sigs/cluster-api/blob/main/.golangci-kal.yml)

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
