### PR TITLE
🌱 E2E: Avoid assertion in Describe

### DIFF
--- a/test/e2e/upgrade_clusterctl_test.go
+++ b/test/e2e/upgrade_clusterctl_test.go
@@ -39,22 +39,11 @@ var (
 
 // Ironic 35.0 -> latest image tag.
 var _ = Describe("When testing cluster upgrade from releases (v1.13=>current)", Label("clusterctl-upgrade"), func() {
-	BeforeEach(func() {
-		k8sVersion = "v1.36.0"
-		validateGlobals(specName)
-		imageURL, imageChecksum := EnsureImage(k8sVersion)
-		os.Setenv("IMAGE_RAW_CHECKSUM", imageChecksum)
-		os.Setenv("IMAGE_RAW_URL", imageURL)
-		clusterctlLogFolder = filepath.Join(artifactFolder, bootstrapClusterProxy.GetName())
-	})
-
 	minorVersion := "1.13"
 	bmoFromRelease := "0.13"
 	ironicFromRelease := "35.0"
 	bmoToRelease := "main"
 	ironicToRelease := "main"
-	capiStableRelease, err := capi_e2e.GetStableReleaseOfMinor(ctx, minorVersion)
-	Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for CAPI minor release : %s", minorVersion)
 
 	// Use the .99 versions available in the local artifact repository (built from
 	// release branch kustomize overlays in e2e_conf.yaml). The old clusterctl binary
@@ -63,6 +52,20 @@ var _ = Describe("When testing cluster upgrade from releases (v1.13=>current)", 
 	// clusterctl has built-in GitHub URLs for them.
 	capm3InitVersion := minorVersion + ".99"
 	ipamInitVersion := minorVersion + ".99"
+	var capiStableRelease string
+
+	BeforeEach(func() {
+		k8sVersion = "v1.36.0"
+		validateGlobals(specName)
+		imageURL, imageChecksum := EnsureImage(k8sVersion)
+		os.Setenv("IMAGE_RAW_CHECKSUM", imageChecksum)
+		os.Setenv("IMAGE_RAW_URL", imageURL)
+		clusterctlLogFolder = filepath.Join(artifactFolder, bootstrapClusterProxy.GetName())
+
+		var err error
+		capiStableRelease, err = capi_e2e.GetStableReleaseOfMinor(ctx, minorVersion)
+		Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for CAPI minor release : %s", minorVersion)
+	})
 
 	capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
 		return capi_e2e.ClusterctlUpgradeSpecInput{
@@ -101,22 +104,11 @@ var _ = Describe("When testing cluster upgrade from releases (v1.13=>current)", 
 
 // Ironic 33.0 -> latest image tag.
 var _ = Describe("When testing cluster upgrade from releases (v1.12=>current)", Label("clusterctl-upgrade"), func() {
-	BeforeEach(func() {
-		k8sVersion = "v1.36.0"
-		validateGlobals(specName)
-		imageURL, imageChecksum := EnsureImage(k8sVersion)
-		os.Setenv("IMAGE_RAW_CHECKSUM", imageChecksum)
-		os.Setenv("IMAGE_RAW_URL", imageURL)
-		clusterctlLogFolder = filepath.Join(artifactFolder, bootstrapClusterProxy.GetName())
-	})
-
 	minorVersion := "1.12"
 	bmoFromRelease := "0.12"
 	ironicFromRelease := "33.0"
 	bmoToRelease := "main"
 	ironicToRelease := "main"
-	capiStableRelease, err := capi_e2e.GetStableReleaseOfMinor(ctx, minorVersion)
-	Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for CAPI minor release : %s", minorVersion)
 
 	// Use the .99 versions available in the local artifact repository (built from
 	// release branch kustomize overlays in e2e_conf.yaml). The old clusterctl binary
@@ -125,6 +117,20 @@ var _ = Describe("When testing cluster upgrade from releases (v1.12=>current)", 
 	// clusterctl has built-in GitHub URLs for them.
 	capm3InitVersion := minorVersion + ".99"
 	ipamInitVersion := minorVersion + ".99"
+	var capiStableRelease string
+
+	BeforeEach(func() {
+		k8sVersion = "v1.36.0"
+		validateGlobals(specName)
+		imageURL, imageChecksum := EnsureImage(k8sVersion)
+		os.Setenv("IMAGE_RAW_CHECKSUM", imageChecksum)
+		os.Setenv("IMAGE_RAW_URL", imageURL)
+		clusterctlLogFolder = filepath.Join(artifactFolder, bootstrapClusterProxy.GetName())
+
+		var err error
+		capiStableRelease, err = capi_e2e.GetStableReleaseOfMinor(ctx, minorVersion)
+		Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for CAPI minor release : %s", minorVersion)
+	})
 
 	capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
 		return capi_e2e.ClusterctlUpgradeSpecInput{


### PR DESCRIPTION
**What this PR does / why we need it**:

Ginkgo doesn't allow assertions during spec tree construction — they must be inside leaf nodes like `BeforeEach`, `It`, etc. The `GetStableReleaseOfMinor` call was failing (likely a network issue in CI), and the resulting panic during tree construction aborted the entire test suite.

This is what it looks like when it fails before this fix:

```
[2026-06-08T07:19:29.010Z] Assertion or Panic detected during tree construction
[2026-06-08T07:19:29.010Z] var _ = Describe("When testing cluster upgrade from releases (v1.13=>current)", Label("clusterctl-upgrade"), func() {
[2026-06-08T07:19:29.010Z] /home/metal3ci/tested_repo/test/e2e/upgrade_clusterctl_test.go:41
[2026-06-08T07:19:29.010Z]   Ginkgo detected a panic while constructing the spec tree.
[2026-06-08T07:19:29.010Z]   You may be trying to make an assertion in the body of a container node
[2026-06-08T07:19:29.010Z]   (i.e. Describe, Context, or When).
[2026-06-08T07:19:29.010Z] 
[2026-06-08T07:19:29.010Z]   Please ensure all assertions are inside leaf nodes such as BeforeEach,
[2026-06-08T07:19:29.010Z]   It, etc.
[2026-06-08T07:19:29.010Z] 
[2026-06-08T07:19:29.010Z]   Here's the content of the panic that was caught:
[2026-06-08T07:19:29.010Z]   Your Test Panicked
[2026-06-08T07:19:29.010Z]   Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for CAPI minor
[2026-06-08T07:19:29.010Z]   release : %s", minorVersion)
[2026-06-08T07:19:29.010Z]   /home/metal3ci/tested_repo/test/e2e/upgrade_clusterctl_test.go:57
[2026-06-08T07:19:29.010Z]     When you, or your assertion library, calls Ginkgo's Fail(),
[2026-06-08T07:19:29.010Z]     Ginkgo panics to prevent subsequent assertions from running.
[2026-06-08T07:19:29.010Z] 
[2026-06-08T07:19:29.010Z]     Normally Ginkgo rescues this panic so you shouldn't see it.
[2026-06-08T07:19:29.010Z] 
[2026-06-08T07:19:29.010Z]     However, if you make an assertion in a goroutine, Ginkgo can't capture the
[2026-06-08T07:19:29.010Z]     panic.
[2026-06-08T07:19:29.010Z]     To circumvent this, you should call
[2026-06-08T07:19:29.010Z] 
[2026-06-08T07:19:29.010Z]     	defer GinkgoRecover()
[2026-06-08T07:19:29.010Z] 
[2026-06-08T07:19:29.010Z]     at the top of the goroutine that caused this panic.
[2026-06-08T07:19:29.010Z] 
[2026-06-08T07:19:29.010Z]     Alternatively, you may have made an assertion outside of a Ginkgo
[2026-06-08T07:19:29.010Z]     leaf node (e.g. in a container node or some out-of-band function) - please
[2026-06-08T07:19:29.010Z]     move your assertion to
[2026-06-08T07:19:29.010Z]     an appropriate Ginkgo node (e.g. a BeforeSuite, BeforeEach, It, etc...).
[2026-06-08T07:19:29.010Z] 
[2026-06-08T07:19:29.010Z]     Learn more at:
[2026-06-08T07:19:29.010Z]     http://onsi.github.io/ginkgo/#mental-model-how-ginkgo-handles-failure
[2026-06-08T07:19:29.010Z] 
[2026-06-08T07:19:29.010Z] 
[2026-06-08T07:19:29.010Z]   Learn more at: http://onsi.github.io/ginkgo/#no-assertions-in-container-nodes
[2026-06-08T07:19:29.010Z] 
[2026-06-08T07:19:29.010Z] Could not open /home/metal3ci/tested_repo/test/e2e/junit.e2e_suite.1.xml:
[2026-06-08T07:19:29.010Z] open /home/metal3ci/tested_repo/test/e2e/junit.e2e_suite.1.xml: no such file or directory
[2026-06-08T07:19:29.010Z] 
[2026-06-08T07:19:29.010Z] Ginkgo ran 1 suite in 1m33.796681087s
[2026-06-08T07:19:29.010Z] 
[2026-06-08T07:19:29.010Z] Test Suite Failed
[2026-06-08T07:19:29.010Z] make[1]: *** [Makefile:325: e2e-tests] Error 1
[2026-06-08T07:19:29.010Z] make[1]: Leaving directory '/home/metal3ci/tested_repo'
[2026-06-08T07:19:29.010Z] make: *** [Makefile:184: test-e2e] Error 2
[2026-06-08T07:19:29.010Z] 03:19:28.954117 common.go:40: exit status 2

```

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
