### PR TITLE
:seedling: fix fkas build permissions for image signing

### DIFF
--- a/.github/workflows/build-fkas-images-action.yml
+++ b/.github/workflows/build-fkas-images-action.yml
@@ -45,6 +45,9 @@ jobs:
     name: Build Metal3-FKAS image
     if: github.repository == 'metal3-io/cluster-api-provider-metal3'
     needs: prepare
+    permissions:
+      contents: read
+      id-token: write
     uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main # zizmor: ignore[unpinned-uses]
     with:
       image-name: "metal3-fkas"


### PR DESCRIPTION
Add id-token: write permission to build_FKAS job so the reusable container-image-build workflow can sign images.

This has been failing fkas builds silently since container signing was introduced.