### PR TITLE
:seedling: Fix ownerRef chain for IPAddress in e2e tests

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -698,13 +698,41 @@ func MachineToIPAddress(ctx context.Context, cli client.Client, m *clusterv1.Mac
 		for _, owner := range m3d.OwnerReferences {
 			if owner.Name == m3Machine.Name {
 				m3Data = &m3DataList.Items[i]
+				break
 			}
+		}
+		if m3Data.Name != "" {
+			break
 		}
 	}
 	if m3Data.Name == "" {
 		return "", errors.New("couldn't find a matching Metal3Data object")
 	}
 
+	// Metal3Data owns IPClaim, and IPClaim owns IPAddress.
+	// Find the IPClaim owned by the Metal3Data for the target pool.
+	ipClaims := &ipamv1.IPClaimList{}
+	err = cli.List(ctx, ipClaims)
+	if err != nil {
+		return "", fmt.Errorf("couldn't list IPClaim objects: %w", err)
+	}
+	var ipClaim *ipamv1.IPClaim
+	for i, claim := range ipClaims.Items {
+		for _, owner := range claim.OwnerReferences {
+			if owner.Name == m3Data.Name && claim.Spec.Pool.Name == ippool.Name {
+				ipClaim = &ipClaims.Items[i]
+				break
+			}
+		}
+		if ipClaim != nil {
+			break
+		}
+	}
+	if ipClaim == nil {
+		return "", errors.New("couldn't find a matching IPClaim object")
+	}
+
+	// Find the IPAddress owned by the IPClaim.
 	IPAddresses := &ipamv1.IPAddressList{}
 	IPAddress := &ipamv1.IPAddress{}
 	err = cli.List(ctx, IPAddresses)
@@ -713,58 +741,13 @@ func MachineToIPAddress(ctx context.Context, cli client.Client, m *clusterv1.Mac
 	}
 	for i, ip := range IPAddresses.Items {
 		for _, owner := range ip.OwnerReferences {
-			if owner.Name == m3Data.Name && ip.Spec.Pool.Name == ippool.Name {
+			if owner.Name == ipClaim.Name {
 				IPAddress = &IPAddresses.Items[i]
+				break
 			}
 		}
-	}
-	if IPAddress.Name == "" {
-		return "", errors.New("couldn't find a matching IPAddress object")
-	}
-
-	return string(IPAddress.Spec.Address), nil
-}
-
-// MachineTiIPAddress gets IPAddress based on machine, from machine -> m3machine -> m3data -> IPAddress.
-// This is a duplicate of MachineToIPAddress, but for v1beta1 API. Remove this function when we switch to CAPI v1beta2 API only.
-func MachineToIPAddress1beta1(ctx context.Context, cli client.Client, m *clusterv1.Machine, ippool ipamv1.IPPool) (string, error) {
-	m3Machine := &infrav1.Metal3Machine{}
-	err := cli.Get(ctx, types.NamespacedName{
-		Namespace: m.Namespace,
-		Name:      m.Spec.InfrastructureRef.Name},
-		m3Machine)
-
-	if err != nil {
-		return "", fmt.Errorf("couldn't get a Metal3Machine within namespace %s with name %s : %w", m.Namespace, m.Spec.InfrastructureRef.Name, err)
-	}
-	m3DataList := &infrav1.Metal3DataList{}
-	m3Data := &infrav1.Metal3Data{}
-	err = cli.List(ctx, m3DataList)
-	if err != nil {
-		return "", fmt.Errorf("coudln't list Metal3Data objects: %w", err)
-	}
-	for i, m3d := range m3DataList.Items {
-		for _, owner := range m3d.OwnerReferences {
-			if owner.Name == m3Machine.Name {
-				m3Data = &m3DataList.Items[i]
-			}
-		}
-	}
-	if m3Data.Name == "" {
-		return "", errors.New("couldn't find a matching Metal3Data object")
-	}
-
-	IPAddresses := &ipamv1.IPAddressList{}
-	IPAddress := &ipamv1.IPAddress{}
-	err = cli.List(ctx, IPAddresses)
-	if err != nil {
-		return "", fmt.Errorf("couldn't list IPAddress objects: %w", err)
-	}
-	for i, ip := range IPAddresses.Items {
-		for _, owner := range ip.OwnerReferences {
-			if owner.Name == m3Data.Name && ip.Spec.Pool.Name == ippool.Name {
-				IPAddress = &IPAddresses.Items[i]
-			}
+		if IPAddress.Name != "" {
+			break
 		}
 	}
 	if IPAddress.Name == "" {

--- a/test/e2e/healthcheck.go
+++ b/test/e2e/healthcheck.go
@@ -52,7 +52,7 @@ func healthcheck(ctx context.Context, inputGetter func() HealthCheckInput) {
 	workerMachineName, err := Metal3MachineToMachineName(workerM3Machines[0])
 	Expect(err).ToNot(HaveOccurred())
 	workerMachine := GetMachine(ctx, bootstrapClusterClient, client.ObjectKey{Name: workerMachineName, Namespace: namespace})
-	workerIP, err := MachineToIPAddress1beta1(ctx, bootstrapClusterClient, &workerMachine, baremetalv4Pool[0])
+	workerIP, err := MachineToIPAddress(ctx, bootstrapClusterClient, &workerMachine, baremetalv4Pool[0])
 	Expect(err).ToNot(HaveOccurred())
 
 	Logf("Stopping kubelet on worker machine")
@@ -77,7 +77,7 @@ func healthcheck(ctx context.Context, inputGetter func() HealthCheckInput) {
 	controlplaneMachineName, err := Metal3MachineToMachineName(controlplaneM3Machines[0])
 	Expect(err).ToNot(HaveOccurred())
 	controlplaneMachine := GetMachine(ctx, bootstrapClusterClient, client.ObjectKey{Name: controlplaneMachineName, Namespace: namespace})
-	controlplaneIP, err := MachineToIPAddress1beta1(ctx, bootstrapClusterClient, &controlplaneMachine, baremetalv4Pool[0])
+	controlplaneIP, err := MachineToIPAddress(ctx, bootstrapClusterClient, &controlplaneMachine, baremetalv4Pool[0])
 	Expect(err).ToNot(HaveOccurred())
 
 	Logf("Stopping kubelet on controlplane machine")
@@ -218,6 +218,7 @@ func DeployMachineHealthCheck(ctx context.Context, cli client.Client, namespace,
 func WaitForHealthCheckCurrentHealthyToMatch(ctx context.Context, cli client.Client, number int32, healthcheck *clusterv1.MachineHealthCheck, timeout, frequency time.Duration) {
 	Eventually(func(g Gomega) int32 {
 		g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(healthcheck), healthcheck)).To(Succeed())
+		g.Expect(healthcheck.Status.CurrentHealthy).NotTo(BeNil())
 		return *healthcheck.Status.CurrentHealthy
 	}, timeout, frequency).Should(Equal(number))
 }


### PR DESCRIPTION
OwnerRef chain was changed and Metal3Data is no longer in ownerRef of IPAddress. This is fixing that by getting Metal3Data from IPClaim.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

Cherry pick of https://github.com/metal3-io/cluster-api-provider-metal3/pull/3312 

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
