### PR TITLE
🐛 Restrict Metal3DataClaim templates to same namespace

### DIFF
--- a/controllers/metal3datatemplate_controller.go
+++ b/controllers/metal3datatemplate_controller.go
@@ -189,15 +189,16 @@ func (r *Metal3DataTemplateReconciler) SetupWithManager(ctx context.Context, mgr
 func (r *Metal3DataTemplateReconciler) Metal3DataClaimToMetal3DataTemplate(_ context.Context, obj client.Object) []ctrl.Request {
 	if m3dc, ok := obj.(*infrav1.Metal3DataClaim); ok {
 		if m3dc.Spec.Template.Name != "" {
-			namespace := m3dc.Spec.Template.Namespace
-			if namespace == "" {
-				namespace = m3dc.Namespace
+			// Always enqueue using the Metal3DataClaim's own namespace.
+			// Cross-namespace template references are not allowed.
+			if m3dc.Spec.Template.Namespace != "" && m3dc.Spec.Template.Namespace != m3dc.Namespace {
+				return []ctrl.Request{}
 			}
 			return []ctrl.Request{
 				{
 					NamespacedName: types.NamespacedName{
 						Name:      m3dc.Spec.Template.Name,
-						Namespace: namespace,
+						Namespace: m3dc.Namespace,
 					},
 				},
 			}

--- a/controllers/metal3datatemplate_controller_test.go
+++ b/controllers/metal3datatemplate_controller_test.go
@@ -340,14 +340,10 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				req := reqs[0]
 				Expect(req.NamespacedName.Name).To(Equal(tc.DataClaim.Spec.Template.Name),
 					"Expected name %s, found %s", tc.DataClaim.Spec.Template.Name, req.NamespacedName.Name)
-				if tc.DataClaim.Spec.Template.Namespace == "" {
-					Expect(req.NamespacedName.Namespace).To(Equal(tc.DataClaim.Namespace),
-						"Expected namespace %s, found %s", tc.DataClaim.Namespace, req.NamespacedName.Namespace)
-				} else {
-					Expect(req.NamespacedName.Namespace).To(Equal(tc.DataClaim.Spec.Template.Namespace),
-						"Expected namespace %s, found %s", tc.DataClaim.Spec.Template.Namespace,
-						req.NamespacedName.Namespace)
-				}
+				// The enqueued request must always use the Metal3DataClaim's own
+				// namespace; cross-namespace template references are ignored.
+				Expect(req.NamespacedName.Namespace).To(Equal(tc.DataClaim.Namespace),
+					"Expected namespace %s, found %s", tc.DataClaim.Namespace, req.NamespacedName.Namespace)
 
 			} else {
 				Expect(reqs).To(BeEmpty(), "Expected 0 request, found %d", len(reqs))
@@ -396,6 +392,23 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 					},
 				},
 				ExpectRequest: true,
+			},
+		),
+		Entry("Metal3DataTemplate in Spec, cross-namespace reference is ignored",
+			TestCaseM3DCToM3DT{
+				DataClaim: &infrav1.Metal3DataClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      metal3DataClaimName,
+						Namespace: namespaceName,
+					},
+					Spec: infrav1.Metal3DataClaimSpec{
+						Template: corev1.ObjectReference{
+							Name:      metal3DataTemplateName,
+							Namespace: "other-namespace",
+						},
+					},
+				},
+				ExpectRequest: false,
 			},
 		),
 	)

--- a/internal/webhooks/v1beta1/metal3dataclaim_webhook.go
+++ b/internal/webhooks/v1beta1/metal3dataclaim_webhook.go
@@ -65,6 +65,15 @@ func (webhook *Metal3DataClaim) ValidateCreate(_ context.Context, obj runtime.Ob
 			),
 		)
 	}
