### PR TITLE
:seedling: add zizmor scanner

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,12 +19,14 @@ updates:
   # Ignore major bumps in main, as it breaks the group bump process
   - dependency-name: "*"
     update-types: [ "version-update:semver-major" ]
+  cooldown:
+    default-days: 7
   commit-message:
     prefix: ":seedling:"
   labels:
   - "ok-to-test"
   # Go
-- package-ecosystem: "gomod"
+- package-ecosystem: "gomod" # zizmor: ignore[dependabot-cooldown]
   directories:
   - "/"
   - "/api"
@@ -75,12 +77,14 @@ updates:
   # Ignore major and minor bumps for release branch
   - dependency-name: "*"
     update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  cooldown:
+    default-days: 7
   commit-message:
     prefix: ":seedling:"
   labels:
   - "ok-to-test"
   # Go
-- package-ecosystem: "gomod"
+- package-ecosystem: "gomod" # zizmor: ignore[dependabot-cooldown]
   directories:
   - "/"
   - "/api"
@@ -130,12 +134,14 @@ updates:
   # Ignore major and minor bumps for release branch
   - dependency-name: "*"
     update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  cooldown:
+    default-days: 7
   commit-message:
     prefix: ":seedling:"
   labels:
   - "ok-to-test"
   # Go
-- package-ecosystem: "gomod"
+- package-ecosystem: "gomod" # zizmor: ignore[dependabot-cooldown]
   directories:
   - "/"
   - "/api"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Calculate go version
       id: vars
       run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
@@ -46,6 +48,7 @@ jobs:
     - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
       name: Commit changes
       with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         author_name: dependabot[bot]
         author_email: 49699333+dependabot[bot]@users.noreply.github.com
         default_author: github_actor

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
     if: github.repository == 'metal3-io/cluster-api-provider-metal3'
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked]
       with:
         fetch-depth: 0
     - name: Get changed files
@@ -119,7 +119,7 @@ jobs:
         curl -fsSL "https://raw.githubusercontent.com/${{ github.repository }}/main/releasenotes/${RELEASE_TAG}.md" \
         -o "${RELEASE_TAG}.md"
     - name: Release
-      uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+      uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0 # zizmor: ignore[superfluous-actions]
       with:
         draft: true
         files: out/*

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,36 @@
+---
+# Static analysis for GitHub Actions workflows
+# https://docs.zizmor.sh/
+name: zizmor
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    # Upload SARIF to Security tab on push to main
+    - name: Run zizmor (SARIF)
+      if: github.event_name == 'push'
+      uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0
+    # Block PRs with findings
+    - name: Run zizmor (PR check)
+      if: github.event_name == 'pull_request'
+      uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0
+      with:
+        advanced-security: false


### PR DESCRIPTION
Zizmor scans workflow files to keep them hardened. It runs on push to produce a report in security tab, and it runs on PRs and blocks them if they is any errors.

    - Harden dependabot workflow: disable persist-credentials on checkout,
      pass token explicitly to add-and-commit action
    - Suppress artipacked on release workflow checkout that needs
      credentials for pushing branches and tags
    - Suppress superfluous-actions on softprops/action-gh-release pending
      replacement with gh CLI
