### PR TITLE
:bug: Fix IsNodeDrained to query workload cluster

### DIFF
--- a/baremetal/manager_factory.go
+++ b/baremetal/manager_factory.go
@@ -93,5 +93,5 @@ func (f ManagerFactory) NewMachineTemplateManager(capm3Template *infrav1.Metal3M
 func (f ManagerFactory) NewRemediationManager(remediation *infrav1.Metal3Remediation,
 	metal3machine *infrav1.Metal3Machine, machine *clusterv1.Machine,
 	remediationLog logr.Logger) (RemediationManagerInterface, error) {
-	return NewRemediationManager(f.client, capm3remote.NewClusterClient, remediation, metal3machine, machine, remediationLog)
+	return NewRemediationManager(f.client, capm3remote.NewClusterClient, capm3remote.NewClusterStorageClient, remediation, metal3machine, machine, remediationLog)
 }

--- a/baremetal/metal3remediation_manager.go
+++ b/baremetal/metal3remediation_manager.go
@@ -27,10 +27,10 @@ import (
 	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta2"
 	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	storagev1client "k8s.io/client-go/kubernetes/typed/storage/v1"
 	"k8s.io/client-go/tools/cache"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util"
@@ -90,14 +90,18 @@ var outOfServiceTaint = &corev1.Taint{
 	Effect: corev1.TaintEffectNoExecute,
 }
 
+// StorageClientGetter returns a storage client for the workload cluster.
+type StorageClientGetter func(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) (storagev1client.StorageV1Interface, error)
+
 // RemediationManager is responsible for performing remediation reconciliation.
 type RemediationManager struct {
-	Client            client.Client
-	CapiClientGetter  ClientGetter
-	Metal3Remediation *infrav1.Metal3Remediation
-	Metal3Machine     *infrav1.Metal3Machine
-	Machine           *clusterv1.Machine
-	Log               logr.Logger
+	Client              client.Client
+	CapiClientGetter    ClientGetter
+	StorageClientGetter StorageClientGetter
+	Metal3Remediation   *infrav1.Metal3Remediation
+	Metal3Machine       *infrav1.Metal3Machine
+	Machine             *clusterv1.Machine
+	Log                 logr.Logger
 }
 
 // enforce implementation of interface.
@@ -105,15 +109,17 @@ var _ RemediationManagerInterface = &RemediationManager{}
 
 // NewRemediationManager returns a new helper for managing a Metal3Remediation object.
 func NewRemediationManager(client client.Client, capiClientGetter ClientGetter,
+	storageClientGetter StorageClientGetter,
 	metal3remediation *infrav1.Metal3Remediation, metal3Machine *infrav1.Metal3Machine, machine *clusterv1.Machine,
 	remediationLog logr.Logger) (*RemediationManager, error) {
 	return &RemediationManager{
-		Client:            client,
-		CapiClientGetter:  capiClientGetter,
-		Metal3Remediation: metal3remediation,
-		Metal3Machine:     metal3Machine,
-		Machine:           machine,
-		Log:               remediationLog,
+		Client:              client,
+		CapiClientGetter:    capiClientGetter,
+		StorageClientGetter: storageClientGetter,
+		Metal3Remediation:   metal3remediation,
+		Metal3Machine:       metal3Machine,
+		Machine:             machine,
+		Log:                 remediationLog,
 	}, nil
 }
 
@@ -487,8 +493,8 @@ func (r *RemediationManager) DeleteNode(ctx context.Context, clusterClient v1.Co
 	return nil
 }
 
-// GetClusterClient returns the client for interacting with the target cluster.
-func (r *RemediationManager) GetClusterClient(ctx context.Context) (v1.CoreV1Interface, error) {
+// getClusterConfig returns the workload Cluster object.
+func (r *RemediationManager) getClusterConfig(ctx context.Context) (*clusterv1.Cluster, error) {
 	capiMachine, err := r.GetCapiMachine(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("metal3Remediation's node could not be retrieved: %w", err)
@@ -499,12 +505,45 @@ func (r *RemediationManager) GetClusterClient(ctx context.Context) (v1.CoreV1Int
 		return nil, fmt.Errorf("machine is missing cluster label or cluster does not exist: %w", err)
 	}
 
+	return cluster, nil
+}
+
+// GetClusterClient returns the client for interacting with the target cluster.
+func (r *RemediationManager) GetClusterClient(ctx context.Context) (v1.CoreV1Interface, error) {
+	if r.CapiClientGetter == nil {
+		return nil, errors.New("cluster client getter is not configured")
+	}
+
+	cluster, err := r.getClusterConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	clusterClient, err := r.CapiClientGetter(ctx, r.Client, cluster)
 	if err != nil {
 		return nil, fmt.Errorf("could not get cluster client: %w", err)
 	}
 
 	return clusterClient, nil
+}
+
+// getClusterStorageClient returns a storage client for the workload cluster.
+func (r *RemediationManager) getClusterStorageClient(ctx context.Context) (storagev1client.StorageV1Interface, error) {
+	if r.StorageClientGetter == nil {
+		return nil, errors.New("storage client getter is not configured")
+	}
+
+	cluster, err := r.getClusterConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	storageClient, err := r.StorageClientGetter(ctx, r.Client, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("could not get cluster storage client: %w", err)
+	}
+
+	return storageClient, nil
 }
 
 // SetNodeBackupAnnotations sets the given node annotations and labels as remediation annotations.
@@ -596,14 +635,18 @@ func (r *RemediationManager) RemoveOutOfServiceTaint(ctx context.Context, cluste
 }
 
 func (r *RemediationManager) IsNodeDrained(ctx context.Context, clusterClient v1.CoreV1Interface, node *corev1.Node) bool {
-	pods, err := clusterClient.Pods("").List(ctx, metav1.ListOptions{})
+	// Apply server-side filtering to avoid listing all pods in the cluster.
+	// This assumes that the node name is unique across the cluster.
+	pods, err := clusterClient.Pods("").List(ctx, metav1.ListOptions{
+		FieldSelector: "spec.nodeName=" + node.Name,
+	})
 	if err != nil {
 		r.Log.Error(err, "Failed to list pods in cluster")
 		return false
 	}
 
 	for _, pod := range pods.Items {
-		if pod.Spec.NodeName == node.Name && pod.ObjectMeta.DeletionTimestamp != nil {
+		if pod.ObjectMeta.DeletionTimestamp != nil {
 			r.Log.Info("Waiting for terminating pod",
 				LogFieldNode, node.Name,
 				LogFieldPod, pod.Name)
@@ -611,17 +654,26 @@ func (r *RemediationManager) IsNodeDrained(ctx context.Context, clusterClient v1
 		}
 	}
 
-	volumeAttachments := &storagev1.VolumeAttachmentList{}
-	if err := r.Client.List(ctx, volumeAttachments); err != nil {
-		r.Log.Error(err, "Failed to list volumeAttachments")
+	storageClient, err := r.getClusterStorageClient(ctx)
+	if err != nil {
+		r.Log.Error(err, "Failed to get workload cluster storage client")
+		return false
+	}
+
+	// Listing volume attachment does not support field selector, so we need to list all and
+	// filter by node name.
+	volumeAttachments, err := storageClient.VolumeAttachments().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		r.Log.Error(err, "Failed to list volumeAttachments in workload cluster")
 		return false
 	}
 
 	for _, va := range volumeAttachments.Items {
 		if va.Spec.NodeName == node.Name {
 			r.Log.Info("Waiting for volumeAttachment deletion",
-				LogFieldNode, node.Name,
-				LogFieldVolumeAttachment, va.Name)
+				LogFieldNode, va.Spec.NodeName,
+				LogFieldVolumeAttachment, va.Name,
+				"attached", va.Status.Attached)
 			return false
 		}
 	}

--- a/baremetal/metal3remediation_manager_test.go
+++ b/baremetal/metal3remediation_manager_test.go
@@ -23,11 +23,15 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	clientfake "k8s.io/client-go/kubernetes/fake"
 	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	storagev1client "k8s.io/client-go/kubernetes/typed/storage/v1"
+	k8stesting "k8s.io/client-go/testing"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -52,7 +56,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 		DescribeTable("Test NewRemediationManager",
 			func(tc testCaseRemediationManager) {
-				_, err := NewRemediationManager(fakeClient, nil,
+				_, err := NewRemediationManager(fakeClient, nil, nil,
 					tc.Metal3Remediation,
 					tc.Metal3Machine,
 					tc.Machine,
@@ -81,7 +85,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 	DescribeTable("Test Finalizers",
 		func(tc testCaseRemediationManager) {
-			remediationMgr, err := NewRemediationManager(nil, nil, tc.Metal3Remediation, nil, nil,
+			remediationMgr, err := NewRemediationManager(nil, nil, nil, tc.Metal3Remediation, nil, nil,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -119,7 +123,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 	DescribeTable("Test if Retry Limit is set",
 		func(tc testCaseRetryLimitSet) {
-			remediationMgr, err := NewRemediationManager(nil, nil, tc.Metal3Remediation, nil, nil,
+			remediationMgr, err := NewRemediationManager(nil, nil, nil, tc.Metal3Remediation, nil, nil,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -175,7 +179,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 	DescribeTable("Test if Retry Limit is reached",
 		func(tc testCaseRetryLimitSet) {
-			remediationMgr, err := NewRemediationManager(nil, nil, tc.Metal3Remediation, nil, nil,
+			remediationMgr, err := NewRemediationManager(nil, nil, nil, tc.Metal3Remediation, nil, nil,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -242,7 +246,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 	DescribeTable("Test OnlineStatus",
 		func(tc testCaseEnsureOnlineStatus) {
-			remediationMgr, err := NewRemediationManager(nil, nil, tc.Metal3Remediation, nil, nil,
+			remediationMgr, err := NewRemediationManager(nil, nil, nil, tc.Metal3Remediation, nil, nil,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -285,7 +289,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 			}
 			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(&host).Build()
 
-			remediationMgr, err := NewRemediationManager(fakeClient, nil, nil, tc.M3Machine, nil,
+			remediationMgr, err := NewRemediationManager(fakeClient, nil, nil, nil, tc.M3Machine, nil,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -402,7 +406,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 	DescribeTable("Test SetUnhealthyAnnotation",
 		func(tc testCaseSetAnnotation) {
 			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(tc.Host).Build()
-			remediationMgr, err := NewRemediationManager(fakeClient, nil, nil, tc.M3Machine, nil,
+			remediationMgr, err := NewRemediationManager(fakeClient, nil, nil, nil, tc.M3Machine, nil,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -483,7 +487,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 	DescribeTable("Test GetRemediationType",
 		func(tc testCaseGetRemediationType) {
-			remediationMgr, err := NewRemediationManager(nil, nil, tc.Metal3Remediation, nil, nil,
+			remediationMgr, err := NewRemediationManager(nil, nil, nil, tc.Metal3Remediation, nil, nil,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -532,7 +536,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 	DescribeTable("Test GetLastRemediatedTime",
 		func(tc testCaseGetRemediatedTime) {
-			remediationMgr, err := NewRemediationManager(nil, nil, tc.Metal3Remediation, nil, nil,
+			remediationMgr, err := NewRemediationManager(nil, nil, nil, tc.Metal3Remediation, nil, nil,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -567,7 +571,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 	DescribeTable("Test TimeToRemediate",
 		func(tc testTimeToRemediate) {
-			remediationMgr, err := NewRemediationManager(nil, nil, tc.Metal3Remediation, nil, nil,
+			remediationMgr, err := NewRemediationManager(nil, nil, nil, tc.Metal3Remediation, nil, nil,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -642,7 +646,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 	DescribeTable("Test GetTimeoutSeconds",
 		func(tc testCaseGetTimeoutSeconds) {
-			remediationMgr, err := NewRemediationManager(nil, nil, tc.Metal3Remediation, nil, nil,
+			remediationMgr, err := NewRemediationManager(nil, nil, nil, tc.Metal3Remediation, nil, nil,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -678,7 +682,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 	DescribeTable("Test SetRemediationPhase",
 		func(tc testCaseRemediationManager) {
-			remediationMgr, err := NewRemediationManager(nil, nil, tc.Metal3Remediation, nil, nil,
+			remediationMgr, err := NewRemediationManager(nil, nil, nil, tc.Metal3Remediation, nil, nil,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -701,7 +705,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 	DescribeTable("Test SetLastRemediationTime",
 		func(tc testCaseRemediationManager) {
-			remediationMgr, err := NewRemediationManager(nil, nil, tc.Metal3Remediation, nil, nil,
+			remediationMgr, err := NewRemediationManager(nil, nil, nil, tc.Metal3Remediation, nil, nil,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -725,7 +729,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 	DescribeTable("Test IncreaseRetryCount",
 		func(tc testCaseRemediationManager) {
-			remediationMgr, err := NewRemediationManager(nil, nil, tc.Metal3Remediation, nil, nil,
+			remediationMgr, err := NewRemediationManager(nil, nil, nil, tc.Metal3Remediation, nil, nil,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -761,7 +765,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 
 	DescribeTable("Test GetRemediationPhase",
 		func(tc testCaseGetRemediationPhase) {
-			remediationMgr, err := NewRemediationManager(nil, nil, tc.Metal3Remediation, nil, nil,
+			remediationMgr, err := NewRemediationManager(nil, nil, nil, tc.Metal3Remediation, nil, nil,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -853,7 +857,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 		It("should set and remove the power off annotation as requested", func() {
 			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(bmhost, m3machine, remediation).Build()
 
-			remediationMgr, err := NewRemediationManager(fakeClient, nil, remediation, m3machine, nil,
+			remediationMgr, err := NewRemediationManager(fakeClient, nil, nil, remediation, m3machine, nil,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -893,7 +897,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).Build()
 			m3Remediation := &infrav1.Metal3Remediation{}
 
-			remediationMgr, err := NewRemediationManager(fakeClient, nil, m3Remediation, nil, nil,
+			remediationMgr, err := NewRemediationManager(fakeClient, nil, nil, m3Remediation, nil, nil,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -976,7 +980,7 @@ var _ = Describe("Metal3Remediation manager", func() {
 			clientGetter := func(_ context.Context, _ client.Client, _ *clusterv1.Cluster) (clientcorev1.CoreV1Interface, error) {
 				return corev1Client, nil
 			}
-			remediationMgr, err := NewRemediationManager(fakeClient, clientGetter, m3Remediation, nil, capiMachine,
+			remediationMgr, err := NewRemediationManager(fakeClient, clientGetter, nil, m3Remediation, nil, capiMachine,
 				logr.Discard(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -1007,5 +1011,122 @@ var _ = Describe("Metal3Remediation manager", func() {
 			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "expected NotFound error")
 		})
 
+	})
+
+	Describe("Test IsNodeDrained", func() {
+		It("should list pods using spec.nodeName field selector", func() {
+			nodeName := "drain-node"
+			clusterClientset := clientfake.NewSimpleClientset()
+
+			usedFieldSelector := ""
+			clusterClientset.Fake.PrependReactor("list", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				listAction, ok := action.(k8stesting.ListAction)
+				Expect(ok).To(BeTrue())
+				usedFieldSelector = listAction.GetListRestrictions().Fields.String()
+
+				now := metav1.Now()
+				return true, &corev1.PodList{Items: []corev1.Pod{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "terminating-pod",
+						DeletionTimestamp: &now,
+					},
+					Spec: corev1.PodSpec{NodeName: nodeName},
+				}}}, nil
+			})
+
+			remediationMgr, err := NewRemediationManager(nil, nil, nil,
+				&infrav1.Metal3Remediation{}, nil, nil, logr.Discard(),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			drained := remediationMgr.IsNodeDrained(context.TODO(), clusterClientset.CoreV1(),
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}},
+			)
+
+			Expect(drained).To(BeFalse())
+			Expect(usedFieldSelector).To(Equal("spec.nodeName=" + nodeName))
+		})
+
+		It("should use injected storage client getter and block drain on matching volume attachment", func() {
+			nodeName := "mynode"
+			clusterName := "mycluster"
+			machineName := "mymachine"
+			remediationName := "myremediation"
+
+			workloadCluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: namespaceName,
+				},
+			}
+
+			machine := &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      machineName,
+					Namespace: namespaceName,
+					Labels: map[string]string{
+						"cluster.x-k8s.io/cluster-name": clusterName,
+					},
+				},
+			}
+
+			remediation := &infrav1.Metal3Remediation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      remediationName,
+					Namespace: namespaceName,
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: clusterv1.GroupVersion.String(),
+						Kind:       "Machine",
+						Name:       machineName,
+					}},
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(
+				workloadCluster,
+				machine,
+				remediation,
+			).Build()
+
+			clusterClientset := clientfake.NewSimpleClientset(&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "running-pod"},
+				Spec:       corev1.PodSpec{NodeName: nodeName},
+			})
+
+			storageClientset := clientfake.NewSimpleClientset(&storagev1.VolumeAttachment{
+				ObjectMeta: metav1.ObjectMeta{Name: "va-match"},
+				Spec: storagev1.VolumeAttachmentSpec{
+					Attacher: "metal3.io",
+					NodeName: nodeName,
+				},
+			})
+
+			storageClientGetterCalled := false
+			listedVolumeAttachments := false
+			storageClientset.Fake.PrependReactor("list", "volumeattachments", func(k8stesting.Action) (bool, runtime.Object, error) {
+				listedVolumeAttachments = true
+				return false, nil, nil
+			})
+
+			storageClientGetter := func(_ context.Context, _ client.Client, cluster *clusterv1.Cluster) (storagev1client.StorageV1Interface, error) {
+				storageClientGetterCalled = true
+				Expect(cluster.Name).To(Equal(clusterName))
+				Expect(cluster.Namespace).To(Equal(namespaceName))
+				return storageClientset.StorageV1(), nil
+			}
+
+			remediationMgr, err := NewRemediationManager(fakeClient, nil, storageClientGetter,
+				remediation, nil, nil, logr.Discard(),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			drained := remediationMgr.IsNodeDrained(context.TODO(), clusterClientset.CoreV1(),
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}},
+			)
+
+			Expect(storageClientGetterCalled).To(BeTrue())
+			Expect(listedVolumeAttachments).To(BeTrue())
+			Expect(drained).To(BeFalse())
+		})
 	})
 })

--- a/baremetal/remote/remote.go
+++ b/baremetal/remote/remote.go
@@ -19,14 +19,16 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	storagev1 "k8s.io/client-go/kubernetes/typed/storage/v1"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	kcfg "sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// NewClusterClient creates a new ClusterClient.
-func NewClusterClient(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) (corev1.CoreV1Interface, error) {
+// acquireRestConfig retrieves the REST configuration for a given cluster.
+func acquireRestConfig(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) (*rest.Config, error) {
 	kubeconfig, err := kcfg.FromSecret(ctx, c, types.NamespacedName{
 		Name:      cluster.Name,
 		Namespace: cluster.Namespace,
@@ -42,5 +44,25 @@ func NewClusterClient(ctx context.Context, c client.Client, cluster *clusterv1.C
 			cluster.Name, cluster.Namespace, err)
 	}
 
+	return restConfig, nil
+}
+
+// NewClusterClient creates a new ClusterClient.
+func NewClusterClient(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) (corev1.CoreV1Interface, error) {
+	restConfig, err := acquireRestConfig(ctx, c, cluster)
+	if err != nil {
+		return nil, err
+	}
+
 	return corev1.NewForConfig(restConfig)
+}
+
+// NewClusterStorageClient creates a storage client for the workload cluster.
+func NewClusterStorageClient(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) (storagev1.StorageV1Interface, error) {
+	restConfig, err := acquireRestConfig(ctx, c, cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	return storagev1.NewForConfig(restConfig)
 }


### PR DESCRIPTION
VolumeAttachments exist on the workload cluster, not the management cluster. Using r.Client (management) to list them meant the check always silently passed, so nodes with attached volumes were incorrectly considered drained.

Introduce StorageClientGetter and NewClusterStorageClient to obtain a storage client for the workload cluster from its kubeconfig secret — the same pattern used for CoreV1 pod listing. Also add a server-side field selector (spec.nodeName) to the pod list to avoid fetching all pods cluster-wide.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

Currently the function that checks if a node is drained fetched the list of pods without utilizing server side filtering. In addition, the function does not correctly fetch the list of volume mounts.

This PR addresses both of these issues.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
