### PR TITLE
:bug: Fix panic on nil DeletionTimestamp printing

### DIFF
--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -100,10 +100,16 @@ func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, fmt.Errorf("failed to get Metal3Machine: %w", err)
 	}
 
-	machineLog.V(baremetal.VerbosityLevelDebug).Info("Fetched Metal3Machine",
-		"resourceVersion", capm3Machine.ResourceVersion,
-		"generation", capm3Machine.Generation,
-		"deletionTimestamp", capm3Machine.DeletionTimestamp)
+	if capm3Machine.DeletionTimestamp != nil {
+		machineLog.V(baremetal.VerbosityLevelDebug).Info("Fetched Metal3Machine",
+			"resourceVersion", capm3Machine.ResourceVersion,
+			"generation", capm3Machine.Generation,
+			"deletionTimestamp", capm3Machine.DeletionTimestamp)
+	} else {
+		machineLog.V(baremetal.VerbosityLevelDebug).Info("Fetched Metal3Machine",
+			"resourceVersion", capm3Machine.ResourceVersion,
+			"generation", capm3Machine.Generation)
+	}
 
 	// Always patch capm3Machine exiting this function so we can persist any Metal3Machine changes.
 	patchHelper, err := patch.NewHelper(capm3Machine, r.Client)


### PR DESCRIPTION
When capm3Machine.DeletionTimestamp is `nil`, passing it to structured logging can cause a nil pointer panic.

**What this PR does / why we need it**:

When more verbose logging is enabled, logging does not handle correctly DeletionTimestamp which may be `nil`.

`I0604 11:05:01.661933       1 metal3machine_controller.go:103] "Fetched Metal3Machine" logger="controllers.Metal3Machine.Metal3Machine-controller" metal3Machine="metal3/test1-fdtp5" resourceVersion="4000" generation=1 deletionTimestamp="<panic: runtime error: invalid memory address or nil pointer dereference>"`


<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
