### PR TITLE
🌱Remove mariadb ref from release notes

### DIFF
--- a/hack/verify-release.sh
+++ b/hack/verify-release.sh
@@ -88,7 +88,6 @@ declare -a release_note_strings=(
 # required strings that are postfixed with correct release number
 declare -a release_note_tag_strings=(
     "The image for this release is: v${VERSION}"
-    "Mariadb image tag is: capm3-v${VERSION}"
 )
 
 # release artefacts


### PR DESCRIPTION
MariaDB reference in our release note is redundant and removing it.