### PR TITLE
✨ feat: add configurable BareMetalHost allocation policy

### DIFF
--- a/api/v1beta1/conversion.go
+++ b/api/v1beta1/conversion.go
@@ -111,6 +111,10 @@ func (src *Metal3Machine) ConvertTo(dstRaw conversion.Hub) error {
 	if ok && restored.Spec.Image.Checksum == nil {
 		dst.Spec.Image.Checksum = nil
 	}
+	// Restore hub-only BareMetalHostAllocationPolicy (no equivalent in v1beta1).
+	if ok {
+		dst.Spec.BareMetalHostAllocationPolicy = restored.Spec.BareMetalHostAllocationPolicy
+	}
 	return nil
 }
 
@@ -143,6 +147,8 @@ func (src *Metal3MachineTemplate) ConvertTo(dstRaw conversion.Hub) error {
 	if restored.Spec.Template.Spec.Image.Checksum == nil {
 		dst.Spec.Template.Spec.Image.Checksum = nil
 	}
+	// Restore hub-only BareMetalHostAllocationPolicy (no equivalent in v1beta1).
+	dst.Spec.Template.Spec.BareMetalHostAllocationPolicy = restored.Spec.Template.Spec.BareMetalHostAllocationPolicy
 
 	return nil
 }

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -1988,6 +1988,7 @@ func autoConvert_v1beta2_Metal3MachineSpec_To_v1beta1_Metal3MachineSpec(in *v1be
 	if err := v1.Convert_string_To_Pointer_string(&in.AutomatedCleaningMode, &out.AutomatedCleaningMode, s); err != nil {
 		return err
 	}
+	// WARNING: in.BareMetalHostAllocationPolicy requires manual conversion: does not exist in peer-type
 	out.FailureDomain = in.FailureDomain
 	return nil
 }

--- a/api/v1beta2/metal3machine_types.go
+++ b/api/v1beta2/metal3machine_types.go
@@ -31,6 +31,10 @@ const (
 	CleaningModeMetadata = "metadata"
 	ClonedFromGroupKind  = "Metal3MachineTemplate.infrastructure.cluster.x-k8s.io"
 	LiveIsoDiskFormat    = "live-iso"
+
+	// AllocationPolicyOrdered selects the available BareMetalHost whose name sorts
+	// first alphabetically.
+	AllocationPolicyOrdered = "ordered"
 )
 
 // Metal3Machine's Ready condition and corresponding reasons that will be used in v1Beta2 API version.
@@ -176,6 +180,14 @@ type Metal3MachineSpec struct {
 	// +kubebuilder:validation:Enum:=metadata;disabled
 	// +optional
 	AutomatedCleaningMode string `json:"automatedCleaningMode,omitempty,omitzero"`
+
+	// bareMetalHostAllocationPolicy controls how a BareMetalHost is selected from the
+	// set of available hosts matching the hostSelector. "random" (the default) picks a
+	// host at random; "ordered" picks the available host whose name sorts first
+	// alphabetically.
+	// +kubebuilder:validation:Enum:=random;ordered
+	// +optional
+	BareMetalHostAllocationPolicy string `json:"bareMetalHostAllocationPolicy,omitempty,omitzero"`
 
 	// failureDomain is the failure domain unique identifier this machine should be attached to, as defined in Cluster API.
 	// +optional

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -25,6 +25,7 @@ import (
 	"math/big"
 	"os"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -2341,14 +2342,25 @@ func (m *MachineManager) pickHost(availableHosts []*bmov1alpha1.BareMetalHost) (
 		}
 	}
 
+	// Pick from hosts in the failureDomain when any matched, otherwise from all
+	// available hosts.
+	hosts := availableHosts
 	if len(availableHostsInFailureDomain) > 0 {
-		rHost, _ := rand.Int(rand.Reader, big.NewInt(int64(len(availableHostsInFailureDomain))))
-		randomHost := rHost.Int64()
-		chosenHost = availableHostsInFailureDomain[randomHost]
+		hosts = availableHostsInFailureDomain
+	}
+
+	// When the allocation policy is "ordered", deterministically select the host
+	// whose name sorts first alphabetically. Otherwise (default "random"), pick at
+	// random to preserve the historical behavior.
+	if m.Metal3Machine.Spec.BareMetalHostAllocationPolicy == infrav1.AllocationPolicyOrdered {
+		sort.Slice(hosts, func(i, j int) bool {
+			return hosts[i].Name < hosts[j].Name
+		})
+		chosenHost = hosts[0]
 	} else {
-		rHost, _ := rand.Int(rand.Reader, big.NewInt(int64(len(availableHosts))))
+		rHost, _ := rand.Int(rand.Reader, big.NewInt(int64(len(hosts))))
 		randomHost := rHost.Int64()
-		chosenHost = availableHosts[randomHost]
+		chosenHost = hosts[randomHost]
 	}
 
 	return chosenHost, nil

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -685,6 +685,38 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 		}
 
