### PR TITLE
:seedling: harden pr-verifier workflow trigger

### DIFF
--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -3,7 +3,7 @@ name: PR Verifier
 permissions: {}
 
 on:
-  pull_request_target:
+  pull_request:
     types: [ opened, edited, reopened, synchronize, ready_for_review ]
 
 jobs:


### PR DESCRIPTION
This is needed to both fix the pr-verifier in branches (pull_request_target + permissions: {} = no op), but also to harden it by removing the target part.