### PR TITLE
🌱 Update FKAS setup to address new CAPI requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ BMO_CONTROLLER_IMG ?= $(REGISTRY)/$(BMO_IMAGE_NAME)
 TEST_EXTENSION_IMG ?= $(REGISTRY)/test-extension:$(TAG)
 TAG ?= v1beta1
 BMO_TAG ?= capm3-$(TAG)
+FKAS_TAG ?= latest
 ARCH ?= $(shell go env GOARCH)
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 
@@ -610,7 +611,7 @@ docker-build-fkas:
 	cd /tmp/fake-apiserver && \
 	$(GO) mod edit -replace=github.com/metal3-io/cluster-api-provider-metal3=./capm3 && \
 	$(GO) mod tidy && \
-	$(CONTAINER_RUNTIME) build --build-arg ARCH=$(ARCH) -t "quay.io/metal3-io/metal3-fkas:latest" . || true
+	$(CONTAINER_RUNTIME) build --build-arg ARCH=$(ARCH) -t "quay.io/metal3-io/metal3-fkas:$(FKAS_TAG)" .
 	rm -rf /tmp/fake-apiserver
 
 .PHONY: docker-build-test-extension

--- a/Makefile
+++ b/Makefile
@@ -605,14 +605,9 @@ CONTAINER_RUNTIME := $(if $(CONTAINER_RUNTIME),$(CONTAINER_RUNTIME),docker)
 export CONTAINER_RUNTIME
 
 docker-build-fkas:
-	cp -r $(FAKE_APISERVER_DIR) /tmp && \
-	mkdir -p /tmp/fake-apiserver/capm3  && \
-	cp -r ./api /tmp/fake-apiserver/capm3 && \
-	cd /tmp/fake-apiserver && \
-	$(GO) mod edit -replace=github.com/metal3-io/cluster-api-provider-metal3=./capm3 && \
-	$(GO) mod tidy && \
-	$(CONTAINER_RUNTIME) build --build-arg ARCH=$(ARCH) -t "quay.io/metal3-io/metal3-fkas:$(FKAS_TAG)" .
-	rm -rf /tmp/fake-apiserver
+	$(CONTAINER_RUNTIME) build --build-arg ARCH=$(ARCH) \
+	-f $(FAKE_APISERVER_DIR)/Dockerfile \
+	-t "quay.io/metal3-io/metal3-fkas:$(FKAS_TAG)" .
 
 .PHONY: docker-build-test-extension
 docker-build-test-extension: ## Build the docker image for test extension

--- a/hack/fake-apiserver/Dockerfile
+++ b/hack/fake-apiserver/Dockerfile
@@ -17,17 +17,21 @@ ARG BUILD_IMAGE=docker.io/golang:1.25.11@sha256:dd7d32e19b28621cd982082397fc0510
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the fkas binary on golang image
+# Use a WORKDIR that mirrors the repo structure so that the replace
+# directive in go.mod resolves correctly to the repo root.
 FROM $BUILD_IMAGE AS base
-WORKDIR /workspace
+WORKDIR /workspace/hack/fake-apiserver
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
 ARG goproxy=https://proxy.golang.org
 ENV GOPROXY=$goproxy
 
 # Copy the Go Modules manifests
-COPY go.mod go.sum ./
+COPY hack/fake-apiserver/go.mod hack/fake-apiserver/go.sum ./
 
-COPY capm3 ./capm3
+# Copy the api module where the replace directive expects it (at ../../api/)
+COPY api/ /workspace/api/
+
 # Cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
@@ -36,7 +40,7 @@ RUN go mod download
 FROM base AS docker-build-fkas
 
 # Copy the sources
