### PR TITLE
⚠️ Add blockmove annotations to allow M3M owner references to be removed from BMH

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ require this label to be set, because they hold ownerReferences to
 BareMetalHost, and that is good enough for clusterctl to move all the hierarchy
 of BareMetalHost object.
 
+CAPM3 also automatically sets the `clusterctl.cluster.x-k8s.io/block-move`
+annotation on a claimed BareMetalHost until its pause and status annotations
+are applied, to prevent it from being moved mid-reconcile. This annotation
+blocks the entire `clusterctl move` operation while present on any object,
+a BareMetalHost stuck in this state can stall the whole move, not just
+its own cluster.
+
 ## Development Environment
 
 There are multiple ways to setup a development environment:

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -29,7 +29,6 @@ import (
 	"sync"
 	"time"
 
-	// comment for go-lint.
 	"github.com/go-logr/logr"
 	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta2"
@@ -71,6 +70,10 @@ const (
 	bmRoleNode         = "node"
 	// PausedAnnotationKey is an annotation to be used for pausing a BMH.
 	PausedAnnotationKey = "metal3.io/capm3"
+	// BlockMoveAnnotation is the clusterctl annotation that prevents an object
+	// from being moved until it is removed. Used to synchronize pause/status
+	// annotation application with clusterctl pivot operations.
+	BlockMoveAnnotation = "clusterctl.cluster.x-k8s.io/block-move"
 	// ProviderIDPrefix is a prefix for ProviderID.
 	ProviderIDPrefix = "metal3://"
 	// ProviderLabelPrefix is a label prefix for ProviderID.
@@ -108,6 +111,7 @@ type MachineManagerInterface interface {
 	Metal3MachineHasProviderID() bool
 	SetPauseAnnotation(context.Context) error
 	RemovePauseAnnotation(context.Context) error
+	EnsureBlockMoveAnnotation(context.Context) error
 	DissociateM3Metadata(context.Context) error
 	AssociateM3Metadata(context.Context) error
 	SetError(string, capierrors.MachineStatusError)
@@ -247,6 +251,46 @@ func (m *MachineManager) role() string {
 	return bmRoleNode
 }
 
+// EnsureBlockMoveAnnotation ensures the block-move annotation is present on
+// the associated BareMetalHost to prevent clusterctl from moving it while the
+// BareMetalHost is not paused.
+// The annotation is NOT re-set if the BMH already has a pause annotation.
+func (m *MachineManager) EnsureBlockMoveAnnotation(ctx context.Context) error {
+	host, helper, err := m.getHost(ctx)
+	if err != nil {
+		return err
+	}
+	if host == nil {
+		return nil
+	}
+	// Only set on BMH that are associated with a Metal3Machine (have a consumer)
+	if host.Spec.ConsumerRef == nil || !consumerRefMatches(host.Spec.ConsumerRef, m.Metal3Machine) {
+		return nil
+	}
+
+	annotations := host.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	if _, exists := annotations[BlockMoveAnnotation]; exists {
+		return nil // Already present
+	}
+
+	// Don't re-set block-move if BMH is already paused — SetPauseAnnotation()
+	// already completed its lifecycle and intentionally removed block-move.
+	if _, paused := annotations[bmov1alpha1.PausedAnnotation]; paused {
+		return nil
+	}
+
+	m.Log.Info("Ensuring block-move annotation on BareMetalHost",
+		LogFieldHost, host.Name,
+		LogFieldNamespace, host.Namespace)
+	annotations[BlockMoveAnnotation] = ""
+	host.SetAnnotations(annotations)
+	return helper.Patch(ctx, host)
+}
+
 // RemovePauseAnnotation checks and/or Removes the pause annotations on associated bmh.
 func (m *MachineManager) RemovePauseAnnotation(ctx context.Context) error {
 	m.Log.V(VerbosityLevelTrace).Info("Checking for pause annotation removal")
@@ -303,6 +347,16 @@ func (m *MachineManager) SetPauseAnnotation(ctx context.Context) error {
 
 	if annotations != nil {
 		if _, ok := annotations[bmov1alpha1.PausedAnnotation]; ok {
+			// BMH is already paused. Clean up block-move annotation if present.
+			if _, hasBlockMove := annotations[BlockMoveAnnotation]; hasBlockMove {
+				m.Log.Info("Removing stale block-move annotation from paused BMH",
+					LogFieldHost, host.Name,
+					LogFieldNamespace, host.Namespace)
+				delete(host.Annotations, BlockMoveAnnotation)
+				if patchErr := helper.Patch(ctx, host); patchErr != nil {
+					return fmt.Errorf("failed to remove stale block-move annotation: %w", patchErr)
+				}
+			}
 			m.Log.Info("BareMetalHost is already paused",
 				LogFieldHost, host.Name,
 				LogFieldNamespace, host.Namespace)
@@ -311,6 +365,24 @@ func (m *MachineManager) SetPauseAnnotation(ctx context.Context) error {
 	} else {
 		host.Annotations = make(map[string]string)
 	}
+
+	// Ensure block-move annotation is present to prevent clusterctl
+	// from moving the BMH before pause and status annotations are set.
+	if _, hasBlockMove := host.Annotations[BlockMoveAnnotation]; !hasBlockMove {
+		m.Log.Info("Setting block-move annotation on BareMetalHost",
+			LogFieldHost, host.Name,
+			LogFieldNamespace, host.Namespace)
+		host.Annotations[BlockMoveAnnotation] = ""
+		if patchErr := helper.Patch(ctx, host); patchErr != nil {
+			return fmt.Errorf("failed to set block-move annotation: %w", patchErr)
+		}
+		helper, err = patch.NewHelper(host, m.client)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Set pause and status annotations
 	m.Log.Info("Adding pause annotation to BareMetalHost",
 		LogFieldHost, host.Name,
 		LogFieldNamespace, host.Namespace)
@@ -337,7 +409,27 @@ func (m *MachineManager) SetPauseAnnotation(ctx context.Context) error {
 		return fmt.Errorf("failed to marshal status annotation: %w", err)
 	}
 	host.Annotations[bmov1alpha1.StatusAnnotation] = string(newAnnotation)
-	return helper.Patch(ctx, host)
+
+	if patchErr := helper.Patch(ctx, host); patchErr != nil {
+		return fmt.Errorf("failed to set pause annotations: %w", patchErr)
+	}
+
+	helper, err = patch.NewHelper(host, m.client)
+	if err != nil {
+		return err
+	}
+
+	if _, hasBlockMove := host.Annotations[BlockMoveAnnotation]; hasBlockMove {
+		m.Log.Info("Removing block-move annotation from BareMetalHost",
+			LogFieldHost, host.Name,
+			LogFieldNamespace, host.Namespace)
+		delete(host.Annotations, BlockMoveAnnotation)
+		if patchErr := helper.Patch(ctx, host); patchErr != nil {
+			return fmt.Errorf("failed to remove block-move annotation: %w", patchErr)
+		}
+	}
+
+	return nil
 }
 
 // Associate associates a machine and is invoked by the Machine Controller.
@@ -489,12 +581,6 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 		if !consumerRefMatches(host.Spec.ConsumerRef, m.Metal3Machine) {
 			m.Log.Info("host already associated with another metal3 machine",
 				LogFieldHost, host.Name)
-			// Remove the ownerreference to this machine, even if the consumer ref
-			// references another machine.
-			host.OwnerReferences, err = m.DeleteOwnerRef(host.OwnerReferences)
-			if err != nil {
-				return err
-			}
 			return nil
 		}
 
@@ -608,7 +694,6 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 			m.Log.Info(msg)
 			return WithTransientError(errors.New(msg), requeueAfter)
 		}
-
 		host.Spec.ConsumerRef = nil
 
 		if m.Cluster != nil {
@@ -676,12 +761,6 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 					}
 				}
 			}
-		}
-
-		// Remove the ownerreference to this machine.
-		host.OwnerReferences, err = m.DeleteOwnerRef(host.OwnerReferences)
-		if err != nil {
-			return err
 		}
 
 		if host.Labels != nil && host.Labels[clusterv1.ClusterNameLabel] == m.Machine.Spec.ClusterName {
@@ -1225,13 +1304,6 @@ func (m *MachineManager) setHostConsumerRef(_ context.Context, host *bmov1alpha1
 		APIVersion: m.Metal3Machine.APIVersion,
 	}
 
-	// Set OwnerReferences.
-	hostOwnerReferences, err := m.SetOwnerRef(host.OwnerReferences, true)
-	if err != nil {
-		return err
-	}
-	host.OwnerReferences = hostOwnerReferences
-
 	// Delete nodeReuseLabelName from host.
 	m.Log.Info("Deleting nodeReuseLabelName from host, if any")
 
@@ -1629,54 +1701,6 @@ func (m *MachineManager) SetMetal3DataReadyConditionTrue(reason string) {
 		Status: metav1.ConditionTrue,
 		Reason: reason,
 	})
-}
-
-// SetOwnerRef adds an ownerreference to this Metal3Machine.
-func (m *MachineManager) SetOwnerRef(refList []metav1.OwnerReference, controller bool) ([]metav1.OwnerReference, error) {
-	return setOwnerRefInList(refList, controller, m.Metal3Machine.TypeMeta,
-		m.Metal3Machine.ObjectMeta,
-	)
-}
-
-// DeleteOwnerRef removes the ownerreference to this Metal3Machine.
-func (m *MachineManager) DeleteOwnerRef(refList []metav1.OwnerReference) ([]metav1.OwnerReference, error) {
-	return deleteOwnerRefFromList(refList, m.Metal3Machine.TypeMeta,
-		m.Metal3Machine.ObjectMeta,
-	)
-}
-
-// DeleteOwnerRefFromList removes the ownerreference to this Metal3Machine.
-func deleteOwnerRefFromList(refList []metav1.OwnerReference,
-	objType metav1.TypeMeta, objMeta metav1.ObjectMeta,
-) ([]metav1.OwnerReference, error) {
-	if len(refList) == 0 {
-		return refList, nil
-	}
-	index, err := findOwnerRefFromList(refList, objType, objMeta)
-	if err != nil {
-		if ok := errors.As(err, &errNotFound); !ok {
-			return nil, err
-		}
-		return refList, nil
-	}
-	if len(refList) == 1 {
-		return []metav1.OwnerReference{}, nil
-	}
-	refListLen := len(refList) - 1
-	refList[index] = refList[refListLen]
-	refList, err = deleteOwnerRefFromList(refList[:refListLen], objType, objMeta)
-	if err != nil {
-		return nil, err
-	}
-	return refList, nil
-}
-
-// FindOwnerRef checks if an ownerreference to this Metal3Machine exists
-// and returns the index.
-func (m *MachineManager) FindOwnerRef(refList []metav1.OwnerReference) (int, error) {
-	return findOwnerRefFromList(refList, m.Metal3Machine.TypeMeta,
-		m.Metal3Machine.ObjectMeta,
-	)
 }
 
 // SetOwnerRef adds an ownerreference to this Metal3Machine.

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -40,6 +40,7 @@ import (
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 const (
@@ -992,11 +993,12 @@ var _ = Describe("Metal3Machine manager", func() {
 	})
 
 	type testCaseSetPauseAnnotation struct {
-		M3Machine           *infrav1.Metal3Machine
-		Host                *bmov1alpha1.BareMetalHost
-		ExpectPausePresent  bool
-		ExpectStatusPresent bool
-		ExpectError         bool
+		M3Machine             *infrav1.Metal3Machine
+		Host                  *bmov1alpha1.BareMetalHost
+		ExpectPausePresent    bool
+		ExpectStatusPresent   bool
+		ExpectBlockMoveAbsent bool
+		ExpectError           bool
 	}
 
 	DescribeTable("Test Set BMH Pause Annotation",
@@ -1049,6 +1051,10 @@ var _ = Describe("Metal3Machine manager", func() {
 			} else {
 				Expect(statusPresent).To(BeFalse())
 			}
+			if tc.ExpectBlockMoveAbsent {
+				_, blockMovePresent := savedHost.Annotations[BlockMoveAnnotation]
+				Expect(blockMovePresent).To(BeFalse(), "block-move annotation should be removed after SetPauseAnnotation")
+			}
 		},
 		Entry("Set BMH Pause Annotation, with valid CAPM3 Paused annotations, already paused", testCaseSetPauseAnnotation{
 			Host: &bmov1alpha1.BareMetalHost{
@@ -1064,8 +1070,9 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations()),
-			ExpectPausePresent: true,
-			ExpectError:        false,
+			ExpectPausePresent:    true,
+			ExpectBlockMoveAbsent: true,
+			ExpectError:           false,
 		}),
 		Entry("Set BMH Pause Annotation, with valid Paused annotations, Empty Key, already paused", testCaseSetPauseAnnotation{
 			Host: &bmov1alpha1.BareMetalHost{
@@ -1081,8 +1088,38 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations()),
-			ExpectPausePresent: true,
-			ExpectError:        false,
+			ExpectPausePresent:    true,
+			ExpectBlockMoveAbsent: true,
+			ExpectError:           false,
+		}),
+		Entry("Set BMH Pause Annotation, already paused with stale block-move", testCaseSetPauseAnnotation{
+			Host: &bmov1alpha1.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            baremetalhostName,
+					Namespace:       namespaceName,
+					OwnerReferences: []metav1.OwnerReference{},
+					Labels: map[string]string{
+						clusterv1.ClusterNameLabel: clusterName,
+					},
+					Annotations: map[string]string{
+						bmov1alpha1.PausedAnnotation: PausedAnnotationKey,
+						BlockMoveAnnotation:          "",
+					},
+				},
+				Spec: bmov1alpha1.BareMetalHostSpec{
+					ConsumerRef: &corev1.ObjectReference{
+						Name:       metal3machineName,
+						Namespace:  namespaceName,
+						Kind:       metal3MachineKind,
+						APIVersion: infrav1.GroupVersion.String(),
+					},
+				},
+			},
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
+				m3mObjectMetaWithValidAnnotations()),
+			ExpectPausePresent:    true,
+			ExpectBlockMoveAbsent: true,
+			ExpectError:           false,
 		}),
 		Entry("Set BMH Pause Annotation, with no Paused annotations", testCaseSetPauseAnnotation{
 			Host: &bmov1alpha1.BareMetalHost{
@@ -1101,11 +1138,538 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
 				m3mObjectMetaWithValidAnnotations()),
-			ExpectPausePresent:  true,
-			ExpectStatusPresent: true,
-			ExpectError:         false,
+			ExpectPausePresent:    true,
+			ExpectStatusPresent:   true,
+			ExpectBlockMoveAbsent: true,
+			ExpectError:           false,
+		}),
+		Entry("Set BMH Pause Annotation, with block-move pre-set by EnsureBlockMoveAnnotation", testCaseSetPauseAnnotation{
+			Host: &bmov1alpha1.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            baremetalhostName,
+					Namespace:       namespaceName,
+					OwnerReferences: []metav1.OwnerReference{},
+					Annotations: map[string]string{
+						BlockMoveAnnotation: "",
+					},
+				},
+				Spec: bmov1alpha1.BareMetalHostSpec{
+					ConsumerRef: &corev1.ObjectReference{
+						Name:       metal3machineName,
+						Namespace:  namespaceName,
+						Kind:       metal3MachineKind,
+						APIVersion: infrav1.GroupVersion.String(),
+					},
+				},
+				Status: bmov1alpha1.BareMetalHostStatus{
+					OperationalStatus: "OK",
+				},
+			},
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
+				m3mObjectMetaWithValidAnnotations()),
+			ExpectPausePresent:    true,
+			ExpectStatusPresent:   true,
+			ExpectBlockMoveAbsent: true,
+			ExpectError:           false,
 		}),
 	)