+		// Available hosts created out of alphabetical order, used to verify the
+		// "ordered" allocation policy selects the alphabetically-first host.
+		orderedHostC := newBareMetalHost("ordered-host-c", &bmov1alpha1.BareMetalHostSpec{}, bmov1alpha1.StateReady, &bmov1alpha1.BareMetalHostStatus{}, true, "metadata", false, "", false)
+		orderedHostA := newBareMetalHost("ordered-host-a", &bmov1alpha1.BareMetalHostSpec{}, bmov1alpha1.StateReady, &bmov1alpha1.BareMetalHostStatus{}, true, "metadata", false, "", false)
+		orderedHostB := newBareMetalHost("ordered-host-b", &bmov1alpha1.BareMetalHostSpec{}, bmov1alpha1.StateReady, &bmov1alpha1.BareMetalHostStatus{}, true, "metadata", false, "", false)
+		// Hosts in a failure domain, out of alphabetical order, to verify ordered
+		// allocation picks the alphabetically-first host within the failure domain.
+		orderedFDHostB := bmov1alpha1.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ordered-fd-host-b",
+				Namespace: namespaceName,
+				Labels:    map[string]string{FailureDomainLabelName: "my-fd-1"},
+			},
+			Status: bmov1alpha1.BareMetalHostStatus{
+				Provisioning: bmov1alpha1.ProvisionStatus{
+					State: bmov1alpha1.StateAvailable,
+				},
+			},
+		}
+		orderedFDHostA := bmov1alpha1.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ordered-fd-host-a",
+				Namespace: namespaceName,
+				Labels:    map[string]string{FailureDomainLabelName: "my-fd-1"},
+			},
+			Status: bmov1alpha1.BareMetalHostStatus{
+				Provisioning: bmov1alpha1.ProvisionStatus{
+					State: bmov1alpha1.StateAvailable,
+				},
+			},
+		}
+
 		m3mconfig, infrastructureRef := newConfig("", map[string]string{},
 			[]infrav1.HostSelectorRequirement{}, "",
 		)
