### PR TITLE
:seedling: Use clusterfilter to make CAPM3 only cache Metal3 based caches

### DIFF
--- a/internal/clusterfilter/metal3_clusterfilter.go
+++ b/internal/clusterfilter/metal3_clusterfilter.go
@@ -1,0 +1,31 @@
+/*
+ Copyright 2026 The Kubernetes Authors.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package clusterfilter
+
+import (
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+)
+
+// IsMetal3Cluster returns true if the Cluster's InfrastructureRef points to a Metal3Cluster.
+func IsMetal3Cluster(cluster *clusterv1.Cluster) bool {
+	if cluster == nil {
+		return false
+	}
+
+	infra := cluster.Spec.InfrastructureRef
+
+	return infra.Kind == "Metal3Cluster" &&
+		infra.APIGroup == infrav1.GroupVersion.Group
+}

--- a/internal/clusterfilter/metal3_clusterfilter_test.go
+++ b/internal/clusterfilter/metal3_clusterfilter_test.go
@@ -1,0 +1,87 @@
+/*
+ Copyright 2026 The Kubernetes Authors.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package clusterfilter_test
+
+import (
+	"testing"
+
+	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta2"
+	"github.com/metal3-io/cluster-api-provider-metal3/internal/clusterfilter"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+)
+
+func TestIsMetal3Cluster(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *clusterv1.Cluster
+		want    bool
+	}{
+		{
+			name:    "nil cluster",
+			cluster: nil,
+			want:    false,
+		},
+		{
+			name: "metal3 infrastructure ref",
+			cluster: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					InfrastructureRef: clusterv1.ContractVersionedObjectReference{
+						Kind:     "Metal3Cluster",
+						APIGroup: infrav1.GroupVersion.Group,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "wrong api group",
+			cluster: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					InfrastructureRef: clusterv1.ContractVersionedObjectReference{
+						Kind:     "Metal3Cluster",
+						APIGroup: "infrastructure.example.io",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "wrong kind",
+			cluster: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					InfrastructureRef: clusterv1.ContractVersionedObjectReference{
+						Kind:     "OtherCluster",
+						APIGroup: infrav1.GroupVersion.Group,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "empty infrastructure ref",
+			cluster: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := clusterfilter.IsMetal3Cluster(tt.cluster); got != tt.want {
+				t.Fatalf("clusterfilter.IsMetal3Cluster() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
 	infraremote "github.com/metal3-io/cluster-api-provider-metal3/baremetal/remote"
 	"github.com/metal3-io/cluster-api-provider-metal3/controllers"
+	"github.com/metal3-io/cluster-api-provider-metal3/internal/clusterfilter"
 	webhooks "github.com/metal3-io/cluster-api-provider-metal3/internal/webhooks/v1beta2"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	"github.com/spf13/pflag"
@@ -465,7 +466,8 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	// requiring a connection to a remote cluster
 
 	clusterCache, err := clustercache.SetupWithManager(ctx, mgr, clustercache.Options{
-		SecretClient: secretCachingClient,
+		SecretClient:  secretCachingClient,
+		ClusterFilter: clusterfilter.IsMetal3Cluster,
 		Cache: clustercache.CacheOptions{
 			Indexes: []clustercache.CacheOptionsIndex{clustercache.NodeProviderIDIndex},
 		},


### PR DESCRIPTION


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**: 
Add a function to check cluster infrastructure to ensure it is a metal3 cluster.
Use it as a filter to make CAPM3 only cache/connect to Metal3 based cluster for security
Add a unit test

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes https://github.com/metal3-io/cluster-api-provider-metal3/issues/3212

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
