### PR TITLE
⚠️ Deprecate Metal3DataTemplate spec.clusterName

### DIFF
--- a/.golangci-kal.yaml
+++ b/.golangci-kal.yaml
@@ -185,6 +185,20 @@ linters:
       text: "optionalfields: field Metal3DataTemplate.Status has a valid zero value"
       linters:
       - kubeapilinter
+    # Metal3DataTemplate.Spec has a valid zero value but incomplete validation.
+    # It became optional after clusterName was deprecated and made optional;
+    # it is optional for the resource type.
+    - path: "api/v1beta2/metal3datatemplate_types.go"
+      text: "optionalfields: field Metal3DataTemplate.Spec has a valid zero value"
+      linters:
+      - kubeapilinter
+    # Metal3DataTemplateSpec.ClusterName is a deprecated field kept for backwards
+    # compatibility. It is optional with a valid zero value, but it must remain a
+    # non-pointer string to preserve conversion round-tripping with v1beta1.
+    - path: "api/v1beta2/metal3datatemplate_types.go"
+      text: "optionalfields: field Metal3DataTemplateSpec.ClusterName has a valid zero value"
+      linters:
+      - kubeapilinter
     # Metal3Machine.Spec and Metal3Machine.Status have valid zero values
     # but incomplete validation. These fields are optional for the resource type.
     - path: "api/v1beta2/metal3machine_types.go"

