### PR TITLE
✨ Bump golang to v1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.25.11@sha256:dd7d32e19b28621cd982082397fc0510d396805b717d5e77466aa2dd692340de
+ARG BUILD_IMAGE=docker.io/golang:1.26.4@sha256:32c0e6e5c4f6707717051091b4d0b077464a679eaab563e11474efc5328e2aa5
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary on golang image

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SHELL:=/usr/bin/env bash
 
 .DEFAULT_GOAL:=help
 
-GO_VERSION ?= 1.25.11
+GO_VERSION ?= 1.26.4
 GO := $(shell type -P go)
 # Use GOPROXY environment variable if set
 ifneq ($(GO),)

--- a/Tiltfile
+++ b/Tiltfile
@@ -171,7 +171,7 @@ def fixup_yaml_empty_arrays(yaml_str):
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.25 as tilt-helper
+FROM golang:1.26 as tilt-helper
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/cluster-api-provider-metal3/api
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/metal3-io/ip-address-manager/api v1.13.0

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -416,7 +416,7 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 		if err != nil {
 			log.V(baremetal.VerbosityLevelDebug).Info("Association failed",
 				baremetal.LogFieldError, err.Error())
-			machineMgr.SetV1Beta1ConditionToFalse(infrav1.AssociateBMHV1Beta1Condition, infrav1.AssociateBMHFailedV1Beta1Reason, clusterv1.ConditionSeverityError, err.Error())
+			machineMgr.SetV1Beta1ConditionToFalse(infrav1.AssociateBMHV1Beta1Condition, infrav1.AssociateBMHFailedV1Beta1Reason, clusterv1.ConditionSeverityError, "%s", err.Error())
 			machineMgr.SetCondition(infrav1.AssociateBareMetalHostCondition, metav1.ConditionFalse, infrav1.AssociateBareMetalHostFailedReason, err.Error())
 			return checkMachineError(machineMgr, err,
 				"failed to associate the Metal3Machine to a BareMetalHost", errType)
@@ -448,7 +448,7 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 	if err != nil {
 		log.V(baremetal.VerbosityLevelDebug).Info("Metadata association failed",
 			baremetal.LogFieldError, err.Error())
-		machineMgr.SetV1Beta1ConditionToFalse(infrav1.KubernetesNodeReadyV1Beta1Condition, infrav1.AssociateM3MetaDataFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, err.Error())
+		machineMgr.SetV1Beta1ConditionToFalse(infrav1.KubernetesNodeReadyV1Beta1Condition, infrav1.AssociateM3MetaDataFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, "%s", err.Error())
 		machineMgr.SetCondition(infrav1.AssociateMetal3MachineMetaDataCondition, metav1.ConditionFalse, infrav1.AssociateMetal3MachineMetaDataFailedReason, err.Error())
 		return checkMachineError(machineMgr, err,
 			"Failed to get the Metal3Metadata", errType)
@@ -589,7 +589,7 @@ func (r *Metal3MachineReconciler) reconcileDelete(ctx context.Context,
 	if err := machineMgr.DissociateM3Metadata(ctx); err != nil {
 		log.V(baremetal.VerbosityLevelDebug).Info("Failed to dissociate M3Metadata",
 			baremetal.LogFieldError, err.Error())
-		machineMgr.SetV1Beta1ConditionToFalse(infrav1.KubernetesNodeReadyV1Beta1Condition, infrav1.DisassociateM3MetaDataFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, err.Error())
+		machineMgr.SetV1Beta1ConditionToFalse(infrav1.KubernetesNodeReadyV1Beta1Condition, infrav1.DisassociateM3MetaDataFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, "%s", err.Error())
 		machineMgr.SetCondition(infrav1.AssociateMetal3MachineMetaDataCondition, metav1.ConditionFalse, infrav1.DisassociateM3MetaDataFailedReason, err.Error())
 
 		return checkMachineError(machineMgr, err,
@@ -602,7 +602,7 @@ func (r *Metal3MachineReconciler) reconcileDelete(ctx context.Context,
 	if err := machineMgr.Delete(ctx); err != nil {
 		log.V(baremetal.VerbosityLevelDebug).Info("Failed to delete Metal3Machine resources",
 			baremetal.LogFieldError, err.Error())
-		machineMgr.SetV1Beta1ConditionToFalse(infrav1.KubernetesNodeReadyV1Beta1Condition, infrav1.DeletionFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, err.Error())
+		machineMgr.SetV1Beta1ConditionToFalse(infrav1.KubernetesNodeReadyV1Beta1Condition, infrav1.DeletionFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, "%s", err.Error())
 		machineMgr.SetCondition(infrav1.AssociateMetal3MachineMetaDataCondition, metav1.ConditionFalse, infrav1.Metal3MachineDeletingFailedReason, err.Error())
 
 		return checkMachineError(machineMgr, err,

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -98,7 +98,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		if tc.AssociateFails {
 			m.EXPECT().Associate(context.TODO()).Return("", errors.New("failed"))
 			m.EXPECT().SetV1Beta1ConditionToFalse(infrav1.AssociateBMHV1Beta1Condition,
-				infrav1.AssociateBMHFailedV1Beta1Reason, clusterv1.ConditionSeverityError, gomock.Any())
+				infrav1.AssociateBMHFailedV1Beta1Reason, clusterv1.ConditionSeverityError, "%s", gomock.Any())
 			m.EXPECT().SetCondition(infrav1.AssociateBareMetalHostCondition,
 				metav1.ConditionFalse, infrav1.AssociateBareMetalHostFailedReason, gomock.Any())
 			m.EXPECT().AssociateM3Metadata(context.TODO()).MaxTimes(0)
@@ -136,7 +136,7 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		} else {
 			m.EXPECT().AssociateM3Metadata(context.TODO()).Return(errors.New("failed"))
 			m.EXPECT().SetV1Beta1ConditionToFalse(infrav1.KubernetesNodeReadyV1Beta1Condition,
-				infrav1.AssociateM3MetaDataFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, gomock.Any())
+				infrav1.AssociateM3MetaDataFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, "%s", gomock.Any())
 			m.EXPECT().SetCondition(infrav1.AssociateMetal3MachineMetaDataCondition,
 				metav1.ConditionFalse, infrav1.AssociateMetal3MachineMetaDataFailedReason, gomock.Any())
 			return m
@@ -178,7 +178,7 @@ func setReconcileDeleteExpectations(ctrl *gomock.Controller,
 
 	if tc.DissociateM3MetadataFails {
 		m.EXPECT().DissociateM3Metadata(context.TODO()).Return(errors.New("failed"))
-		m.EXPECT().SetV1Beta1ConditionToFalse(infrav1.KubernetesNodeReadyV1Beta1Condition, infrav1.DisassociateM3MetaDataFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, gomock.Any())
+		m.EXPECT().SetV1Beta1ConditionToFalse(infrav1.KubernetesNodeReadyV1Beta1Condition, infrav1.DisassociateM3MetaDataFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, "%s", gomock.Any())
 		m.EXPECT().SetCondition(infrav1.AssociateMetal3MachineMetaDataCondition, metav1.ConditionFalse, infrav1.DisassociateM3MetaDataFailedReason, gomock.Any())
 		m.EXPECT().Delete(context.TODO()).MaxTimes(0)
 		m.EXPECT().UnsetFinalizer().MaxTimes(0)
@@ -187,14 +187,14 @@ func setReconcileDeleteExpectations(ctrl *gomock.Controller,
 	if tc.DeleteFails {
 		m.EXPECT().DissociateM3Metadata(context.TODO())
 		m.EXPECT().Delete(context.TODO()).Return(errors.New("failed"))
-		m.EXPECT().SetV1Beta1ConditionToFalse(infrav1.KubernetesNodeReadyV1Beta1Condition, infrav1.DeletionFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, gomock.Any())
+		m.EXPECT().SetV1Beta1ConditionToFalse(infrav1.KubernetesNodeReadyV1Beta1Condition, infrav1.DeletionFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, "%s", gomock.Any())
 		m.EXPECT().SetCondition(infrav1.AssociateMetal3MachineMetaDataCondition, metav1.ConditionFalse, infrav1.Metal3MachineDeletingFailedReason, gomock.Any())
 		m.EXPECT().UnsetFinalizer().MaxTimes(0)
 		return m
 	} else if tc.DeleteRequeue {
 		m.EXPECT().DissociateM3Metadata(context.TODO())
 		m.EXPECT().Delete(context.TODO()).Return(baremetal.WithTransientError(errors.New("failed"), requeueAfter))
-		m.EXPECT().SetV1Beta1ConditionToFalse(infrav1.KubernetesNodeReadyV1Beta1Condition, infrav1.DeletionFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, gomock.Any())
+		m.EXPECT().SetV1Beta1ConditionToFalse(infrav1.KubernetesNodeReadyV1Beta1Condition, infrav1.DeletionFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, "%s", gomock.Any())
 		m.EXPECT().SetCondition(infrav1.AssociateMetal3MachineMetaDataCondition, metav1.ConditionFalse, infrav1.Metal3MachineDeletingFailedReason, gomock.Any())
 		m.EXPECT().UnsetFinalizer().MaxTimes(0)
 		return m

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/cluster-api-provider-metal3
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -26,6 +26,6 @@ else
         --volume "${PWD}:${WORKDIR}:ro,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        docker.io/golang:1.25 \
+        docker.io/golang:1.26 \
         "${WORKDIR}"/hack/build.sh "$@"
 fi

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -29,6 +29,6 @@ else
         --volume "${PWD}:${WORKDIR}:rw,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        docker.io/golang:1.25 \
+        docker.io/golang:1.26 \
         "${WORKDIR}"/hack/codegen.sh "$@"
 fi

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -32,7 +32,7 @@ EOF
     local go_version
     IFS=" " read -ra go_version <<< "$(go version)"
     local minimum_go_version
-    minimum_go_version=go1.25
+    minimum_go_version=go1.26
     if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]] && [[ "${go_version[2]}" != "devel" ]]; then
         cat << EOF
 Detected go version: ${go_version[*]}.

--- a/hack/fake-apiserver/Dockerfile
+++ b/hack/fake-apiserver/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.25.11@sha256:dd7d32e19b28621cd982082397fc0510d396805b717d5e77466aa2dd692340de
+ARG BUILD_IMAGE=docker.io/golang:1.26.4@sha256:32c0e6e5c4f6707717051091b4d0b077464a679eaab563e11474efc5328e2aa5
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the fkas binary on golang image

--- a/hack/fake-apiserver/go.mod
+++ b/hack/fake-apiserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/cluster-api-provider-metal3/hack/fake-apiserver
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/metal3-io/baremetal-operator/apis v0.13.0

--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -41,6 +41,6 @@ else
         --volume "${PWD}:${WORKDIR}:ro,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        docker.io/golang:1.25 \
+        docker.io/golang:1.26 \
         "${WORKDIR}"/hack/gomod.sh "$@"
 fi

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/cluster-api-provider-metal3/hack/tools
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/blang/semver v3.5.1+incompatible

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -19,6 +19,6 @@ else
         --volume "${PWD}:${WORKDIR}:ro,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        docker.io/golang:1.25 \
+        docker.io/golang:1.26 \
         "${WORKDIR}"/hack/unit.sh "$@"
 fi

--- a/test/extension/Dockerfile
+++ b/test/extension/Dockerfile
@@ -1,5 +1,5 @@
 # Build the extension binary
-ARG BUILD_IMAGE=docker.io/golang:1.25.11@sha256:dd7d32e19b28621cd982082397fc0510d396805b717d5e77466aa2dd692340de
+ARG BUILD_IMAGE=docker.io/golang:1.26.4@sha256:32c0e6e5c4f6707717051091b4d0b077464a679eaab563e11474efc5328e2aa5
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 FROM $BUILD_IMAGE AS builder

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/cluster-api-provider-metal3/test
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
- go modules are bumped to use go1.26
- images are built with go1.26.4

Also 
Fix go vet issues required by go1.26 bump
- make v1beta1 condition messages govet-safe by using constant printf formats

Required by https://github.com/kubernetes-sigs/cluster-api/pull/13623 i.e. 1.14.x development

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