@@ -717,6 +749,14 @@ var _ = Describe("Metal3Machine manager", func() {
 		m3mconfig6, infrastructureRef6 := newConfig("", map[string]string{},
 			[]infrav1.HostSelectorRequirement{}, "my-fd-1",
 		)
+		m3mconfigOrdered, infrastructureRefOrdered := newConfig("", map[string]string{},
+			[]infrav1.HostSelectorRequirement{}, "",
+		)
+		m3mconfigOrdered.Spec.BareMetalHostAllocationPolicy = infrav1.AllocationPolicyOrdered
+		m3mconfigOrderedFD, infrastructureRefOrderedFD := newConfig("", map[string]string{},
+			[]infrav1.HostSelectorRequirement{}, "my-fd-1",
+		)
+		m3mconfigOrderedFD.Spec.BareMetalHostAllocationPolicy = infrav1.AllocationPolicyOrdered
 
 		type testCaseChooseHost struct {
 			Machine          *clusterv1.Machine
@@ -987,6 +1027,18 @@ var _ = Describe("Metal3Machine manager", func() {
 				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*availableHost, hostWithLabel, hostWithFailureDomainLabel, hostWithNodeReuseLabelSetToCP}},
 				M3Machine:        m3mconfig6,
 				ExpectedHostName: hostWithNodeReuseLabelSetToCP.Name,
+			}),
+			Entry("Ordered allocation picks the alphabetically-first available host", testCaseChooseHost{
+				Machine:          newMachine(machineName, infrastructureRefOrdered),
+				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*orderedHostC, *orderedHostA, *orderedHostB}},
+				M3Machine:        m3mconfigOrdered,
+				ExpectedHostName: orderedHostA.Name,
+			}),
+			Entry("Ordered allocation picks the alphabetically-first host within the failure domain", testCaseChooseHost{
+				Machine:          newMachine(machineName, infrastructureRefOrderedFD),
+				Hosts:            &bmov1alpha1.BareMetalHostList{Items: []bmov1alpha1.BareMetalHost{*availableHost, orderedFDHostB, orderedFDHostA}},
+				M3Machine:        m3mconfigOrderedFD,
+				ExpectedHostName: orderedFDHostA.Name,
 			}),
 		)
 	})

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machines.yaml
@@ -613,6 +613,16 @@ spec:
                 - metadata
                 - disabled
                 type: string
+              bareMetalHostAllocationPolicy:
+                description: |-
+                  bareMetalHostAllocationPolicy controls how a BareMetalHost is selected from the
+                  set of available hosts matching the hostSelector. "random" (the default) picks a
+                  host at random; "ordered" picks the available host whose name sorts first
+                  alphabetically.
+                enum:
+                - random
+                - ordered
+                type: string
               customDeploy:
                 description: |-
                   customDeploy is a custom deploy procedure.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machinetemplates.yaml
@@ -350,6 +350,16 @@ spec:
                         - metadata
                         - disabled
                         type: string
+                      bareMetalHostAllocationPolicy:
+                        description: |-
+                          bareMetalHostAllocationPolicy controls how a BareMetalHost is selected from the
+                          set of available hosts matching the hostSelector. "random" (the default) picks a
+                          host at random; "ordered" picks the available host whose name sorts first
+                          alphabetically.
+                        enum:
+                        - random
+                        - ordered
+                        type: string
                       customDeploy:
                         description: |-
                           customDeploy is a custom deploy procedure.

--- a/docs/api.md
+++ b/docs/api.md
@@ -306,6 +306,15 @@ The fields are:
   objects. This can be used to limit the set of available `BareMetalHost`
   objects chosen for this `Machine`.
 
+- **bareMetalHostAllocationPolicy** -- Controls how a `BareMetalHost` is selected
+  from the set of available hosts matching the `hostSelector`. When set to
+  `random` (the default when the field is empty), a host is chosen at random,
+  preserving the historical behavior. When set to `ordered`, the available host
+  whose name sorts first alphabetically is chosen, allowing a pool of hosts to be
+  filled deterministically. As with `automatedCleaningMode`, it is recommended to
+  set this via `spec.template.spec.bareMetalHostAllocationPolicy` on the
+  metal3MachineTemplate so that every generated metal3Machine inherits it.
+
 - **automatedCleaningMode** -- An interface to enable or disable Ironic
   automated cleaning during provisioning or deprovisioning of a host. When set
   to `disabled`, automated cleaning will be skipped, where `metadata` value


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

Add an opt-in `bareMetalHostAllocationPolicy` field to Metal3MachineSpec (v1beta2) allowing BareMetalHosts to be allocated either at random (the default, preserving existing behavior) or in alphabetical order by host name ("ordered").

Previously `pickHost` always selected an available host using crypto/rand, so a MachineDeployment scaling up filled its pool non-deterministically. With `ordered`, the available host whose name sorts first is chosen, including within a failure domain.

The field is set on the Metal3MachineTemplate at
`spec.template.spec.bareMetalHostAllocationPolicy` and inherited by every generated Metal3Machine. As it is hub-only, it is restored on v1beta1 conversion. Generated deepcopy is unaffected (plain string field).

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] E2E tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
