### PR TITLE
🌱 E2E: Remove features label from in place upgrade test

### DIFF
--- a/test/e2e/k8s_in_place_upgrade_test.go
+++ b/test/e2e/k8s_in_place_upgrade_test.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("When testing in-place k8s upgrade", Label("in-place-upgrade", "features"), func() {
+var _ = Describe("When testing in-place k8s upgrade", Label("in-place-upgrade"), func() {
 
 	BeforeEach(func() {
 		osType = strings.ToLower(os.Getenv("OS"))


### PR DESCRIPTION
This PR:
- Removes features label from in place upgrade test 
- Fixes e2e feature test running and failing in place upgrade test

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
