### PR TITLE
🌱  Fix serial log collection for CAPI-adopted tests

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -646,7 +646,11 @@ func Metal3MachineToMachineName(m3machine infrav1.Metal3Machine) (string, error)
 }
 
 func Metal3MachineToBmhName(m3machine infrav1.Metal3Machine) string {
-	return strings.Replace(m3machine.GetAnnotations()["metal3.io/BareMetalHost"], "metal3/", "", 1)
+	ref := m3machine.GetAnnotations()["metal3.io/BareMetalHost"]
+	if _, name, ok := strings.Cut(ref, "/"); ok {
+		return name
+	}
+	return ref
 }
 
 // Derives the name of a VM created by metal3-dev-env from the name of a BareMetalHost object.

--- a/test/e2e/logcollector.go
+++ b/test/e2e/logcollector.go
@@ -98,11 +98,11 @@ func (Metal3LogCollector) CollectMachineLog(ctx context.Context, cli client.Clie
 }
 
 func (Metal3LogCollector) CollectInfrastructureLogs(_ context.Context, _ client.Client, _ *clusterv1.Cluster, _ string) error {
-	return errors.New("CollectInfrastructureLogs not implemented")
+	return nil
 }
 
 func (Metal3LogCollector) CollectMachinePoolLog(_ context.Context, _ client.Client, _ *clusterv1.MachinePool, _ string) error {
-	return errors.New("CollectMachinePoolLog not implemented")
+	return nil
 }
 
 // FetchManifests fetches relevant Metal3, CAPI, and Kubernetes core resources


### PR DESCRIPTION
Metal3MachineToBmhName was hardcoded to strip only the 'metal3/' namespace prefix. In CAPI-adopted tests (e.g. clusterctl upgrade), BMHs live in a different namespace so the prefix was left intact, producing an invalid VM name with a slash and a wrong serial log path. Use strings.Cut to strip any namespace prefix generically.

CollectInfrastructureLogs and CollectMachinePoolLog returned hard errors for unimplemented methods, causing spurious test failures. Return nil instead. Metal3 has no infrastructure-level logs to collect beyond what CollectMachineLog already gathers.

Fixes #1609
