### PR TITLE
🐛 Fix logical operator in ConsumerRef validation

### DIFF
--- a/controllers/metal3labelsync_controller.go
+++ b/controllers/metal3labelsync_controller.go
@@ -127,7 +127,7 @@ func (r *Metal3LabelSyncReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		// ignore BMH with no ConsumerRef
 		return ctrl.Result{}, nil
 	}
-	if host.Spec.ConsumerRef.Kind != metal3MachineKind &&
+	if host.Spec.ConsumerRef.Kind != metal3MachineKind ||
 		host.Spec.ConsumerRef.GroupVersionKind().Group != infrav1.GroupVersion.Group {
 		controllerLog.Info("Unknown GroupVersionKind in BareMetalHost Consumer Ref", "groupversion", host.Spec.ConsumerRef.GroupVersionKind())
 		return ctrl.Result{}, nil

--- a/controllers/metal3labelsync_controller_test.go
+++ b/controllers/metal3labelsync_controller_test.go
@@ -381,6 +381,22 @@ var _ = Describe("Metal3LabelSync controller", func() {
 				APIVersion: "not" + infrav1.GroupVersion.String(),
 			},
 		}
+		wrongGroupConsumerRefSpec := bmov1alpha1.BareMetalHostSpec{
+			ConsumerRef: &corev1.ObjectReference{
+				Name:       metal3machineName,
+				Namespace:  namespaceName,
+				Kind:       metal3MachineKind,
+				APIVersion: "not" + infrav1.GroupVersion.String(),
+			},
+		}
+		wrongKindConsumerRefSpec := bmov1alpha1.BareMetalHostSpec{
+			ConsumerRef: &corev1.ObjectReference{
+				Name:       metal3machineName,
+				Namespace:  namespaceName,
+				Kind:       "notMetal3Machine",
+				APIVersion: infrav1.GroupVersion.String(),
+			},
+		}
 		annotation := map[string]string{
 			"metal3.io/metal3-label-sync-prefixes": "foo.metal3.io",
 		}
@@ -478,6 +494,16 @@ var _ = Describe("Metal3LabelSync controller", func() {
 			}),
 			Entry("Unknown API version in BareMetalHost ConsumerRef", testCaseReconcile{
 				host: newBareMetalHost(baremetalhostName, &notMetal3MachineSpec, nil, testLabels, false),
+			}),
+			Entry("ConsumerRef with correct Kind but wrong Group", testCaseReconcile{
+				// Even though a Metal3Machine with this name exists, the controller must
+				// bail out because the Group does not match infrav1.
+				host:          newBareMetalHost(baremetalhostName, &wrongGroupConsumerRefSpec, nil, testLabels, false),
+				metal3Machine: newMetal3Machine(metal3machineName, m3mObjectMetaWithOwnerRef(), nil, nil, false),
+			}),
+			Entry("ConsumerRef with correct Group but wrong Kind", testCaseReconcile{
+				host:          newBareMetalHost(baremetalhostName, &wrongKindConsumerRefSpec, nil, testLabels, false),
+				metal3Machine: newMetal3Machine(metal3machineName, m3mObjectMetaWithOwnerRef(), nil, nil, false),
 			}),
 			Entry("Could not find associated Metal3Machine", testCaseReconcile{
 				host:          newBareMetalHost(baremetalhostName, &metal3MachineSpec, nil, testLabels, false),


### PR DESCRIPTION
**What this PR does / why we need it**:

Changed AND to OR in the condition that validates BareMetalHost ConsumerRef Kind and Group. The controller should reject a ConsumerRef if either the Kind is not Metal3Machine OR the Group does not match infrav1, not only when both conditions are true.

Add test cases for both wrong Kind and wrong Group scenarios.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
