### PR TITLE
:sparkles: Allow Metal3Machine addresses to be sourced from metadata secret

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -1408,10 +1408,12 @@ func (m *MachineManager) getMetaDataFromSecret(ctx context.Context) (map[string]
 		return nil, nil //nolint:nilnil
 	}
 
+	// We do not allow cross-namespace references for MetaData, so use the
+	// Metal3Machine's own namespace and disregard any namespace on the secret ref.
 	secret := &corev1.Secret{}
 	err := m.client.Get(ctx, types.NamespacedName{
 		Name:      m.Metal3Machine.Status.MetaData.Name,
-		Namespace: m.Metal3Machine.Status.MetaData.Namespace,
+		Namespace: m.Metal3Machine.Namespace,
 	}, secret)
 	if err != nil {
 		if apierrors.IsNotFound(err) {

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -56,6 +56,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -1310,8 +1311,11 @@ func (m *MachineManager) CloudProviderEnabled() bool {
 }
 
 // updateMachineStatus updates a Metal3Machine object's status.
-func (m *MachineManager) updateMachineStatus(_ context.Context, host *bmov1alpha1.BareMetalHost) error {
-	addrs := m.nodeAddresses(host)
+func (m *MachineManager) updateMachineStatus(ctx context.Context, host *bmov1alpha1.BareMetalHost) error {
+	addrs, err := m.nodeAddresses(ctx, host)
+	if err != nil {
+		return err
+	}
 
 	metal3MachineOld := m.Metal3Machine.DeepCopy()
 
@@ -1341,12 +1345,34 @@ func (m *MachineManager) updateMachineStatus(_ context.Context, host *bmov1alpha
 
 // NodeAddresses returns a slice of corev1.NodeAddress objects for a
 // given Metal3 machine.
-func (m *MachineManager) nodeAddresses(host *bmov1alpha1.BareMetalHost) []clusterv1.MachineAddress {
+func (m *MachineManager) nodeAddresses(ctx context.Context, host *bmov1alpha1.BareMetalHost) ([]clusterv1.MachineAddress, error) {
 	addrs := []clusterv1.MachineAddress{}
+
+	metadata, err := m.getMetaDataFromSecret(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if metadata != nil {
+		if internalIP, exists := metadata["InternalIP"]; exists && internalIP != "" {
+			addrs = []clusterv1.MachineAddress{
+				{Type: clusterv1.MachineInternalIP, Address: internalIP},
+			}
+		}
+		if externalIP, exists := metadata["ExternalIP"]; exists && externalIP != "" {
+			addrs = append(addrs, clusterv1.MachineAddress{
+				Type:    clusterv1.MachineExternalIP,
+				Address: externalIP,
+			})
+		}
+		if len(addrs) > 0 {
+			return addrs, nil
+		}
+	}
 
 	// If the host is nil or we have no hw details, return an empty address array.
 	if host == nil || host.Status.HardwareDetails == nil {
-		return addrs
+		return addrs, nil
 	}
 
 	for _, nic := range host.Status.HardwareDetails.NIC {
@@ -1371,7 +1397,40 @@ func (m *MachineManager) nodeAddresses(host *bmov1alpha1.BareMetalHost) []cluste
 		})
 	}
 
-	return addrs
+	return addrs, nil
+}
+
+// getMetaDataFromSecret reads the metadata secret referenced by the Metal3Machine
+// status and returns the parsed key-value pairs. Returns nil, nil if no metadata
+// secret is configured or the secret does not exist yet.
+func (m *MachineManager) getMetaDataFromSecret(ctx context.Context) (map[string]string, error) {
+	if m.Metal3Machine.Status.MetaData == nil || m.Metal3Machine.Status.MetaData.Name == "" {
+		return nil, nil //nolint:nilnil
+	}
+
+	secret := &corev1.Secret{}
+	err := m.client.Get(ctx, types.NamespacedName{
+		Name:      m.Metal3Machine.Status.MetaData.Name,
+		Namespace: m.Metal3Machine.Status.MetaData.Namespace,
+	}, secret)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil //nolint:nilnil
+		}
+		return nil, fmt.Errorf("failed to get metaData secret: %w", err)
+	}
+
+	metaDataBytes, ok := secret.Data["metaData"]
+	if !ok {
+		return nil, nil //nolint:nilnil
+	}
+
+	metadata := make(map[string]string)
+	if err := yaml.Unmarshal(metaDataBytes, &metadata); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal metaData: %w", err)
+	}
+
+	return metadata, nil
 }
 
 // GetProviderIDAndBMHID returns providerID and bmhID.

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -1345,6 +1345,12 @@ func (m *MachineManager) updateMachineStatus(ctx context.Context, host *bmov1alp
 
 // NodeAddresses returns a slice of corev1.NodeAddress objects for a
 // given Metal3 machine.
+//
+// If the Metal3Machine's metadata secret contains the keys "InternalIP"
+// and/or "ExternalIP" (case-sensitive, scalar string values), they take
+// precedence over the addresses derived from the BareMetalHost NICs and
+// are returned directly. Non-string or missing values are ignored and
+// fall back to BMH-derived addresses.
 func (m *MachineManager) nodeAddresses(ctx context.Context, host *bmov1alpha1.BareMetalHost) ([]clusterv1.MachineAddress, error) {
 	addrs := []clusterv1.MachineAddress{}
 
@@ -1354,12 +1360,12 @@ func (m *MachineManager) nodeAddresses(ctx context.Context, host *bmov1alpha1.Ba
 	}
 
 	if metadata != nil {
-		if internalIP, exists := metadata["InternalIP"]; exists && internalIP != "" {
+		if internalIP, ok := metadata["InternalIP"].(string); ok && internalIP != "" {
 			addrs = []clusterv1.MachineAddress{
 				{Type: clusterv1.MachineInternalIP, Address: internalIP},
 			}
 		}
-		if externalIP, exists := metadata["ExternalIP"]; exists && externalIP != "" {
+		if externalIP, ok := metadata["ExternalIP"].(string); ok && externalIP != "" {
 			addrs = append(addrs, clusterv1.MachineAddress{
 				Type:    clusterv1.MachineExternalIP,
 				Address: externalIP,
@@ -1401,9 +1407,14 @@ func (m *MachineManager) nodeAddresses(ctx context.Context, host *bmov1alpha1.Ba
 }
 
 // getMetaDataFromSecret reads the metadata secret referenced by the Metal3Machine
-// status and returns the parsed key-value pairs. Returns nil, nil if no metadata
+// status and returns the parsed top-level mapping. Returns nil, nil if no metadata
 // secret is configured or the secret does not exist yet.
-func (m *MachineManager) getMetaDataFromSecret(ctx context.Context) (map[string]string, error) {
+//
+// The secret content is expected to be YAML (cloud-init/BMO metadata) and may
+// contain nested structures and non-string values. Callers should type-assert
+// the values they care about (e.g. "InternalIP", "ExternalIP" as strings) and
+// ignore anything that does not match the expected shape.
+func (m *MachineManager) getMetaDataFromSecret(ctx context.Context) (map[string]any, error) {
 	if m.Metal3Machine.Status.MetaData == nil || m.Metal3Machine.Status.MetaData.Name == "" {
 		return nil, nil //nolint:nilnil
 	}
@@ -1427,7 +1438,7 @@ func (m *MachineManager) getMetaDataFromSecret(ctx context.Context) (map[string]
 		return nil, nil //nolint:nilnil
 	}
 
-	metadata := make(map[string]string)
+	metadata := make(map[string]any)
 	if err := yaml.Unmarshal(metaDataBytes, &metadata); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal metaData: %w", err)
 	}

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -55,6 +55,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -80,6 +81,12 @@ const (
 	ProviderLabelPrefix = "metal3.io/uuid"
 	// FailureDomainLabelName is a label name for FailureDomains.
 	FailureDomainLabelName = "infrastructure.cluster.x-k8s.io/failure-domain"
+	// MetaDataInternalIPKey is the optional, case-sensitive key in the metaData
+	// secret whose value overrides the InternalIP address of the Machine.
+	MetaDataInternalIPKey = "InternalIP"
+	// MetaDataExternalIPKey is the optional, case-sensitive key in the metaData
+	// secret whose value overrides the ExternalIP address of the Machine.
+	MetaDataExternalIPKey = "ExternalIP"
 )
 
 var (
@@ -1386,8 +1393,11 @@ func (m *MachineManager) CloudProviderEnabled() bool {
 }
 
 // updateMachineStatus updates a Metal3Machine object's status.
-func (m *MachineManager) updateMachineStatus(_ context.Context, host *bmov1alpha1.BareMetalHost) error {
-	addrs := m.nodeAddresses(host)
+func (m *MachineManager) updateMachineStatus(ctx context.Context, host *bmov1alpha1.BareMetalHost) error {
+	addrs, err := m.nodeAddresses(ctx, host)
+	if err != nil {
+		return err
+	}
 
 	metal3MachineOld := m.Metal3Machine.DeepCopy()
 
@@ -1415,25 +1425,40 @@ func (m *MachineManager) updateMachineStatus(_ context.Context, host *bmov1alpha
 	return nil
 }
 
-// NodeAddresses returns a slice of corev1.NodeAddress objects for a
+// nodeAddresses returns a slice of clusterv1.MachineAddress objects for a
 // given Metal3 machine.
-func (m *MachineManager) nodeAddresses(host *bmov1alpha1.BareMetalHost) []clusterv1.MachineAddress {
+//
+// The IP addresses are normally derived from the NICs of the BareMetalHost. If
+// the metaData secret of the Metal3Machine provides address overrides, see
+// addressOverridesFromMetaData, those are used instead. The hostname based
+// addresses are always taken from the BareMetalHost, also when the IP addresses
+// are overridden.
+func (m *MachineManager) nodeAddresses(ctx context.Context, host *bmov1alpha1.BareMetalHost) ([]clusterv1.MachineAddress, error) {
 	addrs := []clusterv1.MachineAddress{}
 
-	// If the host is nil or we have no hw details, return an empty address array.
-	if host == nil || host.Status.HardwareDetails == nil {
-		return addrs
+	overrides, err := m.addressOverridesFromMetaData(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	for _, nic := range host.Status.HardwareDetails.NIC {
-		address := clusterv1.MachineAddress{
-			Type:    clusterv1.MachineInternalIP,
-			Address: nic.IP,
+	// If the host is nil or we have no hw details, only the overrides are available.
+	if host == nil || host.Status.HardwareDetails == nil {
+		return append(addrs, overrides...), nil
+	}
+
+	if len(overrides) > 0 {
+		addrs = append(addrs, overrides...)
+	} else {
+		for _, nic := range host.Status.HardwareDetails.NIC {
+			address := clusterv1.MachineAddress{
+				Type:    clusterv1.MachineInternalIP,
+				Address: nic.IP,
+			}
+			if address.Address == "" {
+				continue
+			}
+			addrs = append(addrs, address)
 		}
-		if address.Address == "" {
-			continue
-		}
-		addrs = append(addrs, address)
 	}
 
 	if host.Status.HardwareDetails.Hostname != "" {
@@ -1447,7 +1472,88 @@ func (m *MachineManager) nodeAddresses(host *bmov1alpha1.BareMetalHost) []cluste
 		})
 	}
 
-	return addrs
+	return addrs, nil
+}
+
+// addressOverridesFromMetaData returns the machine addresses configured through
+// the metaData secret referenced by the Metal3Machine status. The secret content
+// is expected to be a YAML mapping, as rendered by the Metal3Data controller from
+// a Metal3DataTemplate, and the optional MetaDataInternalIPKey and
+// MetaDataExternalIPKey keys are read from it. The keys are case-sensitive and
+// only non-empty string values are used.
+//
+// The overrides are best effort: no override is returned when the metaData secret
+// is not referenced, does not exist yet, holds no metaData, cannot be parsed as a
+// YAML mapping or holds values of an unexpected type. Callers fall back to the
+// addresses derived from the BareMetalHost in those cases. An error is only
+// returned when the secret cannot be read, which is expected to be transient.
+func (m *MachineManager) addressOverridesFromMetaData(ctx context.Context) ([]clusterv1.MachineAddress, error) {
+	if m.Metal3Machine.Status.MetaData == nil || m.Metal3Machine.Status.MetaData.Name == "" {
+		return nil, nil
+	}
+
+	// We do not allow cross-namespace references for MetaData, so use the
+	// Metal3Machine's own namespace and disregard any namespace on the secret ref.
+	secretKey := types.NamespacedName{
+		Name:      m.Metal3Machine.Status.MetaData.Name,
+		Namespace: m.Metal3Machine.Namespace,
+	}
+
+	secret := &corev1.Secret{}
+	if err := m.client.Get(ctx, secretKey, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get metaData secret %s: %w", secretKey, err)
+	}
+
+	metaDataBytes, ok := secret.Data["metaData"]
+	if !ok {
+		return nil, nil
+	}
+
+	metaData := map[string]any{}
+	if err := yaml.Unmarshal(metaDataBytes, &metaData); err != nil {
+		// The metaData secret is owned by the user and is not required to be a
+		// YAML mapping. Ignore it instead of blocking the reconciliation.
+		m.Log.V(VerbosityLevelDebug).Info("Ignoring metaData secret that cannot be parsed as a YAML mapping",
+			LogFieldSecretName, secretKey.Name, LogFieldNamespace, secretKey.Namespace,
+			LogFieldMetal3Machine, m.Metal3Machine.Name, LogFieldError, err.Error())
+		return nil, nil
+	}
+
+	// addressOverride returns the address configured under key, if the key is
+	// present and holds a non-empty string.
+	addressOverride := func(key string) (string, bool) {
+		value, found := metaData[key]
+		if !found {
+			return "", false
+		}
+		address, ok := value.(string)
+		if !ok || address == "" {
+			m.Log.V(VerbosityLevelDebug).Info("Ignoring metaData address override that is not a non-empty string",
+				LogFieldSecretName, secretKey.Name, LogFieldNamespace, secretKey.Namespace,
+				LogFieldMetal3Machine, m.Metal3Machine.Name, LogFieldName, key)
+			return "", false
+		}
+		return address, true
+	}
+
+	addrs := []clusterv1.MachineAddress{}
+	if internalIP, ok := addressOverride(MetaDataInternalIPKey); ok {
+		addrs = append(addrs, clusterv1.MachineAddress{
+			Type:    clusterv1.MachineInternalIP,
+			Address: internalIP,
+		})
+	}
+	if externalIP, ok := addressOverride(MetaDataExternalIPKey); ok {
+		addrs = append(addrs, clusterv1.MachineAddress{
+			Type:    clusterv1.MachineExternalIP,
+			Address: externalIP,
+		})
+	}
+
+	return addrs, nil
 }
 
 // ClientGetter prototype.

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -2740,6 +2740,9 @@ var _ = Describe("Metal3Machine manager", func() {
 			}),
 			Entry("Metadata override with InternalIP", testCaseNodeAddress{
 				M3Machine: infrav1.Metal3Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Status: infrav1.Metal3MachineStatus{
 						MetaData: &corev1.SecretReference{
 							Name:      "test-metadata",
@@ -2767,6 +2770,9 @@ var _ = Describe("Metal3Machine manager", func() {
 			}),
 			Entry("Metadata override with ExternalIP", testCaseNodeAddress{
 				M3Machine: infrav1.Metal3Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Status: infrav1.Metal3MachineStatus{
 						MetaData: &corev1.SecretReference{
 							Name:      "test-metadata-external",
@@ -2794,6 +2800,9 @@ var _ = Describe("Metal3Machine manager", func() {
 			}),
 			Entry("Metadata override with both InternalIP and ExternalIP", testCaseNodeAddress{
 				M3Machine: infrav1.Metal3Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Status: infrav1.Metal3MachineStatus{
 						MetaData: &corev1.SecretReference{
 							Name:      "test-metadata-both",
@@ -2826,6 +2835,9 @@ var _ = Describe("Metal3Machine manager", func() {
 			}),
 			Entry("Metadata override with nil host", testCaseNodeAddress{
 				M3Machine: infrav1.Metal3Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Status: infrav1.Metal3MachineStatus{
 						MetaData: &corev1.SecretReference{
 							Name:      "test-metadata-nohost",
@@ -2846,6 +2858,9 @@ var _ = Describe("Metal3Machine manager", func() {
 			}),
 			Entry("Metadata ref exists but secret missing falls back to BMH", testCaseNodeAddress{
 				M3Machine: infrav1.Metal3Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Status: infrav1.Metal3MachineStatus{
 						MetaData: &corev1.SecretReference{
 							Name:      "nonexistent-secret",
@@ -2864,6 +2879,9 @@ var _ = Describe("Metal3Machine manager", func() {
 			}),
 			Entry("Metadata with no InternalIP or ExternalIP falls back to BMH", testCaseNodeAddress{
 				M3Machine: infrav1.Metal3Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Status: infrav1.Metal3MachineStatus{
 						MetaData: &corev1.SecretReference{
 							Name:      "test-metadata-noop",
@@ -2885,6 +2903,9 @@ var _ = Describe("Metal3Machine manager", func() {
 			}),
 			Entry("Malformed metadata returns error", testCaseNodeAddress{
 				M3Machine: infrav1.Metal3Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
 					Status: infrav1.Metal3MachineStatus{
 						MetaData: &corev1.SecretReference{
 							Name:      "test-metadata-bad",

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -2798,6 +2798,64 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 				},
 			}),
+			Entry("Metadata override with IPv6 InternalIP", testCaseNodeAddress{
+				M3Machine: infrav1.Metal3Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
+					Status: infrav1.Metal3MachineStatus{
+						MetaData: &corev1.SecretReference{
+							Name:      "test-metadata-internal-ipv6",
+							Namespace: "default",
+						},
+					},
+				},
+				TestObjects: []runtime.Object{makeMetaDataSecret("test-metadata-internal-ipv6", "default", map[string]string{
+					"InternalIP": "fd00::100",
+				})},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{
+					{
+						Type:    clusterv1.MachineInternalIP,
+						Address: "fd00::100",
+					},
+				},
+			}),
+			Entry("Metadata override with IPv6 ExternalIP", testCaseNodeAddress{
+				M3Machine: infrav1.Metal3Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
+					Status: infrav1.Metal3MachineStatus{
+						MetaData: &corev1.SecretReference{
+							Name:      "test-metadata-external-ipv6",
+							Namespace: "default",
+						},
+					},
+				},
+				TestObjects: []runtime.Object{makeMetaDataSecret("test-metadata-external-ipv6", "default", map[string]string{
+					"ExternalIP": "2001:db8::1",
+				})},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{
+					{
+						Type:    clusterv1.MachineExternalIP,
+						Address: "2001:db8::1",
+					},
+				},
+			}),
 			Entry("Metadata override with both InternalIP and ExternalIP", testCaseNodeAddress{
 				M3Machine: infrav1.Metal3Machine{
 					ObjectMeta: metav1.ObjectMeta{
@@ -2830,6 +2888,74 @@ var _ = Describe("Metal3Machine manager", func() {
 					{
 						Type:    clusterv1.MachineExternalIP,
 						Address: "203.0.113.1",
+					},
+				},
+			}),
+			Entry("Metadata override with IPv6 InternalIP and ExternalIP", testCaseNodeAddress{
+				M3Machine: infrav1.Metal3Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
+					Status: infrav1.Metal3MachineStatus{
+						MetaData: &corev1.SecretReference{
+							Name:      "test-metadata-ipv6",
+							Namespace: "default",
+						},
+					},
+				},
+				TestObjects: []runtime.Object{makeMetaDataSecret("test-metadata-ipv6", "default", map[string]string{
+					"InternalIP": "fd00::100",
+					"ExternalIP": "2001:db8::1",
+				})},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{
+					{
+						Type:    clusterv1.MachineInternalIP,
+						Address: "fd00::100",
+					},
+					{
+						Type:    clusterv1.MachineExternalIP,
+						Address: "2001:db8::1",
+					},
+				},
+			}),
+			Entry("Metadata override with mixed IPv4 InternalIP and IPv6 ExternalIP", testCaseNodeAddress{
+				M3Machine: infrav1.Metal3Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
+					Status: infrav1.Metal3MachineStatus{
+						MetaData: &corev1.SecretReference{
+							Name:      "test-metadata-mixed",
+							Namespace: "default",
+						},
+					},
+				},
+				TestObjects: []runtime.Object{makeMetaDataSecret("test-metadata-mixed", "default", map[string]string{
+					"InternalIP": "10.0.0.100",
+					"ExternalIP": "2001:db8::1",
+				})},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{
+					{
+						Type:    clusterv1.MachineInternalIP,
+						Address: "10.0.0.100",
+					},
+					{
+						Type:    clusterv1.MachineExternalIP,
+						Address: "2001:db8::1",
 					},
 				},
 			}),

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -40,6 +40,7 @@ import (
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -2648,30 +2649,50 @@ var _ = Describe("Metal3Machine manager", func() {
 			Address: "mygreathost",
 		}
 
+		addr4 := clusterv1.MachineAddress{
+			Type:    clusterv1.MachineInternalDNS,
+			Address: "mygreathost",
+		}
+
+		// helper to create a metadata secret with the given key-value pairs.
+		makeMetaDataSecret := func(name, namespace string, data map[string]string) *corev1.Secret {
+			metaDataBytes, err := yaml.Marshal(data)
+			Expect(err).NotTo(HaveOccurred())
+			return &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{
+					"metaData": metaDataBytes,
+				},
+			}
+		}
+
 		type testCaseNodeAddress struct {
 			Machine               clusterv1.Machine
 			M3Machine             infrav1.Metal3Machine
 			Host                  *bmov1alpha1.BareMetalHost
+			TestObjects           []runtime.Object
 			ExpectedNodeAddresses []clusterv1.MachineAddress
+			ExpectError           bool
 		}
 
 		DescribeTable("Test NodeAddress",
 			func(tc testCaseNodeAddress) {
-				var nodeAddresses []clusterv1.MachineAddress
-
-				fakeClient := fake.NewClientBuilder().WithScheme(setupSchemeMm()).Build()
+				fakeClient := fake.NewClientBuilder().WithScheme(setupSchemeMm()).WithRuntimeObjects(tc.TestObjects...).Build()
 				machineMgr, err := NewMachineManager(fakeClient, nil, nil, &tc.Machine,
 					&tc.M3Machine, logr.Discard(),
 				)
 				Expect(err).NotTo(HaveOccurred())
 
-				if tc.Host != nil {
-					nodeAddresses = machineMgr.nodeAddresses(tc.Host)
-					Expect(err).NotTo(HaveOccurred())
+				nodeAddresses, err := machineMgr.nodeAddresses(context.TODO(), tc.Host)
+				if tc.ExpectError {
+					Expect(err).To(HaveOccurred())
+					return
 				}
-				for i, address := range tc.ExpectedNodeAddresses {
-					Expect(nodeAddresses[i]).To(Equal(address))
-				}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(nodeAddresses).To(Equal(tc.ExpectedNodeAddresses))
 			},
 			Entry("One NIC", testCaseNodeAddress{
 				Host: &bmov1alpha1.BareMetalHost{
@@ -2701,7 +2722,7 @@ var _ = Describe("Metal3Machine manager", func() {
 						},
 					},
 				},
-				ExpectedNodeAddresses: []clusterv1.MachineAddress{addr3},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{addr3, addr4},
 			}),
 			Entry("Empty Hostname", testCaseNodeAddress{
 				Host: &bmov1alpha1.BareMetalHost{
@@ -2715,7 +2736,175 @@ var _ = Describe("Metal3Machine manager", func() {
 			}),
 			Entry("No host at all, so this is a no-op", testCaseNodeAddress{
 				Host:                  nil,
-				ExpectedNodeAddresses: nil,
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{},
+			}),
+			Entry("Metadata override with InternalIP", testCaseNodeAddress{
+				M3Machine: infrav1.Metal3Machine{
+					Status: infrav1.Metal3MachineStatus{
+						MetaData: &corev1.SecretReference{
+							Name:      "test-metadata",
+							Namespace: "default",
+						},
+					},
+				},
+				TestObjects: []runtime.Object{makeMetaDataSecret("test-metadata", "default", map[string]string{
+					"InternalIP": "10.0.0.100",
+					"providerid": "ns/bmh/m3m",
+				})},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{
+					{
+						Type:    clusterv1.MachineInternalIP,
+						Address: "10.0.0.100",
+					},
+				},
+			}),
+			Entry("Metadata override with ExternalIP", testCaseNodeAddress{
+				M3Machine: infrav1.Metal3Machine{
+					Status: infrav1.Metal3MachineStatus{
+						MetaData: &corev1.SecretReference{
+							Name:      "test-metadata-external",
+							Namespace: "default",
+						},
+					},
+				},
+				TestObjects: []runtime.Object{makeMetaDataSecret("test-metadata-external", "default", map[string]string{
+					"ExternalIP": "203.0.113.1",
+					"providerid": "ns/bmh/m3m",
+				})},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{
+					{
+						Type:    clusterv1.MachineExternalIP,
+						Address: "203.0.113.1",
+					},
+				},
+			}),
+			Entry("Metadata override with both InternalIP and ExternalIP", testCaseNodeAddress{
+				M3Machine: infrav1.Metal3Machine{
+					Status: infrav1.Metal3MachineStatus{
+						MetaData: &corev1.SecretReference{
+							Name:      "test-metadata-both",
+							Namespace: "default",
+						},
+					},
+				},
+				TestObjects: []runtime.Object{makeMetaDataSecret("test-metadata-both", "default", map[string]string{
+					"InternalIP": "10.0.0.100",
+					"ExternalIP": "203.0.113.1",
+					"providerid": "ns/bmh/m3m",
+				})},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{
+					{
+						Type:    clusterv1.MachineInternalIP,
+						Address: "10.0.0.100",
+					},
+					{
+						Type:    clusterv1.MachineExternalIP,
+						Address: "203.0.113.1",
+					},
+				},
+			}),
+			Entry("Metadata override with nil host", testCaseNodeAddress{
+				M3Machine: infrav1.Metal3Machine{
+					Status: infrav1.Metal3MachineStatus{
+						MetaData: &corev1.SecretReference{
+							Name:      "test-metadata-nohost",
+							Namespace: "default",
+						},
+					},
+				},
+				TestObjects: []runtime.Object{makeMetaDataSecret("test-metadata-nohost", "default", map[string]string{
+					"InternalIP": "10.0.0.100",
+				})},
+				Host: nil,
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{
+					{
+						Type:    clusterv1.MachineInternalIP,
+						Address: "10.0.0.100",
+					},
+				},
+			}),
+			Entry("Metadata ref exists but secret missing falls back to BMH", testCaseNodeAddress{
+				M3Machine: infrav1.Metal3Machine{
+					Status: infrav1.Metal3MachineStatus{
+						MetaData: &corev1.SecretReference{
+							Name:      "nonexistent-secret",
+							Namespace: "default",
+						},
+					},
+				},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{addr1},
+			}),
+			Entry("Metadata with no InternalIP or ExternalIP falls back to BMH", testCaseNodeAddress{
+				M3Machine: infrav1.Metal3Machine{
+					Status: infrav1.Metal3MachineStatus{
+						MetaData: &corev1.SecretReference{
+							Name:      "test-metadata-noop",
+							Namespace: "default",
+						},
+					},
+				},
+				TestObjects: []runtime.Object{makeMetaDataSecret("test-metadata-noop", "default", map[string]string{
+					"providerid": "ns/bmh/m3m",
+				})},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{addr1},
+			}),
+			Entry("Malformed metadata returns error", testCaseNodeAddress{
+				M3Machine: infrav1.Metal3Machine{
+					Status: infrav1.Metal3MachineStatus{
+						MetaData: &corev1.SecretReference{
+							Name:      "test-metadata-bad",
+							Namespace: "default",
+						},
+					},
+				},
+				TestObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-metadata-bad",
+							Namespace: "default",
+						},
+						Data: map[string][]byte{
+							"metaData": []byte("not: [valid, for, string, map]"),
+						},
+					},
+				},
+				Host:        nil,
+				ExpectError: true,
 			}),
 		)
 	})

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -3046,12 +3046,46 @@ var _ = Describe("Metal3Machine manager", func() {
 							Namespace: "default",
 						},
 						Data: map[string][]byte{
-							"metaData": []byte("not: [valid, for, string, map]"),
+							"metaData": []byte("\t: not valid yaml"),
 						},
 					},
 				},
 				Host:        nil,
 				ExpectError: true,
+			}),
+			Entry("Metadata with non-string InternalIP/ExternalIP falls back to BMH", testCaseNodeAddress{
+				M3Machine: infrav1.Metal3Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
+					Status: infrav1.Metal3MachineStatus{
+						MetaData: &corev1.SecretReference{
+							Name:      "test-metadata-non-string",
+							Namespace: "default",
+						},
+					},
+				},
+				TestObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-metadata-non-string",
+							Namespace: "default",
+						},
+						Data: map[string][]byte{
+							// InternalIP is a list, ExternalIP is a number; both
+							// should be ignored and addresses derived from BMH NICs.
+							"metaData": []byte("InternalIP:\n  - 10.0.0.100\nExternalIP: 42\nnested:\n  key: value\n"),
+						},
+					},
+				},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{addr1},
 			}),
 		)
 	})

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -3537,30 +3538,100 @@ var _ = Describe("Metal3Machine manager", func() {
 			Address: "mygreathost",
 		}
 
+		addr4 := clusterv1.MachineAddress{
+			Type:    clusterv1.MachineInternalDNS,
+			Address: "mygreathost",
+		}
+
+		internalIP := func(address string) clusterv1.MachineAddress {
+			return clusterv1.MachineAddress{
+				Type:    clusterv1.MachineInternalIP,
+				Address: address,
+			}
+		}
+
+		externalIP := func(address string) clusterv1.MachineAddress {
+			return clusterv1.MachineAddress{
+				Type:    clusterv1.MachineExternalIP,
+				Address: address,
+			}
+		}
+
+		// helper to create a Metal3Machine referring to a metaData secret.
+		m3mWithMetaData := func(secretName, secretNamespace string) infrav1.Metal3Machine {
+			return infrav1.Metal3Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      metal3machineName,
+					Namespace: namespaceName,
+				},
+				Status: infrav1.Metal3MachineStatus{
+					MetaData: &corev1.SecretReference{
+						Name:      secretName,
+						Namespace: secretNamespace,
+					},
+				},
+			}
+		}
+
+		// helper to create a metaData secret in the Metal3Machine namespace with the
+		// given content.
+		metaDataSecret := func(name, metaData string) *corev1.Secret {
+			return &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespaceName,
+				},
+				Data: map[string][]byte{
+					"metaData": []byte(metaData),
+				},
+			}
+		}
+
+		// helper to create a metaData secret with the given key-value pairs.
+		metaDataSecretWith := func(name string, data map[string]string) *corev1.Secret {
+			metaDataBytes, err := yaml.Marshal(data)
+			Expect(err).NotTo(HaveOccurred())
+			return metaDataSecret(name, string(metaDataBytes))
+		}
+
 		type testCaseNodeAddress struct {
-			Machine               clusterv1.Machine
-			M3Machine             infrav1.Metal3Machine
-			Host                  *bmov1alpha1.BareMetalHost
-			ExpectedNodeAddresses []clusterv1.MachineAddress
+			Machine   clusterv1.Machine
+			M3Machine infrav1.Metal3Machine
+			Host      *bmov1alpha1.BareMetalHost
+			// TestObjects are created before nodeAddresses is called.
+			TestObjects []runtime.Object
+			// SecretGetError, when set, is returned for every secret read.
+			SecretGetError         error
+			ExpectedNodeAddresses  []clusterv1.MachineAddress
+			ExpectedErrorSubstring string
 		}
 
 		DescribeTable("Test NodeAddress",
 			func(tc testCaseNodeAddress) {
-				var nodeAddresses []clusterv1.MachineAddress
-
-				fakeClient := fake.NewClientBuilder().WithScheme(setupSchemeMm()).Build()
-				machineMgr, err := NewMachineManager(fakeClient, nil, nil, &tc.Machine,
+				clientBuilder := fake.NewClientBuilder().WithScheme(setupSchemeMm()).WithRuntimeObjects(tc.TestObjects...)
+				if tc.SecretGetError != nil {
+					clientBuilder = clientBuilder.WithInterceptorFuncs(interceptor.Funcs{
+						Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+							if _, ok := obj.(*corev1.Secret); ok {
+								return tc.SecretGetError
+							}
+							return client.Get(ctx, key, obj, opts...)
+						},
+					})
+				}
+				machineMgr, err := NewMachineManager(clientBuilder.Build(), nil, nil, &tc.Machine,
 					&tc.M3Machine, logr.Discard(),
 				)
 				Expect(err).NotTo(HaveOccurred())
 
-				if tc.Host != nil {
-					nodeAddresses = machineMgr.nodeAddresses(tc.Host)
-					Expect(err).NotTo(HaveOccurred())
+				nodeAddresses, err := machineMgr.nodeAddresses(context.Background(), tc.Host)
+				if tc.ExpectedErrorSubstring != "" {
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring(tc.ExpectedErrorSubstring))
+					return
 				}
-				for i, address := range tc.ExpectedNodeAddresses {
-					Expect(nodeAddresses[i]).To(Equal(address))
-				}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(nodeAddresses).To(Equal(tc.ExpectedNodeAddresses))
 			},
 			Entry("One NIC", testCaseNodeAddress{
 				Host: &bmov1alpha1.BareMetalHost{
@@ -3590,7 +3661,7 @@ var _ = Describe("Metal3Machine manager", func() {
 						},
 					},
 				},
-				ExpectedNodeAddresses: []clusterv1.MachineAddress{addr3},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{addr3, addr4},
 			}),
 			Entry("Empty Hostname", testCaseNodeAddress{
 				Host: &bmov1alpha1.BareMetalHost{
@@ -3604,7 +3675,277 @@ var _ = Describe("Metal3Machine manager", func() {
 			}),
 			Entry("No host at all, so this is a no-op", testCaseNodeAddress{
 				Host:                  nil,
-				ExpectedNodeAddresses: nil,
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{},
+			}),
+			Entry("Metadata override with InternalIP", testCaseNodeAddress{
+				M3Machine: m3mWithMetaData("test-metadata-internal", namespaceName),
+				TestObjects: []runtime.Object{metaDataSecretWith("test-metadata-internal", map[string]string{
+					MetaDataInternalIPKey: "10.0.0.100",
+					"providerid":          "ns/bmh/m3m",
+				})},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{internalIP("10.0.0.100")},
+			}),
+			Entry("Metadata override with ExternalIP", testCaseNodeAddress{
+				M3Machine: m3mWithMetaData("test-metadata-external", namespaceName),
+				TestObjects: []runtime.Object{metaDataSecretWith("test-metadata-external", map[string]string{
+					MetaDataExternalIPKey: "203.0.113.1",
+					"providerid":          "ns/bmh/m3m",
+				})},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{externalIP("203.0.113.1")},
+			}),
+			Entry("Metadata override with IPv6 InternalIP", testCaseNodeAddress{
+				M3Machine: m3mWithMetaData("test-metadata-internal-ipv6", namespaceName),
+				TestObjects: []runtime.Object{metaDataSecretWith("test-metadata-internal-ipv6", map[string]string{
+					MetaDataInternalIPKey: "fd00::100",
+				})},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{internalIP("fd00::100")},
+			}),
+			Entry("Metadata override with IPv6 ExternalIP", testCaseNodeAddress{
+				M3Machine: m3mWithMetaData("test-metadata-external-ipv6", namespaceName),
+				TestObjects: []runtime.Object{metaDataSecretWith("test-metadata-external-ipv6", map[string]string{
+					MetaDataExternalIPKey: "2001:db8::1",
+				})},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{externalIP("2001:db8::1")},
+			}),
+			Entry("Metadata override with both InternalIP and ExternalIP", testCaseNodeAddress{
+				M3Machine: m3mWithMetaData("test-metadata-both", namespaceName),
+				TestObjects: []runtime.Object{metaDataSecretWith("test-metadata-both", map[string]string{
+					MetaDataInternalIPKey: "10.0.0.100",
+					MetaDataExternalIPKey: "203.0.113.1",
+					"providerid":          "ns/bmh/m3m",
+				})},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1, nic2},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{
+					internalIP("10.0.0.100"),
+					externalIP("203.0.113.1"),
+				},
+			}),
+			Entry("Metadata override with IPv6 InternalIP and ExternalIP", testCaseNodeAddress{
+				M3Machine: m3mWithMetaData("test-metadata-ipv6", namespaceName),
+				TestObjects: []runtime.Object{metaDataSecretWith("test-metadata-ipv6", map[string]string{
+					MetaDataInternalIPKey: "fd00::100",
+					MetaDataExternalIPKey: "2001:db8::1",
+				})},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{
+					internalIP("fd00::100"),
+					externalIP("2001:db8::1"),
+				},
+			}),
+			Entry("Metadata override with mixed IPv4 InternalIP and IPv6 ExternalIP", testCaseNodeAddress{
+				M3Machine: m3mWithMetaData("test-metadata-mixed", namespaceName),
+				TestObjects: []runtime.Object{metaDataSecretWith("test-metadata-mixed", map[string]string{
+					MetaDataInternalIPKey: "10.0.0.100",
+					MetaDataExternalIPKey: "2001:db8::1",
+				})},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{
+					internalIP("10.0.0.100"),
+					externalIP("2001:db8::1"),
+				},
+			}),
+			Entry("Metadata override keeps the hostname addresses of the BareMetalHost", testCaseNodeAddress{
+				M3Machine: m3mWithMetaData("test-metadata-hostname", namespaceName),
+				TestObjects: []runtime.Object{metaDataSecretWith("test-metadata-hostname", map[string]string{
+					MetaDataInternalIPKey: "10.0.0.100",
+					MetaDataExternalIPKey: "203.0.113.1",
+				})},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC:      []bmov1alpha1.NIC{nic1},
+							Hostname: "mygreathost",
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{
+					internalIP("10.0.0.100"),
+					externalIP("203.0.113.1"),
+					addr3,
+					addr4,
+				},
+			}),
+			Entry("Metadata override with nil host", testCaseNodeAddress{
+				M3Machine: m3mWithMetaData("test-metadata-nohost", namespaceName),
+				TestObjects: []runtime.Object{metaDataSecretWith("test-metadata-nohost", map[string]string{
+					MetaDataInternalIPKey: "10.0.0.100",
+				})},
+				Host:                  nil,
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{internalIP("10.0.0.100")},
+			}),
+			Entry("Metadata secret is looked up in the Metal3Machine namespace", testCaseNodeAddress{
+				// The namespace of the reference is disregarded, cross-namespace
+				// references are not allowed for the metaData secret.
+				M3Machine: m3mWithMetaData("test-metadata-namespace", "another-namespace"),
+				TestObjects: []runtime.Object{metaDataSecretWith("test-metadata-namespace", map[string]string{
+					MetaDataInternalIPKey: "10.0.0.100",
+				})},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{internalIP("10.0.0.100")},
+			}),
+			Entry("Metadata ref exists but secret missing falls back to BMH", testCaseNodeAddress{
+				M3Machine: m3mWithMetaData("nonexistent-secret", namespaceName),
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{addr1},
+			}),
+			Entry("Metadata secret without metaData key falls back to BMH", testCaseNodeAddress{
+				M3Machine: m3mWithMetaData("test-metadata-empty", namespaceName),
+				TestObjects: []runtime.Object{
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-metadata-empty",
+							Namespace: namespaceName,
+						},
+						Data: map[string][]byte{
+							"networkData": []byte("links: []\n"),
+						},
+					},
+				},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{addr1},
+			}),
+			Entry("Metadata with no InternalIP or ExternalIP falls back to BMH", testCaseNodeAddress{
+				M3Machine: m3mWithMetaData("test-metadata-noop", namespaceName),
+				TestObjects: []runtime.Object{metaDataSecretWith("test-metadata-noop", map[string]string{
+					"providerid": "ns/bmh/m3m",
+				})},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{addr1},
+			}),
+			Entry("Metadata with empty InternalIP falls back to BMH", testCaseNodeAddress{
+				M3Machine: m3mWithMetaData("test-metadata-blank", namespaceName),
+				TestObjects: []runtime.Object{metaDataSecretWith("test-metadata-blank", map[string]string{
+					MetaDataInternalIPKey: "",
+				})},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{addr1},
+			}),
+			Entry("Malformed metadata falls back to BMH", testCaseNodeAddress{
+				M3Machine: m3mWithMetaData("test-metadata-bad", namespaceName),
+				TestObjects: []runtime.Object{
+					metaDataSecret("test-metadata-bad", "\t: not valid yaml"),
+				},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC:      []bmov1alpha1.NIC{nic1},
+							Hostname: "mygreathost",
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{addr1, addr3, addr4},
+			}),
+			Entry("Metadata that is not a mapping falls back to BMH", testCaseNodeAddress{
+				M3Machine: m3mWithMetaData("test-metadata-list", namespaceName),
+				TestObjects: []runtime.Object{
+					metaDataSecret("test-metadata-list", "- InternalIP: 10.0.0.100\n"),
+				},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{addr1},
+			}),
+			Entry("Metadata with non-string InternalIP/ExternalIP falls back to BMH", testCaseNodeAddress{
+				M3Machine: m3mWithMetaData("test-metadata-non-string", namespaceName),
+				TestObjects: []runtime.Object{
+					// InternalIP is a list, ExternalIP is a number; both should be
+					// ignored and the addresses derived from the BMH NICs.
+					metaDataSecret("test-metadata-non-string",
+						"InternalIP:\n  - 10.0.0.100\nExternalIP: 42\nnested:\n  key: value\n"),
+				},
+				Host: &bmov1alpha1.BareMetalHost{
+					Status: bmov1alpha1.BareMetalHostStatus{
+						HardwareDetails: &bmov1alpha1.HardwareDetails{
+							NIC: []bmov1alpha1.NIC{nic1},
+						},
+					},
+				},
+				ExpectedNodeAddresses: []clusterv1.MachineAddress{addr1},
+			}),
+			Entry("Metadata secret that cannot be read returns an error", testCaseNodeAddress{
+				M3Machine:              m3mWithMetaData("test-metadata-error", namespaceName),
+				SecretGetError:         errors.New("simulated get failure"),
+				ExpectedErrorSubstring: "failed to get metaData secret " + namespaceName + "/test-metadata-error",
 			}),
 		)
 	})

--- a/docs/api.md
+++ b/docs/api.md
@@ -341,6 +341,57 @@ When the Metal3Machine gets deleted, the CAPM3 controller will remove its
 ownerreference from the data template object. This will trigger the deletion of
 the generated Metal3Data object and the secrets generated for this machine.
 
+### Node address overrides
+
+The addresses in `Machine.status.addresses` are normally derived from the
+hardware details that Ironic discovered on the BareMetalHost during inspection:
+one `InternalIP` per NIC, plus `Hostname` and `InternalDNS` from the hostname.
+
+The IP addresses can be overridden through the `metaData` secret referenced in
+`Metal3Machine.status.metaData`. The following optional keys are recognized in
+the metadata:
+
+- **InternalIP** : used as the `InternalIP` address of the Machine
+- **ExternalIP** : used as the `ExternalIP` address of the Machine
+
+The keys are case-sensitive and only non-empty string values are used. If either
+key is set, the addresses from the BareMetalHost NICs are not used at all, so
+both keys must be set to get both address types. The `Hostname` and
+`InternalDNS` addresses always come from the BareMetalHost, also when the IP
+addresses are overridden.
+
+This is useful when the BareMetalHost hardware details are unavailable, or when
+the desired addresses differ from the NICs discovered by inspection, for example
+with overlay networks, VIPs or externally routable addresses.
+
+The overrides are best effort. They are ignored, and the addresses are derived
+from the BareMetalHost instead, if the secret does not exist yet, holds no
+`metaData`, cannot be parsed as a YAML mapping, or holds values of an unexpected
+type.
+
+Since the metadata is usually rendered by the Metal3Data controller, the
+addresses are typically set through the `metaData` field of a
+Metal3DataTemplate:
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3DataTemplate
+metadata:
+  name: nodepool-1
+  namespace: metal3
+spec:
+  metaData:
+    ipAddressesFromIPPool:
+    - key: InternalIP
+      name: provisioning-pool
+      apiGroup: ipam.metal3.io
+      kind: IPPool
+    - key: ExternalIP
+      name: external-pool
+      apiGroup: ipam.metal3.io
+      kind: IPPool
+```
+
 ### hostSelector Examples
 
 The `hostSelector field has two possible optional sub-fields:


### PR DESCRIPTION
When a Metal3Machine has a metadata secret (status.metaData), nodeAddresses now reads optional InternalIP and ExternalIP keys from that secret and uses them to populate Machine.Status.Addresses. If neither key is present, the previous behavior of deriving addresses from BareMetalHost NICs is preserved as a fallback.

This lets users provide addresses via Metal3DataTemplate metadata when BMH hardware details are unavailable or when the desired addresses differ from the NICs discovered by inspection (e.g. overlay networks, VIPs, or externally routable IPs).

This address the use-case described https://github.com/metal3-io/cluster-api-provider-metal3/issues/3286

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
