### PR TITLE
🌱Update interface name for leap to enp1s0 from eth0

### DIFF
--- a/test/e2e/data/infrastructure-metal3/main-v1beta1/bases/opensuse-leap-kubeadm-config/opensuse-leap-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/main-v1beta1/bases/opensuse-leap-kubeadm-config/opensuse-leap-kubeadm-config.yaml
@@ -54,7 +54,7 @@ spec:
         }
         vrrp_instance VI_2 {
             state MASTER
-            interface eth1
+            interface enp2s0
             virtual_router_id 2
             priority 101
             advert_int 1
@@ -63,14 +63,14 @@ spec:
             }
         }
       path: /etc/keepalived/keepalived.conf
-    - path: /etc/NetworkManager/system-connections/eth0.nmconnection
+    - path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
       owner: root:root
       permissions: '0600'
       content: |
         [connection]
-        id=eth0
+        id=enp1s0
         type=ethernet
-        interface-name=eth0
+        interface-name=enp1s0
         master=ironicendpoint
         slave-type=bridge
     - content: |
@@ -140,8 +140,8 @@ spec:
     - systemctl restart NetworkManager.service
     - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
     - nmcli connection up ironicendpoint
-    - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
-    - nmcli connection up eth0
+    - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+    - nmcli connection up enp1s0
     - systemctl enable --now keepalived
     - sleep 60
     - systemctl enable --now crio kubelet
@@ -180,14 +180,14 @@ spec:
         permissions: "0755"
       - content: |
           [connection]
-          id=eth0
+          id=enp1s0
           type=ethernet
-          interface-name=eth0
+          interface-name=enp1s0
           master=ironicendpoint
           slave-type=bridge
           autoconnect=yes
           autoconnect-priority=999
-        path: /etc/NetworkManager/system-connections/eth0.nmconnection
+        path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
         owner: root:root
         permissions: '0600'
       - path: /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
@@ -223,7 +223,7 @@ spec:
       - systemctl restart NetworkManager.service
       - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
       - nmcli connection up ironicendpoint
-      - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
-      - nmcli connection up eth0
+      - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+      - nmcli connection up enp1s0
       - systemctl enable --now crio kubelet
       - sleep 120

--- a/test/e2e/data/infrastructure-metal3/main/bases/opensuse-leap-kubeadm-config/opensuse-leap-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/main/bases/opensuse-leap-kubeadm-config/opensuse-leap-kubeadm-config.yaml
@@ -54,7 +54,7 @@ spec:
         }
         vrrp_instance VI_2 {
             state MASTER
-            interface eth1
+            interface enp2s0
             virtual_router_id 2
             priority 101
             advert_int 1
@@ -63,14 +63,14 @@ spec:
             }
         }
       path: /etc/keepalived/keepalived.conf
-    - path: /etc/NetworkManager/system-connections/eth0.nmconnection
+    - path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
       owner: root:root
       permissions: '0600'
       content: |
         [connection]
-        id=eth0
+        id=enp1s0
         type=ethernet
-        interface-name=eth0
+        interface-name=enp1s0
         master=ironicendpoint
         slave-type=bridge
     - content: |
@@ -140,8 +140,8 @@ spec:
     - systemctl restart NetworkManager.service
     - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
     - nmcli connection up ironicendpoint
-    - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
-    - nmcli connection up eth0
+    - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+    - nmcli connection up enp1s0
     - systemctl enable --now keepalived
     - sleep 60
     - systemctl enable --now crio kubelet
@@ -180,14 +180,14 @@ spec:
         permissions: "0755"
       - content: |
           [connection]
-          id=eth0
+          id=enp1s0
           type=ethernet
-          interface-name=eth0
+          interface-name=enp1s0
           master=ironicendpoint
           slave-type=bridge
           autoconnect=yes
           autoconnect-priority=999
-        path: /etc/NetworkManager/system-connections/eth0.nmconnection
+        path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
         owner: root:root
         permissions: '0600'
       - path: /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
@@ -223,7 +223,7 @@ spec:
       - systemctl restart NetworkManager.service
       - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
       - nmcli connection up ironicendpoint
-      - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
-      - nmcli connection up eth0
+      - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+      - nmcli connection up enp1s0
       - systemctl enable --now crio kubelet
       - sleep 120

