### PR TITLE
🌱 Fix missmatch of CAPI version in test

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -30,7 +30,7 @@ require (
 	k8s.io/kubectl v0.35.4
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/cluster-api v1.13.1
-	sigs.k8s.io/cluster-api/test v1.13.0
+	sigs.k8s.io/cluster-api/test v1.13.1
 	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/kustomize/api v0.21.1
 	sigs.k8s.io/kustomize/kyaml v0.21.1

--- a/test/go.sum
+++ b/test/go.sum
@@ -541,8 +541,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUo
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/cluster-api v1.13.1 h1:5qksGznSU1fJOXIxsI4EayTqG1Q9S0qJNp3HdsVm1KU=
 sigs.k8s.io/cluster-api v1.13.1/go.mod h1:Hqq5yucu3OwPiAjNEh/O/zZX4dF63MD8Q6I0cwL/bUU=
-sigs.k8s.io/cluster-api/test v1.13.0 h1:1MWOFmL4YzJDIvd3mPqOIIm0T/RSw6O7Ugge94vhBws=
-sigs.k8s.io/cluster-api/test v1.13.0/go.mod h1:uN9BzpjtzUwDr9nClw95VldtT3L97ZsKiA/z5Dde3Rk=
+sigs.k8s.io/cluster-api/test v1.13.1 h1:NimY83SFiO24J3GhF2Fw+iUcKzRPUY2Ev0wRPbogl2k=
+sigs.k8s.io/cluster-api/test v1.13.1/go.mod h1:3FL7oJBT6ThT63TcbTigSNNXCXK/2CJ5b8ODbaVs3nk=
 sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=
 sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=


### PR DESCRIPTION
There was a miss match of CAPI version in gomod file. This needs to be aligned before doing the minor release. 