### PR TITLE
:bug: Set a consumer reference during node reuse

### DIFF
--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -609,6 +609,8 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 			return WithTransientError(errors.New(msg), requeueAfter)
 		}
 
+		host.Spec.ConsumerRef = nil
+
 		if m.Cluster != nil {
 			// If cluster has DeletionTimestamp set, skip checking if nodeReuse
 			// feature is enabled.
@@ -665,12 +667,16 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 							m.Log.Info("Setting nodeReuseLabelName in host to fetched MachineDeployment", LogFieldHost, host.Name, LogFieldMachineDeployment, mdName)
 							host.Labels[nodeReuseLabelName] = mdName
 						}
+						host.Spec.ConsumerRef = &corev1.ObjectReference{
+							Name:       m.Cluster.Name,
+							Namespace:  m.Cluster.Namespace,
+							APIVersion: clusterv1.GroupVersion.String(),
+							Kind:       "Cluster",
+						}
 					}
 				}
 			}
 		}
-
-		host.Spec.ConsumerRef = nil
 
 		// Remove the ownerreference to this machine.
 		host.OwnerReferences, err = m.DeleteOwnerRef(host.OwnerReferences)
@@ -869,9 +875,11 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmov1alpha1.BareMetal
 			helper, err = patch.NewHelper(&hosts.Items[i], m.client)
 			return &hosts.Items[i], helper, infrav1.AssociateBareMetalHostSuccessReason, err
 		}
-		if host.Spec.ConsumerRef != nil ||
-			(m.nodeReuseLabelExists(ctx, &host) &&
-				!m.nodeReuseLabelMatches(ctx, &host)) {
+		if m.nodeReuseLabelExists(ctx, &host) {
+			if !m.nodeReuseLabelMatches(ctx, &host) {
+				continue
+			}
+		} else if host.Spec.ConsumerRef != nil {
 			continue
 		}
 		if host.GetDeletionTimestamp() != nil {

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -1735,6 +1735,7 @@ var _ = Describe("Metal3Machine manager", func() {
 		Cluster                         *clusterv1.Cluster
 		Metal3MachineTemplate           *infrav1.Metal3MachineTemplate
 		MachineSet                      *clusterv1.MachineSet
+		ExpectedNodeReuseValue          string
 	}
 
 	DescribeTable("Test Delete function",
@@ -1786,14 +1787,22 @@ var _ = Describe("Metal3Machine manager", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				name := ""
+				kind := ""
 				expectedName := ""
+				expectedKind := ""
 				if host.Spec.ConsumerRef != nil {
 					name = host.Spec.ConsumerRef.Name
+					kind = host.Spec.ConsumerRef.Kind
 				}
 				if tc.ExpectedConsumerRef != nil {
 					expectedName = tc.ExpectedConsumerRef.Name
+					expectedKind = tc.ExpectedConsumerRef.Kind
 				}
 				Expect(name).To(Equal(expectedName))
+				Expect(kind).To(Equal(expectedKind))
+				if tc.NodeReuseEnabled {
+					Expect(kind).To(Equal("Cluster"))
+				}
 				if machineMgr.Metal3Machine.Status.MetaData == nil {
 					Expect(host.Spec.MetaData).NotTo(BeNil())
 				}
@@ -1860,18 +1869,6 @@ var _ = Describe("Metal3Machine manager", func() {
 				Expect(savedHost.Labels["foo"]).To(Equal("bar"))
 				Expect(savedCred.Labels["foo"]).To(Equal("bar"))
 			}
-			if tc.NodeReuseEnabled {
-				m3mTemplate := infrav1.Metal3MachineTemplate{}
-				err = fakeClient.Get(context.TODO(),
-					client.ObjectKey{
-						Name:      tc.M3Machine.ObjectMeta.GetAnnotations()[clusterv1.TemplateClonedFromNameAnnotation],
-						Namespace: tc.M3Machine.Namespace,
-					},
-					&m3mTemplate,
-				)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(m3mTemplate.Spec.NodeReuse).To(HaveValue(BeTrue()))
-			}
 
 			if tc.Host != nil {
 				savedbmh := bmov1alpha1.BareMetalHost{}
@@ -1887,6 +1884,10 @@ var _ = Describe("Metal3Machine manager", func() {
 					Expect(Capm3FastTrack).To(Equal("false"))
 				}
 				Expect(savedbmh.Spec.Online).To(Equal(tc.ExpectedBMHOnlineStatus))
+				if tc.NodeReuseEnabled {
+					Expect(savedbmh.Labels).ToNot(BeNil())
+					Expect(savedbmh.Labels[nodeReuseLabelName]).To(Equal(tc.ExpectedNodeReuseValue))
+				}
 			}
 		},
 		Entry("Deprovisioning needed", testCaseDelete{
@@ -2290,6 +2291,17 @@ var _ = Describe("Metal3Machine manager", func() {
 						},
 					},
 				},
+				Spec: clusterv1.MachineSetSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							InfrastructureRef: clusterv1.ContractVersionedObjectReference{
+								Kind:     "Metal3MachineTemplate",
+								Name:     "abc",
+								APIGroup: infrav1.GroupVersion.Group,
+							},
+						},
+					},
+				},
 			},
 			M3Machine: newMetal3Machine(metal3machineName, nil, m3mSecretStatus(),
 				&metav1.ObjectMeta{
@@ -2338,6 +2350,14 @@ var _ = Describe("Metal3Machine manager", func() {
 					},
 					NodeReuse: ptr.To(true),
 				}},
+			NodeReuseEnabled:       true,
+			ExpectedNodeReuseValue: "md-test1",
+			ExpectedConsumerRef: &corev1.ObjectReference{
+				Name:       "baremetal-testcluster",
+				Namespace:  namespaceName,
+				Kind:       "Cluster",
+				APIVersion: clusterv1.GroupVersion.String(),
+			},
 		}),
 		Entry("NodeReuse enabled, machine is controlplane, no error expected", testCaseDelete{
 			Host: newBareMetalHost(baremetalhostName,

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -317,6 +317,9 @@ func DeleteNodeReuseLabelFromHost(ctx context.Context, client client.Client, hos
 	if labels != nil {
 		if _, ok := labels[nodeReuseLabelName]; ok {
 			delete(host.Labels, nodeReuseLabelName)
+			// A labelled host should have a consumer ref set to the cluster. This reference must
+			// be removed too otherwise the node will be unavailable to other consumers.
+			host.Spec.ConsumerRef = nil
 		}
 	}
 	Expect(helper.Patch(ctx, &host)).To(Succeed())


### PR DESCRIPTION
**What this PR does / why we need it**:

Other BareMetalHost users assume that a BareMetalHost is free to use if its Consumer Reference is nil. During node-reuse metal3machine controller consider a reusable node as booked if it has a node reuse label but the consumer reference is empty.

We add a consumer reference to the node while it is booked. It points to the cluster.

Fixes: #3190
