### PR TITLE
🌱 Use proper IPA cache address

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -49,7 +49,7 @@ export KUBERNETES_VERSION=${KUBERNETES_VERSION}
 export IMAGE_OS=${IMAGE_OS}
 export FORCE_REPO_UPDATE="false"
 export SKIP_NODE_IMAGE_PREPULL="true"
-export IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib
+export IPA_BASEURI=https://artifactory.nordix.org/artifactory/openstack-remote/ironic-python-agent/dib
 EOF
 
 # Set USE_IRSO only when IMAGE_OS is not ubuntu and not running scalability tests

--- a/test/e2e/data/ironic-standalone-operator/operator/components/configmap/patch-configmap.yaml
+++ b/test/e2e/data/ironic-standalone-operator/operator/components/configmap/patch-configmap.yaml
@@ -4,4 +4,4 @@ metadata:
   name: ironic-standalone-operator-ironic-standalone-operator-config
   namespace: ironic-standalone-operator-system
 data:
-  IPA_BASEURI: "https://artifactory.nordix.org/artifactory/openstack-remote-cache/ironic-python-agent/dib"
+  IPA_BASEURI: "https://artifactory.nordix.org/artifactory/openstack-remote/ironic-python-agent/dib"


### PR DESCRIPTION
This commit:
 - Makes sure that the correct IPA Nordix proxy is used.

Previous address circumvented the proper cache refresh trigger so in case the cache was empty after a cleanup, cache refresh was not triggered.