### PR TITLE
:bug: Node reuse: transient error treatment

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -710,19 +710,16 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 				var m3mt *infrav1.Metal3MachineTemplate
 				m3mt, err = m.getMetal3MachineTemplate(ctx)
 				if err != nil {
+					return fmt.Errorf("cannot get Metal3MachineTemplate: %w", err)
+				}
+				if m3mt == nil {
 					// we are here, because while normal deprovisioning, Metal3MachineTemplate will be deleted first
 					// and we can't get it even though Metal3Machine has reference to it. We consider it nil and move
 					// forward with normal deprovisioning.
-					m3mt = nil
 					m.Log.Info("Metal3MachineTemplate associated with Metal3Machine is deleted",
-						LogFieldHost, host.Name,
-						LogFieldError, err.Error())
+						LogFieldHost, host.Name)
 				} else {
-					// in case of upgrading, Metal3MachineTemplate will not be deleted and we can fetch it,
-					// in order to check for node reuse feature in the next step.
 					m.Log.Info("Found Metal3machineTemplate", "metal3machineTemplate", m3mt.Name)
-				}
-				if m3mt != nil {
 					if ptr.Deref(m3mt.Spec.NodeReuse, false) {
 						if host.Labels == nil {
 							host.Labels = make(map[string]string)
@@ -1943,85 +1940,106 @@ func (m *MachineManager) getControlPlaneName(_ context.Context) (string, error) 
 // getMachineDeploymentName retrieves the MachineDeployment object name corresponding to the MachineSet.
 func (m *MachineManager) getMachineDeploymentName(ctx context.Context) (string, error) {
 	m.Log.Info("Fetching MachineDeployment name")
-
-	// Fetch MachineSet.
-	m.Log.Info("Fetching MachineSet first to find corresponding MachineDeployment later")
-
 	machineSet, err := m.getMachineSet(ctx)
 	if err != nil {
 		return "", err
 	}
-	if machineSet.ObjectMeta.OwnerReferences == nil {
-		return "", errors.New("machineset owner reference is not populated")
+	if machineSet == nil {
+		return "", errors.New("machineSet is not accessible")
 	}
-	for _, msOwnerRef := range machineSet.ObjectMeta.OwnerReferences {
-		if msOwnerRef.Kind != "MachineDeployment" {
-			continue
-		}
-		aGV, err := schema.ParseGroupVersion(msOwnerRef.APIVersion)
-		if err != nil {
-			return "", errors.New("failed to parse the group and version")
-		}
-		if aGV.Group != clusterv1.GroupVersion.Group {
-			continue
-		}
-		// adding prefix to MachineDeployment name in order to be able to differentiate
-		// MachineDeployment and ControlPlane in case they have the same names set in the cluster.
-		m.Log.Info("Fetched MachineDeployment name", "machinedeployment", "md-"+msOwnerRef.Name)
-		return "md-" + msOwnerRef.Name, nil
+	objRef := m.getMachineDeploymentRef(machineSet)
+	if objRef == nil {
+		return "", errors.New("machine deployment not mentioned in owner reference")
 	}
-	return "", errors.New("machineDeployment name is not found")
+	return "md-" + objRef.Name, nil
 }
 
 // getMachineSet retrieves the MachineSet object corresponding to the CAPI machine.
 func (m *MachineManager) getMachineSet(ctx context.Context) (*clusterv1.MachineSet, error) {
-	m.Log.Info("Fetching MachineSet name")
-	// Get list of MachineSets.
-	machineSets := &clusterv1.MachineSetList{}
 	if m.Machine == nil {
-		return nil, errors.New("could not find corresponding machine object")
+		return nil, nil //nolint:nilnil
 	}
-	if m.isControlPlane() {
-		return nil, errors.New("machine is controlplane, MachineSet can not be associated with it")
+	for _, mOwnerRef := range m.Machine.ObjectMeta.OwnerReferences {
+		if mOwnerRef.Kind != "MachineSet" {
+			continue
+		}
+		gv, err := schema.ParseGroupVersion(mOwnerRef.APIVersion)
+		if err != nil {
+			m.Log.Error(err, "Machine has an owner with unparsable apiversion")
+			continue
+		}
+		if gv.Group != clusterv1.GroupVersion.Group {
+			continue
+		}
+		key := client.ObjectKey{Name: mOwnerRef.Name, Namespace: m.Machine.Namespace}
+		mSet := &clusterv1.MachineSet{}
+		if err := m.client.Get(ctx, key, mSet); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, nil //nolint:nilnil
+			}
+			return nil, err
+		}
+		if mOwnerRef.UID != "" && mSet.UID != mOwnerRef.UID {
+			m.Log.Info("MachineSet UID does not match Machine owner reference UID", LogFieldMachineSet, mSet.Name, "machineSetUID", mSet.UID, "ownerRefUID", mOwnerRef.UID)
+			return nil, nil //nolint:nilnil
+		}
+		return mSet, nil
 	}
-	if m.Machine.ObjectMeta.OwnerReferences == nil {
-		return nil, errors.New("machine owner reference is not populated")
-	}
-	if err := m.client.List(ctx, machineSets, client.InNamespace(m.Machine.Namespace)); err != nil {
-		return nil, err
-	}
+	return nil, nil //nolint:nilnil
+}
 
-	// Iterate over MachineSets list and find MachineSet which references specific machine.
-	var machineSetError string
-	for index := range machineSets.Items {
-		machineset := &machineSets.Items[index]
-		for _, mOwnerRef := range m.Machine.ObjectMeta.OwnerReferences {
-			if mOwnerRef.Kind != "MachineSet" {
-				continue
-			}
-			gv, err := schema.ParseGroupVersion(mOwnerRef.APIVersion)
-			if err != nil {
-				return nil, errors.New("failed to parse ownerRef Group of Machine")
-			}
-			if gv.Group != clusterv1.GroupVersion.Group {
-				machineSetError += fmt.Sprintf("MachineSet %s has different API version %s than Machine %s with API version %s",
-					machineset.Name, machineset.APIVersion, m.Machine.Name, mOwnerRef.APIVersion)
-				continue
-			}
-			if mOwnerRef.UID != machineset.UID {
-				machineSetError = fmt.Sprintf("MachineSet %s has different UID %s than Machine %s with UID %s",
-					machineset.Name, machineset.UID, m.Machine.Name, mOwnerRef.UID)
-				continue
-			}
-			if mOwnerRef.Name == machineset.Name {
-				m.Log.Info("Found MachineSet corresponding to machine", "machineset", machineset.Name)
-				return machineset, nil
-			}
-			machineSetError = fmt.Sprintf("MachineSet %s does not match Machine %s owner reference %s", machineset.Name, m.Machine.Name, mOwnerRef.Name)
+// getMachineDeploymentRef retrieves a reference to the MachineDeployment from a MachineSet resource.
+func (m *MachineManager) getMachineDeploymentRef(machineSet *clusterv1.MachineSet) *corev1.ObjectReference {
+	for _, owner := range machineSet.OwnerReferences {
+		if owner.Kind != "MachineDeployment" {
+			continue
+		}
+		gv, err := schema.ParseGroupVersion(owner.APIVersion)
+		if err != nil {
+			continue
+		}
+		if gv.Group != clusterv1.GroupVersion.Group {
+			continue
+		}
+		return &corev1.ObjectReference{
+			APIVersion: owner.APIVersion,
+			Kind:       owner.Kind,
+			Name:       owner.Name,
+			Namespace:  machineSet.Namespace,
 		}
 	}
+	return nil
+}
 
-	return nil, errors.New(machineSetError)
+func (m *MachineManager) getControlPlaneReference() *corev1.ObjectReference {
+	m.Log.Info("Fetching ControlPlane name")
+	if m.Machine == nil {
+		return nil
+	}
+	if m.Machine.ObjectMeta.OwnerReferences == nil {
+		return nil
+	}
+	for _, mOwnerRef := range m.Machine.ObjectMeta.OwnerReferences {
+		aGV, err := schema.ParseGroupVersion(mOwnerRef.APIVersion)
+		if err != nil {
+			m.Log.Error(err, "Found an unparsable APIVersion in owners", "apiVersion", mOwnerRef.APIVersion)
+			continue
+		}
+		if aGV.Group != controlplanev1.GroupVersion.Group {
+			continue
+		}
+		// adding prefix to ControlPlane name in order to be able to differentiate
+		// ControlPlane and MachineDeployment in case they have the same names set in the cluster.
+		m.Log.Info("Fetched ControlPlane name", "controlPlane", "cp-"+mOwnerRef.Name)
+		objRef := corev1.ObjectReference{
+			Namespace:  m.Machine.Namespace,
+			Name:       mOwnerRef.Name,
+			Kind:       mOwnerRef.Kind,
+			APIVersion: mOwnerRef.APIVersion,
+		}
+		return &objRef
+	}
+	return nil
 }
 
 // getMetal3MachineTemplate retrieves the Metal3MachineTemplate object from Metal3Machine
@@ -2031,10 +2049,6 @@ func (m *MachineManager) getMetal3MachineTemplate(ctx context.Context) (*infrav1
 	if m.Machine == nil {
 		return nil, errors.New("could not find corresponding machine object")
 	}
-	if m.Machine.ObjectMeta.OwnerReferences == nil {
-		return nil, errors.New("machine owner reference is not populated")
-	}
-
 	// Check if this is a worker machine first.
 	if !m.isControlPlane() {
 		// This is a worker machine, get MachineSet first.
@@ -2042,7 +2056,10 @@ func (m *MachineManager) getMetal3MachineTemplate(ctx context.Context) (*infrav1
 		if err != nil {
 			return nil, fmt.Errorf("failed to get MachineSet: %w", err)
 		}
-
+		if machineSet == nil {
+			m.Log.Info("Access to MachineSet permanently deleted")
+			return nil, nil //nolint:nilnil
+		}
 		// Get Metal3MachineTemplate from MachineSet.
 		m3mt := &infrav1.Metal3MachineTemplate{}
 		m3mtKey := client.ObjectKey{
@@ -2050,56 +2067,70 @@ func (m *MachineManager) getMetal3MachineTemplate(ctx context.Context) (*infrav1
 			Namespace: machineSet.Namespace,
 		}
 		if err := m.client.Get(ctx, m3mtKey, m3mt); err != nil {
+			if apierrors.IsNotFound(err) {
+				m.Log.Info("Cannot find machine template", LogFieldMetal3MachineTemplate, machineSet.Spec.Template.Spec.InfrastructureRef.Name)
+				return nil, nil //nolint:nilnil
+			}
 			return nil, fmt.Errorf("failed to get Metal3MachineTemplate from MachineSet: %w", err)
 		}
 		m.Log.Info("Fetched Metal3MachineTemplate from MachineSet", "metal3MachineTemplate", m3mt.Name)
 		return m3mt, nil
 	}
 
-	// This is a control plane machine. Iterate over all owner references and try to find one
-	// that exposes the infra template ref at spec.machineTemplate.spec.infrastructureRef.
+	// This is a control plane machine. Get the controlPlane resource from the cluster and
+	// extract the infra template ref at spec.machineTemplate.spec.infrastructureRef.
 	// We use unstructured to support any control plane provider, not just KubeadmControlPlane,
 	// following the same pattern CAPI uses for all infra providers.
-	for _, mOwnerRef := range m.Machine.ObjectMeta.OwnerReferences {
-		// Fetch the owner object as unstructured to support any control plane provider.
-		cpObj := &unstructured.Unstructured{}
-		cpObj.SetAPIVersion(mOwnerRef.APIVersion)
-		cpObj.SetKind(mOwnerRef.Kind)
-		cpKey := client.ObjectKey{
-			Name:      mOwnerRef.Name,
-			Namespace: m.Machine.Namespace,
-		}
-		if err := m.client.Get(ctx, cpKey, cpObj); err != nil {
-			return nil, fmt.Errorf("failed to get owner object %s %s: %w", mOwnerRef.Kind, mOwnerRef.Name, err)
-		}
-
-		// According to CAPI contract control plane providers must expose the infra template ref at
-		// spec.machineTemplate.spec.infrastructureRef. If not present, this owner is
-		// not a control plane provider - skip it.
-		m3mtName, found, err := unstructured.NestedString(cpObj.Object, "spec", "machineTemplate", "spec", "infrastructureRef", "name")
-		if err != nil || !found || m3mtName == "" {
-			continue
-		}
-
-		m3mtNamespace, _, _ := unstructured.NestedString(cpObj.Object, "spec", "machineTemplate", "spec", "infrastructureRef", "namespace")
-		if m3mtNamespace == "" {
-			m3mtNamespace = m.Machine.Namespace
-		}
-
-		// Get Metal3MachineTemplate.
-		m3mt := &infrav1.Metal3MachineTemplate{}
-		m3mtKey := client.ObjectKey{
-			Name:      m3mtName,
-			Namespace: m3mtNamespace,
-		}
-		if err := m.client.Get(ctx, m3mtKey, m3mt); err != nil {
-			return nil, fmt.Errorf("failed to get Metal3MachineTemplate from control plane %s: %w", mOwnerRef.Kind, err)
-		}
-		m.Log.Info("Fetched Metal3MachineTemplate from control plane", "kind", mOwnerRef.Kind, "metal3MachineTemplate", m3mt.Name)
-		return m3mt, nil
+	objRef := m.getControlPlaneReference()
+	// If the path to the control-plane is broken. It probably means the cluster is
+	// being deleted. Anyway, this will not change.
+	if objRef == nil {
+		return nil, nil //nolint:nilnil
 	}
 
-	return nil, errors.New("no owner reference with spec.machineTemplate.spec.infrastructureRef found in machine owner references")
+	// Fetch the owner object as unstructured to support any control plane provider.
+	cpObj := &unstructured.Unstructured{}
+	cpObj.SetAPIVersion(objRef.APIVersion)
+	cpObj.SetKind(objRef.Kind)
+	cpKey := client.ObjectKey{
+		Name:      objRef.Name,
+		Namespace: objRef.Namespace,
+	}
+	if err := m.client.Get(ctx, cpKey, cpObj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil //nolint:nilnil
+		}
+		return nil, fmt.Errorf("failed to get controlPlane object %s %s: %w", objRef.Kind, objRef.Name, err)
+	}
+
+	// According to CAPI contract control plane providers must expose the infra template ref at
+	// spec.machineTemplate.spec.infrastructureRef. If not present, this owner is
+	// not a control plane provider - skip it.
+	m3mtName, found, err := unstructured.NestedString(cpObj.Object, "spec", "machineTemplate", "spec", "infrastructureRef", "name")
+	if err != nil || !found || m3mtName == "" {
+		// Impossible to recover. We must assume the control-plane is definitively non reachable.
+		return nil, nil //nolint:nilnil,nilerr
+	}
+
+	m3mtNamespace, _, _ := unstructured.NestedString(cpObj.Object, "spec", "machineTemplate", "spec", "infrastructureRef", "namespace")
+	if m3mtNamespace == "" {
+		m3mtNamespace = m.Machine.Namespace
+	}
+
+	// Get Metal3MachineTemplate.
+	m3mt := &infrav1.Metal3MachineTemplate{}
+	m3mtKey := client.ObjectKey{
+		Name:      m3mtName,
+		Namespace: m3mtNamespace,
+	}
+	if err := m.client.Get(ctx, m3mtKey, m3mt); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil //nolint:nilnil
+		}
+		return nil, fmt.Errorf("failed to get Metal3MachineTemplate from control plane %s: %w", objRef.Kind, err)
+	}
+	m.Log.Info("Fetched Metal3MachineTemplate from control plane", "Kind", objRef.Kind, LogFieldMetal3MachineTemplate, m3mt.Name)
+	return m3mt, nil
 }
 
 // getBmhNameFromM3Machine retrieves bmhName from m3m annotations.

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/go-logr/logr"
 	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
@@ -2279,13 +2278,16 @@ var _ = Describe("Metal3Machine manager", func() {
 	)
 
 	type testCaseDelete struct {
-		Host                            *bmov1alpha1.BareMetalHost
-		Secret                          *corev1.Secret
-		Machine                         *clusterv1.Machine
-		M3Machine                       *infrav1.Metal3Machine
-		BMCSecret                       *corev1.Secret
-		ExpectedConsumerRef             *corev1.ObjectReference
-		ExpectedResult                  error
+		Host                *bmov1alpha1.BareMetalHost
+		Secret              *corev1.Secret
+		Machine             *clusterv1.Machine
+		M3Machine           *infrav1.Metal3Machine
+		ControlPlane        *controlplanev1.KubeadmControlPlane
+		BMCSecret           *corev1.Secret
+		ExpectedConsumerRef *corev1.ObjectReference
+		ExpectError         bool
+		ExpectRequeue       bool
+		//		ExpectedResult                  error
 		ExpectSecretDeleted             bool
 		ExpectClusterLabelDeleted       bool
 		ExpectedPausedAnnotationDeleted bool
@@ -2298,6 +2300,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Metal3MachineTemplate           *infrav1.Metal3MachineTemplate
 		MachineSet                      *clusterv1.MachineSet
 		ExpectedNodeReuseValue          string
+		FailingResource                 *client.ObjectKey
 	}
 
 	DescribeTable("Test Delete function",
@@ -2318,10 +2321,18 @@ var _ = Describe("Metal3Machine manager", func() {
 			if tc.MachineSet != nil {
 				objects = append(objects, tc.MachineSet)
 			}
-
+			if tc.ControlPlane != nil {
+				objects = append(objects, tc.ControlPlane)
+			}
 			Capm3FastTrack = tc.capm3fasttrack
 
-			fakeClient := fake.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			scheme := setupSchemeMm()
+			Expect(controlplanev1.AddToScheme(scheme)).To(Succeed())
+
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+			if tc.FailingResource != nil {
+				fakeClient = &FailingClient{WithWatch: fakeClient, FailingResource: *tc.FailingResource}
+			}
 
 			machineMgr, err := NewMachineManager(fakeClient, tc.Cluster, nil, tc.Machine,
 				tc.M3Machine, logr.Discard(),
@@ -2330,12 +2341,15 @@ var _ = Describe("Metal3Machine manager", func() {
 
 			err = machineMgr.Delete(context.TODO())
 
-			if tc.ExpectedResult == nil {
-				Expect(err).NotTo(HaveOccurred())
+			if tc.ExpectError || tc.ExpectRequeue {
+				Expect(err).To(HaveOccurred())
+				if tc.ExpectRequeue {
+					Expect(err).To(BeAssignableToTypeOf(ReconcileError{}))
+				} else {
+					Expect(err).NotTo(BeAssignableToTypeOf(ReconcileError{}))
+				}
 			} else {
-				var reconcileError ReconcileError
-				Expect(errors.As(err, &reconcileError)).To(BeTrue())
-				Expect(reconcileError.IsTransient()).To(BeTrue())
+				Expect(err).NotTo(HaveOccurred())
 			}
 
 			if tc.Host != nil {
@@ -2461,7 +2475,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			ExpectedConsumerRef:     consumerRef(),
-			ExpectedResult:          ReconcileError{},
+			ExpectRequeue:           true,
 			Secret:                  newSecret(),
 			ExpectedBMHOnlineStatus: false,
 		}),
@@ -2474,7 +2488,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			ExpectedConsumerRef:     consumerRef(),
-			ExpectedResult:          ReconcileError{},
+			ExpectRequeue:           true,
 			Secret:                  newSecret(),
 			ExpectedBMHOnlineStatus: false,
 		}),
@@ -2498,7 +2512,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			ExpectedConsumerRef: consumerRef(),
-			ExpectedResult:      ReconcileError{nil, TransientErrorType, time.Second * 30},
+			ExpectRequeue:       true,
 			Secret:              newSecret(),
 		}),
 		Entry("Externally provisioned host should be powered down", testCaseDelete{
@@ -2510,8 +2524,9 @@ var _ = Describe("Metal3Machine manager", func() {
 				m3mObjectMetaWithValidAnnotations(),
 			),
 			ExpectedConsumerRef: consumerRef(),
-			ExpectedResult:      ReconcileError{nil, TransientErrorType, time.Second * 30},
-			Secret:              newSecret(),
+			ExpectRequeue:       true,
+			// ExpectedResult:      ReconcileError{nil, TransientErrorType, time.Second * 30},
+			Secret: newSecret(),
 		}),
 		Entry("Consumer ref should be removed from externally provisioned host",
 			testCaseDelete{
@@ -2683,7 +2698,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			ExpectedResult:          ReconcileError{},
+			ExpectRequeue:           true,
 			ExpectedConsumerRef:     consumerRef(),
 			Secret:                  newSecret(),
 			capm3fasttrack:          "false",
@@ -2696,7 +2711,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			ExpectedResult:          ReconcileError{},
+			ExpectRequeue:           true,
 			ExpectedConsumerRef:     consumerRef(),
 			Secret:                  newSecret(),
 			capm3fasttrack:          "true",
@@ -2709,7 +2724,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			ExpectedResult:          ReconcileError{},
+			ExpectRequeue:           true,
 			ExpectedConsumerRef:     consumerRef(),
 			Secret:                  newSecret(),
 			capm3fasttrack:          "false",
@@ -2722,7 +2737,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			ExpectedResult:          ReconcileError{},
+			ExpectRequeue:           true,
 			ExpectedConsumerRef:     consumerRef(),
 			capm3fasttrack:          "true",
 			Secret:                  newSecret(),
@@ -2735,7 +2750,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			ExpectedResult:          ReconcileError{},
+			ExpectRequeue:           true,
 			ExpectedConsumerRef:     consumerRef(),
 			capm3fasttrack:          "",
 			Secret:                  newSecret(),
@@ -2748,7 +2763,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			ExpectedResult:          ReconcileError{},
+			ExpectRequeue:           true,
 			ExpectedConsumerRef:     consumerRef(),
 			capm3fasttrack:          "",
 			Secret:                  newSecret(),
@@ -2761,7 +2776,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			ExpectedResult:          ReconcileError{},
+			ExpectRequeue:           true,
 			ExpectedConsumerRef:     consumerRef(),
 			capm3fasttrack:          "",
 			Secret:                  newSecret(),
@@ -2774,7 +2789,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			ExpectedResult:          ReconcileError{},
+			ExpectRequeue:           true,
 			ExpectedConsumerRef:     consumerRef(),
 			capm3fasttrack:          "",
 			Secret:                  newSecret(),
@@ -2787,7 +2802,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			ExpectedResult:          ReconcileError{},
+			ExpectRequeue:           true,
 			ExpectedConsumerRef:     consumerRef(),
 			capm3fasttrack:          "true",
 			Secret:                  newSecret(),
@@ -2800,7 +2815,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				m3mObjectMetaWithValidAnnotations(),
 			),
-			ExpectedResult:          ReconcileError{},
+			ExpectRequeue:           true,
 			ExpectedConsumerRef:     consumerRef(),
 			capm3fasttrack:          "true",
 			Secret:                  newSecret(),
@@ -2921,7 +2936,226 @@ var _ = Describe("Metal3Machine manager", func() {
 				APIVersion: clusterv1.GroupVersion.String(),
 			},
 		}),
+		Entry("NodeReuse enabled, machine is worker. Transient error on fetching machineSet is seen", testCaseDelete{
+			Host: newBareMetalHost(baremetalhostName,
+				&bmov1alpha1.BareMetalHostSpec{
+					ConsumerRef: consumerRef(),
+					Online:      false,
+				},
+				bmov1alpha1.StateNone,
+				&bmov1alpha1.BareMetalHostStatus{
+					Provisioning: bmov1alpha1.ProvisionStatus{
+						State: bmov1alpha1.StateNone,
+					},
+				}, false, "metadata", true, "", false),
+			Machine: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      machineName,
+					Namespace: namespaceName,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: clusterv1.GroupVersion.String(),
+							Name:       "myMachineSet",
+							UID:        "123456789",
+							Kind:       "MachineSet",
+						},
+					},
+				},
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						DataSecretName: ptr.To(metal3machineName + "-user-data")},
+				},
+			},
+			MachineSet: &clusterv1.MachineSet{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: clusterv1.GroupVersion.String(),
+					Kind:       "MachineSet",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myMachineSet",
+					Namespace: namespaceName,
+					UID:       "123456789",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: clusterv1.GroupVersion.String(),
+							Kind:       "MachineDeployment",
+							Name:       "test1",
+						},
+					},
+				},
+				Spec: clusterv1.MachineSetSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							InfrastructureRef: clusterv1.ContractVersionedObjectReference{
+								Kind:     "Metal3MachineTemplate",
+								Name:     "abc",
+								APIGroup: infrav1.GroupVersion.Group,
+							},
+						},
+					},
+				},
+			},
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
+				&metav1.ObjectMeta{
+					Name:      metal3machineName,
+					Namespace: namespaceName,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "MachineSet",
+							APIVersion: infrav1.GroupVersion.String(),
+							Name:       "test1",
+							UID:        "123456789",
+						},
+						{
+							APIVersion: clusterv1.GroupVersion.String(),
+							Kind:       "Machine",
+							Name:       "test1-bwjsg",
+							UID:        "070f03fb-b0e1-4863-9d95-7fd681d8d257",
+						},
+					},
+					Labels: map[string]string{
+						clusterv1.ClusterNameLabel: clusterName,
+					},
+					Annotations: map[string]string{
+						HostAnnotation:                           namespaceName + "/" + baremetalhostName,
+						"cluster.x-k8s.io/cloned-from-name":      "abc",
+						"cluster.x-k8s.io/cloned-from-groupkind": infrav1.ClonedFromGroupKind,
+					},
+				}),
+			Cluster:             newCluster(clusterName),
+			Secret:              newSecret(),
+			ExpectSecretDeleted: false,
+			Metal3MachineTemplate: &infrav1.Metal3MachineTemplate{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: infrav1.GroupVersion.String(),
+					Kind:       "Metal3MachineTemplate",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "abc",
+					Namespace: namespaceName,
+				},
+				Spec: infrav1.Metal3MachineTemplateSpec{
+					Template: infrav1.Metal3MachineTemplateResource{
+						Spec: infrav1.Metal3MachineSpec{
+							AutomatedCleaningMode: infrav1.CleaningModeDisabled,
+						},
+					},
+					NodeReuse: ptr.To(true),
+				}},
+			FailingResource:     &client.ObjectKey{Namespace: namespaceName, Name: "myMachineSet"},
+			ExpectedConsumerRef: consumerRef(),
+			ExpectError:         true,
+		}),
 		Entry("NodeReuse enabled, machine is controlplane, no error expected", testCaseDelete{
+			Host: newBareMetalHost(baremetalhostName,
+				&bmov1alpha1.BareMetalHostSpec{
+					ConsumerRef: consumerRef(),
+					Online:      false,
+				},
+				bmov1alpha1.StateNone,
+				&bmov1alpha1.BareMetalHostStatus{
+					Provisioning: bmov1alpha1.ProvisionStatus{
+						State: bmov1alpha1.StateNone,
+					},
+				}, false, "metadata", false, "", false),
+			Machine: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      machineName,
+					Namespace: namespaceName,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "controlplane.cluster.x-k8s.io/v1beta2",
+							Name:       "test1",
+							UID:        "123456789",
+							Kind:       "KubeadmControlPlane",
+						},
+					},
+					Labels: map[string]string{
+						clusterv1.MachineControlPlaneLabel: "cluster.x-k8s.io/control-plane",
+					},
+				},
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						DataSecretName: ptr.To(metal3machineName + "-user-data")},
+				},
+			},
+			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
+				&metav1.ObjectMeta{
+					Name:      metal3machineName,
+					Namespace: namespaceName,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "KubeadmControlPlane",
+							APIVersion: infrav1.GroupVersion.String(),
+							Name:       "test1",
+							UID:        "2a72b7d2-b5bd-4074-a1fe-7d417bdcd95b",
+						},
+						{
+							APIVersion: clusterv1.GroupVersion.String(),
+							Kind:       "Machine",
+							Name:       "test1-bwjsg",
+							UID:        "070f03fb-b0e1-4863-9d95-7fd681d8d257",
+						},
+					},
+					Labels: map[string]string{
+						clusterv1.ClusterNameLabel: clusterName,
+					},
+					Annotations: map[string]string{
+						HostAnnotation:                           namespaceName + "/" + baremetalhostName,
+						"cluster.x-k8s.io/cloned-from-name":      "abc",
+						"cluster.x-k8s.io/cloned-from-groupkind": infrav1.ClonedFromGroupKind,
+					},
+				}),
+			Cluster:             newCluster(clusterName),
+			Secret:              newSecret(),
+			ExpectSecretDeleted: false,
+			NodeReuseEnabled:    true,
+			Metal3MachineTemplate: &infrav1.Metal3MachineTemplate{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: infrav1.GroupVersion.String(),
+					Kind:       "Metal3MachineTemplate",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "abc",
+					Namespace: namespaceName,
+				},
+				Spec: infrav1.Metal3MachineTemplateSpec{
+					Template: infrav1.Metal3MachineTemplateResource{
+						Spec: infrav1.Metal3MachineSpec{
+							AutomatedCleaningMode: infrav1.CleaningModeDisabled,
+						},
+					},
+					NodeReuse: ptr.To(true),
+				}},
+			ControlPlane: &controlplanev1.KubeadmControlPlane{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: controlplanev1.GroupVersion.String(),
+					Kind:       "KubeadmControlPlane",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test1",
+					Namespace: namespaceName,
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
+						Spec: controlplanev1.KubeadmControlPlaneMachineTemplateSpec{
+							InfrastructureRef: clusterv1.ContractVersionedObjectReference{
+								Kind:     "Metal3MachineTemplate",
+								Name:     "abc",
+								APIGroup: infrav1.GroupVersion.Group,
+							},
+						},
+					},
+				}},
+			ExpectedNodeReuseValue: "cp-test1",
+			ExpectedConsumerRef: &corev1.ObjectReference{
+				Name:       "baremetal-testcluster",
+				Namespace:  namespaceName,
+				Kind:       "Cluster",
+				APIVersion: clusterv1.GroupVersion.String(),
+			},
+		}),
+		Entry("NodeReuse enabled, machine is controlplane, transient error", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName,
 				&bmov1alpha1.BareMetalHostSpec{
 					ConsumerRef: consumerRef(),
@@ -3001,6 +3235,29 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 					NodeReuse: ptr.To(true),
 				}},
