### PR TITLE
🐛 Prevent CAPM3 stealing BMHs from other consumers 

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -205,7 +204,7 @@ func (m *MachineManager) IsBaremetalHostProvisioned(ctx context.Context) bool {
 	m.Log.V(VerbosityLevelDebug).Info("Checking if BareMetalHost is provisioned",
 		LogFieldMetal3Machine, m.Metal3Machine.Name,
 		LogFieldNamespace, m.Metal3Machine.Namespace)
-	host, _, err := m.getHost(ctx)
+	host, err := getHost(ctx, m.Metal3Machine, m.client, m.Log)
 	if err != nil {
 		m.Log.V(VerbosityLevelDebug).Info("Failed to get BareMetalHost",
 			LogFieldMetal3Machine, m.Metal3Machine.Name,
@@ -449,7 +448,7 @@ func (m *MachineManager) Associate(ctx context.Context) (string, error) {
 	}
 
 	// look for associated BMH
-	host, helper, err := m.getHost(ctx)
+	host, err := getHost(ctx, m.Metal3Machine, m.client, m.Log)
 	if err != nil {
 		return "", err
 	}
@@ -457,7 +456,7 @@ func (m *MachineManager) Associate(ctx context.Context) (string, error) {
 	// no BMH found, trying to choose from available ones
 	chosenHostReason := infrav1.AssociateBareMetalHostSuccessReason
 	if host == nil {
-		host, helper, chosenHostReason, err = m.chooseHost(ctx)
+		host, chosenHostReason, err = m.chooseHost(ctx)
 		if err != nil {
 			return "", err
 		}
@@ -485,6 +484,8 @@ func (m *MachineManager) Associate(ctx context.Context) (string, error) {
 		return "", err
 	}
 
+	hostBefore := host.DeepCopy()
+
 	m.setHostLabel(ctx, host)
 
 	err = m.setHostConsumerRef(ctx, host)
@@ -500,15 +501,15 @@ func (m *MachineManager) Associate(ctx context.Context) (string, error) {
 		}
 	}
 
-	err = helper.Patch(ctx, host)
-	if err != nil {
-		var aggr kerrors.Aggregate
-		if ok := errors.As(err, &aggr); ok {
-			if slices.ContainsFunc(aggr.Errors(), apierrors.IsConflict) {
-				return "", WithTransientError(nil, requeueAfter)
+	if !equality.Semantic.DeepEqual(hostBefore.ObjectMeta, host.ObjectMeta) ||
+		!equality.Semantic.DeepEqual(hostBefore.Spec, host.Spec) {
+		err = m.client.Update(ctx, host)
+		if err != nil {
+			if apierrors.IsConflict(err) {
+				return "", WithTransientError(fmt.Errorf("conflict updating BareMetalHost %s: %w", host.Name, err), requeueAfter)
 			}
+			return "", err
 		}
-		return "", err
 	}
 
 	err = m.setBMCSecretLabel(ctx, host)
@@ -566,7 +567,7 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 		Capm3FastTrack = "false"
 		m.Log.Info("Capm3FastTrack is not set, setting it to default value false")
 	}
-	host, helper, err := m.getHost(ctx)
+	host, err := getHost(ctx, m.Metal3Machine, m.client, m.Log)
 	if err != nil {
 		return err
 	}
@@ -658,9 +659,15 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 		}
 
 		if bmhUpdated {
-			// Update the BMH object, if the errors are NotFound, do not return the
-			// errors.
-			if err = patchIfFound(ctx, helper, host); err != nil {
+			// Update the BMH object. Use Update() for optimistic locking.
+			err = m.client.Update(ctx, host)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				if apierrors.IsConflict(err) {
+					return WithTransientError(fmt.Errorf("conflict updating BareMetalHost %s: %w", host.Name, err), requeueAfter)
+				}
 				return err
 			}
 
@@ -771,9 +778,15 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 			delete(host.Annotations, bmov1alpha1.PausedAnnotation)
 		}
 
-		// Update the BMH object, if the errors are NotFound, do not return the
-		// errors.
-		if err := patchIfFound(ctx, helper, host); err != nil {
+		// Update the BMH object. Use Update() for optimistic locking.
+		err = m.client.Update(ctx, host)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			if apierrors.IsConflict(err) {
+				return WithTransientError(fmt.Errorf("conflict updating BareMetalHost %s: %w", host.Name, err), requeueAfter)
+			}
 			return err
 		}
 	}
@@ -786,7 +799,7 @@ func (m *MachineManager) Update(ctx context.Context) error {
 	m.Log.V(VerbosityLevelTrace).Info("Updating Metal3Machine",
 		LogFieldMetal3Machine, m.Metal3Machine.Name)
 
-	host, helper, err := m.getHost(ctx)
+	host, err := getHost(ctx, m.Metal3Machine, m.client, m.Log)
 	if err != nil {
 		return err
 	}
@@ -802,6 +815,8 @@ func (m *MachineManager) Update(ctx context.Context) error {
 		return err
 	}
 
+	hostBefore := host.DeepCopy()
+
 	// ensure that the BMH specs are correctly set.
 	err = m.setHostConsumerRef(ctx, host)
 	if err != nil {
@@ -814,9 +829,15 @@ func (m *MachineManager) Update(ctx context.Context) error {
 		return err
 	}
 
-	err = helper.Patch(ctx, host)
-	if err != nil {
-		return err
+	if !equality.Semantic.DeepEqual(hostBefore.ObjectMeta, host.ObjectMeta) ||
+		!equality.Semantic.DeepEqual(hostBefore.Spec, host.Spec) {
+		err = m.client.Update(ctx, host)
+		if err != nil {
+			if apierrors.IsConflict(err) {
+				return WithTransientError(fmt.Errorf("conflict updating BareMetalHost %s: %w", host.Name, err), requeueAfter)
+			}
+			return err
+		}
 	}
 
 	err = m.ensureAnnotation(ctx, host)
@@ -837,7 +858,7 @@ func (m *MachineManager) Update(ctx context.Context) error {
 func (m *MachineManager) exists(ctx context.Context) (bool, error) {
 	m.Log.V(VerbosityLevelTrace).Info("Checking if BareMetalHost exists for Metal3Machine",
 		LogFieldMetal3Machine, m.Metal3Machine.Name)
-	host, _, err := m.getHost(ctx)
+	host, err := getHost(ctx, m.Metal3Machine, m.client, m.Log)
 	if err != nil {
 		return false, err
 	}
@@ -917,18 +938,17 @@ func getHost(ctx context.Context, m3Machine *infrav1.Metal3Machine, cl client.Cl
 //
 // Returns:
 //   - *bmov1alpha1.BareMetalHost: the chosen host, or nil if none is available yet.
-//   - *patch.Helper: a patch helper for the chosen host.
 //   - string: a v1beta2 reason string indicating how the host was selected
 //     (e.g. AssociateBareMetalHostSuccessReason or
 //     AssociateBareMetalHostViaNodeReuseSuccessReason).
 //   - error: non-nil if a transient error occurred (e.g. a nodeReuse host is not
-//     yet ready) or if building the patch helper failed.
-func (m *MachineManager) chooseHost(ctx context.Context) (*bmov1alpha1.BareMetalHost, *patch.Helper, string, error) {
+//     yet ready).
+func (m *MachineManager) chooseHost(ctx context.Context) (*bmov1alpha1.BareMetalHost, string, error) {
 	m.Log.V(VerbosityLevelTrace).Info("Choosing BareMetalHost for Metal3Machine",
 		LogFieldMetal3Machine, m.Metal3Machine.Name)
 	labelSelector, err := hostLabelSelectorForMachine(m.Metal3Machine, m.Log)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, "", err
 	}
 
 	hosts := bmov1alpha1.BareMetalHostList{}
@@ -937,7 +957,7 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmov1alpha1.BareMetal
 		client.MatchingLabelsSelector{Selector: labelSelector},
 	)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, "", err
 	}
 	m.Log.V(VerbosityLevelDebug).Info("Found candidate BareMetalHosts",
 		LogFieldMetal3Machine, m.Metal3Machine.Name,
@@ -948,10 +968,8 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmov1alpha1.BareMetal
 
 	for i, host := range hosts.Items {
 		if host.Spec.ConsumerRef != nil && consumerRefMatches(host.Spec.ConsumerRef, m.Metal3Machine) {
-			var helper *patch.Helper
 			m.Log.Info("Found host with existing ConsumerRef", LogFieldHost, host.Name)
-			helper, err = patch.NewHelper(&hosts.Items[i], m.client)
-			return &hosts.Items[i], helper, infrav1.AssociateBareMetalHostSuccessReason, err
+			return &hosts.Items[i], infrav1.AssociateBareMetalHostSuccessReason, nil
 		}
 		if m.nodeReuseLabelExists(ctx, &host) {
 			if !m.nodeReuseLabelMatches(ctx, &host) {
@@ -1004,7 +1022,7 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmov1alpha1.BareMetal
 	m.Log.Info("Host count available with nodeReuseLabelName while choosing host for Metal3 machine", "hostcount", len(availableHostsWithNodeReuse))
 	m.Log.Info("Host count available while choosing host for Metal3 machine", "hostcount", len(availableHosts))
 	if len(availableHostsWithNodeReuse) == 0 && len(availableHosts) == 0 {
-		return nil, nil, "", nil
+		return nil, "", nil
 	}
 
 	// choose a host.
@@ -1029,7 +1047,7 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmov1alpha1.BareMetal
 				chosenHost, err = m.pickHost(hostsInAvailableStateWithNodeReuse)
 				if err != nil {
 					m.Log.Error(err, "Failed to choose host, not choosing host")
-					return nil, nil, "", err
+					return nil, "", err
 				}
 				if chosenHost != nil {
 					chooseHostReason = infrav1.AssociateBareMetalHostViaNodeReuseSuccessReason
@@ -1037,7 +1055,7 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmov1alpha1.BareMetal
 			} else if len(hostsInNotAvailableStateWithNodeReuse) != 0 {
 				errMessage := fmt.Sprint("Found BareMetalHost(s) with nodeReuseLabelName in not-available state, requeuing the BareMetalHost", "notAvailabeHostCount", len(hostsInNotAvailableStateWithNodeReuse), "hoststate", host.Status.Provisioning.State, "host", host.Name)
 				m.Log.Info(errMessage)
-				return nil, nil, "", WithTransientError(errors.New(errMessage), requeueAfter)
+				return nil, "", WithTransientError(errors.New(errMessage), requeueAfter)
 			}
 		}
 	} else {
@@ -1047,12 +1065,11 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmov1alpha1.BareMetal
 		chosenHost, err = m.pickHost(availableHosts)
 		if err != nil {
 			m.Log.Error(err, "Failed to choose host, not choosing host")
-			return nil, nil, "", err
+			return nil, "", err
 		}
 	}
 
-	helper, err := patch.NewHelper(chosenHost, m.client)
-	return chosenHost, helper, chooseHostReason, err
+	return chosenHost, chooseHostReason, err
 }
 
 // hostLabelSelectorForMachine builds a label selector from the Metal3Machine's host selector.

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -746,7 +746,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				)
 				Expect(err).NotTo(HaveOccurred())
 
-				result, _, _, err := machineMgr.chooseHost(context.TODO())
+				result, _, err := machineMgr.chooseHost(context.TODO())
 
 				if tc.ExpectedHostName == "" {
 					Expect(result).To(BeNil())

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -685,6 +685,19 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			},
 		}
+		hostWithDeletionTimestamp := bmov1alpha1.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "hostWithDeletionTimestamp",
+				Namespace:         namespaceName,
+				Finalizers:        []string{"test.finalizer"},
+				DeletionTimestamp: ptr.To(metav1.Now()),
+			},
+			Status: bmov1alpha1.BareMetalHostStatus{
+				Provisioning: bmov1alpha1.ProvisionStatus{
+					State: bmov1alpha1.StateAvailable,
+				},
+			},
+		}
 
 		m3mconfig, infrastructureRef := newConfig("", map[string]string{},
 			[]infrav1.HostSelectorRequirement{}, "",
@@ -724,6 +737,9 @@ var _ = Describe("Metal3Machine manager", func() {
 			Hosts            *bmov1alpha1.BareMetalHostList
 			M3Machine        *infrav1.Metal3Machine
 			ExpectedHostName string
+			ExpectedReason   string
+			ExpectError      bool
+			ExpectRequeue    bool
 		}
 
 		DescribeTable("Test ChooseHost",
@@ -746,16 +762,26 @@ var _ = Describe("Metal3Machine manager", func() {
 				)
 				Expect(err).NotTo(HaveOccurred())
 
-				result, _, err := machineMgr.chooseHost(context.TODO())
+				result, reason, err := machineMgr.chooseHost(context.TODO())
+				if tc.ExpectError {
+					Expect(err).To(HaveOccurred())
+					if tc.ExpectRequeue {
+						Expect(err).To(BeAssignableToTypeOf(ReconcileError{}))
+					}
+					Expect(result).To(BeNil())
+					Expect(reason).To(Equal(tc.ExpectedReason))
+					return
+				}
 
 				if tc.ExpectedHostName == "" {
+					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(BeNil())
+					Expect(reason).To(Equal(tc.ExpectedReason))
 					return
 				}
 				Expect(err).NotTo(HaveOccurred())
-				if tc.ExpectedHostName != "" {
-					Expect(result.Name).To(Equal(tc.ExpectedHostName))
-				}
+				Expect(result.Name).To(Equal(tc.ExpectedHostName))
+				Expect(reason).To(Equal(tc.ExpectedReason))
 			},
 			Entry("Pick hostWithNodeReuseLabelSetToCP, which has a matching nodeReuseLabelName", testCaseChooseHost{
 				Machine: &clusterv1.Machine{
@@ -781,8 +807,9 @@ var _ = Describe("Metal3Machine manager", func() {
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithOtherConsRef, *availableHost, hostWithNodeReuseLabelSetToCP}},
 				M3Machine:        m3mconfig,
 				ExpectedHostName: hostWithNodeReuseLabelSetToCP.Name,
+				ExpectedReason:   infrav1.AssociateBareMetalHostViaNodeReuseSuccessReason,
 			}),
-			Entry("Requeu hostWithNodeReuseLabelStateNone, which has a matching nodeReuseLabelName", testCaseChooseHost{
+			Entry("Requeue hostWithNodeReuseLabelStateNone, which has a matching nodeReuseLabelName", testCaseChooseHost{
 				Machine: &clusterv1.Machine{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      machineName,
@@ -806,12 +833,16 @@ var _ = Describe("Metal3Machine manager", func() {
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithOtherConsRef, *availableHost, hostWithNodeReuseLabelStateNone}},
 				M3Machine:        m3mconfig,
 				ExpectedHostName: "",
+				ExpectedReason:   "",
+				ExpectError:      true,
+				ExpectRequeue:    true,
 			}),
 			Entry("Pick availableHost which lacks ConsumerRef", testCaseChooseHost{
 				Machine:          newMachine(machineName, infrastructureRef),
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithOtherConsRef, *availableHost}},
 				M3Machine:        m3mconfig,
 				ExpectedHostName: availableHost.Name,
+				ExpectedReason:   infrav1.AssociateBareMetalHostSuccessReason,
 			}),
 			Entry("Ignore discoveredHost and pick availableHost, which lacks a ConsumerRef",
 				testCaseChooseHost{
@@ -819,6 +850,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{discoveredHost, hostWithOtherConsRef, *availableHost}},
 					M3Machine:        m3mconfig,
 					ExpectedHostName: availableHost.Name,
+					ExpectedReason:   infrav1.AssociateBareMetalHostSuccessReason,
 				},
 			),
 			Entry("Ignore hostWithUnhealthyAnnotation and pick availableHost, which lacks a ConsumerRef",
@@ -827,6 +859,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithUnhealthyAnnotation, hostWithOtherConsRef, *availableHost}},
 					M3Machine:        m3mconfig,
 					ExpectedHostName: availableHost.Name,
+					ExpectedReason:   infrav1.AssociateBareMetalHostSuccessReason,
 				},
 			),
 			Entry("Ignore hostWithUnhealthyAnnotationDeprecated and pick availableHost, which lacks a ConsumerRef",
@@ -835,6 +868,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithUnhealthyAnnotationDeprecated, hostWithOtherConsRef, *availableHost}},
 					M3Machine:        m3mconfig,
 					ExpectedHostName: availableHost.Name,
+					ExpectedReason:   infrav1.AssociateBareMetalHostSuccessReason,
 				},
 			),
 			Entry("Ignore hostWithPausedAnnotation and pick availableHost, which lacks a ConsumerRef",
@@ -843,6 +877,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithPausedAnnotation, hostWithOtherConsRef, *availableHost}},
 					M3Machine:        m3mconfig,
 					ExpectedHostName: availableHost.Name,
+					ExpectedReason:   infrav1.AssociateBareMetalHostSuccessReason,
 				},
 			),
 			Entry("Pick hostWithConRef, which has a matching ConsumerRef", testCaseChooseHost{
@@ -850,6 +885,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithOtherConsRef, *availableHost, hostWithConRef}},
 				M3Machine:        newMetal3Machine(metal3machineName, nil, m3mSecretStatus(), nil),
 				ExpectedHostName: hostWithConRef.Name,
+				ExpectedReason:   infrav1.AssociateBareMetalHostSuccessReason,
 			}),
 
 			Entry("Two hosts already taken, third is in another namespace",
@@ -858,6 +894,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithOtherConsRef, hostWithConRef, hostInOtherNS}},
 					M3Machine:        m3mconfig,
 					ExpectedHostName: "",
