### PR TITLE
:warning: Remove all code related to legacy form of ProviderID

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -98,7 +98,6 @@ type MachineManagerInterface interface {
 	Delete(context.Context) error
 	Update(context.Context) error
 	HasAnnotation() bool
-	GetProviderIDAndBMHID() (string, *string)
 	SetProviderID(string)
 	SetDefaultProviderID() error
 	SetProviderIDFromCloudProviderNode(context.Context, ClientGetter) error
@@ -1394,27 +1393,6 @@ func (m *MachineManager) nodeAddresses(host *bmov1alpha1.BareMetalHost) []cluste
 	return addrs
 }
 
-// GetProviderIDAndBMHID returns providerID and bmhID.
-func (m *MachineManager) GetProviderIDAndBMHID() (string, *string) {
-	providerID := m.Metal3Machine.Spec.ProviderID
-	if providerID == "" {
-		return "", nil
-	}
-	bmhID := providerID
-	if strings.Contains(bmhID, ProviderIDPrefix) {
-		bmhID = strings.TrimPrefix(bmhID, ProviderIDPrefix)
-	}
-	// If the providerID is in new format, it does not contain the BMH ID, but
-	// instead contains / to separate the names. In that case we return nil for
-	// the bmh ID to force the controller to fetch it differently.
-	if strings.Contains(bmhID, "/") {
-		m.Log.Info("ProviderID is in new format, it does not contain the BMH ID", "providerID", providerID)
-		return providerID, nil
-	}
-	m.Log.V(VerbosityLevelDebug).Info("ProviderID contains the BMH ID", "providerID", providerID)
-	return providerID, ptr.To(bmhID)
-}
-
 // ClientGetter prototype.
 type ClientGetter func(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) (clientcorev1.CoreV1Interface, error)
 
@@ -1462,7 +1440,7 @@ func (m *MachineManager) SetProviderID(providerID string) {
 	m.Metal3Machine.Spec.ProviderID = providerID
 }
 