+
+	type testCaseEnsureBlockMoveAnnotation struct {
+		M3Machine              *infrav1.Metal3Machine
+		Host                   *bmov1alpha1.BareMetalHost
+		ExpectBlockMovePresent bool
+		ExpectError            bool
+	}
+
+	DescribeTable("Test EnsureBlockMoveAnnotation",
+		func(tc testCaseEnsureBlockMoveAnnotation) {
+			objects := []client.Object{tc.M3Machine}
+			if tc.Host != nil {
+				objects = append(objects, tc.Host)
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(
+				objects...).Build()
+
+			machineMgr, err := NewMachineManager(fakeClient, nil, nil, nil, tc.M3Machine, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			err = machineMgr.EnsureBlockMoveAnnotation(context.TODO())
+			if tc.ExpectError {
+				Expect(err).To(HaveOccurred())
+				return
+			}
+			Expect(err).NotTo(HaveOccurred())
+
+			if tc.Host == nil {
+				return
+			}
+
+			savedHost := bmov1alpha1.BareMetalHost{}
+			err = fakeClient.Get(context.TODO(),
+				client.ObjectKey{
+					Name:      tc.Host.Name,
+					Namespace: tc.Host.Namespace,
+				},
+				&savedHost,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			_, blockMovePresent := savedHost.Annotations[BlockMoveAnnotation]
+			if tc.ExpectBlockMovePresent {
+				Expect(blockMovePresent).To(BeTrue())
+			} else {
+				Expect(blockMovePresent).To(BeFalse())
+			}
+		},
+		Entry("No associated BMH found (host is nil)", testCaseEnsureBlockMoveAnnotation{
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
+				&metav1.ObjectMeta{
+					Name:      metal3machineName,
+					Namespace: namespaceName,
+					Annotations: map[string]string{
+						HostAnnotation: namespaceName + "/nonexistent-bmh",
+					},
+				}),
+			Host:                   nil,
+			ExpectBlockMovePresent: false,
+			ExpectError:            false,
+		}),
+		Entry("BMH has no ConsumerRef", testCaseEnsureBlockMoveAnnotation{
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
+				m3mObjectMetaWithValidAnnotations()),
+			Host: &bmov1alpha1.BareMetalHost{
+				ObjectMeta: *bmhObjectMetaEmptyAnnotations(),
+				Spec: bmov1alpha1.BareMetalHostSpec{
+					ConsumerRef: nil,
+				},
+			},
+			ExpectBlockMovePresent: false,
+			ExpectError:            false,
+		}),
+		Entry("ConsumerRef does not match Metal3Machine", testCaseEnsureBlockMoveAnnotation{
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
+				m3mObjectMetaWithValidAnnotations()),
+			Host: &bmov1alpha1.BareMetalHost{
+				ObjectMeta: *bmhObjectMetaEmptyAnnotations(),
+				Spec: bmov1alpha1.BareMetalHostSpec{
+					ConsumerRef: &corev1.ObjectReference{
+						Name:       "someothermachine",
+						Namespace:  namespaceName,
+						Kind:       metal3MachineKind,
+						APIVersion: infrav1.GroupVersion.String(),
+					},
+				},
+			},
+			ExpectBlockMovePresent: false,
+			ExpectError:            false,
+		}),
+		Entry("Block-move annotation already present", testCaseEnsureBlockMoveAnnotation{
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
+				m3mObjectMetaWithValidAnnotations()),
+			Host: &bmov1alpha1.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            baremetalhostName,
+					Namespace:       namespaceName,
+					OwnerReferences: []metav1.OwnerReference{},
+					Annotations: map[string]string{
+						BlockMoveAnnotation: "",
+					},
+				},
+				Spec: bmov1alpha1.BareMetalHostSpec{
+					ConsumerRef: &corev1.ObjectReference{
+						Name:       metal3machineName,
+						Namespace:  namespaceName,
+						Kind:       metal3MachineKind,
+						APIVersion: infrav1.GroupVersion.String(),
+					},
+				},
+			},
+			ExpectBlockMovePresent: true,
+			ExpectError:            false,
+		}),
+		Entry("BMH already has pause annotation, block-move not re-set", testCaseEnsureBlockMoveAnnotation{
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
+				m3mObjectMetaWithValidAnnotations()),
+			Host: &bmov1alpha1.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            baremetalhostName,
+					Namespace:       namespaceName,
+					OwnerReferences: []metav1.OwnerReference{},
+					Annotations: map[string]string{
+						bmov1alpha1.PausedAnnotation: PausedAnnotationKey,
+					},
+				},
+				Spec: bmov1alpha1.BareMetalHostSpec{
+					ConsumerRef: &corev1.ObjectReference{
+						Name:       metal3machineName,
+						Namespace:  namespaceName,
+						Kind:       metal3MachineKind,
+						APIVersion: infrav1.GroupVersion.String(),
+					},
+				},
+			},
+			ExpectBlockMovePresent: false,
+			ExpectError:            false,
+		}),
+		Entry("Happy path - block-move annotation added to unpaused associated BMH", testCaseEnsureBlockMoveAnnotation{
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
+				m3mObjectMetaWithValidAnnotations()),
+			Host: &bmov1alpha1.BareMetalHost{
+				ObjectMeta: *bmhObjectMetaEmptyAnnotations(),
+				Spec: bmov1alpha1.BareMetalHostSpec{
+					ConsumerRef: &corev1.ObjectReference{
+						Name:       metal3machineName,
+						Namespace:  namespaceName,
+						Kind:       metal3MachineKind,
+						APIVersion: infrav1.GroupVersion.String(),
+					},
+				},
+			},
+			ExpectBlockMovePresent: true,
+			ExpectError:            false,
+		}),
+		Entry("BMH annotations map is nil - block-move annotation added", testCaseEnsureBlockMoveAnnotation{
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
+				m3mObjectMetaWithValidAnnotations()),
+			Host: &bmov1alpha1.BareMetalHost{
+				ObjectMeta: *bmhObjectMetaNoAnnotations(),
+				Spec: bmov1alpha1.BareMetalHostSpec{
+					ConsumerRef: &corev1.ObjectReference{
+						Name:       metal3machineName,
+						Namespace:  namespaceName,
+						Kind:       metal3MachineKind,
+						APIVersion: infrav1.GroupVersion.String(),
+					},
+				},
+			},
+			ExpectBlockMovePresent: true,
+			ExpectError:            false,
+		}),
+		Entry("getHost returns error from invalid HostAnnotation value", testCaseEnsureBlockMoveAnnotation{
+			M3Machine: newMetal3Machine(metal3machineName, m3mSpec(), nil,
+				&metav1.ObjectMeta{
+					Name:      metal3machineName,
+					Namespace: namespaceName,
+					Annotations: map[string]string{
+						HostAnnotation: "ns/extra/slashes",
+					},
+				}),
+			Host:                   nil,
+			ExpectBlockMovePresent: false,
+			ExpectError:            true,
+		}),
+	)
+
+	It("SetPauseAnnotation removes block-move annotation after pausing BMH", func() {
+		host := &bmov1alpha1.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            baremetalhostName,
+				Namespace:       namespaceName,
+				OwnerReferences: []metav1.OwnerReference{},
+				Labels: map[string]string{
+					clusterv1.ClusterNameLabel: clusterName,
+				},
+				Annotations: map[string]string{
+					BlockMoveAnnotation: "",
+				},
+			},
+			Spec: bmov1alpha1.BareMetalHostSpec{
+				ConsumerRef: &corev1.ObjectReference{
+					Name:       metal3machineName,
+					Namespace:  namespaceName,
+					Kind:       metal3MachineKind,
+					APIVersion: infrav1.GroupVersion.String(),
+				},
+			},
+		}
+		m3Machine := newMetal3Machine(metal3machineName, m3mSpec(), nil,
+			m3mObjectMetaWithValidAnnotations())
+
+		fakeClient := fake.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(
+			host, m3Machine).Build()
+
+		machineMgr, err := NewMachineManager(fakeClient, nil, nil, nil, m3Machine, logr.Discard())
+		Expect(err).NotTo(HaveOccurred())
+
+		err = machineMgr.SetPauseAnnotation(context.TODO())
+		Expect(err).NotTo(HaveOccurred())
+
+		savedHost := bmov1alpha1.BareMetalHost{}
+		err = fakeClient.Get(context.TODO(),
+			client.ObjectKey{
+				Name:      baremetalhostName,
+				Namespace: namespaceName,
+			},
+			&savedHost,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Pause annotation should be present
+		_, pausePresent := savedHost.Annotations[bmov1alpha1.PausedAnnotation]
+		Expect(pausePresent).To(BeTrue())
+
+		// Block-move annotation should have been removed
+		_, blockMovePresent := savedHost.Annotations[BlockMoveAnnotation]
+		Expect(blockMovePresent).To(BeFalse())
+	})
+
+	It("SetPauseAnnotation with nil annotations adds block-move, pauses, then removes block-move", func() {
+		host := &bmov1alpha1.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            baremetalhostName,
+				Namespace:       namespaceName,
+				OwnerReferences: []metav1.OwnerReference{},
+				Labels: map[string]string{
+					clusterv1.ClusterNameLabel: clusterName,
+				},
+				// No Annotations field — nil map
+			},
+			Spec: bmov1alpha1.BareMetalHostSpec{
+				ConsumerRef: &corev1.ObjectReference{
+					Name:       metal3machineName,
+					Namespace:  namespaceName,
+					Kind:       metal3MachineKind,
+					APIVersion: infrav1.GroupVersion.String(),
+				},
+			},
+			Status: bmov1alpha1.BareMetalHostStatus{
+				OperationalStatus: "OK",
+			},
+		}
+		m3Machine := newMetal3Machine(metal3machineName, m3mSpec(), nil,
+			m3mObjectMetaWithValidAnnotations())
+
+		fakeClient := fake.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(
+			host, m3Machine).Build()
+
+		machineMgr, err := NewMachineManager(fakeClient, nil, nil, nil, m3Machine, logr.Discard())
+		Expect(err).NotTo(HaveOccurred())
+
+		err = machineMgr.SetPauseAnnotation(context.TODO())
+		Expect(err).NotTo(HaveOccurred())
+
+		savedHost := bmov1alpha1.BareMetalHost{}
+		err = fakeClient.Get(context.TODO(),
+			client.ObjectKey{
+				Name:      baremetalhostName,
+				Namespace: namespaceName,
+			},
+			&savedHost,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Pause annotation should be present
+		_, pausePresent := savedHost.Annotations[bmov1alpha1.PausedAnnotation]
+		Expect(pausePresent).To(BeTrue())
+
+		// Status annotation should be present
+		_, statusPresent := savedHost.Annotations[bmov1alpha1.StatusAnnotation]
+		Expect(statusPresent).To(BeTrue())
+
+		// Block-move annotation should have been removed after pause completed
+		_, blockMovePresent := savedHost.Annotations[BlockMoveAnnotation]
+		Expect(blockMovePresent).To(BeFalse())
+	})
+
+	It("SetPauseAnnotation removes stale block-move from already-paused BMH", func() {
+		host := &bmov1alpha1.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            baremetalhostName,
+				Namespace:       namespaceName,
+				OwnerReferences: []metav1.OwnerReference{},
+				Labels: map[string]string{
+					clusterv1.ClusterNameLabel: clusterName,
+				},
+				Annotations: map[string]string{
+					bmov1alpha1.PausedAnnotation: PausedAnnotationKey,
+					BlockMoveAnnotation:          "",
+				},
+			},
+			Spec: bmov1alpha1.BareMetalHostSpec{
+				ConsumerRef: &corev1.ObjectReference{
+					Name:       metal3machineName,
+					Namespace:  namespaceName,
+					Kind:       metal3MachineKind,
+					APIVersion: infrav1.GroupVersion.String(),
+				},
+			},
+		}
+		m3Machine := newMetal3Machine(metal3machineName, m3mSpec(), nil,
+			m3mObjectMetaWithValidAnnotations())
+
+		fakeClient := fake.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(
+			host, m3Machine).Build()
+
+		machineMgr, err := NewMachineManager(fakeClient, nil, nil, nil, m3Machine, logr.Discard())
+		Expect(err).NotTo(HaveOccurred())
+
+		err = machineMgr.SetPauseAnnotation(context.TODO())
+		Expect(err).NotTo(HaveOccurred())
+
+		savedHost := bmov1alpha1.BareMetalHost{}
+		err = fakeClient.Get(context.TODO(),
+			client.ObjectKey{
+				Name:      baremetalhostName,
+				Namespace: namespaceName,
+			},
+			&savedHost,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Pause annotation should still be present
+		_, pausePresent := savedHost.Annotations[bmov1alpha1.PausedAnnotation]
+		Expect(pausePresent).To(BeTrue())
+
+		// Stale block-move annotation should have been removed
+		_, blockMovePresent := savedHost.Annotations[BlockMoveAnnotation]
+		Expect(blockMovePresent).To(BeFalse())
+	})
+
+	It("SetPauseAnnotation returns error when block-move patch fails", func() {
+		host := &bmov1alpha1.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            baremetalhostName,
+				Namespace:       namespaceName,
+				OwnerReferences: []metav1.OwnerReference{},
+				Labels: map[string]string{
+					clusterv1.ClusterNameLabel: clusterName,
+				},
+				Annotations: map[string]string{},
+			},
+			Spec: bmov1alpha1.BareMetalHostSpec{
+				ConsumerRef: &corev1.ObjectReference{
+					Name:       metal3machineName,
+					Namespace:  namespaceName,
+					Kind:       metal3MachineKind,
+					APIVersion: infrav1.GroupVersion.String(),
+				},
+			},
+		}
+		m3Machine := newMetal3Machine(metal3machineName, m3mSpec(), nil,
+			m3mObjectMetaWithValidAnnotations())
+
+		// Use an interceptor to simulate a patch failure when block-move is being set
+		fakeClient := fake.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(
+			host, m3Machine).WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, client client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if bmh, ok := obj.(*bmov1alpha1.BareMetalHost); ok {
+					if _, hasBlockMove := bmh.Annotations[BlockMoveAnnotation]; hasBlockMove {
+						// Fail on the first patch that sets block-move
+						if _, hasPause := bmh.Annotations[bmov1alpha1.PausedAnnotation]; !hasPause {
+							return errors.New("simulated patch failure")
+						}
+					}
+				}
+				return client.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+
+		machineMgr, err := NewMachineManager(fakeClient, nil, nil, nil, m3Machine, logr.Discard())
+		Expect(err).NotTo(HaveOccurred())
+
+		err = machineMgr.SetPauseAnnotation(context.TODO())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to set block-move annotation"))
+	})
+
+	It("SetPauseAnnotation returns error when block-move removal patch fails", func() {
+		host := &bmov1alpha1.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            baremetalhostName,
+				Namespace:       namespaceName,
+				OwnerReferences: []metav1.OwnerReference{},
+				Labels: map[string]string{
+					clusterv1.ClusterNameLabel: clusterName,
+				},
+				Annotations: map[string]string{},
+			},
+			Spec: bmov1alpha1.BareMetalHostSpec{
+				ConsumerRef: &corev1.ObjectReference{
+					Name:       metal3machineName,
+					Namespace:  namespaceName,
+					Kind:       metal3MachineKind,
+					APIVersion: infrav1.GroupVersion.String(),
+				},
+			},
+			Status: bmov1alpha1.BareMetalHostStatus{
+				OperationalStatus: "OK",
+			},
+		}
+		m3Machine := newMetal3Machine(metal3machineName, m3mSpec(), nil,
+			m3mObjectMetaWithValidAnnotations())
+
+		// Track patch calls — fail only on the final patch that removes block-move
+		patchCount := 0
+		fakeClient := fake.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(
+			host, m3Machine).WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, client client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if _, ok := obj.(*bmov1alpha1.BareMetalHost); ok {
+					patchCount++
+					// The 3rd patch is the block-move removal (1st = set block-move, 2nd = set pause+status)
+					if patchCount == 3 {
+						return errors.New("simulated removal patch failure")
+					}
+				}
+				return client.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+
+		machineMgr, err := NewMachineManager(fakeClient, nil, nil, nil, m3Machine, logr.Discard())
+		Expect(err).NotTo(HaveOccurred())
+
+		err = machineMgr.SetPauseAnnotation(context.TODO())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to remove block-move annotation"))
+	})
+
+	It("SetPauseAnnotation returns error when host disappears after block-move patch", func() {
+		host := &bmov1alpha1.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            baremetalhostName,
+				Namespace:       namespaceName,
+				OwnerReferences: []metav1.OwnerReference{},
+				Labels: map[string]string{
+					clusterv1.ClusterNameLabel: clusterName,
+				},
+				Annotations: map[string]string{},
+			},
+			Spec: bmov1alpha1.BareMetalHostSpec{
+				ConsumerRef: &corev1.ObjectReference{
+					Name:       metal3machineName,
+					Namespace:  namespaceName,
+					Kind:       metal3MachineKind,
+					APIVersion: infrav1.GroupVersion.String(),
+				},
+			},
+		}
+		m3Machine := newMetal3Machine(metal3machineName, m3mSpec(), nil,
+			m3mObjectMetaWithValidAnnotations())
+
+		// After the first patch (set block-move), delete the host so that
+		// the re-fetch in getHost returns nil.
+		patchCount := 0
+		fakeClient := fake.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(
+			host, m3Machine).WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, client client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if _, ok := obj.(*bmov1alpha1.BareMetalHost); ok {
+					patchCount++
+					if patchCount == 1 {
+						// Let the first patch succeed, then delete the host
+						if err := client.Patch(ctx, obj, patch, opts...); err != nil {
+							return err
+						}
+						return client.Delete(ctx, obj)
+					}
+				}
+				return client.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+
+		machineMgr, err := NewMachineManager(fakeClient, nil, nil, nil, m3Machine, logr.Discard())
+		Expect(err).NotTo(HaveOccurred())
+
+		err = machineMgr.SetPauseAnnotation(context.TODO())
+		Expect(err).To(HaveOccurred())
+	})
 
 	type testCaseRemovePauseAnnotation struct {
 		Cluster       *clusterv1.Cluster
@@ -1368,8 +1932,6 @@ var _ = Describe("Metal3Machine manager", func() {
 			Expect(tc.Host.Spec.ConsumerRef.Namespace).
 				To(Equal(m3mconfig.Namespace))
 			Expect(tc.Host.Spec.ConsumerRef.Kind).To(Equal(metal3MachineKind))
-			_, err = machineMgr.FindOwnerRef(tc.Host.OwnerReferences)
-			Expect(err).NotTo(HaveOccurred())
 
 			if tc.expectNodeReuseLabelDeleted {
 				Expect(tc.Host.Labels[nodeReuseLabelName]).To(Equal(""))
@@ -3006,7 +3568,6 @@ var _ = Describe("Metal3Machine manager", func() {
 		Data               *infrav1.Metal3Data
 		ExpectRequeue      bool
 		ExpectClusterLabel bool
-		ExpectOwnerRef     bool
 	}
 
 	DescribeTable("Test Associate function",
@@ -3057,12 +3618,6 @@ var _ = Describe("Metal3Machine manager", func() {
 				&savedHost,
 			)
 			Expect(err).NotTo(HaveOccurred())
-			_, err = machineMgr.FindOwnerRef(savedHost.OwnerReferences)
-			if tc.ExpectOwnerRef {
-				Expect(err).NotTo(HaveOccurred())
-			} else {
-				Expect(err).To(HaveOccurred())
-			}
 			if tc.ExpectClusterLabel {
 				// get the BMC credential
 				savedCred := corev1.Secret{}
@@ -3087,8 +3642,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				Host: newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil,
 					false, "metadata", false, "", false,
 				),
-				ExpectRequeue:  false,
-				ExpectOwnerRef: true,
+				ExpectRequeue: false,
 			},
 		),
 		Entry("Associate empty machine, Metal3 machine spec set",
@@ -3100,9 +3654,8 @@ var _ = Describe("Metal3Machine manager", func() {
 				Host: newBareMetalHost(baremetalhostName, bmhSpecBMC(), bmov1alpha1.StateNone, nil,
 					false, "metadata", false, "", false,
 				),
-				BMCSecret:      newBMCSecret("mycredentials", false),
-				ExpectRequeue:  false,
-				ExpectOwnerRef: true,
+				BMCSecret:     newBMCSecret("mycredentials", false),
+				ExpectRequeue: false,
 			},
 		),
 		Entry("Associate empty machine, host empty, Metal3 machine spec set",
@@ -3111,9 +3664,8 @@ var _ = Describe("Metal3Machine manager", func() {
 				M3Machine: newMetal3Machine(metal3machineName, m3mSpecAll(), nil,
 					m3mObjectMetaWithValidAnnotations(),
 				),
-				Host:           newBareMetalHost("", nil, bmov1alpha1.StateNone, nil, false, "metadata", false, "", false),
-				ExpectRequeue:  true,
-				ExpectOwnerRef: false,
+				Host:          newBareMetalHost("", nil, bmov1alpha1.StateNone, nil, false, "metadata", false, "", false),
+				ExpectRequeue: true,
 			},
 		),
 		Entry("Associate machine, host nil, Metal3 machine spec set, requeue",
@@ -3134,7 +3686,6 @@ var _ = Describe("Metal3Machine manager", func() {
 				BMCSecret:          newBMCSecret("mycredentials", false),
 				ExpectClusterLabel: true,
 				ExpectRequeue:      false,
-				ExpectOwnerRef:     true,
 			},
 		),
 		Entry("Associate machine with DataTemplate missing",
@@ -3161,7 +3712,6 @@ var _ = Describe("Metal3Machine manager", func() {
 				BMCSecret:          newBMCSecret("mycredentials", false),
 				ExpectClusterLabel: true,
 				ExpectRequeue:      false,
-				ExpectOwnerRef:     true,
 			},
 		),
 		Entry("Associate machine with DataTemplate and Data ready",
@@ -3207,7 +3757,6 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 				ExpectClusterLabel: true,
 				ExpectRequeue:      false,
-				ExpectOwnerRef:     true,
 			},
 		),
 	)
@@ -3259,267 +3808,6 @@ var _ = Describe("Metal3Machine manager", func() {
 			),
 			Host:        newBareMetalHost(baremetalhostName, nil, bmov1alpha1.StateNone, nil, false, "metadata", false, "", false),
 			ExpectError: true,
-		}),
-	)
-
-	type testCaseFindOwnerRef struct {
-		M3Machine     infrav1.Metal3Machine
-		OwnerRefs     []metav1.OwnerReference
-		ExpectError   bool
-		ExpectedIndex int
-	}
-
-	DescribeTable("Test FindOwnerRef",
-		func(tc testCaseFindOwnerRef) {
-			machineMgr, err := NewMachineManager(nil, nil, nil, nil, &tc.M3Machine,
-				logr.Discard(),
-			)
-			Expect(err).NotTo(HaveOccurred())
-
-			index, err := machineMgr.FindOwnerRef(tc.OwnerRefs)
-			if tc.ExpectError {
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(BeAssignableToTypeOf(&NotFoundError{}))
-			} else {
-				Expect(err).ToNot(HaveOccurred())
-				Expect(index).To(BeEquivalentTo(tc.ExpectedIndex))
-			}
-		},
-		Entry("Empty list", testCaseFindOwnerRef{
-			M3Machine:   *newMetal3Machine("myName", nil, nil, nil),
-			OwnerRefs:   []metav1.OwnerReference{},
-			ExpectError: true,
-		}),
-		Entry("Absent", testCaseFindOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
-			OwnerRefs: []metav1.OwnerReference{
-				{
-					APIVersion: "abc.com/v1",
-					Kind:       "def",
-					Name:       "ghi",
-					UID:        "adfasdf",
-				},
-			},
-			ExpectError: true,
-		}),
-		Entry("Present 0", testCaseFindOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
-			OwnerRefs: []metav1.OwnerReference{
-				{
-					Kind:       metal3MachineKind,
-					APIVersion: infrav1.GroupVersion.String(),
-					Name:       "myName",
-					UID:        "adfasdf",
-				},
-				{
-					APIVersion: "abc.com/v1",
-					Kind:       "def",
-					Name:       "ghi",
-					UID:        "adfasdf",
-				},
-			},
-			ExpectError:   false,
-			ExpectedIndex: 0,
-		}),
-		Entry("Present 1", testCaseFindOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
-			OwnerRefs: []metav1.OwnerReference{
-				{
-					APIVersion: "abc.com/v1",
-					Kind:       "def",
-					Name:       "ghi",
-					UID:        "adfasdf",
-				},
-				{
-					Kind:       metal3MachineKind,
-					APIVersion: infrav1.GroupVersion.String(),
-					Name:       "myName",
-					UID:        "adfasdf",
-				},
-			},
-			ExpectError:   false,
-			ExpectedIndex: 1,
-		}),
-		Entry("Present but different versions", testCaseFindOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
-			OwnerRefs: []metav1.OwnerReference{
-				{
-					APIVersion: "abc.com/v1",
-					Kind:       "def",
-					Name:       "ghi",
-					UID:        "adfasdf",
-				},
-				{
-					Kind:       metal3MachineKind,
-					APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha1",
-					Name:       "myName",
-					UID:        "adfasdf",
-				},
-			},
-			ExpectError:   false,
-			ExpectedIndex: 1,
-		}),
-		Entry("Wrong group", testCaseFindOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
-			OwnerRefs: []metav1.OwnerReference{
-				{
-					APIVersion: "abc.com/v1",
-					Kind:       "def",
-					Name:       "ghi",
-					UID:        "adfasdf",
-				},
-				{
-					Kind:       metal3MachineKind,
-					APIVersion: "nfrastructure.cluster.x-k8s.io/v1alpha1",
-					Name:       "myName",
-					UID:        "adfasdf",
-				},
-			},
-			ExpectError: true,
-		}),
-	)
-
-	type testCaseOwnerRef struct {
-		M3Machine  infrav1.Metal3Machine
-		OwnerRefs  []metav1.OwnerReference
-		Controller bool
-	}
-
-	DescribeTable("Test DeleteOwnerRef",
-		func(tc testCaseOwnerRef) {
-			machineMgr, err := NewMachineManager(nil, nil, nil, nil, &tc.M3Machine,
-				logr.Discard(),
-			)
-			Expect(err).NotTo(HaveOccurred())
-
-			refList, err := machineMgr.DeleteOwnerRef(tc.OwnerRefs)
-			Expect(err).ToNot(HaveOccurred())
-			_, err = machineMgr.FindOwnerRef(refList)
-			Expect(err).To(HaveOccurred())
-		},
-		Entry("Empty list", testCaseOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
-			OwnerRefs: []metav1.OwnerReference{},
-		}),
-		Entry("Absent", testCaseOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
-			OwnerRefs: []metav1.OwnerReference{
-				{
-					APIVersion: "abc.com/v1",
-					Kind:       "def",
-					Name:       "ghi",
-					UID:        "adfasdf",
-				},
-			},
-		}),
-		Entry("Present 0", testCaseOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
-			OwnerRefs: []metav1.OwnerReference{
-				{
-					Kind:       metal3MachineKind,
-					APIVersion: infrav1.GroupVersion.String(),
-					Name:       "myName",
-					UID:        "adfasdf",
-				},
-				{
-					APIVersion: "abc.com/v1",
-					Kind:       "def",
-					Name:       "ghi",
-					UID:        "adfasdf",
-				},
-			},
-		}),
-		Entry("Present 1", testCaseOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
-			OwnerRefs: []metav1.OwnerReference{
-				{
-					APIVersion: "abc.com/v1",
-					Kind:       "def",
-					Name:       "ghi",
-					UID:        "adfasdf",
-				},
-				{
-					Kind:       metal3MachineKind,
-					APIVersion: infrav1.GroupVersion.String(),
-					Name:       "myName",
-					UID:        "adfasdf",
-				},
-			},
-		}),
-		Entry("Present", testCaseOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
-			OwnerRefs: []metav1.OwnerReference{
-				{
-					Kind:       metal3MachineKind,
-					APIVersion: infrav1.GroupVersion.String(),
-					Name:       "myName",
-					UID:        "adfasdf",
-				},
-			},
-		}),
-	)
-
-	DescribeTable("Test SetOwnerRef",
-		func(tc testCaseOwnerRef) {
-			machineMgr, err := NewMachineManager(nil, nil, nil, nil, &tc.M3Machine,
-				logr.Discard(),
-			)
-			Expect(err).NotTo(HaveOccurred())
-
-			refList, err := machineMgr.SetOwnerRef(tc.OwnerRefs, tc.Controller)
-			Expect(err).ToNot(HaveOccurred())
-			index, err := machineMgr.FindOwnerRef(refList)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(*refList[index].Controller).To(BeEquivalentTo(tc.Controller))
-		},
-		Entry("Empty list", testCaseOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
-			OwnerRefs: []metav1.OwnerReference{},
-		}),
-		Entry("Absent", testCaseOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
-			OwnerRefs: []metav1.OwnerReference{
-				{
-					APIVersion: "abc.com/v1",
-					Kind:       "def",
-					Name:       "ghi",
-					UID:        "adfasdf",
-				},
-			},
-		}),
-		Entry("Present 0", testCaseOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
-			OwnerRefs: []metav1.OwnerReference{
-				{
-					Kind:       metal3MachineKind,
-					APIVersion: infrav1.GroupVersion.String(),
-					Name:       "myName",
-					UID:        "adfasdf",
-				},
-				{
-					APIVersion: "abc.com/v1",
-					Kind:       "def",
-					Name:       "ghi",
-					UID:        "adfasdf",
-				},
-			},
-		}),
-		Entry("Present 1", testCaseOwnerRef{
-			M3Machine: *newMetal3Machine("myName", nil, nil, nil),
-			OwnerRefs: []metav1.OwnerReference{
-				{
-					APIVersion: "abc.com/v1",
-					Kind:       "def",
-					Name:       "ghi",
-					UID:        "adfasdf",
-				},
-				{
-					Kind:       metal3MachineKind,
-					APIVersion: infrav1.GroupVersion.String(),
-					Name:       "myName",
-					UID:        "adfasdf",
-				},
-			},
 		}),
 	)
 