--- a/test/e2e/data/infrastructure-metal3/v1.12/bases/opensuse-leap-kubeadm-config/opensuse-leap-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.12/bases/opensuse-leap-kubeadm-config/opensuse-leap-kubeadm-config.yaml
@@ -54,7 +54,7 @@ spec:
         }
         vrrp_instance VI_2 {
             state MASTER
-            interface eth1
+            interface enp2s0
             virtual_router_id 2
             priority 101
             advert_int 1
@@ -63,14 +63,14 @@ spec:
             }
         }
       path: /etc/keepalived/keepalived.conf
-    - path: /etc/NetworkManager/system-connections/eth0.nmconnection
+    - path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
       owner: root:root
       permissions: '0600'
       content: |
         [connection]
-        id=eth0
+        id=enp1s0
         type=ethernet
-        interface-name=eth0
+        interface-name=enp1s0
         master=ironicendpoint
         slave-type=bridge
     - content: |
@@ -140,8 +140,8 @@ spec:
     - systemctl restart NetworkManager.service
     - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
     - nmcli connection up ironicendpoint
-    - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
-    - nmcli connection up eth0
+    - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+    - nmcli connection up enp1s0
     - systemctl enable --now keepalived
     - sleep 60
     - systemctl enable --now crio kubelet
@@ -180,14 +180,14 @@ spec:
         permissions: "0755"
       - content: |
           [connection]
-          id=eth0
+          id=enp1s0
           type=ethernet
-          interface-name=eth0
+          interface-name=enp1s0
           master=ironicendpoint
           slave-type=bridge
           autoconnect=yes
           autoconnect-priority=999
-        path: /etc/NetworkManager/system-connections/eth0.nmconnection
+        path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
         owner: root:root
         permissions: '0600'
       - path: /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
@@ -223,7 +223,7 @@ spec:
       - systemctl restart NetworkManager.service
       - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
       - nmcli connection up ironicendpoint
-      - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
-      - nmcli connection up eth0
+      - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+      - nmcli connection up enp1s0
       - systemctl enable --now crio kubelet
       - sleep 120

--- a/test/e2e/data/infrastructure-metal3/v1.13/bases/opensuse-leap-kubeadm-config/opensuse-leap-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.13/bases/opensuse-leap-kubeadm-config/opensuse-leap-kubeadm-config.yaml
@@ -54,7 +54,7 @@ spec:
         }
         vrrp_instance VI_2 {
             state MASTER
-            interface eth1
+            interface enp2s0
             virtual_router_id 2
             priority 101
             advert_int 1
@@ -63,14 +63,14 @@ spec:
             }
         }
       path: /etc/keepalived/keepalived.conf
-    - path: /etc/NetworkManager/system-connections/eth0.nmconnection
+    - path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
       owner: root:root
       permissions: '0600'
       content: |
         [connection]
-        id=eth0
+        id=enp1s0
         type=ethernet
-        interface-name=eth0
+        interface-name=enp1s0
         master=ironicendpoint
         slave-type=bridge
     - content: |
@@ -140,8 +140,8 @@ spec:
     - systemctl restart NetworkManager.service
     - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
     - nmcli connection up ironicendpoint
-    - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
-    - nmcli connection up eth0
+    - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+    - nmcli connection up enp1s0
     - systemctl enable --now keepalived
     - sleep 60
     - systemctl enable --now crio kubelet
@@ -180,14 +180,14 @@ spec:
         permissions: "0755"
       - content: |
           [connection]
-          id=eth0
+          id=enp1s0
           type=ethernet
-          interface-name=eth0
+          interface-name=enp1s0
           master=ironicendpoint
           slave-type=bridge
           autoconnect=yes
           autoconnect-priority=999
-        path: /etc/NetworkManager/system-connections/eth0.nmconnection
+        path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
         owner: root:root
         permissions: '0600'
       - path: /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
@@ -223,7 +223,7 @@ spec:
       - systemctl restart NetworkManager.service
       - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
       - nmcli connection up ironicendpoint
-      - nmcli connection load /etc/NetworkManager/system-connections/eth0.nmconnection
-      - nmcli connection up eth0
+      - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+      - nmcli connection up enp1s0
       - systemctl enable --now crio kubelet
       - sleep 120

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -205,9 +205,6 @@ func CreateClusterctlLocalRepository(config *clusterctl.E2EConfig, repositoryFol
 	cniProvider := config.MustGetVariable("CNI_PROVIDER")
 
 	cniInterface := "enp2s0"
-	if osType == osTypeLeap {
-		cniInterface = "eth1"
-	}
 	switch cniProvider {
 	case "cilium":
 		updateCilium(config, cniPath)


### PR DESCRIPTION
Tests are failing for leap image because of interface name change. So need to update the interface name to enp1s0 from eth0 and enp2s0 from eth1