+			ControlPlane: &controlplanev1.KubeadmControlPlane{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: controlplanev1.GroupVersion.String(),
+					Kind:       "KubeadmControlPlane",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test1",
+					Namespace: namespaceName,
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
+						Spec: controlplanev1.KubeadmControlPlaneMachineTemplateSpec{
+							InfrastructureRef: clusterv1.ContractVersionedObjectReference{
+								Kind:     "Metal3MachineTemplate",
+								Name:     "abc",
+								APIGroup: infrav1.GroupVersion.Group,
+							},
+						},
+					},
+				}},
+			FailingResource:     &client.ObjectKey{Namespace: namespaceName, Name: "test1"},
+			ExpectedConsumerRef: consumerRef(),
+			ExpectError:         true,
 		}),
 	)
 
@@ -4554,6 +4811,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		expectedMD         bool
 		expectedMDName     string
 		expectError        bool
+		failingResource    *client.ObjectKey
 	}
 	DescribeTable("Test GetMachineDeploymentName",
 		func(tc testCaseGetMachineDeploymentName) {
@@ -4567,6 +4825,9 @@ var _ = Describe("Metal3Machine manager", func() {
 				}
 			}
 			fakeClient := fake.NewClientBuilder().WithScheme(setupSchemeMm()).WithObjects(objects...).Build()
+			if tc.failingResource != nil {
+				fakeClient = &FailingClient{WithWatch: fakeClient, FailingResource: *tc.failingResource}
+			}
 			machineMgr, err := NewMachineSetManager(fakeClient, tc.Machine,
 				tc.MachineSetList, logr.Discard(),
 			)
@@ -4640,6 +4901,49 @@ var _ = Describe("Metal3Machine manager", func() {
 			expectedMD:     true,
 			expectedMDName: "md-test1",
 		}),
+		Entry("Should return an error when a transient error occurs while fetching machineSet", testCaseGetMachineDeploymentName{
+			Machine: machineOwnedByMachineSet(),
+			MachineSetList: &clusterv1.MachineSetList{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: clusterv1.GroupVersion.String(),
+					Kind:       "MachineSetList",
+				},
+				ListMeta: metav1.ListMeta{},
+				Items: []clusterv1.MachineSet{
+					{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: clusterv1.GroupVersion.String(),
+							Kind:       "MachineSet",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ms-test1",
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									APIVersion: clusterv1.GroupVersion.String(),
+									Kind:       "MachineDeployment",
+									Name:       "test1",
+								},
+							},
+						},
+					},
+					{
+						TypeMeta: metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test2",
+						},
+					},
+					{
+						TypeMeta: metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test3",
+						},
+					},
+				},
+			},
+			failingResource: &client.ObjectKey{Name: "ms-test1"},
+			expectError:     true,
+		}),
+
 		Entry("Should not find the expected MachineDeployment name, MachineSet OwnerRef Kind is not correct", testCaseGetMachineDeploymentName{
 			Machine: machineOwnedByMachineSet(),
 			MachineSetList: &clusterv1.MachineSetList{
@@ -4781,7 +5085,11 @@ var _ = Describe("Metal3Machine manager", func() {
 				Expect(tc.expectedMachineSet).To(BeNil())
 			} else {
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result.Name).To(Equal(tc.expectedMachineSet.Name))
+				if tc.expectedMachineSet != nil {
+					Expect(result.Name).To(Equal(tc.expectedMachineSet.Name))
+				} else {
+					Expect(result).To(BeNil())
+				}
 			}
 		},
 		Entry("Should find the expected Machineset", testCaseGetMachineSet{
@@ -4821,13 +5129,13 @@ var _ = Describe("Metal3Machine manager", func() {
 				ObjectMeta: testObjectMeta("ms-test1", "", ""),
 			},
 		}),
-		Entry("Should not find the Machineset and error when machine is nil", testCaseGetMachineSet{
+		Entry("Should not find the Machineset when machine is nil", testCaseGetMachineSet{
 			Machine:            nil,
 			expectedMachineSet: nil,
 			MachineSetList:     nil,
-			expectError:        true,
+			expectError:        false,
 		}),
-		Entry("Should not find the Machineset and error when machine is a controlplane", testCaseGetMachineSet{
+		Entry("Should not find the Machineset when machine is a controlplane", testCaseGetMachineSet{
 			Machine: &clusterv1.Machine{
 				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
@@ -4838,9 +5146,9 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 			expectedMachineSet: nil,
 			MachineSetList:     nil,
-			expectError:        true,
+			expectError:        false,
 		}),
-		Entry("Should not find the Machineset and error when machine ownerRef is empty", testCaseGetMachineSet{
+		Entry("Should not find the Machineset when machine ownerRef is empty", testCaseGetMachineSet{
 			Machine: &clusterv1.Machine{
 				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
@@ -4849,7 +5157,7 @@ var _ = Describe("Metal3Machine manager", func() {
 			},
 			expectedMachineSet: nil,
 			MachineSetList:     nil,
-			expectError:        true,
+			expectError:        false,
 		}),
 		Entry("Should not find the Machineset when machine ownerRef Kind is not correct", testCaseGetMachineSet{
 			Machine: &clusterv1.Machine{
@@ -4887,7 +5195,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			},
 			expectedMachineSet: nil,
-			expectError:        true,
+			expectError:        false,
 		}),
 		Entry("Should not find the Machineset when machine ownerRef APIVersion is not correct", testCaseGetMachineSet{
 			Machine: &clusterv1.Machine{
@@ -4925,7 +5233,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			},
 			expectedMachineSet: nil,
-			expectError:        true,
+			expectError:        false,
 		}),
 		Entry("Should not find the Machineset when UID is not correct", testCaseGetMachineSet{
 			Machine: &clusterv1.Machine{
@@ -4965,7 +5273,7 @@ var _ = Describe("Metal3Machine manager", func() {
 				},
 			},
 			expectedMachineSet: nil,
-			expectError:        true,
+			expectError:        false,
 		}),
 	)
 
@@ -5298,4 +5606,18 @@ func filterCondition(conditions []metav1.Condition, conditionType string) []meta
 		}
 	}
 	return filtered
+}
+
+type FailingClient struct {
+	client.WithWatch
+	FailingResource client.ObjectKey
+}
+
+var errTransient = errors.New("transient failure")
+
+func (fc *FailingClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if key == fc.FailingResource {
+		return errTransient
+	}
+	return fc.WithWatch.Get(ctx, key, obj, opts...)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
While looking for Metal3 templates, there are two kinds of potential problems:

* A transient error occurred while fetching a resource
* A resource no longer exists

In the second case, it is reasonable to consider that there is no node reuse, but in the first case, a retry must be done.

Fixes: #3385