+					ExpectedReason:   "",
 				}),
 
 			Entry("Choose hosts with a label, even without a label selector",
@@ -866,6 +903,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithLabel}},
 					M3Machine:        m3mconfig,
 					ExpectedHostName: hostWithLabel.Name,
+					ExpectedReason:   infrav1.AssociateBareMetalHostSuccessReason,
 				},
 			),
 			Entry("Choose hosts with a nodeReuseLabelName set to CP, even without a label selector",
@@ -893,6 +931,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithNodeReuseLabelSetToCP}},
 					M3Machine:        m3mconfig,
 					ExpectedHostName: hostWithNodeReuseLabelSetToCP.Name,
+					ExpectedReason:   infrav1.AssociateBareMetalHostViaNodeReuseSuccessReason,
 				},
 			),
 			Entry("Choose the host with the right label", testCaseChooseHost{
@@ -900,18 +939,21 @@ var _ = Describe("Metal3Machine manager", func() {
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithLabel, *availableHost}},
 				M3Machine:        m3mconfig2,
 				ExpectedHostName: hostWithLabel.Name,
+				ExpectedReason:   infrav1.AssociateBareMetalHostSuccessReason,
 			}),
 			Entry("No host that matches required label", testCaseChooseHost{
 				Machine:          newMachine(machineName, infrastructureRef3),
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*availableHost, hostWithLabel}},
 				M3Machine:        m3mconfig3,
 				ExpectedHostName: "",
