### PR TITLE
:bug: Restrict namespace secret references in Metal3Machine

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -342,7 +342,10 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 
 	// A machine bootstrap not ready case is caught in the controller
 	// ReconcileNormal function
-	m.getUserDataSecretName(ctx)
+	err = m.getUserDataSecretName(ctx)
+	if err != nil {
+		return err
+	}
 
 	m.setHostLabel(ctx, host)
 
@@ -421,16 +424,20 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 	return nil
 }
 
-// getUserDataSecretName gets the UserDataSecretName from the machine and exposes it as a secret
-// for the BareMetalHost through Metal3Machine. The UserDataSecretName might already be in a secret with
-// CABPK v0.3.0+, but if it is in a different namespace than the BareMetalHost,
-// then we need to create the secret.
-func (m *MachineManager) getUserDataSecretName(_ context.Context) {
+// getUserDataSecretName resolves the userData secret reference for the BareMetalHost.
+// If Metal3Machine.Spec.UserData is set, it is used directly but must reference the
+// same namespace as the Metal3Machine (cross-namespace references are rejected).
+// Otherwise, the bootstrap DataSecretName or ConfigRef from the CAPI Machine is used.
+func (m *MachineManager) getUserDataSecretName(_ context.Context) error {
 	if m.Metal3Machine.Status.UserData != nil {
-		return
+		return nil
 	}
 
 	if m.Metal3Machine.Spec.UserData != nil {
+		if m.Metal3Machine.Spec.UserData.Namespace != "" && m.Metal3Machine.Spec.UserData.Namespace != m.Metal3Machine.Namespace {
+			return fmt.Errorf("cross-namespace secret reference is not allowed for userData (namespace %q does not match %q)",
+				m.Metal3Machine.Spec.UserData.Namespace, m.Metal3Machine.Namespace)
+		}
 		m.Metal3Machine.Status.UserData = m.Metal3Machine.Spec.UserData
 	}
 
@@ -440,13 +447,14 @@ func (m *MachineManager) getUserDataSecretName(_ context.Context) {
 			Name:      *m.Machine.Spec.Bootstrap.DataSecretName,
 			Namespace: m.Machine.Namespace,
 		}
-		return
+		return nil
 	} else if m.Machine.Spec.Bootstrap.ConfigRef.IsDefined() {
 		m.Metal3Machine.Status.UserData = &corev1.SecretReference{
 			Name:      m.Machine.Spec.Bootstrap.ConfigRef.Name,
 			Namespace: m.Machine.Namespace,
 		}
 	}
+	return nil
 }
 
 // Delete deletes a metal3 machine and is invoked by the Machine Controller.
@@ -1093,22 +1101,34 @@ func (m *MachineManager) setHostSpec(_ context.Context, host *bmov1alpha1.BareMe
 			}
 		}
 		host.Spec.UserData = m.Metal3Machine.Status.UserData
