### PR TITLE
🐛 Enforce same-namespace BareMetalHost lookups

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -741,24 +741,30 @@ func getHost(ctx context.Context, m3Machine *infrav1.Metal3Machine, cl client.Cl
 	if annotations == nil {
 		return nil, nil //nolint:nilnil
 	}
-	hostKey, ok := annotations[HostAnnotation]
+	hostAnnotationValue, ok := annotations[HostAnnotation]
 	if !ok {
 		return nil, nil //nolint:nilnil
 	}
-	hostNamespace, hostName, err := cache.SplitMetaNamespaceKey(hostKey)
+	// The namespace prefix is ignored; the Metal3Machine's own namespace is always used
+	// to prevent cross-namespace BareMetalHost references regardless of annotation content.
+	_, hostName, err := cache.SplitMetaNamespaceKey(hostAnnotationValue)
 	if err != nil {
-		mLog.Error(err, "Error parsing annotation value", "annotation key", hostKey)
+		mLog.Error(err, "Error parsing annotation value",
+			"annotation key", HostAnnotation,
+			"annotation value", hostAnnotationValue)
 		return nil, err
 	}
 
 	host := bmov1alpha1.BareMetalHost{}
 	key := client.ObjectKey{
 		Name:      hostName,
-		Namespace: hostNamespace,
+		Namespace: m3Machine.Namespace,
 	}
 	err = cl.Get(ctx, key, &host)
 	if apierrors.IsNotFound(err) {
-		mLog.Info("Annotated host not found", "host", hostKey)
+		mLog.Info("Annotated host not found",
+			"host", hostName,
+			"namespace", m3Machine.Namespace)
 		return nil, nil //nolint:nilnil
 	} else if err != nil {
 		return nil, err

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -1491,6 +1491,39 @@ var _ = Describe("Metal3Machine manager", func() {
 				),
 				ExpectPresent: false,
 			}),
+			Entry("Should find host in own namespace when annotation contains a foreign namespace prefix",
+				testCaseGetHost{
+					Machine: &clusterv1.Machine{},
+					M3Machine: newMetal3Machine(metal3machineName, nil, nil,
+						&metav1.ObjectMeta{
+							Name:      metal3machineName,
+							Namespace: namespaceName,
+							Annotations: map[string]string{
+								HostAnnotation: "other-namespace/" + baremetalhostName,
+							},
+						},
+					),
+					ExpectPresent: true,
+				},
+			),
+			Entry("Should not find host in other namespace",
+				// The BMH is in namespaceName for all these tests.
+				// We should not be able to find any BMH in the other-namespace,
+				// where the M3M is located in this test.
+				testCaseGetHost{
+					Machine: &clusterv1.Machine{},
+					M3Machine: newMetal3Machine(metal3machineName, nil, nil,
+						&metav1.ObjectMeta{
+							Name:      metal3machineName,
+							Namespace: "other-namespace",
+							Annotations: map[string]string{
+								HostAnnotation: namespaceName + "/" + baremetalhostName,
+							},
+						},
+					),
+					ExpectPresent: false,
+				},
+			),
 		)
 	})
 

--- a/baremetal/metal3remediation_manager.go
+++ b/baremetal/metal3remediation_manager.go
@@ -257,25 +257,31 @@ func getUnhealthyHost(ctx context.Context, m3Machine *infrav1.Metal3Machine, cl 
 		err := fmt.Errorf("unable to get %s annotations", m3Machine.Name)
 		return nil, err
 	}
-	hostKey, ok := annotations[HostAnnotation]
+	hostAnnotationValue, ok := annotations[HostAnnotation]
 	if !ok {
 		err := fmt.Errorf("unable to get %s HostAnnotation", m3Machine.Name)
 		return nil, err
 	}
-	hostNamespace, hostName, err := cache.SplitMetaNamespaceKey(hostKey)
+	// The namespace prefix is ignored; the Metal3Machine's own namespace is always used
+	// to prevent cross-namespace BareMetalHost references regardless of annotation content.
+	_, hostName, err := cache.SplitMetaNamespaceKey(hostAnnotationValue)
 	if err != nil {
-		rLog.Error(err, "Error parsing annotation value", "annotation key", hostKey)
+		rLog.Error(err, "Error parsing annotation value",
+			"annotation key", HostAnnotation,
+			"annotation value", hostAnnotationValue)
 		return nil, err
 	}
 
 	host := bmov1alpha1.BareMetalHost{}
 	key := client.ObjectKey{
 		Name:      hostName,
-		Namespace: hostNamespace,
+		Namespace: m3Machine.Namespace,
 	}
 	err = cl.Get(ctx, key, &host)
 	if apierrors.IsNotFound(err) {
-		rLog.Info("Annotated host not found", "host", hostKey)
+		rLog.Info("Annotated BareMetalHost not found",
+			"host", hostName,
+			"namespace", m3Machine.Namespace)
 		return nil, err
 	} else if err != nil {
 		return nil, err

--- a/baremetal/metal3remediation_manager_test.go
+++ b/baremetal/metal3remediation_manager_test.go
@@ -369,6 +369,35 @@ var _ = Describe("Metal3Remediation manager", func() {
 			},
 			ExpectPresent: false,
 		}),