--- a/baremetal/mocks/zz_generated.metal3machine_manager.go
+++ b/baremetal/mocks/zz_generated.metal3machine_manager.go
@@ -134,6 +134,20 @@ func (mr *MockMachineManagerInterfaceMockRecorder) DissociateM3Metadata(arg0 any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DissociateM3Metadata", reflect.TypeOf((*MockMachineManagerInterface)(nil).DissociateM3Metadata), arg0)
 }
 
+// EnsureBlockMoveAnnotation mocks base method.
+func (m *MockMachineManagerInterface) EnsureBlockMoveAnnotation(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureBlockMoveAnnotation", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureBlockMoveAnnotation indicates an expected call of EnsureBlockMoveAnnotation.
+func (mr *MockMachineManagerInterfaceMockRecorder) EnsureBlockMoveAnnotation(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureBlockMoveAnnotation", reflect.TypeOf((*MockMachineManagerInterface)(nil).EnsureBlockMoveAnnotation), arg0)
+}
+
 // GetMetal3Machine mocks base method.
 func (m *MockMachineManagerInterface) GetMetal3Machine() *v1beta2.Metal3Machine {
 	m.ctrl.T.Helper()

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -216,6 +216,12 @@ func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	machineLog.V(baremetal.VerbosityLevelTrace).Info("Created MachineManager, checking pause state")
 
+	// Ensure block-move annotation is always present on associated BMH.
+	if err := machineMgr.EnsureBlockMoveAnnotation(ctx); err != nil {
+		machineLog.Info("failed to ensure block-move annotation on associated BMH",
+			baremetal.LogFieldError, err.Error())
+	}
+
 	// Check pause annotation on associated bmh (if any)
 	setPause := cluster.Spec.Paused != nil && *cluster.Spec.Paused
 	machineLog.V(baremetal.VerbosityLevelDebug).Info("Cluster pause check",

--- a/test/e2e/node_reuse.go
+++ b/test/e2e/node_reuse.go
@@ -510,19 +510,15 @@ func updateNodeReuse(ctx context.Context, namespace string, nodeReuse bool, m3Ma
 // has the correct node reuse condition reason set.
 func verifyMetal3MachineNodeReuseCondition(ctx context.Context, managementClusterClient client.Client, bmhKey types.NamespacedName, namespace string, intervals []interface{}) {
 	By("Verify Metal3Machine has correct node reuse condition reason [node_reuse]")
-	var m3mName string
 	Eventually(
 		func(g Gomega) {
 			bmh := bmov1alpha1.BareMetalHost{}
 			g.Expect(managementClusterClient.Get(ctx, bmhKey, &bmh)).To(Succeed())
-			// Find Metal3Machine from BMH owner references
-			for _, ownerRef := range bmh.OwnerReferences {
-				if ownerRef.Kind == "Metal3Machine" {
-					m3mName = ownerRef.Name
-					break
-				}
-			}
-			g.Expect(m3mName).NotTo(BeEmpty(), "Metal3Machine owner reference not found on BMH")
+			// Find Metal3Machine from BMH ConsumerRef
+			g.Expect(bmh.Spec.ConsumerRef).NotTo(BeNil(), "ConsumerRef not set on BMH")
+			g.Expect(bmh.Spec.ConsumerRef.Kind).To(Equal("Metal3Machine"), "ConsumerRef does not point to a Metal3Machine")
+			m3mName := bmh.Spec.ConsumerRef.Name
+			g.Expect(m3mName).NotTo(BeEmpty(), "Metal3Machine name in ConsumerRef is empty")
 
 			// Get Metal3Machine and check condition
 			m3m := infrav1.Metal3Machine{}


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

- Add a `EnsureBlockMoveAnnotation` function which is called at the start of every reconciliation and adds the blockmove annotation to any BMH which is not paused.
- The annotation prevents objects from being moved until removed
- Modify `SetPauseAnnotation` to check if ensure `blockmove` has been added (and patch the BMH if not) before setting the spec and pause annotations.  Remove `blockmove` after the other annotations have been added.
- All M3M ownership references have been removed.
- `metal3machine_controller.go` logs errors if block-move annotations have not been added
- `pivoting.go` has added waiting periods to ensure block move annotations are set




<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