-		if host.Spec.UserData != nil && host.Spec.UserData.Namespace == "" {
-			host.Spec.UserData.Namespace = host.Namespace
+		if host.Spec.UserData != nil {
+			if host.Spec.UserData.Namespace == "" {
+				host.Spec.UserData.Namespace = host.Namespace
+			} else if host.Spec.UserData.Namespace != m.Metal3Machine.Namespace {
+				return fmt.Errorf("cross-namespace secret reference is not allowed for userData on host %s", host.Name)
+			}
 		}
 
 		// Set metadata from gathering from Spec.metadata and from the template.
 		if m.Metal3Machine.Status.MetaData != nil {
 			host.Spec.MetaData = m.Metal3Machine.Status.MetaData
 		}
-		if host.Spec.MetaData != nil && host.Spec.MetaData.Namespace == "" {
-			host.Spec.MetaData.Namespace = m.Machine.Namespace
+		if host.Spec.MetaData != nil {
+			if host.Spec.MetaData.Namespace == "" {
+				host.Spec.MetaData.Namespace = m.Machine.Namespace
+			} else if host.Spec.MetaData.Namespace != m.Metal3Machine.Namespace {
+				return fmt.Errorf("cross-namespace secret reference is not allowed for metaData on host %s", host.Name)
+			}
 		}
 		if m.Metal3Machine.Status.NetworkData != nil {
 			host.Spec.NetworkData = m.Metal3Machine.Status.NetworkData
 		}
-		if host.Spec.NetworkData != nil && host.Spec.NetworkData.Namespace == "" {
-			host.Spec.NetworkData.Namespace = m.Machine.Namespace
+		if host.Spec.NetworkData != nil {
+			if host.Spec.NetworkData.Namespace == "" {
+				host.Spec.NetworkData.Namespace = m.Machine.Namespace
+			} else if host.Spec.NetworkData.Namespace != m.Metal3Machine.Namespace {
+				return fmt.Errorf("cross-namespace secret reference is not allowed for networkData on host %s", host.Name)
+			}
 		}
 	}
 	// Set automatedCleaningMode from metal3Machine.spec.automatedCleaningMode.
@@ -1614,11 +1634,20 @@ func findOwnerRefFromList(refList []metav1.OwnerReference, objType metav1.TypeMe
 // AssociateM3Metadata fetches the Metal3DataTemplate object and sets the
 // owner references.
 func (m *MachineManager) AssociateM3Metadata(ctx context.Context) error {
-	// If the secrets were provided by the user, use them.
+	// If the secrets were provided by the user, use them after enforcing
+	// same-namespace constraint to prevent cross-namespace secret disclosure.
 	if m.Metal3Machine.Spec.MetaData != nil {
+		if m.Metal3Machine.Spec.MetaData.Namespace != "" && m.Metal3Machine.Spec.MetaData.Namespace != m.Metal3Machine.Namespace {
+			return fmt.Errorf("cross-namespace secret reference is not allowed for metaData (namespace %q does not match %q)",
+				m.Metal3Machine.Spec.MetaData.Namespace, m.Metal3Machine.Namespace)
+		}
 		m.Metal3Machine.Status.MetaData = m.Metal3Machine.Spec.MetaData
 	}
 	if m.Metal3Machine.Spec.NetworkData != nil {
+		if m.Metal3Machine.Spec.NetworkData.Namespace != "" && m.Metal3Machine.Spec.NetworkData.Namespace != m.Metal3Machine.Namespace {
+			return fmt.Errorf("cross-namespace secret reference is not allowed for networkData (namespace %q does not match %q)",
+				m.Metal3Machine.Spec.NetworkData.Namespace, m.Metal3Machine.Namespace)
+		}
 		m.Metal3Machine.Status.NetworkData = m.Metal3Machine.Spec.NetworkData
 	}
 

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -1091,6 +1091,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		ExpectedCustomDeploy        *bmov1alpha1.CustomDeploy
 		ExpectUserData              bool
 		expectNodeReuseLabelDeleted bool
+		ExpectError                 bool
 	}
 
 	DescribeTable("Test SetHostSpec",
@@ -1114,6 +1115,10 @@ var _ = Describe("Metal3Machine manager", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			err = machineMgr.setHostSpec(context.TODO(), tc.Host)
+			if tc.ExpectError {
+				Expect(err).To(HaveOccurred())
+				return
+			}
 			Expect(err).NotTo(HaveOccurred())
 
 			// validate the saved host
@@ -1161,6 +1166,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			),
 			ExpectedImage:  expectedImg(),
 			ExpectUserData: true,
+			ExpectError:    true,
 		}),
 		Entry("User data has no namespace", testCaseSetHostSpec{
 			UserDataNamespace:         "",
@@ -2614,7 +2620,12 @@ var _ = Describe("Metal3Machine manager", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			machineMgr.getUserDataSecretName(context.TODO())
+			err = machineMgr.getUserDataSecretName(context.TODO())
+			if tc.ExpectError {
+				Expect(err).To(HaveOccurred())
+				return
+			}
+			Expect(err).NotTo(HaveOccurred())
 
 			// Expect the reference to the secret to be passed through
 			if tc.Machine.Spec.Bootstrap.DataSecretName != nil &&
@@ -2766,6 +2777,19 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 			M3Machine: newMetal3Machine(metal3machineName, nil, nil, nil),
 			BMHost:    newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
+		}),
+		Entry("User data has explicit alternate namespace", testCaseGetUserDataSecretName{
+			Machine: &clusterv1.Machine{
+				ObjectMeta: testObjectMeta("", namespaceName, ""),
+			},
+			M3Machine: newMetal3Machine(metal3machineName, &infrav1.Metal3MachineSpec{
+				UserData: &corev1.SecretReference{
+					Name:      "foreign-secret",
+					Namespace: "other-ns",
+				},
+			}, nil, nil),
+			BMHost:      newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false, ""),
+			ExpectError: true,
 		}),
 	)
 
@@ -3329,9 +3353,9 @@ var _ = Describe("Metal3Machine manager", func() {
 				} else {
 					Expect(err).NotTo(BeAssignableToTypeOf(ReconcileError{}))
 				}
-			} else {
-				Expect(err).NotTo(HaveOccurred())
+				return
 			}
+			Expect(err).NotTo(HaveOccurred())
 			if tc.M3Machine.Spec.MetaData != nil {
 				Expect(tc.M3Machine.Status.MetaData).To(Equal(tc.M3Machine.Spec.MetaData))
 			}
@@ -3424,6 +3448,18 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			},
 			expectClaim: true,