+		Entry("Should find host in own namespace when annotation contains a foreign namespace prefix", testCaseGetUnhealthyHost{
+			M3Machine: &infrav1.Metal3Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            metal3machineName,
+					Namespace:       namespaceName,
+					OwnerReferences: []metav1.OwnerReference{},
+					Annotations: map[string]string{
+						HostAnnotation: "other-namespace/" + baremetalhostName,
+					},
+				},
+			},
+			ExpectPresent: true,
+		}),
+		Entry("Should not find host in other namespace", testCaseGetUnhealthyHost{
+			// The BMH is in namespaceName for all these tests.
+			// We should not be able to find any BMH in the other-namespace,
+			// where the M3M is located in this test.
+			M3Machine: &infrav1.Metal3Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            metal3machineName,
+					Namespace:       "other-namespace",
+					OwnerReferences: []metav1.OwnerReference{},
+					Annotations: map[string]string{
+						HostAnnotation: namespaceName + "/" + baremetalhostName,
+					},
+				},
+			},
+			ExpectPresent: false,
+		}),
 	)
 
 	type testCaseSetAnnotation struct {

--- a/controllers/metal3labelsync_controller.go
+++ b/controllers/metal3labelsync_controller.go
@@ -320,14 +320,16 @@ func (r *Metal3LabelSyncReconciler) Metal3ClusterToBareMetalHosts(ctx context.Co
 			log.Error(errors.Errorf("no %v annotation on Metal3Machine: %v", baremetal.HostAnnotation, name), "failed to get BareMetalHost annotation in Metal3Machine")
 			continue
 		}
-		hostNamespace, hostName, err := cache.SplitMetaNamespaceKey(hostKey)
+		// The namespace prefix is ignored; the Metal3Machine's own namespace is always used
+		// to prevent cross-namespace BareMetalHost references regardless of annotation content.
+		_, hostName, err := cache.SplitMetaNamespaceKey(hostKey)
 		if err != nil {
 			log.Error(err, "could not parse host annotation")
 			continue
 		}
 		hostObjKey := client.ObjectKey{
 			Name:      hostName,
-			Namespace: hostNamespace,
+			Namespace: capm3Machine.Namespace,
 		}
 		log.V(baremetal.VerbosityLevelTrace).Info("found BareMetalHost", "name", hostObjKey)
 		result = append(result, ctrl.Request{NamespacedName: hostObjKey})

--- a/controllers/metal3labelsync_controller_test.go
+++ b/controllers/metal3labelsync_controller_test.go
@@ -333,6 +333,33 @@ var _ = Describe("Metal3LabelSync controller", func() {
 				},
 			},
 		),
+		Entry("Host annotation with wrong namespace",
+			// We should ignore the namespace in the annotation and only look in the M3M namespace
+			TestCaseMetal3ClusterToBMHs{
+				Cluster:   newCluster(clusterName, nil, nil),
+				M3Cluster: newMetal3Cluster(metal3ClusterName, bmcOwnerRef(), bmcSpec(), nil, nil, false),
+				Machine:   newMachine(clusterName, machineName, metal3machineName, ""),
+				M3Machine: newMetal3Machine(metal3machineName, &metav1.ObjectMeta{
+					Name:            metal3machineName,
+					Namespace:       namespaceName,
+					OwnerReferences: m3mOwnerRefs(),
+					Labels: map[string]string{
+						clusterv1.ClusterNameLabel: clusterName,
+					},
+					Annotations: map[string]string{
+						baremetal.HostAnnotation: "other-namespace/" + baremetalhostName,
+					},
+				}, nil, nil, false),
+				ExpectRequests: []ctrl.Request{
+					{
+						NamespacedName: types.NamespacedName{
+							Name:      baremetalhostName,
+							Namespace: namespaceName,
+						},
+					},
+				},
+			},
+		),
 	)
 	Describe("Test labelsync Reconcile functions", func() {
 		testLabels := map[string]string{


### PR DESCRIPTION
Manual backport of #3288

**What this PR does / why we need it**:

Ignore namespace prefix in host annotations and always use the Metal3Machine's own namespace when looking up BareMetalHost resources. This prevents cross-namespace references regardless of annotation content.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