+				ExpectedReason:   "",
 			}),
 			Entry("Host that matches a matchExpression", testCaseChooseHost{
 				Machine:          newMachine(machineName, infrastructureRef4),
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*availableHost, hostWithLabel}},
 				M3Machine:        m3mconfig4,
 				ExpectedHostName: hostWithLabel.Name,
+				ExpectedReason:   infrav1.AssociateBareMetalHostSuccessReason,
 			}),
 			Entry("No Host available that matches a matchExpression",
 				testCaseChooseHost{
@@ -919,6 +961,7 @@ var _ = Describe("Metal3Machine manager", func() {
 					Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*availableHost}},
 					M3Machine:        m3mconfig4,
 					ExpectedHostName: "",
+					ExpectedReason:   "",
 				},
 			),
 			Entry("No host chosen, invalid match expression", testCaseChooseHost{
@@ -926,18 +969,29 @@ var _ = Describe("Metal3Machine manager", func() {
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*availableHost, hostWithLabel, hostWithOtherConsRef}},
 				M3Machine:        m3mconfig5,
 				ExpectedHostName: "",
+				ExpectedReason:   "",
+				ExpectError:      true,
+			}),
+			Entry("Skip host with deletion timestamp and pick available host", testCaseChooseHost{
+				Machine:          newMachine(machineName, infrastructureRef),
+				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{hostWithDeletionTimestamp, *availableHost}},
+				M3Machine:        m3mconfig,
+				ExpectedHostName: availableHost.Name,
+				ExpectedReason:   infrav1.AssociateBareMetalHostSuccessReason,
 			}),
 			Entry("Choose a host in Failure Domain", testCaseChooseHost{
 				Machine:          newMachine(machineName, infrastructureRef6),
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*availableHost, hostWithLabel, hostWithOtherConsRef, hostWithFailureDomainLabel}},
 				M3Machine:        m3mconfig6,
 				ExpectedHostName: hostWithFailureDomainLabel.Name,
