### PR TITLE
:bug: Return error on list API failure

### DIFF
--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -906,6 +906,7 @@ func (m *DataManager) releaseAddressFromM3Pool(ctx context.Context, poolRef infr
 	ipClaimsList, err := m.fetchIPClaimsWithLabels(ctx, poolRef.Name)
 	if err != nil {
 		m.Log.Error(err, "Failed to fetch IPClaims with labels", LogFieldPoolRef, poolRef.Name, LogFieldMetal3Data, m.Data.Name)
+		return err
 	}
 	if len(ipClaimsList) > 0 {
 		for _, ipClaimWithLabels := range ipClaimsList {

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -1896,6 +1896,7 @@ var _ = Describe("Metal3Data manager", func() {
 		ipClaim         *ipamv1.IPClaim
 		expectError     bool
 		injectDeleteErr bool
+		injectListErr   bool
 	}
 
 	DescribeTable("Test releaseAddressFromM3Pool",
@@ -1907,6 +1908,7 @@ var _ = Describe("Metal3Data manager", func() {
 			fake := &releaseAddressFromPoolFakeClient{
 				Client:          fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build(),
 				injectDeleteErr: tc.injectDeleteErr,
+				injectListErr:   tc.injectListErr,
 			}
 			dataMgr, err := NewDataManager(fake, tc.m3d,
 				logr.Discard(),
@@ -1928,7 +1930,11 @@ var _ = Describe("Metal3Data manager", func() {
 				}
 
 				err = dataMgr.client.Get(context.TODO(), claimNamespacedName, capm3IPClaim)
-				if tc.injectDeleteErr {
+				if tc.injectListErr {
+					// List failed early, claim must be untouched (still exists with finalizer)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(capm3IPClaim.Finalizers).To(ContainElement(infrav1.DataFinalizer))
+				} else if tc.injectDeleteErr {
 					// There was an error deleting the claim, so we expect it to still be there
 					Expect(err).ToNot(HaveOccurred())
 					// We expect the finalizer to be gone
@@ -1976,6 +1982,25 @@ var _ = Describe("Metal3Data manager", func() {
 			},
 			injectDeleteErr: true,
 			expectError:     true,
+		}),
+		Entry("List error is returned without proceeding to deletion", testCaseReleaseAddressFromM3Pool{
+			m3d: &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Metal3Data",
+					APIVersion: infrav1.GroupVersion.String(),
+				},
+			},
+			poolRef: infrav1.IPPoolReference{Name: testPoolName},
+			ipClaim: &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       metal3DataName + "-" + testPoolName,
+					Namespace:  namespaceName,
+					Finalizers: []string{infrav1.DataFinalizer},
+				},
+			},
+			injectListErr: true,
+			expectError:   true,
 		}),
 	)
 
@@ -4806,6 +4831,7 @@ var _ = Describe("Metal3Data manager", func() {
 type releaseAddressFromPoolFakeClient struct {
 	client.Client
 	injectDeleteErr bool
+	injectListErr   bool
 }
 
 func (f *releaseAddressFromPoolFakeClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
@@ -4813,6 +4839,13 @@ func (f *releaseAddressFromPoolFakeClient) Delete(ctx context.Context, obj clien
 		return errors.New("failed to delete for some weird reason")
 	}
 	return f.Client.Delete(ctx, obj, opts...)
+}
+
+func (f *releaseAddressFromPoolFakeClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if f.injectListErr {
+		return errors.New("failed to list for some weird reason")
+	}
+	return f.Client.List(ctx, list, opts...)
 }
 
 var _ = Describe("poolRefs map", func() {


### PR DESCRIPTION
If the client list API call fails, fetchIPClaimsWithLabels now returns the error to the caller instead of continuing. This ensures the reconcile loop retries rather than proceeding on an error.

Previously, if the list call failed the function continued execution with no data, which could cause cleanup steps to be skipped.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

Make sure clean up is run correctly.