### PR TITLE
:seedling: Patch overlay image

### DIFF
--- a/test/e2e/data/infrastructure-metal3/overlays/release-1.11/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/overlays/release-1.11/kustomization.yaml
@@ -3,3 +3,8 @@ kind: Kustomization
 
 resources:
 - https://github.com/metal3-io/cluster-api-provider-metal3/config/default?ref=release-1.11
+
+images:
+- name: quay.io/metal3-io/cluster-api-provider-metal3
+  newTag: release-1.11
+

--- a/test/e2e/data/infrastructure-metal3/overlays/release-1.12/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/overlays/release-1.12/kustomization.yaml
@@ -3,3 +3,7 @@ kind: Kustomization
 
 resources:
 - https://github.com/metal3-io/cluster-api-provider-metal3/config/default?ref=release-1.12
+
+images:
+- name: quay.io/metal3-io/cluster-api-provider-metal3
+  newTag: release-1.12

--- a/test/e2e/data/ipamprovider-metal3/overlays/release-1.11/kustomization.yaml
+++ b/test/e2e/data/ipamprovider-metal3/overlays/release-1.11/kustomization.yaml
@@ -3,3 +3,7 @@ kind: Kustomization
 
 resources:
 - https://github.com/metal3-io/ip-address-manager/config/default?ref=release-1.11
+
+images:
+- name: quay.io/metal3-io/ip-address-manager
+  newTag: release-1.11

--- a/test/e2e/data/ipamprovider-metal3/overlays/release-1.12/kustomization.yaml
+++ b/test/e2e/data/ipamprovider-metal3/overlays/release-1.12/kustomization.yaml
@@ -3,3 +3,7 @@ kind: Kustomization
 
 resources:
 - https://github.com/metal3-io/ip-address-manager/config/default?ref=release-1.12
+
+images:
+- name: quay.io/metal3-io/ip-address-manager
+  newTag: release-1.12