--- a/api/v1beta2/metal3datatemplate_types.go
+++ b/api/v1beta2/metal3datatemplate_types.go
@@ -888,8 +888,10 @@ type NetworkData struct {
 // Metal3DataTemplateSpec defines the desired state of Metal3DataTemplate.
 type Metal3DataTemplateSpec struct {
 	// clusterName is the name of the Cluster this object belongs to.
-	// +required
-	// +kubebuilder:validation:MinLength=1
+	//
+	// Deprecated: This field is deprecated and will be removed in a future release.
+	// It is no longer used by the controllers.
+	// +optional
 	// +kubebuilder:validation:MaxLength=512
 	ClusterName string `json:"clusterName,omitempty"`
 
@@ -923,6 +925,7 @@ type Metal3DataTemplateStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true
+// +kubebuilder:metadata:labels="clusterctl.cluster.x-k8s.io/move="
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this template belongs"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Metal3DataTemplate"
 

--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -163,7 +163,7 @@ func (m *DataManager) createSecrets(ctx context.Context) error {
 	}
 	// Fetch the Metal3DataTemplate object to get the templates
 	m3dt, err := fetchM3DataTemplate(ctx, m.Data.Spec.Template, m.client,
-		m.Log, m.Data.Labels[clusterv1.ClusterNameLabel],
+		m.Log,
 	)
 	if err != nil {
 		return err
@@ -292,7 +292,7 @@ func (m *DataManager) createSecrets(ctx context.Context) error {
 			return err
 		}
 		if err := createSecret(ctx, m.client, m.Data.Spec.MetaData.Name,
-			m.Data.Namespace, m3dt.Labels[clusterv1.ClusterNameLabel],
+			m.Data.Namespace, capiMachine.Spec.ClusterName,
 			ownerRefs, map[string][]byte{"metaData": metadata},
 		); err != nil {
 			return err
@@ -307,7 +307,7 @@ func (m *DataManager) createSecrets(ctx context.Context) error {
 			return err
 		}
 		if err := createSecret(ctx, m.client, m.Data.Spec.NetworkData.Name,
-			m.Data.Namespace, m3dt.Labels[clusterv1.ClusterNameLabel],
+			m.Data.Namespace, capiMachine.Spec.ClusterName,
 			ownerRefs, map[string][]byte{"networkData": networkData},
 		); err != nil {
 			return err
@@ -332,7 +332,7 @@ func (m *DataManager) ReleaseLeases(ctx context.Context) error {
 	}
 	// Fetch the Metal3DataTemplate object to get the templates
 	m3dt, err := fetchM3DataTemplate(ctx, m.Data.Spec.Template, m.client,
-		m.Log, m.Data.Labels[clusterv1.ClusterNameLabel],
+		m.Log,
 	)
 	if err != nil {
 		return err
@@ -756,7 +756,7 @@ func (m *DataManager) ensureM3IPClaim(ctx context.Context, poolRef infrav1.IPPoo
 	}
 
 	m3dt, err := fetchM3DataTemplate(ctx, m.Data.Spec.Template, m.client,
-		m.Log, m.Data.Labels[clusterv1.ClusterNameLabel],
+		m.Log,
 	)
 	if err != nil {
 		return reconciledClaim{m3Claim: ipClaim}, err

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -1648,7 +1648,7 @@ var _ = Describe("Metal3Data manager", func() {
 
 				err = dataMgr.client.Get(context.TODO(), claimNamespacedName, capm3IPClaim)
 				Expect(err).NotTo(HaveOccurred())
-				_, err := findOwnerRefFromList(capm3IPClaim.OwnerReferences,
+				err = findOwnerRefFromList(capm3IPClaim.OwnerReferences,
 					tc.m3d.TypeMeta, tc.m3d.ObjectMeta)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(capm3IPClaim.Finalizers).To(ContainElement(infrav1.DataFinalizer))
@@ -2256,7 +2256,7 @@ var _ = Describe("Metal3Data manager", func() {
 			err = fc.Get(context.Background(), nn, claim)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err := findOwnerRefFromList(claim.OwnerReferences,
+			err = findOwnerRefFromList(claim.OwnerReferences,
 				m3d.TypeMeta, m3d.ObjectMeta)
 			Expect(err).NotTo(HaveOccurred())
 		} else {
@@ -2325,7 +2325,7 @@ var _ = Describe("Metal3Data manager", func() {
 			err = fc.Get(context.Background(), nn, claim)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err := findOwnerRefFromList(claim.OwnerReferences,
+			err = findOwnerRefFromList(claim.OwnerReferences,
 				m3d.TypeMeta, m3d.ObjectMeta)
 			Expect(err).NotTo(HaveOccurred())
 		} else {
@@ -2414,7 +2414,7 @@ var _ = Describe("Metal3Data manager", func() {
 
 				err = dataMgr.client.Get(context.TODO(), nn, claim)
 				Expect(err).NotTo(HaveOccurred())
-				_, err := findOwnerRefFromList(claim.OwnerReferences,
+				err = findOwnerRefFromList(claim.OwnerReferences,
 					tc.m3d.TypeMeta, tc.m3d.ObjectMeta)
 				Expect(err).NotTo(HaveOccurred())
 			}
@@ -5756,7 +5756,7 @@ var _ = Describe("When using BMH name based pre-allocation", func() {
 			err = fc.Get(context.Background(), nn, claim)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err := findOwnerRefFromList(claim.OwnerReferences,
+			err = findOwnerRefFromList(claim.OwnerReferences,
 				m3d.TypeMeta, m3d.ObjectMeta)
 			Expect(err).NotTo(HaveOccurred())
 		} else {

--- a/baremetal/metal3datatemplate_manager.go
+++ b/baremetal/metal3datatemplate_manager.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -41,7 +40,6 @@ import (
 type DataTemplateManagerInterface interface {
 	SetFinalizer()
 	UnsetFinalizer()
-	SetClusterOwnerRef(*clusterv1.Cluster) error
 	// UpdateDatas handles the Metal3DataClaims and creates or deletes Metal3Data accordingly.
 	// It returns if there are still Data object and undeleted DataClaims objects.
 	UpdateDatas(context.Context) (bool, bool, error)
@@ -78,34 +76,6 @@ func (m *DataTemplateManager) UnsetFinalizer() {
 	// Remove the finalizer.
 	m.Log.V(VerbosityLevelTrace).Info("Removing finalizer from Metal3DataTemplate")
 	controllerutil.RemoveFinalizer(m.DataTemplate, infrav1.DataTemplateFinalizer)
-}
-
-// SetClusterOwnerRef sets ownerRef.
-func (m *DataTemplateManager) SetClusterOwnerRef(cluster *clusterv1.Cluster) error {
-	m.Log.V(VerbosityLevelTrace).Info("Setting cluster owner reference on Metal3DataTemplate")
-	// Verify that the owner reference is there, if not add it and update object,
-	// if error requeue.
-	if cluster == nil {
-		return errors.New("missing cluster")
-	}
-	_, err := findOwnerRefFromList(m.DataTemplate.OwnerReferences,
-		cluster.TypeMeta, cluster.ObjectMeta)
-	if err != nil {
-		if ok := errors.As(err, &errNotFound); !ok {
-			return err
-		}
-		m.Log.V(VerbosityLevelDebug).Info("Adding cluster owner reference",
-			LogFieldMetal3DataTemplate, m.DataTemplate.Name,
-			LogFieldCluster, cluster.Name)
-		m.DataTemplate.OwnerReferences, err = setOwnerRefInList(
-			m.DataTemplate.OwnerReferences, false, cluster.TypeMeta,
-			cluster.ObjectMeta,
-		)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // RecreateStatus recreates the status if empty.
@@ -319,8 +289,15 @@ func (m *DataTemplateManager) createData(ctx context.Context,
 
 	m.Log.Info("Index assigned", LogFieldMetal3DataClaim, dataClaim.Name, LogFieldIndex, claimIndex)
 
-	// Create the Metal3Data object, with an Owner ref to the Metal3Machine
-	// (curOwnerRef) and to the Metal3DataTemplate. Also add a finalizer.
+	// Create the Metal3Data object with the Metal3DataClaim as its controlling
+	// owner and the Metal3Machine as an additional owner. The Metal3DataClaim is
+	// deliberately the controlling owner (instead of the Metal3DataTemplate) so
+	// that the Metal3Data participates in the Cluster garbage-collection chain
+	// (Cluster -> Machine -> Metal3Machine -> Metal3DataClaim -> Metal3Data).
+	// The Metal3DataTemplate is not referenced as an owner because it can be
+	// shared across clusters and outlives any single Cluster; keeping it as an
+	// owner would block garbage collection of the Metal3Data. Also add a
+	// finalizer.
 	dataObject := &infrav1.Metal3Data{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Metal3Data",
@@ -334,19 +311,13 @@ func (m *DataTemplateManager) createData(ctx context.Context,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					Controller: ptr.To(true),
-					APIVersion: m.DataTemplate.APIVersion,
-					Kind:       m.DataTemplate.Kind,
-					Name:       m.DataTemplate.Name,
-					UID:        m.DataTemplate.UID,
-				},
-				{
-					APIVersion: dataClaim.APIVersion,
-					Kind:       dataClaim.Kind,
+					APIVersion: infrav1.GroupVersion.String(),
+					Kind:       metal3DataClaimKind,
 					Name:       dataClaim.Name,
 					UID:        dataClaim.UID,
 				},
 				{
-					APIVersion: dataClaim.APIVersion,
+					APIVersion: infrav1.GroupVersion.String(),
 					Kind:       metal3MachineKind,
 					Name:       m3mName,
 					UID:        m3mUID,

--- a/baremetal/metal3datatemplate_manager_test.go
+++ b/baremetal/metal3datatemplate_manager_test.go
@@ -60,74 +60,6 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		}),
 	)
 
-	type testCaseSetClusterOwnerRef struct {
-		cluster     *clusterv1.Cluster
-		template    *infrav1.Metal3DataTemplate
-		expectError bool
-	}
-
-	DescribeTable("Test SetClusterOwnerRef",
-		func(tc testCaseSetClusterOwnerRef) {
-			templateMgr, err := NewDataTemplateManager(nil, tc.template,
-				logr.Discard(),
-			)
-			Expect(err).NotTo(HaveOccurred())
-			err = templateMgr.SetClusterOwnerRef(tc.cluster)
-			if tc.expectError {
-				Expect(err).To(HaveOccurred())
-			} else {
-				Expect(err).NotTo(HaveOccurred())
-				_, err := findOwnerRefFromList(tc.template.OwnerReferences,
-					tc.cluster.TypeMeta, tc.cluster.ObjectMeta)
-				Expect(err).NotTo(HaveOccurred())
-			}
-		},
-		Entry("Cluster missing", testCaseSetClusterOwnerRef{
-			expectError: true,
-		}),
-		Entry("no previous ownerref", testCaseSetClusterOwnerRef{
-			template: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta(metal3DataTemplateName, "", ""),
-			},
-			cluster: &clusterv1.Cluster{
-				ObjectMeta: testObjectMeta("abc-cluster", "", ""),
-			},
-		}),
-		Entry("previous ownerref", testCaseSetClusterOwnerRef{
-			template: &infrav1.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "abc",
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							Name: "def",
-						},
-					},
-				},
-			},
-			cluster: &clusterv1.Cluster{
-				ObjectMeta: testObjectMeta("abc-cluster", "", ""),
-			},
-		}),
-		Entry("ownerref present", testCaseSetClusterOwnerRef{
-			template: &infrav1.Metal3DataTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "abc",
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							Name: "def",
-						},
-						{
-							Name: "abc-cluster",
-						},
-					},
-				},
-			},
-			cluster: &clusterv1.Cluster{
-				ObjectMeta: testObjectMeta("abc-cluster", "", ""),
-			},
-		}),
-	)
-
 	type testGetIndexes struct {
 		template        *infrav1.Metal3DataTemplate
 		indexes         []*infrav1.Metal3Data
@@ -494,6 +426,127 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			},
 			expectedNbIndexes: 2,
 		}),
+		// A single Metal3DataTemplate can be consumed by more than one Cluster.
+		// Index allocation is scoped to the template, not to a Cluster: claims
+		// coming from different Clusters share the same index space. Existing
+		// indexes from every Cluster are tracked together, and a new claim from
+		// any Cluster continues the shared sequence without colliding.
+		Entry("Single template shared by two clusters", testCaseUpdateDatas{
+			template: &infrav1.Metal3DataTemplate{
+				ObjectMeta: templateMeta,
+				Spec:       infrav1.Metal3DataTemplateSpec{},
+			},
+			dataClaims: []*infrav1.Metal3DataClaim{
+				// Already-rendered claim from cluster-a (index 0).
+				{
+					ObjectMeta: func() metav1.ObjectMeta {
+						om := testObjectMetaWithOR("cluster-a-claim-0", metal3machineName)
+						om.Labels = map[string]string{clusterv1.ClusterNameLabel: "cluster-a"}
+						return om
+					}(),
+					Spec: infrav1.Metal3DataClaimSpec{
+						Template: &infrav1.Metal3ObjectRef{
+							Name:      templateMeta.Name,
+							Namespace: namespaceName,
+						},
+					},
+					Status: infrav1.Metal3DataClaimStatus{
+						RenderedData: &infrav1.Metal3ObjectRef{
+							Name:      "abc-0",
+							Namespace: namespaceName,
+						},
+					},
+				},
+				// Already-rendered claim from cluster-b (index 1) on the same template.
+				{
+					ObjectMeta: func() metav1.ObjectMeta {
+						om := testObjectMetaWithOR("cluster-b-claim-0", metal3machineName)
+						om.Labels = map[string]string{clusterv1.ClusterNameLabel: "cluster-b"}
+						return om
+					}(),
+					Spec: infrav1.Metal3DataClaimSpec{
+						Template: &infrav1.Metal3ObjectRef{
+							Name:      templateMeta.Name,
+							Namespace: namespaceName,
+						},
+					},
+					Status: infrav1.Metal3DataClaimStatus{
+						RenderedData: &infrav1.Metal3ObjectRef{
+							Name:      "abc-1",
+							Namespace: namespaceName,
+						},
+					},
+				},
+				// New, unrendered claim from cluster-a. It must get the next free
+				// index in the template-wide space (2), not reuse cluster-b's index.
+				{
+					ObjectMeta: func() metav1.ObjectMeta {
+						om := testObjectMetaWithOR("cluster-a-claim-1", metal3machineName)
+						om.Labels = map[string]string{clusterv1.ClusterNameLabel: "cluster-a"}
+						return om
+					}(),
+					Spec: infrav1.Metal3DataClaimSpec{
+						Template: &infrav1.Metal3ObjectRef{
+							Name:      templateMeta.Name,
+							Namespace: namespaceName,
+						},
+					},
+				},
+			},
+			datas: []*infrav1.Metal3Data{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc-0",
+						Namespace: namespaceName,
+					},
+					Spec: infrav1.Metal3DataSpec{
+						Template: &infrav1.Metal3ObjectRef{
+							Name:      templateMeta.Name,
+							Namespace: namespaceName,
+						},
+						Claim: &infrav1.Metal3ObjectRef{
+							Name:      "cluster-a-claim-0",
+							Namespace: namespaceName,
+						},
+						Index: ptr.To(int32(0)),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc-1",
+						Namespace: namespaceName,
+					},
+					Spec: infrav1.Metal3DataSpec{
+						Template: &infrav1.Metal3ObjectRef{
+							Name:      templateMeta.Name,
+							Namespace: namespaceName,
+						},
+						Claim: &infrav1.Metal3ObjectRef{
+							Name:      "cluster-b-claim-0",
+							Namespace: namespaceName,
+						},
+						Index: ptr.To(int32(1)),
+					},
+				},
+			},
+			// getIndexes returns the sorted, template-wide index space across
+			// both clusters (0, 1); the new cluster-a claim then extends it to 2.
+			expectedIndexes: []infrav1.IndexEntry{
+				{
+					Name:  "cluster-a-claim-0",
+					Index: ptr.To(int32(0)),
+				},
+				{
+					Name:  "cluster-b-claim-0",
+					Index: ptr.To(int32(1)),
+				},
+				{
+					Name:  "cluster-a-claim-1",
+					Index: ptr.To(int32(2)),
+				},
+			},
+			expectedNbIndexes: 2,
+		}),
 	)
 
 	type testCaseCreateAddresses struct {
@@ -543,7 +596,30 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			// Iterate over the Metal3Data objects to find all indexes and objects
 			for _, address := range dataObjects.Items {
 				Expect(tc.expectedDatas).To(ContainElement(address.Name))
-				// TODO add further testing later
+				// Metal3Data created by createData must be owned by the
+				// Metal3DataClaim (controlling) and the Metal3Machine, but not
+				// by the Metal3DataTemplate, so that they are garbage collected
+				// with the Cluster. Skip pre-existing fixtures used to trigger
+				// requeue/error paths, which have no owner references.
+				if tc.expectRequeue || tc.expectError {
+					continue
+				}
+				var claimOwner, machineOwner *metav1.OwnerReference
+				for i := range address.OwnerReferences {
+					ref := &address.OwnerReferences[i]
+					Expect(ref.Kind).NotTo(Equal("Metal3DataTemplate"))
+					switch ref.Kind {
+					case metal3DataClaimKind:
+						claimOwner = ref
+					case metal3MachineKind:
+						machineOwner = ref
+					}
+				}
+				Expect(address.OwnerReferences).To(HaveLen(2))
+				Expect(claimOwner).NotTo(BeNil())
+				Expect(claimOwner.Controller).To(Equal(ptr.To(true)))
+				Expect(claimOwner.Name).To(Equal(tc.dataClaim.Name))
+				Expect(machineOwner).NotTo(BeNil())
 			}
 			Expect(tc.dataClaim.Finalizers).To(HaveLen(1))
 

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -85,7 +85,6 @@ const (
 var (
 	// Capm3FastTrack is the variable fetched from the CAPM3_FAST_TRACK environment variable.
 	Capm3FastTrack    = os.Getenv("CAPM3_FAST_TRACK")
-	errNotFound       *NotFoundError
 	associateBMHMutex sync.Mutex
 )
 
@@ -1667,54 +1666,29 @@ func (m *MachineManager) SetMetal3DataReadyConditionTrue(reason string) {
 	})
 }
 
-// SetOwnerRef adds an ownerreference to this Metal3Machine.
-func setOwnerRefInList(refList []metav1.OwnerReference, controller bool,
-	objType metav1.TypeMeta, objMeta metav1.ObjectMeta,
-) ([]metav1.OwnerReference, error) {
-	index, err := findOwnerRefFromList(refList, objType, objMeta)
-	if err != nil {
-		if ok := errors.As(err, &errNotFound); !ok {
-			return nil, err
-		}
-		refList = append(refList, metav1.OwnerReference{
-			APIVersion: objType.APIVersion,
-			Kind:       objType.Kind,
-			Name:       objMeta.Name,
-			UID:        objMeta.UID,
-			Controller: ptr.To(controller),
-		})
-	} else {
-		// The UID and the APIVersion might change due to move or version upgrade.
-		refList[index].APIVersion = objType.APIVersion
-		refList[index].UID = objMeta.UID
-		refList[index].Controller = ptr.To(controller)
-	}
-	return refList, nil
-}
-
 // findOwnerRefFromList finds OwnerRef to this Metal3Machine.
 func findOwnerRefFromList(refList []metav1.OwnerReference, objType metav1.TypeMeta,
 	objMeta metav1.ObjectMeta,
-) (int, error) {
-	for i, curOwnerRef := range refList {
+) error {
+	for _, curOwnerRef := range refList {
 		aGV, err := schema.ParseGroupVersion(curOwnerRef.APIVersion)
 		if err != nil {
-			return 0, err
+			return err
 		}
 
 		bGV, err := schema.ParseGroupVersion(objType.APIVersion)
 		if err != nil {
-			return 0, err
+			return err
 		}
 		// not matching on UID since when pivoting it might change.
 		// Not matching on API version as this might change.
 		if curOwnerRef.Name == objMeta.Name &&
 			curOwnerRef.Kind == objType.Kind &&
 			aGV.Group == bGV.Group {
-			return i, nil
+			return nil
 		}
 	}
-	return 0, &NotFoundError{}
+	return &NotFoundError{}
 }
 
 // AssociateM3Metadata associates metal3Data object to metal3Machine, if it

--- a/baremetal/mocks/zz_generated.metal3datatemplate_manager.go
+++ b/baremetal/mocks/zz_generated.metal3datatemplate_manager.go
@@ -32,7 +32,6 @@ import (
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
-	v1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
 
 // MockDataTemplateManagerInterface is a mock of DataTemplateManagerInterface interface.
@@ -57,20 +56,6 @@ func NewMockDataTemplateManagerInterface(ctrl *gomock.Controller) *MockDataTempl
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDataTemplateManagerInterface) EXPECT() *MockDataTemplateManagerInterfaceMockRecorder {
 	return m.recorder
-}
-
-// SetClusterOwnerRef mocks base method.
-func (m *MockDataTemplateManagerInterface) SetClusterOwnerRef(arg0 *v1beta2.Cluster) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetClusterOwnerRef", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetClusterOwnerRef indicates an expected call of SetClusterOwnerRef.
-func (mr *MockDataTemplateManagerInterfaceMockRecorder) SetClusterOwnerRef(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetClusterOwnerRef", reflect.TypeOf((*MockDataTemplateManagerInterface)(nil).SetClusterOwnerRef), arg0)
 }
 
 // SetFinalizer mocks base method.

--- a/baremetal/utils.go
+++ b/baremetal/utils.go
@@ -42,6 +42,8 @@ const (
 	metal3SecretType corev1.SecretType = "infrastructure.cluster.x-k8s.io/secret"
 	// metal3MachineKind is the Kind of the Metal3Machine.
 	metal3MachineKind = "Metal3Machine"
+	// metal3DataClaimKind is the Kind of the Metal3DataClaim.
+	metal3DataClaimKind = "Metal3DataClaim"
 
 	// Logging verbosity levels follow the Kubernetes logging conventions:
 	// - Level 0 (Info): Always logged - errors, warnings, important state changes
@@ -254,7 +256,6 @@ func checkSecretExists(ctx context.Context, cl client.Client, name string,
 // fetchM3DataTemplate returns the Metal3DataTemplate object.
 func fetchM3DataTemplate(ctx context.Context,
 	templateRef *infrav1.Metal3ObjectRef, cl client.Client, mLog logr.Logger,
-	clusterName string,
 ) (*infrav1.Metal3DataTemplate, error) {
 	// If the user did not specify a Metal3DataTemplate, just keep going.
 	if templateRef == nil {
@@ -278,11 +279,6 @@ func fetchM3DataTemplate(ctx context.Context,
 		}
 		err = fmt.Errorf("failed to get Metal3DataTemplate: %w", err)
 		return nil, err
-	}
-
-	// Verify that this Metal3DataTemplate belongs to the correct cluster.
-	if clusterName != metal3DataTemplate.Spec.ClusterName {
-		return nil, errors.New("metal3DataTemplate associated with another cluster")
 	}
 
 	return metal3DataTemplate, nil

--- a/baremetal/utils_test.go
+++ b/baremetal/utils_test.go
@@ -403,7 +403,6 @@ var _ = Describe("Metal3 manager utils", func() {
 
 	type testCaseFetchM3DataTemplate struct {
 		DataTemplate  *infrav1.Metal3DataTemplate
-		ClusterName   string
 		TemplateRef   *infrav1.Metal3ObjectRef
 		ExpectError   bool
 		ExpectEmpty   bool
@@ -418,7 +417,7 @@ var _ = Describe("Metal3 manager utils", func() {
 			}
 
 			result, err := fetchM3DataTemplate(context.TODO(), tc.TemplateRef, k8sClient,
-				logr.Discard(), tc.ClusterName,
+				logr.Discard(),
 			)
 			if tc.ExpectError || tc.ExpectRequeue {
 				Expect(err).To(HaveOccurred())
@@ -456,28 +455,13 @@ var _ = Describe("Metal3 manager utils", func() {
 			},
 			ExpectError: true,
 		}),
-		Entry("Object with wrong cluster", testCaseFetchM3DataTemplate{
+		Entry("Object exists", testCaseFetchM3DataTemplate{
 			DataTemplate: &infrav1.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
 				Spec: infrav1.Metal3DataTemplateSpec{
 					ClusterName: clusterName,
 				},
 			},
-			ClusterName: "def",
-			TemplateRef: &infrav1.Metal3ObjectRef{
-				Name:      metal3DataTemplateName,
-				Namespace: namespaceName,
-			},
-			ExpectError: true,
-		}),
-		Entry("Object with correct cluster", testCaseFetchM3DataTemplate{
-			DataTemplate: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
-				Spec: infrav1.Metal3DataTemplateSpec{
-					ClusterName: clusterName,
-				},
-			},
-			ClusterName: clusterName,
 			TemplateRef: &infrav1.Metal3ObjectRef{
 				Name:      metal3DataTemplateName,
 				Namespace: namespaceName,

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3datatemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3datatemplates.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    clusterctl.cluster.x-k8s.io/move: ""
   name: metal3datatemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -1361,10 +1363,12 @@ spec:
             description: spec defines the desired state of Metal3DataTemplate.
             properties:
               clusterName:
-                description: clusterName is the name of the Cluster this object belongs
-                  to.
+                description: |-
+                  clusterName is the name of the Cluster this object belongs to.
+
+                  Deprecated: This field is deprecated and will be removed in a future release.
+                  It is no longer used by the controllers.
                 maxLength: 512
-                minLength: 1
                 type: string
               metaData:
                 description: metaData contains the information needed to generate
@@ -3000,8 +3004,6 @@ spec:
                         type: string
                     type: object
                 type: object
-            required:
-            - clusterName
             type: object
           status:
             description: status defines the observed state of Metal3DataTemplate.

--- a/controllers/metal3datatemplate_controller.go
+++ b/controllers/metal3datatemplate_controller.go
@@ -26,7 +26,6 @@ import (
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -65,8 +64,6 @@ type Metal3DataTemplateReconciler struct {
 // +kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddressclaims/status,verbs=get;watch
 // +kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddresses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddresses/status,verbs=get
-// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;watch
-// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters/status,verbs=get
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
@@ -91,8 +88,7 @@ func (r *Metal3DataTemplateReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 	log.V(baremetal.VerbosityLevelDebug).Info("Metal3DataTemplate fetched successfully",
-		"generation", metal3DataTemplate.Generation,
-		"clusterName", metal3DataTemplate.Spec.ClusterName)
+		"generation", metal3DataTemplate.Generation)
 
 	log.V(baremetal.VerbosityLevelTrace).Info("Creating patch helper")
 	helper, err := patch.NewHelper(metal3DataTemplate, r.Client)
@@ -109,22 +105,12 @@ func (r *Metal3DataTemplateReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}()
 
-	cluster := &clusterv1.Cluster{}
-	key := client.ObjectKey{
-		Name:      metal3DataTemplate.Spec.ClusterName,
-		Namespace: metal3DataTemplate.Namespace,
-	}
-
-	// Fetch the Cluster. Ignore an error if the deletion timestamp is set
-	log.V(baremetal.VerbosityLevelTrace).Info("Fetching Cluster",
-		baremetal.LogFieldCluster, metal3DataTemplate.Spec.ClusterName)
-	err = r.Client.Get(ctx, key, cluster)
-	if metal3DataTemplate.ObjectMeta.DeletionTimestamp.IsZero() {
-		if err != nil {
-			log.V(baremetal.VerbosityLevelDebug).Info("Error fetching cluster, may not exist yet")
-			log.Info("Error fetching cluster. It might not exist yet, Requeuing")
-			return ctrl.Result{}, nil
-		}
+	// A Metal3DataTemplate is not bound to a single Cluster; multiple Clusters
+	// may reference the same template. Honor a pause requested directly on the
+	// object via the pause annotation instead of deriving an owning Cluster.
+	if annotations.HasPaused(metal3DataTemplate) {
+		log.Info("Metal3DataTemplate is currently paused. Remove pause annotation to continue reconciliation.")
+		return ctrl.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
 	}
 
 	// Create a helper for managing the Metal3DataTemplate object.
@@ -134,23 +120,6 @@ func (r *Metal3DataTemplateReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, fmt.Errorf("failed to create helper for managing the Metal3DataTemplate: %w", err)
 	}
 	log.V(baremetal.VerbosityLevelDebug).Info("DataTemplateManager created successfully")
-
-	if metal3DataTemplate.Spec.ClusterName != "" && cluster.Name != "" {
-		log = log.WithValues(baremetal.LogFieldCluster, cluster.Name)
-		log.V(baremetal.VerbosityLevelTrace).Info("Setting cluster owner reference")
-		if err := dataTemplateMgr.SetClusterOwnerRef(cluster); err != nil {
-			log.V(baremetal.VerbosityLevelDebug).Info("Failed to set cluster owner reference",
-				baremetal.LogFieldError, err.Error())
-			return ctrl.Result{}, err
-		}
-		// Return early if the Metal3DataTemplate or Cluster is paused.
-		log.V(baremetal.VerbosityLevelTrace).Info("Checking pause status")
-		if annotations.IsPaused(cluster, metal3DataTemplate) {
-			log.V(baremetal.VerbosityLevelDebug).Info("Reconciliation paused")
-			log.Info("reconciliation is paused for this object")
-			return ctrl.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
-		}
-	}
 
 	// Handle deletion of Metal3DataTemplate
 	if !metal3DataTemplate.ObjectMeta.DeletionTimestamp.IsZero() {

--- a/controllers/metal3datatemplate_controller_test.go
+++ b/controllers/metal3datatemplate_controller_test.go
@@ -30,7 +30,6 @@ import (
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,12 +44,10 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		expectRequeue        bool
 		expectManager        bool
 		m3dt                 *infrav1.Metal3DataTemplate
-		cluster              *clusterv1.Cluster
 		managerError         bool
 		reconcileNormal      bool
 		reconcileNormalError bool
 		reconcileDeleteError bool
-		setOwnerRefError     bool
 	}
 
 	DescribeTable("Test Reconcile",
@@ -63,24 +60,12 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			if tc.m3dt != nil {
 				objects = append(objects, tc.m3dt)
 			}
-			if tc.cluster != nil {
-				objects = append(objects, tc.cluster)
-			}
 			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
 
 			if tc.managerError {
 				mf.EXPECT().NewDataTemplateManager(gomock.Any(), gomock.Any()).Return(nil, errors.New(""))
 			} else if tc.expectManager {
 				mf.EXPECT().NewDataTemplateManager(gomock.Any(), gomock.Any()).Return(m, nil)
-			}
-			if tc.expectManager {
-				if tc.setOwnerRefError {
-					m.EXPECT().SetClusterOwnerRef(gomock.Any()).Return(errors.New(""))
-				} else {
-					if tc.cluster != nil {
-						m.EXPECT().SetClusterOwnerRef(gomock.Any()).Return(nil)
-					}
-				}
 			}
 			if tc.m3dt != nil && !tc.m3dt.DeletionTimestamp.IsZero() && tc.reconcileDeleteError {
 				m.EXPECT().UpdateDatas(context.Background()).Return(false, false, errors.New(""))
@@ -128,13 +113,7 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			gomockCtrl.Finish()
 		},
 		Entry("Metal3DataTemplate not found", testCaseReconcile{}),
-		Entry("Cluster not found", testCaseReconcile{
-			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
-			},
-		}),
-		Entry("Deletion, Cluster not found", testCaseReconcile{
+		Entry("Deletion", testCaseReconcile{
 			m3dt: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              metal3DataTemplateName,
@@ -142,11 +121,10 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 					DeletionTimestamp: &timestampNow,
 					Finalizers:        []string{"foo"},
 				},
-				Spec: infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
 			expectManager: true,
 		}),
-		Entry("Deletion, Cluster not found, error", testCaseReconcile{
+		Entry("Deletion, error", testCaseReconcile{
 			m3dt: &infrav1.Metal3DataTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              metal3DataTemplateName,
@@ -154,43 +132,32 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 					DeletionTimestamp: &timestampNow,
 					Finalizers:        []string{"foo"},
 				},
-				Spec: infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
 			},
 			expectManager:        true,
 			reconcileDeleteError: true,
 			expectError:          true,
 		}),
-		Entry("Paused cluster", testCaseReconcile{
+		Entry("Paused via annotation", testCaseReconcile{
 			m3dt: &infrav1.Metal3DataTemplate{
-				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
-			},
-			cluster: &clusterv1.Cluster{
-				ObjectMeta: testObjectMeta(clusterName, namespaceName, ""),
-				Spec: clusterv1.ClusterSpec{
-					Paused: ptr.To(true),
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      metal3DataTemplateName,
+					Namespace: namespaceName,
+					Annotations: map[string]string{
+						clusterv1.PausedAnnotation: "true",
+					},
 				},
 			},
 			expectRequeue: true,
-			expectManager: true,
 		}),
 		Entry("Error in manager", testCaseReconcile{
 			m3dt: &infrav1.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
-			},
-			cluster: &clusterv1.Cluster{
-				ObjectMeta: testObjectMeta(clusterName, namespaceName, ""),
 			},
 			managerError: true,
 		}),
 		Entry("Reconcile normal error", testCaseReconcile{
 			m3dt: &infrav1.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
-			},
-			cluster: &clusterv1.Cluster{
-				ObjectMeta: testObjectMeta(clusterName, namespaceName, ""),
 			},
 			reconcileNormal:      true,
 			reconcileNormalError: true,
@@ -199,10 +166,6 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		Entry("Reconcile normal no error", testCaseReconcile{
 			m3dt: &infrav1.Metal3DataTemplate{
 				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
-				Spec:       infrav1.Metal3DataTemplateSpec{ClusterName: clusterName},
-			},
-			cluster: &clusterv1.Cluster{
-				ObjectMeta: testObjectMeta(clusterName, namespaceName, ""),
 			},
 			reconcileNormal: true,
 			expectManager:   true,

--- a/internal/webhooks/v1beta2/metal3datatemplate_webhook.go
+++ b/internal/webhooks/v1beta2/metal3datatemplate_webhook.go
@@ -41,7 +41,11 @@ var _ admission.Validator[*infrav1.Metal3DataTemplate] = &Metal3DataTemplate{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (webhook *Metal3DataTemplate) ValidateCreate(_ context.Context, obj *infrav1.Metal3DataTemplate) (admission.Warnings, error) {
-	return nil, webhook.validate(nil, obj)
+	var warnings admission.Warnings
+	if obj.Spec.ClusterName != "" {
+		warnings = append(warnings, "spec.clusterName is deprecated and will be removed in a future release. It is no longer used by the controllers.")
+	}
+	return warnings, webhook.validate(nil, obj)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
@@ -54,6 +58,11 @@ func (webhook *Metal3DataTemplate) ValidateUpdate(_ context.Context, oldM3dt, ne
 
 	if oldM3dt == nil {
 		return nil, apierrors.NewInternalError(errors.New("unable to convert existing object"))
+	}
+
+	var warnings admission.Warnings
+	if newM3dt.Spec.ClusterName != "" {
+		warnings = append(warnings, "spec.clusterName is deprecated and will be removed in a future release. It is no longer used by the controllers.")
 	}
 
 	if !reflect.DeepEqual(newM3dt.Spec.MetaData, oldM3dt.Spec.MetaData) {
@@ -77,9 +86,9 @@ func (webhook *Metal3DataTemplate) ValidateUpdate(_ context.Context, oldM3dt, ne
 	}
 
 	if len(allErrs) == 0 {
-		return nil, nil
+		return warnings, nil
 	}
-	return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind("Metal3DataTemplate").GroupKind(), newM3dt.Name, allErrs)
+	return warnings, apierrors.NewInvalid(infrav1.GroupVersion.WithKind("Metal3DataTemplate").GroupKind(), newM3dt.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.

--- a/internal/webhooks/v1beta2/metal3datatemplate_webhook_test.go
+++ b/internal/webhooks/v1beta2/metal3datatemplate_webhook_test.go
@@ -396,3 +396,64 @@ func TestMetal3DataTemplateUpdateValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestMetal3DataTemplateClusterNameDeprecationWarning(t *testing.T) {
+	g := NewWithT(t)
+	webhook := &Metal3DataTemplate{}
+
+	t.Run("should return warning when clusterName is set on create", func(_ *testing.T) {
+		dt := &infrav1.Metal3DataTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+			},
+			Spec: infrav1.Metal3DataTemplateSpec{
+				ClusterName: "test-cluster",
+			},
+		}
+		warnings, err := webhook.ValidateCreate(ctx, dt)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(warnings).To(HaveLen(1))
+		g.Expect(warnings[0]).To(ContainSubstring("spec.clusterName is deprecated"))
+	})
+
+	t.Run("should not return warning when clusterName is empty on create", func(_ *testing.T) {
+		dt := &infrav1.Metal3DataTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+			},
+			Spec: infrav1.Metal3DataTemplateSpec{},
+		}
+		warnings, err := webhook.ValidateCreate(ctx, dt)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(warnings).To(BeEmpty())
+	})
+
+	t.Run("should return warning when clusterName is set on update", func(_ *testing.T) {
+		oldDT := &infrav1.Metal3DataTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+			},
+			Spec: infrav1.Metal3DataTemplateSpec{
+				ClusterName: "test-cluster",
+			},
+		}
+		newDT := oldDT.DeepCopy()
+		warnings, err := webhook.ValidateUpdate(ctx, oldDT, newDT)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(warnings).To(HaveLen(1))
+		g.Expect(warnings[0]).To(ContainSubstring("spec.clusterName is deprecated"))
+	})
+
+	t.Run("should not return warning when clusterName is empty on update", func(_ *testing.T) {
+		oldDT := &infrav1.Metal3DataTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+			},
+			Spec: infrav1.Metal3DataTemplateSpec{},
+		}
+		newDT := oldDT.DeepCopy()
+		warnings, err := webhook.ValidateUpdate(ctx, oldDT, newDT)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(warnings).To(BeEmpty())
+	})
+}

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -175,31 +175,27 @@ func DumpSpecResourcesAndCleanup(ctx context.Context, specName string, bootstrap
 			ArtifactFolder:       filepath.Join(artifactFolder, "delete-cluster"),
 		}, intervalsGetter(specName, "wait-delete-cluster")...)
 
-		// Waiting for Metal3Datas, Metal3DataTemplates and Metal3DataClaims, as these may take longer time to delete
-		By("Checking leftover Metal3Datas, Metal3DataTemplates and Metal3DataClaims")
+		// Waiting for Metal3Datas and Metal3DataClaims, as these may take longer time to delete.
+		// Metal3DataTemplates are intentionally not checked: they are decoupled from the Cluster
+		// (they can be shared across clusters) and are therefore not garbage-collected on cluster deletion.
+		By("Checking leftover Metal3Datas and Metal3DataClaims")
 		Eventually(func(g Gomega) {
 			opts := &client.ListOptions{}
 			datas := infrav1.Metal3DataList{}
-			dataTemplates := infrav1.Metal3DataTemplateList{}
 			dataClaims := infrav1.Metal3DataClaimList{}
 			g.Expect(clusterClient.List(ctx, &datas, opts)).To(Succeed())
-			g.Expect(clusterClient.List(ctx, &dataTemplates, opts)).To(Succeed())
 			g.Expect(clusterClient.List(ctx, &dataClaims, opts)).To(Succeed())
 			for _, dataObject := range datas.Items {
 				By(fmt.Sprintf("Data named: %s is not delete", dataObject.Name))
-			}
-			for _, dataObject := range dataTemplates.Items {
-				By(fmt.Sprintf("Datatemplate named: %s is not deleted", dataObject.Name))
 			}
 			for _, dataObject := range dataClaims.Items {
 				By(fmt.Sprintf("Dataclaim named: %s is not deleted", dataObject.Name))
 			}
 			g.Expect(datas.Items).To(BeEmpty())
-			g.Expect(dataTemplates.Items).To(BeEmpty())
 			g.Expect(dataClaims.Items).To(BeEmpty())
-			Logf("Waiting for Metal3Datas, Metal3DataTemplates and Metal3DataClaims to be deleted")
+			Logf("Waiting for Metal3Datas and Metal3DataClaims to be deleted")
 		}, intervalsGetter(specName, "wait-delete-cluster")...).Should(Succeed())
-		Logf("Metal3Datas, Metal3DataTemplates and Metal3DataClaims are deleted")
+		Logf("Metal3Datas and Metal3DataClaims are deleted")
 	}
 }
 

--- a/test/e2e/remediation.go
+++ b/test/e2e/remediation.go
@@ -263,7 +263,6 @@ func Remediation(ctx context.Context, inputGetter func() RemediationInput) {
 
 	newM3DataTemplate.Spec.MetaData = m3dataTemplate.Spec.MetaData
 	newM3DataTemplate.Spec.NetworkData = m3dataTemplate.Spec.NetworkData
-	newM3DataTemplate.Spec.ClusterName = input.ClusterName
 
 	newM3DataTemplate.ObjectMeta.Name = newM3dataTemplateName
 	newM3DataTemplate.ObjectMeta.Namespace = m3dataTemplate.Namespace


### PR DESCRIPTION
Historically a `Metal3DataTemplate` was tied to one `Cluster` via `spec.clusterName`, and the controller set a `Cluster` owner reference on it. This PR deprecates that field and decouples the template from any single Cluster, so one template can be shared across multiple clusters. Removing the coupling exposed a few behaviors that assumed a single owning Cluster, which this PR also fixes.

### Changes

1. **Deprecate `spec.clusterName`.** A validating webhook warns when the field is set. The controller no longer derives an owning Cluster from it or sets a Cluster owner reference on the template.
2. **Object-level pause.** Uses the pause annotation set directly on the template (`HasPaused(template)`) instead of the cluster-derived `IsPaused(cluster, obj)`, since a template may belong to many clusters.
3. **Secret(metaData and networkData) cluster-name label.** Derives the cluster name from the consuming machine (`machine.Spec.ClusterName`) instead of the template's own label.
4. **`Metal3Data` GC leak.** With the template no longer Cluster-owned, its leftover owner reference kept `Metal3Data` alive after cluster deletion. Removed it and made `Metal3DataClaim` the controlling owner, so `Metal3Data` is now in the Cluster's GC chain.
5. **Pivot (`clusterctl move`).** Added the `clusterctl.cluster.x-k8s.io/move` label to the CRD so the template is relocated during pivot even without a Cluster owner reference.
6. **Index allocation.** Made template-scoped, so a shared template hands out non-colliding indexes across clusters.
7. **E2E cleanup.** Teardown no longer waits for `Metal3DataTemplate` deletion on cluster removal, since it's intentionally no longer GC'd with the Cluster.

### Tests

**Unit** (baremetal, webhooks, controllers):
- **Shared-template index allocation** — a template already holding indexes `0` and `1` from two clusters gives a third cluster's claim index `2`, proving collision-free sharing.
- **`Metal3Data` owner references** — asserts the two-owner layout (controlling `Metal3DataClaim` + `Metal3Machine`, no `Metal3DataTemplate`), locking in the GC fix.
- **Webhook deprecation warning** — warns when `spec.clusterName` is set, not when empty.
- **Controller pause** — reconciliation is skipped via the template's own pause annotation.

**E2E** (e2e):
- **Pivot** — verifies the template is moved to the target cluster via the new move label.
- **Cleanup** — waits for `Metal3Data`/`Metal3DataClaim` GC on cluster deletion, no longer for `Metal3DataTemplate`.


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->



<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Part of https://github.com/metal3-io/cluster-api-provider-metal3/issues/3521
Also related to https://github.com/metal3-io/cluster-api-provider-metal3/issues/1358

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] E2E tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
