### PR TITLE
🌱 Removed zizmor inline ignore

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
     if: github.repository == 'metal3-io/cluster-api-provider-metal3'
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked]
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
     - name: Get changed files

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -6,3 +6,8 @@ rules:
   dependabot-cooldown:
     config:
       days: 3
+
+  # persist-credentials needed later in the workflow
+  artipacked:
+    ignore:
+    - release.yaml


### PR DESCRIPTION
Removed the `zizmor: ignore[artipacked]` inline suppression comment from `.github/workflows/release.yaml`. The zizmor warning is handled by the `.zyzmor.yml` config at the repo root instead.