### PR TITLE
🌱 Fix capm3, capi and ipam versions for main branch

### DIFF
--- a/clusterctl-settings.json
+++ b/clusterctl-settings.json
@@ -2,6 +2,6 @@
   "name": "infrastructure-metal3",
   "config": {
     "componentsFile": "infrastructure-components.yaml",
-    "nextVersion": "v1.13.99"
+    "nextVersion": "v1.14.99"
   }
 }

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -18,13 +18,9 @@ if [[ "${CAPM3RELEASEBRANCH}" == release-* ]]; then
     export IPAMRELEASE="v${CAPM3_RELEASE_PREFIX}.99"
     export CAPI_RELEASE_PREFIX="v${CAPM3_RELEASE_PREFIX}."
 else
-    export CAPM3RELEASE="v1.13.99"
-    export IPAMRELEASE="v1.13.99"
-    # Commenting this out as CAPI release prefix and exporting CAPIRELEASE
-    # during pre-release phase of CAPI.
-    # We will change when minor is released.
-    # export CAPI_RELEASE_PREFIX="v1.12."
-    export CAPIRELEASE="v1.13.0-rc.1"
+    export CAPM3RELEASE="v1.14.99"
+    export IPAMRELEASE="v1.14.99"
+    export CAPI_RELEASE_PREFIX="v1.13."
 fi
 
 # Default CAPI_CONFIG_FOLDER to $HOME/.config folder if XDG_CONFIG_HOME not set


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

Fixes the CAPM3, CAPI, and IPAM versions. Updated the CAPM3 and IPAM versions to 14.99, which points to local resources, and updated the CAPI version to the latest stable 1.13 release instead of the RC version.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
