### PR TITLE
:bug: Rename leap interfaces from eth to enp

### DIFF
--- a/test/e2e/data/infrastructure-metal3/main/bases/opensuse-leap-kubeadm-config/opensuse-leap-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/main/bases/opensuse-leap-kubeadm-config/opensuse-leap-kubeadm-config.yaml
@@ -54,7 +54,7 @@ spec:
         }
         vrrp_instance VI_2 {
             state MASTER
-            interface eth1
+            interface enp2s0
             virtual_router_id 2
             priority 101
             advert_int 1
@@ -63,14 +63,14 @@ spec:
             }
         }
       path: /etc/keepalived/keepalived.conf
-    - path: /etc/NetworkManager/system-connections/eth0.nmconnection
+    - path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
       owner: root:root
       permissions: '0600'
       content: |
         [connection]
-        id=eth0
+        id=enp1s0
         type=ethernet
-        interface-name=eth0
+        interface-name=enp1s0
         master=ironicendpoint
         slave-type=bridge
     - content: |
@@ -140,8 +140,8 @@ spec:
     - systemctl restart NetworkManager.service
     - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
     - nmcli connection up ironicendpoint
-    - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
-    - nmcli connection up eth0
+    - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+    - nmcli connection up enp1s0
     - systemctl enable --now keepalived
     - sleep 60
     - systemctl enable --now crio kubelet
@@ -180,14 +180,14 @@ spec:
         permissions: "0755"
       - content: |
           [connection]
-          id=eth0
+          id=enp1s0
           type=ethernet
-          interface-name=eth0
+          interface-name=enp1s0
           master=ironicendpoint
           slave-type=bridge
           autoconnect=yes
           autoconnect-priority=999
-        path: /etc/NetworkManager/system-connections/eth0.nmconnection
+        path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
         owner: root:root
         permissions: '0600'
       - path: /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
@@ -223,7 +223,7 @@ spec:
       - systemctl restart NetworkManager.service
       - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
       - nmcli connection up ironicendpoint
-      - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
-      - nmcli connection up eth0
+      - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+      - nmcli connection up enp1s0
       - systemctl enable --now crio kubelet
       - sleep 120

--- a/test/e2e/data/infrastructure-metal3/v1.12/bases/opensuse-leap-kubeadm-config/opensuse-leap-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.12/bases/opensuse-leap-kubeadm-config/opensuse-leap-kubeadm-config.yaml
@@ -54,7 +54,7 @@ spec:
         }
         vrrp_instance VI_2 {
             state MASTER
-            interface eth1
+            interface enp2s0
             virtual_router_id 2
             priority 101
             advert_int 1
@@ -63,14 +63,14 @@ spec:
             }
         }
       path: /etc/keepalived/keepalived.conf
-    - path: /etc/NetworkManager/system-connections/eth0.nmconnection
+    - path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
       owner: root:root
       permissions: '0600'
       content: |
         [connection]
-        id=eth0
+        id=enp1s0
         type=ethernet
-        interface-name=eth0
+        interface-name=enp1s0
         master=ironicendpoint
         slave-type=bridge
     - content: |
@@ -140,8 +140,8 @@ spec:
     - systemctl restart NetworkManager.service
     - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
     - nmcli connection up ironicendpoint
-    - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
-    - nmcli connection up eth0
+    - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+    - nmcli connection up enp1s0
     - systemctl enable --now keepalived
     - sleep 60
     - systemctl enable --now crio kubelet
@@ -180,14 +180,14 @@ spec:
         permissions: "0755"
       - content: |
           [connection]
-          id=eth0
+          id=enp1s0
           type=ethernet
-          interface-name=eth0
+          interface-name=enp1s0
           master=ironicendpoint
           slave-type=bridge
           autoconnect=yes
           autoconnect-priority=999
-        path: /etc/NetworkManager/system-connections/eth0.nmconnection
+        path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
         owner: root:root
         permissions: '0600'
       - path: /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
@@ -223,7 +223,7 @@ spec:
       - systemctl restart NetworkManager.service
       - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
       - nmcli connection up ironicendpoint
-      - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
-      - nmcli connection up eth0
+      - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+      - nmcli connection up enp1s0
       - systemctl enable --now crio kubelet
       - sleep 120


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

It renames network interfaces in the Opensuse Leap templates from eth0/eth1 to enp1s0 and enp2s0. 

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] E2E tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