-// SetDefaultProviderID sets the ProviderID on this Metal3Machine using the new format.
+// SetDefaultProviderID sets the ProviderID on this Metal3Machine using the proper format.
 func (m *MachineManager) SetDefaultProviderID() error {
 	namespace := m.Metal3Machine.GetNamespace()
 	m3mName := m.Metal3Machine.GetName()
@@ -1478,8 +1456,8 @@ func (m *MachineManager) SetDefaultProviderID() error {
 	return nil
 }
 
-// getPossibleProviderIDs returns the ProviderID for this Metal3Machine in the legacy and the new format.
-func (m *MachineManager) getPossibleProviderIDs(ctx context.Context) (providerIDLegacy string, providerIDNew string, err error) {
+// getProviderID returns the ProviderID for this Metal3Machine in proper format.
+func (m *MachineManager) getProviderID() (providerID string, err error) {
 	namespace := m.Metal3Machine.GetNamespace()
 	m3mName := m.Metal3Machine.GetName()
 	bmhName, err := m.getBmhNameFromM3Machine()
@@ -1489,15 +1467,7 @@ func (m *MachineManager) getPossibleProviderIDs(ctx context.Context) (providerID
 		err = fmt.Errorf("%s: %w", errMessage, err)
 		return
 	}
-	bmhUID, err := m.getBmhUIDFromM3Machine(ctx)
-	if err != nil {
-		errMessage := "unable to retrieve BMH UID from Metal3Machine"
-		m.Log.Info(errMessage)
-		err = fmt.Errorf("%s: %w", errMessage, err)
-		return
-	}
-	providerIDLegacy = "metal3://" + bmhUID
-	providerIDNew = fmt.Sprintf("metal3://%s/%s/%s", namespace, bmhName, m3mName)
+	providerID = fmt.Sprintf("metal3://%s/%s/%s", namespace, bmhName, m3mName)
 
 	return
 }
@@ -1505,12 +1475,12 @@ func (m *MachineManager) getPossibleProviderIDs(ctx context.Context) (providerID
 // SetProviderIDFromCloudProviderNode finds a Node by ProviderID and copies that ProviderID to the Metal3Machine.
 func (m *MachineManager) SetProviderIDFromCloudProviderNode(ctx context.Context, clientFactory ClientGetter) error {
 	m.Log.V(VerbosityLevelTrace).Info("Setting ProviderID from cloud provider node")
-	providerIDLegacy, providerIDNew, err := m.getPossibleProviderIDs(ctx)
+	providerID, err := m.getProviderID()
 	if err != nil {
 		return WithTransientError(err, requeueAfter)
 	}
 
-	node, err := m.getNodeByProviderID(ctx, providerIDLegacy, providerIDNew, clientFactory)
+	node, err := m.getNodeByProviderID(ctx, providerID, clientFactory)
 	if err != nil {
 		errMessage := "error retrieving node, requeuing"
 		m.Log.Info(errMessage)
@@ -1529,12 +1499,12 @@ func (m *MachineManager) NodeWithMatchingProviderIDExists(ctx context.Context, c
 		return false
 	}
 
-	providerIDLegacy, providerIDNew, err := m.getPossibleProviderIDs(ctx)
+	providerID, err := m.getProviderID()
 	if err != nil {
 		return false
 	}
 
-	node, err := m.getNodeByProviderID(ctx, providerIDLegacy, providerIDNew, clientFactory)
+	node, err := m.getNodeByProviderID(ctx, providerID, clientFactory)
 	if err != nil {
 		errMessage := "error retrieving node, requeuing"
 		m.Log.Info(errMessage)
@@ -1577,7 +1547,7 @@ func (m *MachineManager) SetProviderIDFromNodeLabel(ctx context.Context, clientF
 		return false, fmt.Errorf("found multiple target nodes with the same label: (%s): %w", nodeLabel, err)
 	}
 
-	providerIDLegacy, providerIDNew, err := m.getPossibleProviderIDs(ctx)
+	providerID, err := m.getProviderID()
 	if err != nil {
 		errMessage := fmt.Sprintf("unable to retrieve BMH name from Metal3Machine: %v", err)
 		m.Log.Info(errMessage)
@@ -1589,9 +1559,9 @@ func (m *MachineManager) SetProviderIDFromNodeLabel(ctx context.Context, clientF
 		providerIDOnNode := node.Spec.ProviderID
 		if providerIDOnNode == "" {
 			// By default we use the new format, if not set on the node.
-			m.SetProviderID(providerIDNew)
+			m.SetProviderID(providerID)
 			m.SetReadyTrue()
-			err = m.setNodeProviderID(ctx, corev1Remote, node, providerIDNew)
+			err = m.setNodeProviderID(ctx, corev1Remote, node, providerID)
 
 			if err != nil {
 				return false, err
@@ -1600,19 +1570,13 @@ func (m *MachineManager) SetProviderIDFromNodeLabel(ctx context.Context, clientF
 			return true, nil
 		}
 
-		if providerIDOnNode == providerIDNew {
-			m.SetProviderID(providerIDNew)
+		if providerIDOnNode == providerID {
+			m.SetProviderID(providerID)
 			m.SetReadyTrue()
 			return true, nil
 		}
 
-		if providerIDOnNode == providerIDLegacy {
-			m.SetProviderID(providerIDLegacy)
-			m.SetReadyTrue()
-			return true, nil
-		}
-
-		m.Log.Info("node using unsupported providerID format", "providerID", providerIDOnNode, "providerIDLegacy", providerIDLegacy, "providerIDNew", providerIDNew)
+		m.Log.Info("node using unsupported providerID format", "providerID", providerIDOnNode, "providerID", providerID)
 		return false, fmt.Errorf("node using unsupported providerID format: %w", err)
 	}
 
@@ -2236,7 +2200,7 @@ func (m *MachineManager) SetNodeProviderIDByHostname(ctx context.Context, client
 	return nil
 }
 
-func (m *MachineManager) getNodeByProviderID(ctx context.Context, providerIDLegacy, providerIDNew string, clientFactory ClientGetter) (corev1.Node, error) {
+func (m *MachineManager) getNodeByProviderID(ctx context.Context, providerID string, clientFactory ClientGetter) (corev1.Node, error) {
 	corev1Remote, err := clientFactory(ctx, m.client, m.Cluster)
 	if err != nil {
 		return corev1.Node{}, fmt.Errorf("error creating a remote client: %w", err)
@@ -2256,10 +2220,8 @@ func (m *MachineManager) getNodeByProviderID(ctx context.Context, providerIDLega
 		providerIDOnNode := node.Spec.ProviderID
 		if providerIDOnNode == "" {
 			m.Log.Info("no providerID value found on node", LogFieldNode, node.GetName())
-		} else if providerIDOnNode == providerIDNew {
-			matchingNodeProviderID = providerIDNew
-		} else if providerIDOnNode == providerIDLegacy {
-			matchingNodeProviderID = providerIDLegacy
+		} else if providerIDOnNode == providerID {
+			matchingNodeProviderID = providerID
 		} else {
 			m.Log.Info("The node does not match expected providerID. Considering other nodes ", LogFieldNode, node.GetName(), LogFieldProviderID, providerIDOnNode)
 		}
@@ -2267,7 +2229,7 @@ func (m *MachineManager) getNodeByProviderID(ctx context.Context, providerIDLega
 			validNodes[providerIDOnNode] = append(validNodes[providerIDOnNode], node)
 		}
 	}
-	err = m.duplicateProviderIDsExist(validNodes, providerIDLegacy, providerIDNew)
+	err = m.duplicateProviderIDsExist(validNodes, providerID)
 	if err != nil {
 		// There are, at least, two nodes. Details are in err
 		return corev1.Node{}, err
@@ -2291,35 +2253,31 @@ func getNodeNames(nodes []corev1.Node) string {
 	return strings.Join(names, ", ")
 }
 
-// duplicateProviderIDsExist determnes if a providerID is already in use by other nodes.
-func (m *MachineManager) duplicateProviderIDsExist(validNodes map[string][]corev1.Node, providerIDLegacy, providerIDNew string) error {
+// duplicateProviderIDsExist determines if a providerID is already in use by other nodes.
+func (m *MachineManager) duplicateProviderIDsExist(validNodes map[string][]corev1.Node, providerID string) error {
 	duplicateUsageCounter := 0
 	var duplicateNodes []corev1.Node
 	// Check if any node has metal3://<namespace>/<bmh>/ as a beginning of providerID
-	newProviderIDMatch := providerIDNew[:strings.LastIndex(providerIDNew, "/")+1]
-	for providerID, nodes := range validNodes {
-		// verify if the same providerId is not consumed twice. Example:
-		// legacy provider-id: metal3://d668eb95-5df6-4c10-a01a-fc69f4299fc6
-		// new format provider-id:   metal3://metal3/node-0/test-controlplane-xyz
-		// The above two providerIDs are the same and would consume the same bmh node,
-		// the former using uuid and the latter using a name.
+	providerIDMatch := providerID[:strings.LastIndex(providerID, "/")+1]
+	for nodeProviderID, nodes := range validNodes {
+		// verify if the same providerId is not consumed twice.
 		// The check below prevents such double providerID consumptions.
-		if providerID == providerIDLegacy || strings.Contains(providerID, newProviderIDMatch) {
+		if strings.Contains(nodeProviderID, providerIDMatch) {
 			duplicateUsageCounter++
 			duplicateNodes = append(duplicateNodes, nodes...)
 		}
-		// duplicates due to the same, at least, two instances of legacy OR new OR unknown formats being used in multiple nodes.
+		// duplicates due to the same, at least, two instances proper OR unknown formats being used in multiple nodes.
 		if len(nodes) > 1 {
 			matchingNodes := getNodeNames(nodes)
-			errMessage := fmt.Sprintf("providerID %s is in use by multiple nodes: (%s)", providerID, matchingNodes)
+			errMessage := fmt.Sprintf("providerID %s is in use by multiple nodes: (%s)", nodeProviderID, matchingNodes)
 			m.Log.Info(errMessage)
 			return errors.New(errMessage)
 		}
 	}
-	// duplicates due to both the legacy AND new providerIDs being used by multiple nodes.
+	// duplicates due to providerID being used by multiple nodes.
 	if duplicateUsageCounter > 1 {
 		duplicateNodesNames := getNodeNames(duplicateNodes)
-		errMessage := fmt.Sprintf("both providerIDs (%s and %s) cannot be used at the same time by node: (%s)", providerIDLegacy, providerIDNew, duplicateNodesNames)
+		errMessage := fmt.Sprintf("providerID (%s) cannot be used at the same time by node: (%s)", providerID, duplicateNodesNames)
 		m.Log.Info(errMessage)
 		return errors.New(errMessage)
 	}

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -51,8 +51,8 @@ const (
 	cpName                    = "cp-pool1"
 )
 
-var Bmhuid = types.UID("4d25a2c2-46e4-11ec-81d3-0242ac130003")
-var ProviderID = fmt.Sprintf("metal3://%s", Bmhuid)
+var ProviderID = fmt.Sprintf("metal3://%s/%s/%s", namespaceName, baremetalhostName, metal3machineName)
+var defaultBMHUID = types.UID("4d25a2c2-46e4-11ec-81d3-0242ac130003")
 
 var testImageDiskFormat = "raw"
 
@@ -2726,40 +2726,6 @@ var _ = Describe("Metal3Machine manager", func() {
 		)
 	})
 
-	type testCaseGetProviderIDAndBMHID struct {
-		providerID    string
-		expectedBMHID string
-	}
-
-	DescribeTable("Test GetProviderIDAndBMHID",
-		func(tc testCaseGetProviderIDAndBMHID) {
-			m3m := infrav1.Metal3Machine{
-				Spec: infrav1.Metal3MachineSpec{
-					ProviderID: tc.providerID,
-				},
-			}
-
-			machineMgr, err := NewMachineManager(nil, nil, nil, nil, &m3m, logr.Discard())
-			Expect(err).NotTo(HaveOccurred())
-
-			providerID, bmhID := machineMgr.GetProviderIDAndBMHID()
-
-			if tc.providerID != "" {
-				Expect(providerID).To(Equal(tc.providerID))
-				Expect(bmhID).NotTo(BeNil())
-				Expect(*bmhID).To(Equal(tc.expectedBMHID))
-			} else {
-				Expect(providerID).To(Equal(""))
-				Expect(bmhID).To(BeNil())
-			}
-		},
-		Entry("Empty providerID", testCaseGetProviderIDAndBMHID{}),
-		Entry("Provider ID set", testCaseGetProviderIDAndBMHID{
-			providerID:    ProviderID,
-			expectedBMHID: string(Bmhuid),
-		}),
-	)
-
 	Describe("Test SetNodeProviderID", func() {
 		s := runtime.NewScheme()
 		err := clusterv1.AddToScheme(s)
@@ -4696,11 +4662,10 @@ var _ = Describe("Metal3Machine manager", func() {
 	)
 
 	type testCaseDuplicateProviderIDsExist struct {
-		Machine          *clusterv1.Machine
-		validNodes       map[string][]corev1.Node
-		providerIDLegacy string
-		providerIDNew    string
-		expectError      bool
+		Machine     *clusterv1.Machine
+		validNodes  map[string][]corev1.Node
+		providerID  string
+		expectError bool
 	}
 
 	DescribeTable("Test duplicateProviderIDsExist",
@@ -4710,112 +4675,70 @@ var _ = Describe("Metal3Machine manager", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = machineMgr.duplicateProviderIDsExist(tc.validNodes, tc.providerIDLegacy, tc.providerIDNew)
+			err = machineMgr.duplicateProviderIDsExist(tc.validNodes, tc.providerID)
 			if tc.expectError {
 				Expect(err).To(HaveOccurred())
 			} else {
 				Expect(err).NotTo(HaveOccurred())
 			}
 		},
-		Entry("Should find duplicates if both providerIDNew and providerIDLegacy are in use by multiple nodes", testCaseDuplicateProviderIDsExist{
-			validNodes: map[string][]corev1.Node{
-				"metal3://d668eb95-5df6-4c10-a01a-fc69f4299fc6": {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test1"}}},
-				"metal3://metal3/node-0/test-controlplane-xyz":  {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test2"}}},
-			},
-			providerIDLegacy: "metal3://d668eb95-5df6-4c10-a01a-fc69f4299fc6",
-			providerIDNew:    "metal3://metal3/node-0/test-controlplane-xyz",
-			expectError:      true,
-		}),
+
 		Entry("Should find duplicates if validNodes node count is more than 1 for a providerID", testCaseDuplicateProviderIDsExist{
 			validNodes: map[string][]corev1.Node{
-				"metal3://d668eb95-5df6-4c10-a01a-fc69f4299fc6": {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test1"}}, corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test2"}}},
+				"metal3://metal3/node-0/test-controlplane-xyz": {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test1"}}, corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test2"}}},
 			},
-			providerIDLegacy: "",
-			providerIDNew:    "",
-			expectError:      true,
+			providerID:  "",
+			expectError: true,
 		}),
-		Entry("Should not find duplicates if ether providerIDNew or providerIDLegacy are in use by single node", testCaseDuplicateProviderIDsExist{
-			validNodes: map[string][]corev1.Node{
-				"metal3://d668eb95-5df6-4c10-a01a-fc69f4299fc6": {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test1"}}},
-			},
-			providerIDLegacy: "metal3://d668eb95-5df6-4c10-a01a-fc69f4299fc6",
-			providerIDNew:    "metal3://metal3/node-0/test-controlplane-xyz",
-			expectError:      false,
-		}),
-		Entry("Should not find duplicates if both providerIDNew and providerIDLegacy are in use by single node", testCaseDuplicateProviderIDsExist{
+		Entry("Should not find duplicates if providerID is in use by single node", testCaseDuplicateProviderIDsExist{
 			validNodes: map[string][]corev1.Node{
 				"metal3://metal3/node-0/test-controlplane-xyz": {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test1"}}},
 			},
-			providerIDLegacy: "metal3://d668eb95-5df6-4c10-a01a-fc69f4299fc6",
-			providerIDNew:    "metal3://metal3/node-0/test-controlplane-xyz",
-			expectError:      false,
+			providerID:  "metal3://metal3/node-0/test-controlplane-xyz",
+			expectError: false,
 		}),
 		Entry("Should not find duplicates if validNodes is nil", testCaseDuplicateProviderIDsExist{
-			validNodes:       nil,
-			providerIDLegacy: "metal3://d668eb95-5df6-4c10-a01a-fc69f4299fc6",
-			providerIDNew:    "metal3://metal3/node-0/test-controlplane-xyz",
-			expectError:      false,
+			validNodes:  nil,
+			providerID:  "metal3://metal3/node-0/test-controlplane-xyz",
+			expectError: false,
 		}),
-		Entry("Should find duplicates if providerIDNew's common prefix metal3://<namespace>/<bmh>/  is a substring of multible validNodes providerIDs", testCaseDuplicateProviderIDsExist{
+		Entry("Should find duplicates if providerID's common prefix metal3://<namespace>/<bmh>/ is a substring of multiple validNodes providerIDs", testCaseDuplicateProviderIDsExist{
 			validNodes: map[string][]corev1.Node{
 				"metal3://metal3/node-0/test-controlplane-xyz": {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test1"}}},
 				"metal3://metal3/node-0/test-controlplane-123": {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test2"}}},
 			},
-			providerIDLegacy: "",
-			providerIDNew:    "metal3://metal3/node-0/test-controlplane-000",
-			expectError:      true,
-		}),
-		Entry("Should find duplicates if providerIDNew's common prefix metal3://<namespace>/<bmh>/  is a substring of validNodes providerID and providerIDLegacy is used", testCaseDuplicateProviderIDsExist{
-			validNodes: map[string][]corev1.Node{
-				"metal3://d668eb95-5df6-4c10-a01a-fc69f4299fc6": {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test1"}}},
-				"metal3://metal3/node-0/test-controlplane-123":  {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test2"}}},
-			},
-			providerIDLegacy: "metal3://d668eb95-5df6-4c10-a01a-fc69f4299fc6",
-			providerIDNew:    "metal3://metal3/node-0/test-controlplane-000",
-			expectError:      true,
-		}),
-		Entry("Should not find duplicates if there are overlapping names of validNodes providerID in the legacy format", testCaseDuplicateProviderIDsExist{
-			validNodes: map[string][]corev1.Node{
-				"metal3://d668eb95-5df6-4c10-a01a-fc69f4299fc6": {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test1"}}},
-				"metal3://d668eb95-5df6-4c10-a01a":              {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test2"}}},
-			},
-			providerIDLegacy: "metal3://d668eb95-5df6-4c10-a01a",
-			providerIDNew:    "metal3://metal3/node-0/test-controlplane-000",
-			expectError:      false,
+			providerID:  "metal3://metal3/node-0/test-controlplane-000",
+			expectError: true,
 		}),
 		Entry("Should find duplicates if there are overlapping names of validNodes providerID in the 'new' format without common prefix", testCaseDuplicateProviderIDsExist{
 			validNodes: map[string][]corev1.Node{
 				"metal3://worker-1":  {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test1"}}},
 				"metal3://worker-10": {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test2"}}},
 			},
-			providerIDLegacy: "",
-			providerIDNew:    "metal3://worker-1",
-			expectError:      true,
-		}),
-		Entry("Should find duplicates when providerIDNew is empty, validNodes length is more than 1 and legacy format is used", testCaseDuplicateProviderIDsExist{
-			validNodes: map[string][]corev1.Node{
-				"metal3://d668eb95-5df6-4c10-a01a-fc69f4299fc6": {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test1"}}},
-				"metal3://d668eb95-5df6-4c10-a01a":              {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test2"}}},
-			},
-			providerIDLegacy: "metal3://d668eb95-5df6-4c10-a01a",
-			providerIDNew:    "",
-			expectError:      true,
+			providerID:  "metal3://worker-1",
+			expectError: true,
 		}),
 		Entry("Should not find duplicates when providerIDNew is empty and validNodes length is 1", testCaseDuplicateProviderIDsExist{
 			validNodes: map[string][]corev1.Node{
-				"metal3://d668eb95-5df6-4c10-a01a": {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test1"}}},
+				"metal3://metal3/node-0/test-controlplane-xyz": {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test1"}}},
 			},
-			providerIDLegacy: "metal3://d668eb95-5df6-4c10-a01a",
-			providerIDNew:    "",
-			expectError:      false,
+			providerID:  "",
+			expectError: false,
 		}),
-		Entry("Should not find duplicates when providerIDNew and providerIDLegacy are empty and validNodes length is 1", testCaseDuplicateProviderIDsExist{
+		Entry("Should not find duplicates if validNodes contains a single node with a completely different providerID", testCaseDuplicateProviderIDsExist{
 			validNodes: map[string][]corev1.Node{
-				"metal3://d668eb95-5df6-4c10-a01a": {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test1"}}},
+				"metal3://metal3/other-bmh/other-m3m": {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test1"}}},
 			},
-			providerIDLegacy: "",
-			providerIDNew:    "",
-			expectError:      false,
+			providerID:  "metal3://metal3/node-0/test-controlplane-000",
+			expectError: false,
+		}),
+		Entry("Should not find duplicates if validNodes contains multiple nodes but only one shares the same BMH prefix", testCaseDuplicateProviderIDsExist{
+			validNodes: map[string][]corev1.Node{
+				"metal3://metal3/node-0/test-controlplane-xyz": {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test1"}}},
+				"metal3://metal3/other-bmh/other-m3m":          {corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test2"}}},
+			},
+			providerID:  "metal3://metal3/node-0/test-controlplane-000",
+			expectError: false,
 		}),
 	)
 })
@@ -4971,7 +4894,7 @@ func newBareMetalHost(name string,
 		}
 	}
 
-	uid := Bmhuid
+	uid := defaultBMHUID
 	if bmhUID != "" {
 		uid = types.UID(bmhUID)
 	}

--- a/baremetal/mocks/zz_generated.metal3machine_manager.go
+++ b/baremetal/mocks/zz_generated.metal3machine_manager.go
@@ -148,21 +148,6 @@ func (mr *MockMachineManagerInterfaceMockRecorder) GetMetal3Machine() *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetal3Machine", reflect.TypeOf((*MockMachineManagerInterface)(nil).GetMetal3Machine))
 }
 
-// GetProviderIDAndBMHID mocks base method.
-func (m *MockMachineManagerInterface) GetProviderIDAndBMHID() (string, *string) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProviderIDAndBMHID")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(*string)
-	return ret0, ret1
-}
-
-// GetProviderIDAndBMHID indicates an expected call of GetProviderIDAndBMHID.
-func (mr *MockMachineManagerInterfaceMockRecorder) GetProviderIDAndBMHID() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProviderIDAndBMHID", reflect.TypeOf((*MockMachineManagerInterface)(nil).GetProviderIDAndBMHID))
-}
-
 // HasAnnotation mocks base method.
 func (m *MockMachineManagerInterface) HasAnnotation() bool {
 	m.ctrl.T.Helper()

--- a/baremetal/utils.go
+++ b/baremetal/utils.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 	"time"
 
 	// comment for go-lint.
@@ -398,10 +397,6 @@ func getM3Machine(ctx context.Context, cl client.Client, mLog logr.Logger,
 		return nil, nil //nolint:nilnil
 	}
 	return tmpM3Machine, nil
-}
-
-func parseProviderID(providerID string) string {
-	return strings.TrimPrefix(providerID, ProviderIDPrefix)
 }
 
 func ConvertTypedLocalObjectReferenceToIPPoolReference(

--- a/baremetal/utils_test.go
+++ b/baremetal/utils_test.go
@@ -98,7 +98,6 @@ var _ = Describe("Metal3 manager utils", func() {
 			Namespace: namespaceName,
 		},
 		Spec: infrav1.Metal3MachineSpec{
-			ProviderID:            "abcdef",
 			AutomatedCleaningMode: "metadata",
 			Image: infrav1.Image{
 				URL:      "http://example.com/image.qcow2",
@@ -118,7 +117,6 @@ var _ = Describe("Metal3 manager utils", func() {
 			Namespace: namespaceName,
 		},
 		Spec: infrav1.Metal3MachineSpec{
-			ProviderID: "abcdefg",
 			Image: infrav1.Image{
 				URL:      "http://example.com/image.qcow2",
 				Checksum: ptr.To("abcd1234"),
@@ -689,9 +687,4 @@ var _ = Describe("Metal3 manager utils", func() {
 			ExpectEmpty: true,
 		}),
 	)
-
-	It("Parses the providerID properly", func() {
-		Expect(parseProviderID(ProviderIDPrefix + "abcd")).To(Equal("abcd"))
-		Expect(parseProviderID("foo://abcd")).To(Equal("foo://abcd"))
-	})
 })

--- a/controllers/metal3machine_controller_integration_test.go
+++ b/controllers/metal3machine_controller_integration_test.go
@@ -45,9 +45,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-var bmhuid = types.UID("63856098-4b80-11ec-81d3-0242ac130003")
+var defaultBMHUID = types.UID("63856098-4b80-11ec-81d3-0242ac130003")
 
-var providerID = fmt.Sprintf("%s%s", baremetal.ProviderIDPrefix, bmhuid)
+var providerID = fmt.Sprintf("%s%s/%s/%s", baremetal.ProviderIDPrefix, namespaceName, baremetalhostName, metal3machineName)
 
 var bootstrapDataSecretName = "testdatasecret"
 
@@ -205,7 +205,6 @@ var _ = Describe("Reconcile metal3machine", func() {
 		CheckBMState               bool
 		CheckBMProviderID          bool
 		CheckBMProviderIDUnchanged bool
-		CheckBMProviderIDNew       bool
 		CheckBootStrapReady        bool
 		CheckBMHostCleaned         bool
 		CheckBMHostProvisioned     bool
@@ -288,16 +287,10 @@ var _ = Describe("Reconcile metal3machine", func() {
 				Expect(ptr.Deref(testBMmachine.Status.Initialization.Provisioned, false)).To(BeTrue())
 			}
 			if tc.CheckBMProviderID {
+				Expect(testBMmachine.Spec.ProviderID).To(Equal(fmt.Sprintf("%s%s/%s/%s", baremetal.ProviderIDPrefix,
+					testBMHost.ObjectMeta.Namespace, testBMHost.ObjectMeta.Name, testBMmachine.ObjectMeta.Name)))
 				if tc.CheckBMProviderIDUnchanged {
 					Expect(testBMmachine.Spec.ProviderID).To(Equal(oldProviderID))
-				} else {
-					if tc.CheckBMProviderIDNew {
-						Expect(testBMmachine.Spec.ProviderID).To(Equal(fmt.Sprintf("%s%s/%s/%s", baremetal.ProviderIDPrefix,
-							testBMHost.ObjectMeta.Namespace, testBMHost.ObjectMeta.Name, testBMmachine.ObjectMeta.Name)))
-					} else {
-						Expect(testBMmachine.Spec.ProviderID).To(Equal(fmt.Sprintf("%s%s", baremetal.ProviderIDPrefix,
-							string(testBMHost.ObjectMeta.UID))))
-					}
 				}
 			}
 			if tc.CheckBootStrapReady {
@@ -627,7 +620,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 			},
 		),
 		//Given: Machine(with Bootstrap data), M3Machine (Annotation Given, no provider ID), BMH (provisioned)
-		//Expected: No Error, BMH.Spec.ProviderID is set properly based on the UID
+		//Expected: No Error, BMH.Spec.ProviderID is set properly based on "metal3://<namespace>/<bmh-name>/<m3m-name>".
 		Entry("Should set ProviderID when bootstrap data is available, ProviderID is not given, BMH is provisioned",
 			TestCaseReconcile{
 				Objects: []client.Object{
@@ -656,13 +649,12 @@ var _ = Describe("Reconcile metal3machine", func() {
 						Spec: corev1.NodeSpec{},
 					},
 				},
-				ErrorExpected:        false,
-				RequeueExpected:      false,
-				ClusterInfraReady:    true,
-				CheckBMFinalizer:     true,
-				CheckBMProviderID:    true,
-				CheckBMProviderIDNew: true,
-				CheckBootStrapReady:  true,
+				ErrorExpected:       false,
+				RequeueExpected:     false,
+				ClusterInfraReady:   true,
+				CheckBMFinalizer:    true,
+				CheckBMProviderID:   true,
+				CheckBootStrapReady: true,
 				ConditionsExpected: []metav1.Condition{
 					{
 						Type:   infrav1.AssociateBareMetalHostCondition,
@@ -702,19 +694,18 @@ var _ = Describe("Reconcile metal3machine", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "node-1",
 							Labels: map[string]string{
-								baremetal.ProviderLabelPrefix: string(bmhuid),
+								baremetal.ProviderLabelPrefix: string(defaultBMHUID),
 							},
 						},
 						Spec: corev1.NodeSpec{},
 					},
 				},
-				ErrorExpected:        false,
-				RequeueExpected:      false,
-				ClusterInfraReady:    true,
-				CheckBMFinalizer:     true,
-				CheckBMProviderID:    true,
-				CheckBMProviderIDNew: true,
-				CheckBootStrapReady:  true,
+				ErrorExpected:       false,
+				RequeueExpected:     false,
+				ClusterInfraReady:   true,
+				CheckBMFinalizer:    true,
+				CheckBMProviderID:   true,
+				CheckBootStrapReady: true,
 				ConditionsExpected: []metav1.Condition{
 					{
 						Type:   infrav1.AssociateBareMetalHostCondition,
@@ -733,7 +724,7 @@ var _ = Describe("Reconcile metal3machine", func() {
 		),
 		// Given: Machine(with Bootstrap data), M3Machine (Annotation Given, no provider ID), BMH (provisioning)
 		// Expected: No Error, Requeue expected
-		// BMH.Spec.ProviderID is not set based on the UID since BMH is in provisioning
+		// BMH.Spec.ProviderID is not set based on "metal3://<namespace>/<bmh-name>/<m3m-name>" since BMH is in provisioning
 		Entry("Should requeue when bootstrap data is available, ProviderID is not given, BMH is provisioning",
 			TestCaseReconcile{
 				Objects: []client.Object{
@@ -899,19 +890,18 @@ var _ = Describe("Reconcile metal3machine", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "node-0",
 							Labels: map[string]string{
-								baremetal.ProviderLabelPrefix: string(bmhuid),
+								baremetal.ProviderLabelPrefix: string(defaultBMHUID),
 							},
 						},
 						Spec: corev1.NodeSpec{},
 					},
 				},
-				ErrorExpected:        false,
-				RequeueExpected:      false,
-				ClusterInfraReady:    true,
-				CheckBMFinalizer:     true,
-				CheckBMProviderID:    true,
-				CheckBMProviderIDNew: true,
-				CheckBootStrapReady:  true,
+				ErrorExpected:       false,
+				RequeueExpected:     false,
+				ClusterInfraReady:   true,
+				CheckBMFinalizer:    true,
+				CheckBMProviderID:   true,
+				CheckBootStrapReady: true,
 			},
 		),
 		//Given: Deletion timestamp on M3Machine, No BMHost Given

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -72,7 +72,6 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		m.EXPECT().IsBootstrapReady().MaxTimes(0)
 		m.EXPECT().AssociateM3Metadata(context.TODO()).MaxTimes(0)
 		m.EXPECT().HasAnnotation().MaxTimes(0)
-		m.EXPECT().GetProviderIDAndBMHID().MaxTimes(0)
 		return m
 	}
 
@@ -86,7 +85,6 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 			"Waiting for bootstrap data to be ready before proceeding")
 		m.EXPECT().AssociateM3Metadata(context.TODO()).MaxTimes(0)
 		m.EXPECT().HasAnnotation().MaxTimes(0)
-		m.EXPECT().GetProviderIDAndBMHID().MaxTimes(0)
 		m.EXPECT().Update(context.TODO()).MaxTimes(0)
 		return m
 	}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -391,7 +391,7 @@ func newBareMetalHost(bmhName string, spec *bmov1alpha1.BareMetalHostSpec,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      bmhName,
 			Namespace: namespaceName,
-			UID:       bmhuid,
+			UID:       defaultBMHUID,
 		},
 		Spec:   *spec,
 		Status: *status,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -195,7 +195,7 @@ spec:
     apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Machine
     name: test1-controlplane-0
-  providerID: metal3://8e16d3b6-d48c-41e0-af0f-e43dbf5ec0cd
+  providerID: metal3://metal3/node-1/test1-controlplane-0
   version: v1.18.0
 status:
   addresses:
@@ -247,7 +247,7 @@ spec:
   image:
     checksum: http://172.22.0.1/images/bionic-server-cloudimg-amd64.img.sha256sum
     url: http://172.22.0.1/images/bionic-server-cloudimg-amd64.img
-  providerID: metal3://8e16d3b6-d48c-41e0-af0f-e43dbf5ec0cd
+  providerID: metal3://metal3/node-1/test1-controlplane-0
   # dataTemplate comes from CR 'dataTemplate' and is added by 'CAPM3'
   dataTemplate:
     name: test1-workers-template

--- a/test/e2e/node_reuse.go
+++ b/test/e2e/node_reuse.go
@@ -98,8 +98,8 @@ func NodeReuse(ctx context.Context, inputGetter func() NodeReuseInput) {
 		Condition:   framework.PhasePodCondition(corev1.PodRunning),
 	}, input.E2EConfig.GetIntervals(input.SpecName, "wait-all-pod-to-be-running-on-target-cluster")...)
 
-	By("Get the provisioned BMH names and UUIDs [node_reuse]")
-	kcpBmhBeforeUpgrade := getProvisionedBmhNamesUuids(ctx, input.Namespace, clusterClient)
+	By("Get the provisioned BMH names before upgrade [node_reuse]")
+	kcpBmhBeforeUpgrade := getProvisionedBmhNames(ctx, input.Namespace, clusterClient)
 
 	By("Download image [node_reuse]")
 	imageURL, imageChecksum := EnsureImage(toK8sVersion)
@@ -226,8 +226,8 @@ func NodeReuse(ctx context.Context, inputGetter func() NodeReuseInput) {
 	}, input.E2EConfig.GetIntervals(input.SpecName, "wait-all-pod-to-be-running-on-target-cluster")...)
 	Logf("The CP upgrade process has ended [node_reuse]")
 
-	By("Get the provisioned BMH names and UUIDs after upgrade [node_reuse]")
-	kcpBmhAfterUpgrade := getProvisionedBmhNamesUuids(ctx, input.Namespace, clusterClient)
+	By("Get the provisioned BMH names after upgrade [node_reuse]")
+	kcpBmhAfterUpgrade := getProvisionedBmhNames(ctx, input.Namespace, clusterClient)
 
 	By("Check difference between before and after upgrade mappings")
 	equal := reflect.DeepEqual(kcpBmhBeforeUpgrade, kcpBmhAfterUpgrade)
@@ -327,8 +327,8 @@ func NodeReuse(ctx context.Context, inputGetter func() NodeReuseInput) {
 		Condition:   framework.PhasePodCondition(corev1.PodRunning),
 	}, input.E2EConfig.GetIntervals(input.SpecName, "wait-all-pod-to-be-running-on-target-cluster")...)
 
-	By("Get the provisioned BMH names and UUIDs before starting upgrade in MachineDeployment [node_reuse]")
-	mdBmhBeforeUpgrade := getProvisionedBmhNamesUuids(ctx, input.Namespace, clusterClient)
+	By("Get the provisioned BMH names before starting upgrade in MachineDeployment [node_reuse]")
+	mdBmhBeforeUpgrade := getProvisionedBmhNames(ctx, input.Namespace, clusterClient)
 
 	By("List all available BMHs, remove nodeReuse label from them if any [node_reuse]")
 	bmhs := bmov1alpha1.BareMetalHostList{}
@@ -439,8 +439,8 @@ func NodeReuse(ctx context.Context, inputGetter func() NodeReuseInput) {
 	})
 	verifyMetal3MachineNodeReuseCondition(ctx, clusterClient, workerBmhkey, input.Namespace, input.E2EConfig.GetIntervals(input.SpecName, "wait-bmh-available-provisioning"))
 
-	By("Get provisioned BMH names and UUIDs after upgrade in MachineDeployment [node_reuse]")
-	mdBmhAfterUpgrade := getProvisionedBmhNamesUuids(ctx, input.Namespace, clusterClient)
+	By("Get provisioned BMH names after upgrade in MachineDeployment [node_reuse]")
+	mdBmhAfterUpgrade := getProvisionedBmhNames(ctx, input.Namespace, clusterClient)
 
 	By("Check difference between before and after upgrade mappings in MachineDeployment [node_reuse]")
 	equal = reflect.DeepEqual(mdBmhBeforeUpgrade, mdBmhAfterUpgrade)
@@ -480,17 +480,16 @@ func NodeReuse(ctx context.Context, inputGetter func() NodeReuseInput) {
 	By("NODE REUSE TESTS PASSED!")
 }
 
-func getProvisionedBmhNamesUuids(ctx context.Context, namespace string, clusterClient client.Client) []string {
+func getProvisionedBmhNames(ctx context.Context, namespace string, clusterClient client.Client) []string {
 	bmhs := bmov1alpha1.BareMetalHostList{}
-	var nameUUIDList []string
+	var nameList []string
 	Expect(clusterClient.List(ctx, &bmhs, client.InNamespace(namespace))).To(Succeed())
 	for _, item := range bmhs.Items {
 		if item.WasProvisioned() {
-			concat := "metal3/" + item.Name + "=metal3://" + (string)(item.UID)
-			nameUUIDList = append(nameUUIDList, concat)
+			nameList = append(nameList, item.Namespace+"/"+item.Name)
 		}
 	}
-	return nameUUIDList
+	return nameList
 }
 
 func updateNodeReuse(ctx context.Context, namespace string, nodeReuse bool, m3MachineTemplateName string, clusterClient client.Client) {

--- a/test/e2e/upgrade_clusterctl_test.go
+++ b/test/e2e/upgrade_clusterctl_test.go
@@ -346,8 +346,6 @@ func preInitFunc(clusterProxy framework.ClusterProxy, bmoRelease string, ironicR
 
 	// These exports bellow we need them after applying the management cluster template and before
 	// applying the workload. if exported before it will break creating the management because it uses v1beta1 templates and default IPs.
-	// override the provider id format
-	os.Setenv("PROVIDER_ID_FORMAT", "metal3://{{ ds.meta_data.uuid }}")
 	// override default IPs for the workload cluster
 	os.Setenv("CLUSTER_APIENDPOINT_HOST", "192.168.111.250")
 	os.Setenv("IPAM_EXTERNALV4_POOL_RANGE_START", "192.168.111.201")


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->
## Remove legacy ProviderID format support

### Summary

Removes all code and tests that supported the legacy `metal3://<BMH-UUID>` ProviderID format. The only supported format is now `metal3://<namespace>/<bmh-name>/<m3m-name>`.

### Changes

#### `baremetal/metal3machine_manager.go`

- Removed `GetProviderIDAndBMHID()` method from `MachineManagerInterface` and its implementation. This method existed to extract the BMH UUID from a legacy-format ProviderID and is no longer needed.
- Replaced `getPossibleProviderIDs(ctx)` (which returned both a legacy and a new format ProviderID) with `getProviderID()` (returns only the new format `metal3://<namespace>/<bmh-name>/<m3m-name>`).
- Updated `getNodeByProviderID`, `duplicateProviderIDsExist`, `SetProviderIDFromCloudProviderNode`, `NodeWithMatchingProviderIDExists`, and `SetProviderIDFromNodeLabel` to accept a single `providerID` string instead of separate `providerIDLegacy` and `providerIDNew` strings.
- Removed the legacy UID lookup (`getBmhUIDFromM3Machine`) from the ProviderID resolution path.
- Simplified duplicate-detection logic in `duplicateProviderIDsExist` by removing the legacy-format branch.

#### `baremetal/utils.go`

- Removed the `parseProviderID` helper (which stripped the `metal3://` prefix from a legacy ProviderID).

#### `baremetal/metal3machine_manager_test.go`

- Updated the `ProviderID` test variable from the legacy `metal3://<UUID>` format to the new `metal3://<namespace>/<bmh-name>/<m3m-name>` format.
- Renamed `Bmhuid` to `defaultBMHUID` to reflect that it is a test fixture value, not a ProviderID component.
- Removed the `TestGetProviderIDAndBMHID` test table (tests a deleted method).
- Updated `testCaseDuplicateProviderIDsExist` struct: replaced `providerIDLegacy`/`providerIDNew` fields with a single `providerID` field.
- Removed test entries that covered legacy-format duplicate detection scenarios.
- Added new test entries covering new-format-only duplicate detection scenarios.

#### `docs/architecture.md`

- Updated `providerID` fields in the `Machine` and `Metal3Machine` YAML examples from `metal3://8e16d3b6-d48c-41e0-af0f-e43dbf5ec0cd` to `metal3://metal3/node-1/test1-controlplane-0`.

#### `test/e2e/node_reuse.go`

- Renamed `getProvisionedBmhNamesUuids` to `getProvisionedBmhNames` and changed the mapping from `"<namespace>/<bmh-name>=metal3://<uid>"` to `"<namespace>/<bmh-name>"`, removing the UID-based string entirely.


<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
