### PR TITLE
:seedling: Do not delete bootstrap user-data secrets

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -672,21 +672,6 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 
 		host.Spec.ConsumerRef = nil
 
-		// Delete created secret, if data was set without DataSecretName
-		if m.Machine.Spec.Bootstrap.DataSecretName == nil {
-			m.Log.Info("Deleting User data secret for machine")
-			if m.Metal3Machine.Status.UserData != nil {
-				err = deleteSecret(ctx, m.client, m.Metal3Machine.Status.UserData.Name,
-					m.Metal3Machine.Namespace,
-				)
-				if err != nil {
-					return err
-				}
-			}
-		}
-
-		host.Spec.ConsumerRef = nil
-
 		// Remove the ownerreference to this machine.
 		host.OwnerReferences, err = m.DeleteOwnerRef(host.OwnerReferences)
 		if err != nil {

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -1924,7 +1924,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Secret:              newSecret(),
-			ExpectSecretDeleted: true,
+			ExpectSecretDeleted: false,
 		}),
 		Entry("Deprovisioning in progress", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(),
@@ -1960,7 +1960,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					m3mObjectMetaWithValidAnnotations(),
 				),
 				Secret:              newSecret(),
-				ExpectSecretDeleted: true,
+				ExpectSecretDeleted: false,
 			},
 		),
 		Entry("Consumer ref should be removed from unmanaged host",
@@ -1973,7 +1973,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					m3mObjectMetaWithValidAnnotations(),
 				),
 				Secret:              newSecret(),
-				ExpectSecretDeleted: true,
+				ExpectSecretDeleted: false,
 			},
 		),
 		Entry("Consumer ref should be removed, BMH state is available", testCaseDelete{
@@ -1985,7 +1985,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Secret:              newSecret(),
-			ExpectSecretDeleted: true,
+			ExpectSecretDeleted: false,
 		}),
 		Entry("Consumer ref should be removed", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(), bmov1alpha1.StateReady,
@@ -1996,7 +1996,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			Secret:              newSecret(),
-			ExpectSecretDeleted: true,
+			ExpectSecretDeleted: false,
 		}),
 		Entry("Consumer ref should be removed, secret not deleted", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName, bmhSpecNoImg(), bmov1alpha1.StateReady,

--- a/baremetal/utils.go
+++ b/baremetal/utils.go
@@ -252,29 +252,6 @@ func checkSecretExists(ctx context.Context, cl client.Client, name string,
 	return tmpBootstrapSecret, err
 }
 
-func deleteSecret(ctx context.Context, cl client.Client, name string,
-	namespace string,
-) error {
-	tmpBootstrapSecret, err := checkSecretExists(ctx, cl, name, namespace)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return err
-	} else if err == nil {
-		// unset the finalizers (remove all since we do not expect anything else
-		// to control that object).
-		tmpBootstrapSecret.Finalizers = []string{}
-		err = updateObject(ctx, cl, &tmpBootstrapSecret)
-		if err != nil {
-			return err
-		}
-		// Delete the secret with metadata.
-		err = cl.Delete(ctx, &tmpBootstrapSecret)
-		if err != nil && !apierrors.IsNotFound(err) {
-			return err
-		}
-	}
-	return nil
-}
-
 // fetchM3DataTemplate returns the Metal3DataTemplate object.
 func fetchM3DataTemplate(ctx context.Context,
 	templateRef *infrav1.Metal3ObjectRef, cl client.Client, mLog logr.Logger,

--- a/baremetal/utils_test.go
+++ b/baremetal/utils_test.go
@@ -403,36 +403,6 @@ var _ = Describe("Metal3 manager utils", func() {
 		Entry("Object exists", true),
 	)
 
-	DescribeTable("Test deleteSecret",
-		func(secretExists bool) {
-			if secretExists {
-				err := k8sClient.Create(context.TODO(), &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:       "abc",
-						Namespace:  namespaceName,
-						Finalizers: []string{"foo.bar/foo"},
-					},
-				})
-				Expect(err).NotTo(HaveOccurred())
-			}
-
-			err := deleteSecret(context.TODO(), k8sClient, "abc", namespaceName)
-			Expect(err).NotTo(HaveOccurred())
-			savedSecret := corev1.Secret{}
-			err = k8sClient.Get(context.TODO(),
-				client.ObjectKey{
-					Name:      "abc",
-					Namespace: namespaceName,
-				},
-				&savedSecret,
-			)
-			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsNotFound(err)).To(BeTrue())
-		},
-		Entry("Object does not exist", false),
-		Entry("Object exists", true),
-	)
-
 	type testCaseFetchM3DataTemplate struct {
 		DataTemplate  *infrav1.Metal3DataTemplate
 		ClusterName   string


### PR DESCRIPTION
Do not remove secrets created by the bootstrap provider (KubeadmConfig). Rely on OwnerReferences and Kubernetes garbage collection to clean up.

Eliminate code and unit test for no longer used `deleteSecret()`.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

We should not delete an object which is not created by capm3.