-COPY cmd/metal3-fkas/*.go ./
+COPY hack/fake-apiserver/cmd/metal3-fkas/*.go ./
 
 # Build
 ARG ARCH=amd64
@@ -48,7 +52,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
 FROM base AS docker-build-fkas-reconciler
 
 # Copy the sources
-COPY cmd/metal3-fkas-reconciler/*.go ./
+COPY hack/fake-apiserver/cmd/metal3-fkas-reconciler/*.go ./
 
 # Build
 ARG ARCH=amd64
@@ -60,7 +64,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
 FROM $BASE_IMAGE
 WORKDIR /
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies
-COPY --from=docker-build-fkas /workspace/fkas .
-COPY --from=docker-build-fkas-reconciler /workspace/reconciler .
+COPY --from=docker-build-fkas /workspace/hack/fake-apiserver/fkas .
+COPY --from=docker-build-fkas-reconciler /workspace/hack/fake-apiserver/reconciler .
 USER 65532
 ENTRYPOINT ["/fkas"]

--- a/hack/fake-apiserver/cmd/metal3-fkas/main.go
+++ b/hack/fake-apiserver/cmd/metal3-fkas/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"encoding/json"
+	"errors"
 	"math/rand/v2"
 	"net/http"
 	"os"
@@ -18,6 +19,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	rest "k8s.io/client-go/rest"
 	cmanager "sigs.k8s.io/cluster-api/test/infrastructure/inmemory/pkg/runtime/manager"
 	"sigs.k8s.io/cluster-api/test/infrastructure/inmemory/pkg/server"
@@ -38,8 +40,9 @@ var (
 	etcdInfoMap                 = make(map[string]etcdInfo)
 	podIP                       string
 	workloadListenerActivations = make(map[string]bool)
-	timeoutDuration             = 10 * time.Second
-	idleDuration                = 15 * time.Second
+	heartbeatInterval           = 10 * time.Second
+	serverTimeout               = 60 * time.Second
+	idleDuration                = 120 * time.Second
 )
 
 func init() {
@@ -335,6 +338,13 @@ func updateNode(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		workloadListenerActivations[resourceName] = true
+
+		// Create the etcd member BEFORE creating the node, so that KCP
+		// cannot observe the API server without a functioning etcd.
+		if err := setupEtcdMember(resourceName, clusterName, nodeName, requestData.Namespace, w); err != nil {
+			// Error already reported to the HTTP response by setupEtcdMember
+			return
+		}
 	}
 
 	if activated := workloadListenerActivations[resourceName]; !activated {
@@ -410,10 +420,10 @@ func updateNode(w http.ResponseWriter, r *http.Request) {
 	}
 	setupLog.Info("Created node object", "nodeName", nodeName)
 
-	// Start a goroutine to update the LastHeartbeatTime every 10 seconds
+	// Start a goroutine to update the LastHeartbeatTime periodically
 	go func(nodeName string) {
 		setupLog.Info("Starting heartbeat goroutine", "nodeName", nodeName)
-		ticker := time.NewTicker(timeoutDuration)
+		ticker := time.NewTicker(heartbeatInterval)
 		defer ticker.Stop()
 
 		for range ticker.C {
@@ -439,38 +449,73 @@ func updateNode(w http.ResponseWriter, r *http.Request) {
 		}
 	}(nodeName)
 
-	if !isControlPlane {
-		return
-	}
+	if isControlPlane {
+		// Create the kube-apiserver pod
+		if err := createControlPlanePod(ctx, c, "kube-apiserver", FakePod{
+			PodName:         "kube-apiserver-" + nodeName,
+			NodeName:        nodeName,
+			TransactionTime: metav1.Now(),
+		}); err != nil {
+			setupLog.Error(err, "failed to create kube-apiserver pod")
+			http.Error(w, "", http.StatusInternalServerError)
+			return
+		}
 
-	// create etcd member
-	// Wait for some time after the node is provisioned
-	waitForRandomSeconds()
+		// Create the kube-controller-manager
+		if err := createControlPlanePod(ctx, c, "kube-controller-manager", FakePod{
+			PodName:         "kube-controller-manager-" + nodeName,
+			NodeName:        nodeName,
+			TransactionTime: metav1.Now(),
+		}); err != nil {
+			setupLog.Error(err, "failed to create kube-controller-manager pod")
+			http.Error(w, "", http.StatusInternalServerError)
+			return
+		}
+
+		// Create the kube-scheduler
+		if err := createControlPlanePod(ctx, c, "kube-scheduler", FakePod{
+			PodName:         "kube-scheduler-" + nodeName,
+			NodeName:        nodeName,
+			TransactionTime: metav1.Now(),
+		}); err != nil {
+			setupLog.Error(err, "failed to create scheduler Pod")
+			http.Error(w, "", http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
+// setupEtcdMember creates the etcd pod and registers the etcd member for a control plane node.
+// This is called BEFORE the node is created to ensure that KCP never observes an API server
+// without a functioning etcd cluster (which would cause "no leader found" errors).
+func setupEtcdMember(resourceName, clusterName, nodeName, namespace string, w http.ResponseWriter) error {
+	c := cloudMgr.GetResourceGroup(resourceName).GetClient()
+
 	etcdSecretName := clusterName + "-etcd"
-	etcdCertRaw, etcdKeyRaw, err := getSecretKeyAndCert(ctx, bootstrapClient, requestData.Namespace, etcdSecretName)
+	etcdCertRaw, etcdKeyRaw, err := getSecretKeyAndCert(ctx, bootstrapClient, namespace, etcdSecretName)
 	if err != nil {
 		logLine := "Error adding node: " + nodeName
 		http.Error(w, logLine, http.StatusInternalServerError)
 		setupLog.Error(err, "Failed to get etcd secrets for cluster", "cluster name", resourceName)
-		return
+		return err
 	}
 
 	etcdCert, err := certs.DecodeCertPEM(etcdCertRaw)
 	if err != nil {
 		http.Error(w, "", http.StatusInternalServerError)
 		setupLog.Error(err, "failed to generate etcdCert")
-		return
+		return err
 	}
 	etcdKey, err := certs.DecodePrivateKeyPEM(etcdKeyRaw)
 	if err != nil {
 		http.Error(w, "", http.StatusInternalServerError)
 		setupLog.Error(err, "failed to generate etcdKey")
-		return
+		return err
 	}
 	if etcdKey == nil {
 		http.Error(w, "", http.StatusInternalServerError)
-		setupLog.Error(err, "failed to generate etcdKey")
-		return
+		setupLog.Error(nil, "etcd key is nil")
+		return errors.New("etcd key is nil")
 	}
 
 	// Create the etcd pod
@@ -491,14 +536,15 @@ func updateNode(w http.ResponseWriter, r *http.Request) {
 		if !apierrors.IsNotFound(err) {
 			setupLog.Error(err, "failed to get etcd pod")
 			http.Error(w, "", http.StatusInternalServerError)
-			return
+			return err
 		}
 
 		// Gets info about the current etcd cluster, if any.
-		var info etcdInfo
-		info, ok = etcdInfoMap[resourceName]
+		info, ok := etcdInfoMap[resourceName]
 		if !ok {
-			info = etcdInfo{}
+			info = etcdInfo{
+				members: sets.New[string](),
+			}
 			for {
 				info.clusterID = strconv.Itoa(int(rand.Uint32())) //nolint:gosec // weak random number generator is good enough here
 				if info.clusterID != "0" {
@@ -516,6 +562,9 @@ func updateNode(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		// Track the member
+		info.members.Insert(memberID)
+
 		// Annotate the pod with the info about the etcd cluster.
 		etcdPod.Annotations = map[string]string{
 			EtcdClusterIDAnnotationName: info.clusterID,
@@ -525,6 +574,7 @@ func updateNode(w http.ResponseWriter, r *http.Request) {
 		// If the etcd cluster is being created it doesn't have a leader yet, so set this member as a leader.
 		if info.leaderID == "" {
 			etcdPod.Annotations[EtcdLeaderFromAnnotationName] = time.Now().Format(time.RFC3339)
+			info.leaderID = memberID
 		}
 
 		etcdInfoMap[resourceName] = info
@@ -532,54 +582,25 @@ func updateNode(w http.ResponseWriter, r *http.Request) {
 		if err = c.Create(ctx, etcdPod); err != nil && !apierrors.IsAlreadyExists(err) {
 			setupLog.Error(err, "failed to create etcd pod")
 			http.Error(w, "Failed to create etcd pod", http.StatusInternalServerError)
-			return
+			return err
 		}
 	}
 
 	etcdPrivKey, ok := etcdKey.(*rsa.PrivateKey)
 	if !ok {
 		setupLog.Error(nil, "etcdKey is not *rsa.PrivateKey")
-		return
+		http.Error(w, "etcdKey is not *rsa.PrivateKey", http.StatusInternalServerError)
+		return errors.New("etcdKey is not *rsa.PrivateKey")
 	}
 	err = apiServerMux.AddEtcdMember(resourceName, nodeName, etcdCert, etcdPrivKey)
 	if err != nil {
 		setupLog.Error(err, "failed to add etcd member")
 		http.Error(w, "", http.StatusInternalServerError)
-		return
+		return err
 	}
 
-	// Create the kube-apiserver pod
-	if err := createControlPlanePod(ctx, c, "kube-apiserver", FakePod{
-		PodName:         "kube-apiserver-" + nodeName,
-		NodeName:        nodeName,
-		TransactionTime: metav1.Now(),
-	}); err != nil {
-		setupLog.Error(err, "failed to create kube-apiserver pod")
-		http.Error(w, "", http.StatusInternalServerError)
-		return
-	}
-
-	// Create the kube-controller-manager
-	if err := createControlPlanePod(ctx, c, "kube-controller-manager", FakePod{
-		PodName:         "kube-controller-manager-" + nodeName,
-		NodeName:        nodeName,
-		TransactionTime: metav1.Now(),
-	}); err != nil {
-		setupLog.Error(err, "failed to create kube-controller-manager pod")
-		http.Error(w, "", http.StatusInternalServerError)
-		return
-	}
-
-	// Create the kube-scheduler
-	if err := createControlPlanePod(ctx, c, "kube-scheduler", FakePod{
-		PodName:         "kube-scheduler-" + nodeName,
-		NodeName:        nodeName,
-		TransactionTime: metav1.Now(),
-	}); err != nil {
-		setupLog.Error(err, "failed to create scheduler Pod")
-		http.Error(w, "", http.StatusInternalServerError)
-		return
-	}
+	setupLog.Info("Successfully set up etcd member", "nodeName", nodeName, "resourceName", resourceName)
+	return nil
 }
 
 func main() {
@@ -622,8 +643,8 @@ func main() {
 	server := &http.Server{
 		Addr:         ":3333",
 		Handler:      nil,
-		ReadTimeout:  timeoutDuration,
-		WriteTimeout: timeoutDuration,
+		ReadTimeout:  serverTimeout,
+		WriteTimeout: serverTimeout,
 		IdleTimeout:  idleDuration,
 	}
 	if err := server.ListenAndServe(); err != nil {

--- a/hack/fake-apiserver/cmd/metal3-fkas/main.go
+++ b/hack/fake-apiserver/cmd/metal3-fkas/main.go
@@ -361,6 +361,17 @@ func updateNode(w http.ResponseWriter, r *http.Request) {
 		},
 		Spec: corev1.NodeSpec{
 			ProviderID: requestData.ProviderID,
+			Taints: func() []corev1.Taint {
+				if isControlPlane {
+					return []corev1.Taint{
+						{
+							Key:    "node-role.kubernetes.io/control-plane",
+							Effect: corev1.TaintEffectNoSchedule,
+						},
+					}
+				}
+				return nil
+			}(),
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{

--- a/hack/fake-apiserver/cmd/metal3-fkas/utils.go
+++ b/hack/fake-apiserver/cmd/metal3-fkas/utils.go
@@ -3,9 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"math/rand"
-	"strconv"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -165,16 +162,4 @@ func getSecretKeyAndCert(
 	}
 
 	return tlsCrt, tlsKey, nil
-}
-
-func waitForRandomSeconds() {
-	// Generate a random number of seconds between 1 and timeoutDuration
-	randomSeconds := rand.Intn(int(timeoutDuration.Seconds())) + 1 //nolint:gosec // weak random number generator is good enough here
-
-	setupLog.Info("Waiting for " + strconv.Itoa(randomSeconds) + " seconds...\n")
-
-	// Wait for the random number of seconds
-	time.Sleep(time.Duration(randomSeconds) * time.Second)
-
-	setupLog.Info("Done waiting!")
 }

--- a/hack/fake-apiserver/go.mod
+++ b/hack/fake-apiserver/go.mod
@@ -14,7 +14,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.23.3
 )
 
-replace github.com/metal3-io/cluster-api-provider-metal3 => ../..
+replace github.com/metal3-io/cluster-api-provider-metal3/api => ../../api
 
 require (
 	cel.dev/expr v0.25.1 // indirect
@@ -59,7 +59,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
-	github.com/onsi/gomega v1.39.1 // indirect
+	github.com/onsi/gomega v1.41.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect

--- a/hack/fake-apiserver/go.sum
+++ b/hack/fake-apiserver/go.sum
@@ -108,8 +108,6 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/metal3-io/baremetal-operator/apis v0.13.0 h1:jCqUMbv/qVNY+77fqD7N5nIoWJXHq4rZ5epFY/q4k4Q=
 github.com/metal3-io/baremetal-operator/apis v0.13.0/go.mod h1:BeqKSSGFuC3X36+CN8CIImtXvWwKSR7rJBDP5825Fno=
-github.com/metal3-io/cluster-api-provider-metal3/api v1.13.0 h1:+OzjA9IXeB346NLBVw6t3Xqk6M3tpDH7VQ1Nep6oeio=
-github.com/metal3-io/cluster-api-provider-metal3/api v1.13.0/go.mod h1:FPNj7LBez9qDSSPnP4bWHfnmZQ3DB8KRNo05l3DKUjQ=
 github.com/metal3-io/ip-address-manager/api v1.13.0 h1:Yi6XLJZdgd/+kZDEglxcNGsmE3Qcc6qboQ1mhQEh8WM=
 github.com/metal3-io/ip-address-manager/api v1.13.0/go.mod h1:pfhUOnMeD5m2WuKkr7UfRU+7PKqTJ2glQoC4walT40I=
 github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
@@ -126,8 +124,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.28.2 h1:DTrMfpqxiNUyQ3Y0zhn1n3cOO2euFgQPYIpkWwxVFps=
 github.com/onsi/ginkgo/v2 v2.28.2/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
-github.com/onsi/gomega v1.39.1 h1:1IJLAad4zjPn2PsnhH70V4DKRFlrCzGBNrNaru+Vf28=
-github.com/onsi/gomega v1.39.1/go.mod h1:hL6yVALoTOxeWudERyfppUcZXjMwIMLnuSfruD2lcfg=
+github.com/onsi/gomega v1.41.0 h1:OwKp4pXNgVxf6sCplzYo794OFNuoL2q2SBMU5NSWOjA=
+github.com/onsi/gomega v1.41.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -90,6 +90,8 @@ case "${GINKGO_FOCUS:-}" in
     sed -i "s/^export NUM_NODES=.*/export NUM_NODES=30/" "${M3_DEV_ENV_PATH}/config_${USER}.sh"
     echo 'CLUSTER_TOPOLOGY: true' >>"${CAPI_CONFIG_FOLDER}/clusterctl.yaml"
     echo 'export BOOTSTRAP_CLUSTER="minikube"' >>"${M3_DEV_ENV_PATH}/config_${USER}.sh"