+		}),
+		Entry("MetaData has explicit alternate namespace", testCaseM3MetaData{
+			M3Machine: newMetal3Machine("myName", &infrav1.Metal3MachineSpec{
+				MetaData: &corev1.SecretReference{Name: "secret", Namespace: "other-ns"},
+			}, nil, nil),
+			ExpectError: true,
+		}),
+		Entry("NetworkData has explicit alternate namespace", testCaseM3MetaData{
+			M3Machine: newMetal3Machine("myName", &infrav1.Metal3MachineSpec{
+				NetworkData: &corev1.SecretReference{Name: "secret", Namespace: "other-ns"},
+			}, nil, nil),
+			ExpectError: true,
 		}),
 	)
 

--- a/internal/webhooks/v1beta1/metal3machine_webhook.go
+++ b/internal/webhooks/v1beta1/metal3machine_webhook.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -79,8 +80,26 @@ func (webhook *Metal3Machine) validate(newM3M *infrav1.Metal3Machine) error {
 		allErrs = append(allErrs, newM3M.Spec.Image.Validate(*field.NewPath("Spec", "Image"))...)
 	}
 
+	allErrs = append(allErrs, validateSecretNamespace(newM3M.Spec.UserData, newM3M.Namespace, field.NewPath("spec", "userData"))...)
+	allErrs = append(allErrs, validateSecretNamespace(newM3M.Spec.MetaData, newM3M.Namespace, field.NewPath("spec", "metaData"))...)
+	allErrs = append(allErrs, validateSecretNamespace(newM3M.Spec.NetworkData, newM3M.Namespace, field.NewPath("spec", "networkData"))...)
+
 	if len(allErrs) == 0 {
 		return nil
 	}
 	return apierrors.NewInvalid(infrav1.GroupVersion.WithKind("Metal3Machine").GroupKind(), newM3M.Name, allErrs)
+}
+
+// validateSecretNamespace rejects secret references that point to a namespace
+// other than the Metal3Machine's own namespace, preventing cross-namespace
+// secret disclosure.
+func validateSecretNamespace(ref *corev1.SecretReference, m3mNamespace string, fldPath *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	if ref != nil && ref.Namespace != "" && ref.Namespace != m3mNamespace {
+		errs = append(errs, field.Forbidden(
+			fldPath.Child("namespace"),
+			"cross-namespace secret references are not allowed",
+		))
+	}
+	return errs
 }

