### PR TITLE
🌱Add image validation fuzzing for CAPM3 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,24 @@ unit-cover-verbose:
 .PHONY: test
 test: lint unit ## Run tests
 
+## Fuzz testing variables
+FUZZ_TIME ?= 30s
+
+.PHONY: fuzz
+fuzz: ## Run fuzz tests with seed corpus (no fuzzing, regression test only)
+	cd test/fuzz && $(GO) test -race -v -run='^Fuzz' ./...
+
+.PHONY: fuzz-run
+fuzz-run: ## Run all fuzz tests sequentially with fuzzing enabled (use FUZZ_TIME=duration)
+	@echo "Discovering fuzz tests..."
+	@cd test/fuzz && ( \
+		while read -r fuzz_test; do \
+			echo "Running $$fuzz_test for $(FUZZ_TIME)..."; \
+			$(GO) test -fuzz=$$fuzz_test -fuzztime='$(FUZZ_TIME)' || exit 1; \
+		done < <($(GO) test -list='Fuzz.*' ./... | grep '^Fuzz') \
+	)
+	@echo "All fuzz tests completed successfully!"
+
 .PHONY: test-e2e
 test-e2e: ## Run e2e tests with capi e2e testing framework
 	./scripts/ci-e2e.sh

--- a/test/fuzz/README.md
+++ b/test/fuzz/README.md
@@ -1,0 +1,59 @@
+# Fuzzing
+
+## Overview
+
+Fuzz tests in this directory target critical validation and parsing functions
+in CAPM3 that handle user-provided data. The goal is to ensure these functions
+handle all possible inputs gracefully without crashing.
+
+## Running Fuzz Tests
+
+### Quick Start with Make
+
+The easiest way to run fuzz tests is using Make targets:
+
+```bash
+# Run fuzz tests as regression tests (using seed corpus only, fast)
+make fuzz
+
+# Run all fuzz tests with fuzzing enabled (default: 30 seconds each)
+make fuzz-run
+
+# Run all fuzz tests with custom duration (e.g., 5 minutes each)
+make fuzz-run FUZZ_TIME=5m
+```
+
+### Running Individual Fuzz Tests
+
+To run a specific fuzz test directly:
+
+```bash
+# Run a specific fuzz test with fuzzing enabled
+cd test/fuzz && go test -fuzz=FuzzImageValidate -fuzztime=30s
+
+# Run with longer duration to find more edge cases
+cd test/fuzz && go test -fuzz=FuzzImageValidate -fuzztime=5m
+
+# Run only as regression test (no fuzzing, just seed corpus)
+cd test/fuzz && go test -run=FuzzImageValidate
+```
+
+## Crash Corpus and Regression Testing
+
+When fuzzing discovers a crash or failure, Go automatically saves the failing
+input to `testdata/fuzz/<FuzzTestName>/` in the test directory. These crash
+files should be committed to the repository:
+
+```bash
+git add test/fuzz/testdata/
+git commit -m "Add fuzz crash corpus"
+```
+
+Once committed, these crashes are automatically replayed as regression tests
+when running `make fuzz` (or `go test -run='^Fuzz'` to run all fuzz tests, or
+`go test -run=FuzzImageValidate` for a specific test without fuzzing).
+
+## Resources
+
+- [Go Fuzzing Documentation](https://go.dev/doc/fuzz/)
+- [Go Fuzzing Tutorial](https://go.dev/security/fuzz/)

--- a/test/fuzz/image_validate_fuzz_test.go
+++ b/test/fuzz/image_validate_fuzz_test.go
@@ -1,0 +1,161 @@
+package fuzz
+
+import (
+	"strings"
+	"testing"
+
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta2"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// FuzzImageValidate tests the Image.Validate function with random inputs
+// to discover edge cases, panics, or unexpected behaviors.
+func FuzzImageValidate(f *testing.F) {
+	// Valid cases
+	f.Add("http://example.com/image.qcow2", "sha256:abc123", "qcow2", false)
+	f.Add("https://example.com/image.qcow2", "http://example.com/checksum.sha256", "qcow2", false)
+	f.Add("http://172.22.0.1/rhcos.qcow2", "f7600f7a274d974a236c4da5161265859c32da93a7c8de6a77d560378a1384ef", "raw", false)
+	f.Add("http://172.22.0.1:8080/images/rhcos.qcow2", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "qcow2", false)
+	f.Add("http://example.com/live.iso", "", "live-iso", true) // live-iso doesn't require checksum
+
+	// Invalid/edge cases
+	f.Add("", "", "", false)
+	f.Add("not-a-url", "checksum", "", false)
+	f.Add("http://example.com/image", "", "", false)
+	f.Add("http://example.com", "http://:invalid", "", false)
+	f.Add("ftp://example.com/image", "checksum", "", false)
+	f.Add("http://example.com/image", "https://", "", false)
+	f.Add("http://", "checksum", "", false)
+	f.Add("://example.com", "checksum", "", false)
+	f.Add("http://example.com/\x00", "checksum", "", false)
+	f.Add("http://example.com/image", "http://\x00", "", false)
+	f.Add(strings.Repeat("a", 10000), "checksum", "", false)
+	f.Add("http://example.com", strings.Repeat("a", 10000), "", false)
+
+	f.Fuzz(func(t *testing.T, url, checksum, diskFormat string, isLiveISO bool) {
+		// Create Image struct with fuzzed inputs
+		// In v1beta2: Checksum is *string, DiskFormat is string
+		img := &infrav1.Image{
+			URL: url,
+		}
+
+		// Always set the Checksum pointer first so the fuzzer can exercise
+		// both nil and non-nil representations of the empty string.
+		img.Checksum = &checksum
+		if checksum == "" && (len(url)+len(diskFormat))%2 == 0 && !isLiveISO {
+			img.Checksum = nil
+		}
+
+		// Set DiskFormat if provided (it's a string, not pointer in v1beta2)
+		if diskFormat != "" {
+			img.DiskFormat = diskFormat
+		}
+
+		// Override with live-iso format if specified
+		if isLiveISO {
+			img.DiskFormat = infrav1.LiveISODiskFormat
+		}
+
+		// Create a field path for validation errors
+		basePath := field.NewPath("Spec", "Image")
+
+		// The main assertion: Validate should never panic
+		// It doesn't concern us if it returns errors (that's expected for invalid input),
+		// but it should always complete without crashing
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("Image.Validate panicked with input:\n  URL: %q\n  Checksum: %q\n  DiskFormat: %v\n  Panic: %v",
+					url, checksum, diskFormat, r)
+			}
+		}()
+
+		// Call the function under test
+		errors := img.Validate(*basePath)
+
+		// Basic sanity checks on the result
+		if errors == nil {
+			// If no errors returned, we expect the inputs to be valid
+			// For valid inputs, URL should not be empty
+			if img.URL == "" {
+				t.Errorf("Validate returned nil errors for empty URL")
+			}
+		}
+
+		// Ensure returned errors are properly structured
+		for _, err := range errors {
+			if err == nil {
+				t.Error("Validate returned nil error in ErrorList")
+			}
+			// Ensure error has required fields
+			if err != nil && err.Type == "" {
+				t.Errorf("Validation error missing Type field: %v", err)
+			}
+		}
+
+		// Additional invariant checks
+		checkInvariants(t, img, errors)
+	})
+}
+
+// checkInvariants verifies logical consistency of validation results.
+func checkInvariants(t *testing.T, img *infrav1.Image, errors field.ErrorList) {
+	t.Helper()
+
+	// Invariant 1: Empty URL should always produce an error
+	// When both URL and Checksum are empty, error may be on base field or URL field
+	if img.URL == "" {
+		hasURLError := false
+		for _, err := range errors {
+			if err.Field == "Spec.Image.URL" || err.Field == "Spec.Image" {
+				hasURLError = true
+				break
+			}
+		}
+		if !hasURLError {
+			t.Error("Empty URL should produce validation error")
+		}
+	}
+
+	// Invariant 2: Non-live-iso images without checksum should error
+	// In v1beta2: DiskFormat is string (not pointer)
+	if img.DiskFormat != infrav1.LiveISODiskFormat {
+		if (img.Checksum == nil || *img.Checksum == "") && img.URL != "" {
+			hasChecksumError := false
+			for _, err := range errors {
+				if err.Field == "Spec.Image.Checksum" {
+					hasChecksumError = true
+					break
+				}
+			}
+			if !hasChecksumError {
+				t.Error("Missing checksum for non-live-iso image should produce validation error")
+			}
+		}
+	}
+
+	// Invariant 3: live-iso format should not require checksum
+	// In v1beta2: DiskFormat is string (not pointer)
+	if img.DiskFormat == infrav1.LiveISODiskFormat {
+		for _, err := range errors {
+			if err.Field == "Spec.Image.Checksum" && err.Type == field.ErrorTypeRequired {
+				t.Error("live-iso format should not require checksum, but got Required error")
+			}
+		}
+	}
+
+	// Invariant 4: Checksum values may be URLs; only malformed checksum URLs
+	// should yield a field.ErrorTypeInvalid on Spec.Image.Checksum, and any
+	// such structured error should reference the checksum field/value.
+	// In v1beta2: Checksum is *string (pointer)
+	if img.Checksum != nil && *img.Checksum != "" {
+		if strings.HasPrefix(*img.Checksum, "http://") || strings.HasPrefix(*img.Checksum, "https://") {
+			for _, err := range errors {
+				if err.Field == "Spec.Image.Checksum" && err.Type == field.ErrorTypeInvalid {
+					if err.BadValue != *img.Checksum {
+						t.Errorf("Checksum invalid error should reference the checksum value, got bad value: %#v", err.BadValue)
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
The image validation fuzz test functions works in the following way:

```
FuzzImageValidate
├─ Creates test inputs (17 seeds + millions of mutations)
├─ For each input:
     ├─ Build Image struct
     ├─ [Panic Recovery] Call Validate()
     ├─ Check result is well-formed
     └─ Call checkInvariants()
          └─ Verify 4 rules hold true
```