+	if c.Spec.Template.Namespace != "" && c.Spec.Template.Namespace != c.Namespace {
+		allErrs = append(allErrs,
+			field.Invalid(
+				field.NewPath("spec", "template", "namespace"),
+				c.Spec.Template.Namespace,
+				"must be empty or match the Metal3DataClaim namespace; cross-namespace template references are not allowed",
+			),
+		)
+	}
 
 	if len(allErrs) == 0 {
 		return nil, nil
@@ -84,6 +93,16 @@ func (webhook *Metal3DataClaim) ValidateUpdate(_ context.Context, oldObj, newObj
 	oldMetal3DataClaim, ok := oldObj.(*infrav1.Metal3DataClaim)
 	if !ok || oldMetal3DataClaim == nil {
 		return nil, apierrors.NewInternalError(errors.New("unable to convert existing object"))
+	}
+
+	if newMetal3DataClaim.Spec.Template.Namespace != "" && newMetal3DataClaim.Spec.Template.Namespace != newMetal3DataClaim.Namespace {
+		allErrs = append(allErrs,
+			field.Invalid(
+				field.NewPath("spec", "template", "namespace"),
+				newMetal3DataClaim.Spec.Template.Namespace,
+				"must be empty or match the Metal3DataClaim namespace; cross-namespace template references are not allowed",
+			),
+		)
 	}
 
 	if newMetal3DataClaim.Spec.Template.Name != oldMetal3DataClaim.Spec.Template.Name {

--- a/internal/webhooks/v1beta1/metal3dataclaim_webhook_test.go
+++ b/internal/webhooks/v1beta1/metal3dataclaim_webhook_test.go
@@ -47,13 +47,19 @@ func TestMetal3DataClaimValidation(t *testing.T) {
 		Spec: infrav1.Metal3DataClaimSpec{
 			Template: corev1.ObjectReference{
 				Name:      "abc",
-				Namespace: "abc",
+				Namespace: "foo",
 			},
 		},
 	}
 
 	invalidHost1 := valid.DeepCopy()
 	invalidHost1.Spec.Template.Name = ""
+
+	validEmptyNs := valid.DeepCopy()
+	validEmptyNs.Spec.Template.Namespace = ""
+
+	crossNamespace := valid.DeepCopy()
+	crossNamespace.Spec.Template.Namespace = "other"
 
 	tests := []struct {
 		name      string
@@ -69,6 +75,16 @@ func TestMetal3DataClaimValidation(t *testing.T) {
 			name:      "should succeed when endpoint correct",
 			expectErr: false,
 			c:         valid,
+		},
+		{
+			name:      "should succeed when template namespace is empty",
+			expectErr: false,
+			c:         validEmptyNs,
+		},
+		{
+			name:      "should fail when template namespace differs from claim namespace",
+			expectErr: true,
+			c:         crossNamespace,
 		},
 	}
 
@@ -174,6 +190,38 @@ func TestMetal3DataClaimUpdateValidation(t *testing.T) {
 				Template: corev1.ObjectReference{
 					Name: "abc",
 					Kind: "abcd",
+				},
+			},
+		},
+		{
+			name:      "should fail when new template namespace differs from claim namespace",
+			expectErr: true,
+			new: &infrav1.Metal3DataClaimSpec{
+				Template: corev1.ObjectReference{
+					Name:      "abc",
+					Namespace: "other",
+				},
+			},
+			old: &infrav1.Metal3DataClaimSpec{
+				Template: corev1.ObjectReference{
+					Name:      "abc",
+					Namespace: "other",
+				},
+			},
+		},
+		{
+			name:      "should succeed when new template namespace matches claim namespace",
+			expectErr: false,
+			new: &infrav1.Metal3DataClaimSpec{
+				Template: corev1.ObjectReference{
+					Name:      "abc",
+					Namespace: "foo",
+				},
+			},
+			old: &infrav1.Metal3DataClaimSpec{
+				Template: corev1.ObjectReference{
+					Name:      "abc",
+					Namespace: "foo",
 				},
 			},
 		},


### PR DESCRIPTION
Manual backport of #3322

**What this PR does / why we need it**:

Prevent cross-namespace template references by:
- Rejecting cross-namespace specs in webhooks
- Ignoring cross-namespace references in controller
- Always using the claim's own namespace for reconciliation

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
