### PR TITLE
:bug: Fix typo causing Metal3Cluster to reconcile on every status update

### DIFF
--- a/controllers/metal3cluster_controller.go
+++ b/controllers/metal3cluster_controller.go
@@ -345,7 +345,7 @@ func (r *Metal3ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 						newClusterCopy := newCluster.DeepCopy()
 						oldClusterCopy.Status = infrav1.Metal3ClusterStatus{}
 						newClusterCopy.Status = infrav1.Metal3ClusterStatus{}
-						oldCluster.ObjectMeta.ResourceVersion = ""
+						oldClusterCopy.ObjectMeta.ResourceVersion = ""
 						newClusterCopy.ObjectMeta.ResourceVersion = ""
 						return !reflect.DeepEqual(oldClusterCopy, newClusterCopy)
 					},


### PR DESCRIPTION
Fixes typo that cleared ResourceVersion on oldCluster instead of oldClusterCopy, causing the predicate to always trigger on status updates.