+				ExpectedReason:   infrav1.AssociateBareMetalHostSuccessReason,
 			}),
 			Entry("Choose available host, when hosts in FailureDomain not available", testCaseChooseHost{
 				Machine:          newMachine(machineName, infrastructureRef6),
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*availableHost, hostWithOtherConsRef, hostWithNodeReuseLabelSetToCP}},
 				M3Machine:        m3mconfig6,
 				ExpectedHostName: availableHost.Name,
+				ExpectedReason:   infrav1.AssociateBareMetalHostSuccessReason,
 			}),
 			Entry("Choose a host in Failure Domain, when NodeReuse is set", testCaseChooseHost{
 				Machine: &clusterv1.Machine{
@@ -963,6 +1017,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*availableHost, hostWithLabel, hostWithFailureDomainLabel, hostWithNodeReuseLabelSetToCPinFailureDomain}},
 				M3Machine:        m3mconfig6,
 				ExpectedHostName: hostWithNodeReuseLabelSetToCPinFailureDomain.Name,
+				ExpectedReason:   infrav1.AssociateBareMetalHostViaNodeReuseSuccessReason,
 			}),
 			Entry("Choose host is not in Failure Domain, when NodeReuse is set", testCaseChooseHost{
 				Machine: &clusterv1.Machine{
@@ -988,6 +1043,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*availableHost, hostWithLabel, hostWithFailureDomainLabel, hostWithNodeReuseLabelSetToCP}},
 				M3Machine:        m3mconfig6,
 				ExpectedHostName: hostWithNodeReuseLabelSetToCP.Name,
+				ExpectedReason:   infrav1.AssociateBareMetalHostViaNodeReuseSuccessReason,
 			}),
 		)
 	})


### PR DESCRIPTION
Patch() does not reject writes when the resourceVersion has changed, allowing CAPM3 to steal a BMH already claimed by another consumer.  Patch() applies on top of the whatever stored, if bmh already claimed by other machine, Patch overwrites that and claims that bmh. 

In this PR we have replaces Patch() with Update(). Update() checks resource version before applying the change, if resource version is changed, someone else claimed and updated it, api server returns Conflict error. 
On the next reconcile, machine will get another bmh. 

We also avoid calling update on every reconcile(https://github.com/metal3-io/cluster-api-provider-metal3/issues/79) by comparing the objectMeta and spec fields, if nothing has changes update is not be called. 


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes # https://github.com/metal3-io/cluster-api-provider-metal3/issues/3189

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