+    # Build FKAS image from source so that the scalability test uses the latest code
+    FKAS_TAG=ci make docker-build-fkas
   ;;
 
   in-place-upgrade)
@@ -112,6 +114,15 @@ fi
 pushd "${M3_DEV_ENV_PATH}" || exit 1
 make
 popd || exit 1
+
+# Load the locally-built FKAS image into minikube for the scalability test.
+# We use podman on CentOS, so we cannot use 'minikube image load <name>' which
+# looks in the Docker daemon. Instead, export from podman to a tar and load that.
+if [[ "${GINKGO_FOCUS:-}" == "scalability" ]]; then
+  podman save quay.io/metal3-io/metal3-fkas:ci -o /tmp/fkas-ci.tar
+  minikube image load /tmp/fkas-ci.tar
+  rm -f /tmp/fkas-ci.tar
+fi
 
 # Binaries checked below should have been installed by metal3-dev-env make.
 # Verify they are available and have correct versions.

--- a/test/e2e/data/fkas/resources.yaml
+++ b/test/e2e/data/fkas/resources.yaml
@@ -57,13 +57,13 @@ spec:
       hostNetwork: true
       containers:
       - name: metal3-fkas-reconciler
-        image: quay.io/metal3-io/metal3-fkas:latest
+        image: quay.io/metal3-io/metal3-fkas:ci
         imagePullPolicy: IfNotPresent
         command: [ "/reconciler" ]
         env:
         - name: DEBUG
           value: "true"
-      - image: quay.io/metal3-io/metal3-fkas:latest
+      - image: quay.io/metal3-io/metal3-fkas:ci
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3333


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes the scalability tests by adapting FKAS to newer requirements in CAPI.

- Reorganize etcd member creation to occur before node creation, ensuring KCP never observes an API server without a functioning etcd cluster. Extract setupEtcdMember into a separate function and improve timeout configuration. Track etcd members in the cluster info and set initial leader atomically.
- Set expected taints on the fake nodes. CAPI checks this now and will mark the Machines as unhealthy if they differ.

Additionally, this makes sure that we build the FKAS code and image as part of the job. This allows us to properly test PRs and avoids issues with stale images in periodic jobs.

Finally, I hit an issue where go was not installed on the host. The previous workaround to build FKAS made it necessary to have go on the host for adjusting go.mod. We can avoid this requirement and workaround by passing the whole repo as build context to docker.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #3442

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