--- a/internal/webhooks/v1beta1/metal3machine_webhook_test.go
+++ b/internal/webhooks/v1beta1/metal3machine_webhook_test.go
@@ -19,6 +19,7 @@ import (
 
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
@@ -69,6 +70,42 @@ func TestMetal3MachineValidation(t *testing.T) {
 		},
 	}
 
+	neitherImageNorCustomDeploy := &infrav1.Metal3Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+		},
+		Spec: infrav1.Metal3MachineSpec{
+			// Neither Image nor CustomDeploy specified
+		},
+	}
+
+	crossNsUserData := valid.DeepCopy()
+	crossNsUserData.Spec.UserData = &corev1.SecretReference{Name: "secret", Namespace: "other-ns"}
+
+	crossNsMetaData := valid.DeepCopy()
+	crossNsMetaData.Spec.MetaData = &corev1.SecretReference{Name: "secret", Namespace: "other-ns"}
+
+	crossNsNetworkData := valid.DeepCopy()
+	crossNsNetworkData.Spec.NetworkData = &corev1.SecretReference{Name: "secret", Namespace: "other-ns"}
+
+	sameNsUserData := valid.DeepCopy()
+	sameNsUserData.Spec.UserData = &corev1.SecretReference{Name: "secret", Namespace: "foo"}
+
+	sameNsMetaData := valid.DeepCopy()
+	sameNsMetaData.Spec.MetaData = &corev1.SecretReference{Name: "secret", Namespace: "foo"}
+
+	sameNsNetworkData := valid.DeepCopy()
+	sameNsNetworkData.Spec.NetworkData = &corev1.SecretReference{Name: "secret", Namespace: "foo"}
+
+	noNsUserData := valid.DeepCopy()
+	noNsUserData.Spec.UserData = &corev1.SecretReference{Name: "secret"}
+
+	noNsMetaData := valid.DeepCopy()
+	noNsMetaData.Spec.MetaData = &corev1.SecretReference{Name: "secret"}
+
+	noNsNetworkData := valid.DeepCopy()
+	noNsNetworkData.Spec.NetworkData = &corev1.SecretReference{Name: "secret"}
+
 	tests := []struct {
 		name      string
 		expectErr bool
@@ -98,6 +135,56 @@ func TestMetal3MachineValidation(t *testing.T) {
 			name:      "should succeed with customDeploy",
 			expectErr: false,
 			c:         validCustomDeploy,
+		},
+		{
+			name:      "should return error when both image and customDeploy are missing",
+			expectErr: true,
+			c:         neitherImageNorCustomDeploy,
+		},
+		{
+			name:      "should return error when userData references a different namespace",
+			expectErr: true,
+			c:         crossNsUserData,
+		},
+		{
+			name:      "should return error when metaData references a different namespace",
+			expectErr: true,
+			c:         crossNsMetaData,
+		},
+		{
+			name:      "should return error when networkData references a different namespace",
+			expectErr: true,
+			c:         crossNsNetworkData,
+		},
+		{
+			name:      "should succeed when userData references the same namespace",
+			expectErr: false,
+			c:         sameNsUserData,
+		},
+		{
+			name:      "should succeed when metaData references the same namespace",
+			expectErr: false,
+			c:         sameNsMetaData,
+		},
+		{
+			name:      "should succeed when networkData references the same namespace",
+			expectErr: false,
+			c:         sameNsNetworkData,
+		},
+		{
+			name:      "should succeed when userData has no namespace",
+			expectErr: false,
+			c:         noNsUserData,
+		},
+		{
+			name:      "should succeed when metaData has no namespace",
+			expectErr: false,
+			c:         noNsMetaData,
+		},
+		{
+			name:      "should succeed when networkData has no namespace",
+			expectErr: false,
+			c:         noNsNetworkData,
 		},
 	}
 


### PR DESCRIPTION
Manual cherry-pick of https://github.com/metal3-io/cluster-api-provider-metal3/pull/3327
Validate that userData, metaData, and networkData secret references do not point to namespaces other than the Metal3Machine's own namespace.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
