### PR TITLE
🌱 Remove legacy provider id from clustectl tests

### DIFF
--- a/test/e2e/upgrade_clusterctl_test.go
+++ b/test/e2e/upgrade_clusterctl_test.go
@@ -340,8 +340,6 @@ func preInitFunc(clusterProxy framework.ClusterProxy, bmoRelease string, ironicR
 
 	// These exports bellow we need them after applying the management cluster template and before
 	// applying the workload. if exported before it will break creating the management because it uses v1beta1 templates and default IPs.
-	// override the provider id format
-	os.Setenv("PROVIDER_ID_FORMAT", "metal3://{{ ds.meta_data.uuid }}")
 	// override default IPs for the workload cluster
 	os.Setenv("CLUSTER_APIENDPOINT_HOST", "192.168.111.250")
 	os.Setenv("IPAM_EXTERNALV4_POOL_RANGE_START", "192.168.111.201")
@@ -460,8 +458,6 @@ func preCleanupManagementCluster(clusterProxy framework.ClusterProxy, ironicRele
 	// Capi/capm3 versions
 	os.Unsetenv("CAPI_VERSION")
 	os.Unsetenv("CAPM3_VERSION")
-	// The provider id format
-	os.Unsetenv("PROVIDER_ID_FORMAT")
 	// IPs
 	os.Unsetenv("CLUSTER_APIENDPOINT_HOST")
 	os.Unsetenv("IPAM_EXTERNALV4_POOL_RANGE_START")


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:
Remove legacy provider id from clustectl tests

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
