### PR TITLE
 🐛 Allow OCI image URLs without checksum

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -65,7 +65,9 @@ type Image struct {
 	URL string `json:"url"`
 
 	// Checksum is a md5sum, sha256sum or sha512sum value or a URL to retrieve one.
-	Checksum string `json:"checksum"`
+	// Optional for live-iso and oci:// URLs; required otherwise.
+	// +optional
+	Checksum string `json:"checksum,omitempty"`
 
 	// ChecksumType is the checksum algorithm for the image.
 	// e.g md5, sha256, sha512
@@ -87,6 +89,11 @@ type CustomDeploy struct {
 	Method string `json:"method"`
 }
 
+// IsOCI reports whether the image URL is an OCI reference.
+func (i *Image) IsOCI() bool {
+	return i != nil && strings.HasPrefix(strings.ToLower(i.URL), "oci://")
+}
+
 // Validate performs validation on [Image], returning a list of field errors using the provided base path.
 // It is intended to be used in the validation webhooks of resources containing [Image].
 func (i *Image) Validate(base field.Path) field.ErrorList {
@@ -105,8 +112,20 @@ func (i *Image) Validate(base field.Path) field.ErrorList {
 			errors = append(errors, field.Invalid(base.Child("URL"), i.URL, "not a valid URL"))
 		}
 	}
+	// Checksum is not required for OCI.
+	if i.IsOCI() {
+		if i.Checksum != "" {
+			errors = append(errors, field.Forbidden(base.Child("Checksum"), "must be empty for OCI images"))
+		}
+		if i.ChecksumType != nil && *i.ChecksumType != "" {
+			errors = append(errors, field.Forbidden(base.Child("ChecksumType"), "must be empty for OCI images"))
+		}
+		return errors
+	}
+
 	// Checksum is not required for live-iso.
-	if i.DiskFormat == nil || *i.DiskFormat != LiveISODiskFormat {
+	liveISO := i.DiskFormat != nil && *i.DiskFormat == LiveISODiskFormat
+	if !liveISO {
 		if i.Checksum == "" {
 			errors = append(errors, field.Required(base.Child("Checksum"), "cannot be empty"))
 		}

--- a/api/v1beta1/common_types_test.go
+++ b/api/v1beta1/common_types_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 )
 
 func TestImageValidate(t *testing.T) {
@@ -96,6 +97,29 @@ func TestImageValidate(t *testing.T) {
 			},
 			ErrorExpected: false,
 			Name:          "Valid spec with live-iso diskFormat",
+		},
+		{
+			Image: Image{
+				URL: "oci://example.com/image:latest",
+			},
+			ErrorExpected: false,
+			Name:          "OCI image without checksum",
+		},
+		{
+			Image: Image{
+				URL:      "oci://example.com/image:latest",
+				Checksum: "sha256hash",
+			},
+			ErrorExpected: true,
+			Name:          "OCI image with checksum",
+		},
+		{
+			Image: Image{
+				URL:          "oci://example.com/image:latest",
+				ChecksumType: ptr.To("sha256"),
+			},
+			ErrorExpected: true,
+			Name:          "OCI image with checksumType",
 		},
 	}
 

--- a/api/v1beta2/common_types.go
+++ b/api/v1beta2/common_types.go
@@ -98,8 +98,8 @@ type Image struct {
 	URL string `json:"url,omitempty"`
 
 	// checksum is a md5sum, sha256sum or sha512sum value or a URL to retrieve one.
-	// When diskFormat is live-iso, empty string is also a valid value.
-	// +required
+	// Optional for live-iso and oci:// URLs; required otherwise.
+	// +optional
 	// +kubebuilder:validation:MinLength=0
 	// +kubebuilder:validation:MaxLength=512
 	Checksum *string `json:"checksum,omitempty"`
@@ -143,6 +143,11 @@ type Metal3ObjectRef struct {
 	Namespace string `json:"namespace,omitempty"`
 }
 
+// IsOCI reports whether the image URL is an OCI reference.
+func (i *Image) IsOCI() bool {
+	return i != nil && strings.HasPrefix(strings.ToLower(i.URL), "oci://")
+}
+
 // Validate performs validation on [Image], returning a list of field errors using the provided base path.
 // It is intended to be used in the validation webhooks of resources containing [Image].
 func (i *Image) Validate(base field.Path) field.ErrorList {
@@ -161,6 +166,18 @@ func (i *Image) Validate(base field.Path) field.ErrorList {
 			errors = append(errors, field.Invalid(base.Child("URL"), i.URL, "not a valid URL"))
 		}
 	}
+
+	// Checksum is not required for OCI.
+	if i.IsOCI() {
+		if i.Checksum != nil && *i.Checksum != "" {
+			errors = append(errors, field.Forbidden(base.Child("Checksum"), "must be empty for OCI images"))
+		}
+		if i.ChecksumType != "" {
+			errors = append(errors, field.Forbidden(base.Child("ChecksumType"), "must be empty for OCI images"))
+		}
+		return errors
+	}
+
 	// Checksum is not required for live-iso.
 	if i.DiskFormat != LiveISODiskFormat {
 		if i.Checksum == nil || *i.Checksum == "" {

--- a/api/v1beta2/common_types_test.go
+++ b/api/v1beta2/common_types_test.go
@@ -98,6 +98,37 @@ func TestImageValidate(t *testing.T) {
 			ErrorExpected: false,
 			Name:          "Valid spec with live-iso diskFormat",
 		},
+		{
+			Image: Image{
+				URL: "oci://example.com/image:latest",
+			},
+			ErrorExpected: false,
+			Name:          "OCI image without checksum",
+		},
+		{
+			Image: Image{
+				URL:      "oci://example.com/image:latest",
+				Checksum: ptr.To(""),
+			},
+			ErrorExpected: false,
+			Name:          "OCI image with empty checksum",
+		},
+		{
+			Image: Image{
+				URL:      "oci://example.com/image:latest",
+				Checksum: ptr.To("sha256hash"),
+			},
+			ErrorExpected: true,
+			Name:          "OCI image with checksum",
+		},
+		{
+			Image: Image{
+				URL:          "oci://example.com/image:latest",
+				ChecksumType: "sha256",
+			},
+			ErrorExpected: true,
+			Name:          "OCI image with checksumType",
+		},
 	}
 
 	for _, tc := range cases {

--- a/baremetal/metal3machine_manager.go
+++ b/baremetal/metal3machine_manager.go
@@ -1155,15 +1155,11 @@ func (m *MachineManager) setHostSpec(_ context.Context, host *bmov1alpha1.BareMe
 			return fmt.Errorf("Metal3Machine %s has neither Image.URL nor CustomDeploy.Method configured", m.Metal3Machine.Name)
 		}
 
-		checksumType := ""
-		if m.Metal3Machine.Spec.Image.ChecksumType != "" {
-			checksumType = m.Metal3Machine.Spec.Image.ChecksumType
-		}
 		if imageConfigured {
 			host.Spec.Image = &bmov1alpha1.Image{
 				URL:          m.Metal3Machine.Spec.Image.URL,
 				Checksum:     ptr.Deref(m.Metal3Machine.Spec.Image.Checksum, ""),
-				ChecksumType: bmov1alpha1.ChecksumType(checksumType),
+				ChecksumType: bmov1alpha1.ChecksumType(m.Metal3Machine.Spec.Image.ChecksumType),
 				DiskFormat:   &m.Metal3Machine.Spec.Image.DiskFormat,
 			}
 		}

--- a/baremetal/metal3machine_manager_test.go
+++ b/baremetal/metal3machine_manager_test.go
@@ -1211,6 +1211,7 @@ var _ = Describe("Metal3Machine manager", func() {
 	type testCaseSetHostSpec struct {
 		UserDataNamespace           string
 		UseCustomDeploy             *bmov1alpha1.CustomDeploy
+		OverrideImage               *infrav1.Image
 		ExpectedUserDataNamespace   string
 		Host                        *bmov1alpha1.BareMetalHost
 		ExpectedImage               *bmov1alpha1.Image
@@ -1232,6 +1233,9 @@ var _ = Describe("Metal3Machine manager", func() {
 				m3mconfig.Spec.CustomDeploy = infrav1.CustomDeploy{
 					Method: tc.UseCustomDeploy.Method,
 				}
+			}
+			if tc.OverrideImage != nil {
+				m3mconfig.Spec.Image = *tc.OverrideImage
 			}
 			machine := newMachine(machineName, infrastructureRef)
 
@@ -1341,6 +1345,46 @@ var _ = Describe("Metal3Machine manager", func() {
 				),
 				ExpectedCustomDeploy: expectedCustomDeployTest(),
 				ExpectUserData:       false,
+			},
+		),
+		Entry("OCI image without checksum",
+			testCaseSetHostSpec{
+				UserDataNamespace:         "",
+				ExpectedUserDataNamespace: namespaceName,
+				OverrideImage: &infrav1.Image{
+					URL:        "oci://example.com/image:latest",
+					DiskFormat: testImageDiskFormat,
+				},
+				Host: newBareMetalHost("host2", nil, bmov1alpha1.StateNone,
+					nil, false, "metadata", false, "", false,
+				),
+				ExpectedImage: &bmov1alpha1.Image{
+					URL:        "oci://example.com/image:latest",
+					DiskFormat: &testImageDiskFormat,
+				},
+				ExpectUserData: true,
+			},
+		),
+		Entry("Non-OCI image with checksum and checksumType",
+			testCaseSetHostSpec{
+				UserDataNamespace:         "",
+				ExpectedUserDataNamespace: namespaceName,
+				OverrideImage: &infrav1.Image{
+					URL:          testImageURL,
+					Checksum:     ptr.To(testImageChecksumURL),
+					ChecksumType: "sha256",
+					DiskFormat:   testImageDiskFormat,
+				},
+				Host: newBareMetalHost("host2", nil, bmov1alpha1.StateNone,
+					nil, false, "metadata", false, "", false,
+				),
+				ExpectedImage: &bmov1alpha1.Image{
+					URL:          testImageURL,
+					Checksum:     testImageChecksumURL,
+					ChecksumType: bmov1alpha1.ChecksumType("sha256"),
+					DiskFormat:   &testImageDiskFormat,
+				},
+				ExpectUserData: true,
 			},
 		),
 	)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machines.yaml
@@ -178,8 +178,9 @@ spec:
                 description: Image is the image to be provisioned.
                 properties:
                   checksum:
-                    description: Checksum is a md5sum, sha256sum or sha512sum value
-                      or a URL to retrieve one.
+                    description: |-
+                      Checksum is a md5sum, sha256sum or sha512sum value or a URL to retrieve one.
+                      Optional for live-iso and oci:// URLs; required otherwise.
                     type: string
                   checksumType:
                     description: |-
@@ -203,7 +204,6 @@ spec:
                     description: URL is a location of an image to deploy.
                     type: string
                 required:
-                - checksum
                 - url
                 type: object
               metaData:
@@ -709,7 +709,7 @@ spec:
                   checksum:
                     description: |-
                       checksum is a md5sum, sha256sum or sha512sum value or a URL to retrieve one.
-                      When diskFormat is live-iso, empty string is also a valid value.
+                      Optional for live-iso and oci:// URLs; required otherwise.
                     maxLength: 512
                     minLength: 0
                     type: string
@@ -738,7 +738,6 @@ spec:
                     minLength: 1
                     type: string
                 required:
-                - checksum
                 - url
                 type: object
               metaData:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machinetemplates.yaml
@@ -178,8 +178,9 @@ spec:
                         description: Image is the image to be provisioned.
                         properties:
                           checksum:
-                            description: Checksum is a md5sum, sha256sum or sha512sum
-                              value or a URL to retrieve one.
+                            description: |-
+                              Checksum is a md5sum, sha256sum or sha512sum value or a URL to retrieve one.
+                              Optional for live-iso and oci:// URLs; required otherwise.
                             type: string
                           checksumType:
                             description: |-
@@ -203,7 +204,6 @@ spec:
                             description: URL is a location of an image to deploy.
                             type: string
                         required:
-                        - checksum
                         - url
                         type: object
                       metaData:
@@ -448,7 +448,7 @@ spec:
                           checksum:
                             description: |-
                               checksum is a md5sum, sha256sum or sha512sum value or a URL to retrieve one.
-                              When diskFormat is live-iso, empty string is also a valid value.
+                              Optional for live-iso and oci:// URLs; required otherwise.
                             maxLength: 512
                             minLength: 0
                             type: string
@@ -477,7 +477,6 @@ spec:
                             minLength: 1
                             type: string
                         required:
-                        - checksum
                         - url
                         type: object
                       metaData:


### PR DESCRIPTION
**What this PR does / why we need it**:

OCI URLs (`oci://`) embed the content digest in the URL itself, so a separate `Image.Checksum` is not meaningful. BMO's `BareMetalHost` webhook explicitly forbids it (see [baremetal-operator#3186](https://github.com/metal3-io/baremetal-operator/pull/3186)), but CAPM3 still required a non-empty checksum and silently propagated whatever the user set to the `BareMetalHost`, causing the BMH patch to fail with `checksum must be empty for OCI images`.

This PR:

- Relaxes `Image.Validate()` so that an OCI URL is valid without a checksum, and rejects a non-empty checksum for OCI URLs with a clear error.
- Makes `setHostSpec()` refuse the same combination instead of forwarding a meaningless checksum to the `BareMetalHost`.
- Updates the generated CRDs so that `checksum` is no longer a required field (it remains required at runtime for non-OCI, non-live-iso images via `Image.Validate()`).
- Adds unit tests covering the OCI valid / invalid cases in `api/v1beta2/common_types_test.go`.

Fixes #3503

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.