### PR TITLE
🌱 Use proper IPA cache address

### DIFF
--- a/test/e2e/data/ironic-deployment/overlays/pr-test/ironic_bmo_configmap.env
+++ b/test/e2e/data/ironic-deployment/overlays/pr-test/ironic_bmo_configmap.env
@@ -10,4 +10,4 @@ DEPLOY_KERNEL_URL=http://172.22.0.2:6180/images/ironic-python-agent.kernel
 DEPLOY_RAMDISK_URL=http://172.22.0.2:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.2:6385/v1/
 USE_IRONIC_INSPECTOR=false
-IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote/ironic-python-agent/dib

--- a/test/e2e/data/ironic-deployment/overlays/release-27.0/ironic_bmo_configmap.env
+++ b/test/e2e/data/ironic-deployment/overlays/release-27.0/ironic_bmo_configmap.env
@@ -10,4 +10,4 @@ DEPLOY_KERNEL_URL=http://172.22.0.2:6180/images/ironic-python-agent.kernel
 DEPLOY_RAMDISK_URL=http://172.22.0.2:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.2:6385/v1/
 USE_IRONIC_INSPECTOR=false
-IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote/ironic-python-agent/dib

--- a/test/e2e/data/ironic-deployment/overlays/release-29.0/ironic_bmo_configmap.env
+++ b/test/e2e/data/ironic-deployment/overlays/release-29.0/ironic_bmo_configmap.env
@@ -10,4 +10,4 @@ DEPLOY_KERNEL_URL=http://172.22.0.2:6180/images/ironic-python-agent.kernel
 DEPLOY_RAMDISK_URL=http://172.22.0.2:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.2:6385/v1/
 USE_IRONIC_INSPECTOR=false
-IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote/ironic-python-agent/dib

--- a/test/e2e/data/ironic-deployment/overlays/release-31.0/ironic_bmo_configmap.env
+++ b/test/e2e/data/ironic-deployment/overlays/release-31.0/ironic_bmo_configmap.env
@@ -10,4 +10,4 @@ DEPLOY_KERNEL_URL=http://172.22.0.2:6180/images/ironic-python-agent.kernel
 DEPLOY_RAMDISK_URL=http://172.22.0.2:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.2:6385/v1/
 USE_IRONIC_INSPECTOR=false
-IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote/ironic-python-agent/dib

--- a/test/e2e/data/ironic-deployment/overlays/release-32.0/ironic_bmo_configmap.env
+++ b/test/e2e/data/ironic-deployment/overlays/release-32.0/ironic_bmo_configmap.env
@@ -10,4 +10,4 @@ DEPLOY_KERNEL_URL=http://172.22.0.2:6180/images/ironic-python-agent.kernel
 DEPLOY_RAMDISK_URL=http://172.22.0.2:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.2:6385/v1/
 USE_IRONIC_INSPECTOR=false
-IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote/ironic-python-agent/dib

--- a/test/e2e/data/ironic-deployment/overlays/release-latest/ironic_bmo_configmap.env
+++ b/test/e2e/data/ironic-deployment/overlays/release-latest/ironic_bmo_configmap.env
@@ -9,4 +9,4 @@ DHCP_RANGE=172.22.0.10,172.22.0.100
 DEPLOY_KERNEL_URL=http://172.22.0.2:6180/images/ironic-python-agent.kernel
 DEPLOY_RAMDISK_URL=http://172.22.0.2:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.2:6385/v1/
-IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
+IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote/ironic-python-agent/dib


### PR DESCRIPTION
This commit:
 - Makes sure that the correct IPA Nordix proxy is used.

Previous address circumvented the proper cache refresh trigger so in case the cache was empty after a cleanup, cache refresh was not triggered.