--- a/test/e2e/upgrade_clusterctl_test.go
+++ b/test/e2e/upgrade_clusterctl_test.go
@@ -20,11 +20,9 @@ import (
 )
 
 const (
-	workDir                  = "/opt/metal3-dev-env/"
-	capiContract             = "v1beta2"
-	capm3Contract            = "v1beta2"
-	releaseMarkerPrefixCAPM3 = "go://github.com/metal3-io/cluster-api-provider-metal3@v%s"
-	releaseMarkerPrefixIPAM  = "go://github.com/metal3-io/ip-address-manager@v%s"
+	workDir       = "/opt/metal3-dev-env/"
+	capiContract  = "v1beta2"
+	capm3Contract = "v1beta2"
 )
 
 var (
@@ -57,10 +55,14 @@ var _ = Describe("When testing cluster upgrade from releases (v1.12=>current)", 
 	ironicToRelease := "main"
 	capiStableRelease, err := capi_e2e.GetStableReleaseOfMinor(ctx, minorVersion)
 	Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for CAPI minor release : %s", minorVersion)
-	capm3StableRelease, err := GetStableReleaseOfMinor(ctx, releaseMarkerPrefixCAPM3, minorVersion)
-	Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for CAPM3 minor release : %s", minorVersion)
-	ipamStableRelease, err := GetStableReleaseOfMinor(ctx, releaseMarkerPrefixIPAM, minorVersion)
-	Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for IPAM minor release : %s", minorVersion)
+
+	// Use the .99 versions available in the local artifact repository (built from
+	// release branch kustomize overlays in e2e_conf.yaml). The old clusterctl binary
+	// resolves provider components from the local repo, which only has .99 versions —
+	// not the actual released patch versions. Core CAPI providers work because
+	// clusterctl has built-in GitHub URLs for them.
+	capm3InitVersion := minorVersion + ".99"
+	ipamInitVersion := minorVersion + ".99"
 
 	capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
 		return capi_e2e.ClusterctlUpgradeSpecInput{
@@ -72,8 +74,8 @@ var _ = Describe("When testing cluster upgrade from releases (v1.12=>current)", 
 			InitWithCoreProvider:            fmt.Sprintf(providerCAPIPrefix, capiStableRelease),
 			InitWithBootstrapProviders:      []string{fmt.Sprintf(providerKubeadmPrefix, capiStableRelease)},
 			InitWithControlPlaneProviders:   []string{fmt.Sprintf(providerKubeadmPrefix, capiStableRelease)},
-			InitWithInfrastructureProviders: []string{fmt.Sprintf(providerMetal3Prefix, capm3StableRelease)},
-			InitWithIPAMProviders:           []string{fmt.Sprintf(providerMetal3Prefix, ipamStableRelease)},
+			InitWithInfrastructureProviders: []string{fmt.Sprintf(providerMetal3Prefix, capm3InitVersion)},
+			InitWithIPAMProviders:           []string{fmt.Sprintf(providerMetal3Prefix, ipamInitVersion)},
 			InitWithKubernetesVersion:       k8sVersion,
 			WorkloadKubernetesVersion:       k8sVersion,
 			InitWithBinary:                  fmt.Sprintf(clusterctlDownloadURL, capiStableRelease),
@@ -115,10 +117,14 @@ var _ = Describe("When testing cluster upgrade from releases (v1.11=>current)", 
 	ironicToRelease := "main"
 	capiStableRelease, err := capi_e2e.GetStableReleaseOfMinor(ctx, minorVersion)
 	Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for CAPI minor release : %s", minorVersion)
-	capm3StableRelease, err := GetStableReleaseOfMinor(ctx, releaseMarkerPrefixCAPM3, minorVersion)
-	Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for CAPM3 minor release : %s", minorVersion)
-	ipamStableRelease, err := GetStableReleaseOfMinor(ctx, releaseMarkerPrefixIPAM, minorVersion)
-	Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for IPAM minor release : %s", minorVersion)
+
+	// Use the .99 versions available in the local artifact repository (built from
+	// release branch kustomize overlays in e2e_conf.yaml). The old clusterctl binary
+	// resolves provider components from the local repo, which only has .99 versions —
+	// not the actual released patch versions. Core CAPI providers work because
+	// clusterctl has built-in GitHub URLs for them.
+	capm3InitVersion := minorVersion + ".99"
+	ipamInitVersion := minorVersion + ".99"
 
 	capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
 		return capi_e2e.ClusterctlUpgradeSpecInput{
@@ -130,8 +136,8 @@ var _ = Describe("When testing cluster upgrade from releases (v1.11=>current)", 
 			InitWithCoreProvider:            fmt.Sprintf(providerCAPIPrefix, capiStableRelease),
 			InitWithBootstrapProviders:      []string{fmt.Sprintf(providerKubeadmPrefix, capiStableRelease)},
 			InitWithControlPlaneProviders:   []string{fmt.Sprintf(providerKubeadmPrefix, capiStableRelease)},
-			InitWithInfrastructureProviders: []string{fmt.Sprintf(providerMetal3Prefix, capm3StableRelease)},
-			InitWithIPAMProviders:           []string{fmt.Sprintf(providerMetal3Prefix, ipamStableRelease)},
+			InitWithInfrastructureProviders: []string{fmt.Sprintf(providerMetal3Prefix, capm3InitVersion)},
+			InitWithIPAMProviders:           []string{fmt.Sprintf(providerMetal3Prefix, ipamInitVersion)},
 			InitWithKubernetesVersion:       k8sVersion,
 			WorkloadKubernetesVersion:       k8sVersion,
 			InitWithBinary:                  fmt.Sprintf(clusterctlDownloadURL, capiStableRelease),


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

Patch release-1.11 and release-1.12 overlays images. This should fix failing clusterctl upgrade test.

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
