### PR TITLE
:seedling: Add missing conditions to m3c manager and m3m controller

### DIFF
--- a/api/v1beta2/errors.go
+++ b/api/v1beta2/errors.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+// MachineStatusError defines errors states for Machine objects.
+// These are duplicated from the deprecated sigs.k8s.io/cluster-api/api/deprecated/errors
+// package to allow CAPM3 to eventually remove the dependency on that package.
+type MachineStatusError string
+
+const (
+	// InvalidConfigurationMachineError represents that the combination
+	// of configuration in the MachineSpec is not supported by this cluster.
+	// This is not a transient error, but indicates a state that must be
+	// fixed before progress can be made.
+	InvalidConfigurationMachineError MachineStatusError = "InvalidConfiguration"
+
+	// CreateMachineError indicates an error while trying to create a Node to match this
+	// Machine. This may indicate a transient problem that will be fixed
+	// automatically with time, such as a service outage, or a terminal
+	// error during creation that doesn't match a more specific
+	// MachineStatusError value.
+	CreateMachineError MachineStatusError = "CreateError"
+
+	// UpdateMachineError indicates an error while trying to update a Node that this
+	// Machine represents. This may indicate a transient problem that will be
+	// fixed automatically with time, such as a service outage.
+	UpdateMachineError MachineStatusError = "UpdateError"
+
+	// DeleteMachineError indicates an error was encountered while trying to delete the Node
+	// that this Machine represents. This could be a transient or terminal error, but
+	// will only be observable if the provider's Machine controller has
+	// added a finalizer to the object to more gracefully handle deletions.
+	DeleteMachineError MachineStatusError = "DeleteError"
+)
+
+// ClusterStatusError defines errors states for Cluster objects.
+// These are duplicated from the deprecated sigs.k8s.io/cluster-api/api/deprecated/errors
+// package to allow CAPM3 to eventually remove the dependency on that package.
+type ClusterStatusError string
+
+const (
+	// InvalidConfigurationClusterError indicates that the cluster
+	// configuration is invalid.
+	InvalidConfigurationClusterError ClusterStatusError = "InvalidConfiguration"
+
+	// CreateClusterError indicates that an error was encountered
+	// when trying to create the cluster.
+	CreateClusterError ClusterStatusError = "CreateError"
+
+	// UpdateClusterError indicates that an error was encountered
+	// when trying to update the cluster.
+	UpdateClusterError ClusterStatusError = "UpdateError"
+
+	// DeleteClusterError indicates that an error was encountered
+	// when trying to delete the cluster.
+	DeleteClusterError ClusterStatusError = "DeleteError"
+)

--- a/api/v1beta2/metal3cluster_types.go
+++ b/api/v1beta2/metal3cluster_types.go
@@ -44,6 +44,7 @@ const (
 	ControlPlaneEndpointFailedReason      = "ControlPlaneEndpointFailed"
 	FailedToGetOwnerClusterReason         = "FailedToGetOwnerCluster"
 	Metal3ClusterDeletingReason           = clusterv1.DeletingReason
+	InvalidConfigurationReason            = string(InvalidConfigurationClusterError)
 )
 
 // Metal3ClusterSpec defines the desired state of Metal3Cluster.

--- a/api/v1beta2/metal3machine_types.go
+++ b/api/v1beta2/metal3machine_types.go
@@ -117,6 +117,19 @@ const (
 	// Metal3MachineDeletingFailedReason (Severity=Warning) documents a condition not in Status=True because the underlying object
 	// encountered problems during deletion. This is a warning because the reconciler will retry deletion.
 	Metal3MachineDeletingFailedReason = "DeletionFailed"
+
+	// CreateMachineErrorReason surfaces when an error occurs during machine creation.
+	CreateMachineErrorReason = string(CreateMachineError)
+
+	// UpdateMachineErrorReason surfaces when an error occurs during machine update.
+	UpdateMachineErrorReason = string(UpdateMachineError)
+
+	// DeleteMachineErrorReason surfaces when an error occurs during machine deletion.
+	DeleteMachineErrorReason = string(DeleteMachineError)
+
+	// InvalidConfigurationMachineReason is used to indicate that the Metal3Machine
+	// has an invalid configuration.
+	InvalidConfigurationMachineReason = string(InvalidConfigurationMachineError)
 )
 
 // Metal3MachineSpec defines the desired state of Metal3Machine.

--- a/baremetal/metal3cluster_manager.go
+++ b/baremetal/metal3cluster_manager.go
@@ -99,6 +99,12 @@ func (s *ClusterManager) Create(_ context.Context) error {
 		s.Log.V(VerbosityLevelDebug).Info("Invalid Metal3Cluster configuration",
 			LogFieldError, err.Error())
 		s.setError("Invalid Metal3Cluster provided", capierrors.InvalidConfigurationClusterError)
+		conditions.Set(s.Metal3Cluster, metav1.Condition{
+			Type:    infrav1.BaremetalInfrastructureReadyCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.InvalidConfigurationReason,
+			Message: "Invalid Metal3Cluster provided: " + err.Error(),
+		})
 		return err
 	}
 	s.Log.V(VerbosityLevelDebug).Info("Metal3Cluster configuration is valid")

--- a/controllers/metal3cluster_controller_integration_test.go
+++ b/controllers/metal3cluster_controller_integration_test.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
-	capierrors "sigs.k8s.io/cluster-api/api/deprecated/errors"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -36,13 +35,11 @@ import (
 var _ = Describe("Reconcile metal3Cluster", func() {
 
 	type TestCaseReconcileBMC struct {
-		Objects             []client.Object
-		ErrorType           error
-		ErrorExpected       bool
-		RequeueExpected     bool
-		ErrorReasonExpected bool
-		ErrorReason         capierrors.ClusterStatusError
-		ConditionsExpected  []metav1.Condition
+		Objects            []client.Object
+		ErrorType          error
+		ErrorExpected      bool
+		RequeueExpected    bool
+		ConditionsExpected []metav1.Condition
 	}
 
 	DescribeTable("Reconcile tests metal3Cluster",
@@ -82,12 +79,6 @@ var _ = Describe("Reconcile metal3Cluster", func() {
 			} else {
 				Expect(res.Requeue).To(BeFalse())
 			}
-			if tc.ErrorReasonExpected {
-				Expect(testclstr.Status.Deprecated).NotTo(BeNil())
-				Expect(testclstr.Status.Deprecated.V1Beta1).NotTo(BeNil())
-				Expect(testclstr.Status.Deprecated.V1Beta1.FailureReason).NotTo(BeNil())
-				Expect(tc.ErrorReason).To(Equal(*testclstr.Status.Deprecated.V1Beta1.FailureReason))
-			}
 			for _, condExp := range tc.ConditionsExpected {
 				condGot := conditions.Get(testclstr, condExp.Type)
 				Expect(condGot).NotTo(BeNil())
@@ -113,10 +104,8 @@ var _ = Describe("Reconcile metal3Cluster", func() {
 				Objects: []client.Object{
 					newMetal3Cluster(metal3ClusterName, bmcOwnerRef(), bmcSpec(), nil, nil, false),
 				},
-				ErrorExpected:       true,
-				ErrorReasonExpected: true,
-				ErrorReason:         capierrors.InvalidConfigurationClusterError,
-				RequeueExpected:     false,
+				ErrorExpected:   true,
+				RequeueExpected: false,
 			},
 		),
 		// Given cluster and metal3cluster with no owner reference
@@ -137,10 +126,15 @@ var _ = Describe("Reconcile metal3Cluster", func() {
 					newMetal3Cluster(metal3ClusterName, bmcOwnerRef(), nil, Metal3ClusterStatusWithPausedConditionFalse(), nil, false),
 					newCluster(clusterName, nil, nil),
 				},
-				ErrorExpected:       true,
-				RequeueExpected:     false,
-				ErrorReasonExpected: true,
-				ErrorReason:         capierrors.InvalidConfigurationClusterError,
+				ErrorExpected:   true,
+				RequeueExpected: false,
+				ConditionsExpected: []metav1.Condition{
+					{
+						Type:   infrav1.BaremetalInfrastructureReadyCondition,
+						Status: metav1.ConditionFalse,
+						Reason: infrav1.InvalidConfigurationReason,
+					},
+				},
 			},
 		),
 

--- a/controllers/metal3machine_controller.go
+++ b/controllers/metal3machine_controller.go
@@ -159,6 +159,12 @@ func (r *Metal3MachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err != nil {
 		setErrorM3Machine(capm3Machine, "", "")
 		machineLog.Info("Machine is missing cluster label or cluster does not exist")
+		conditions.Set(capm3Machine, metav1.Condition{
+			Type:    infrav1.AssociateBareMetalHostCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.WaitingForClusterInfrastructureReadyReason,
+			Message: "Machine is missing cluster label or cluster does not exist",
+		})
 		return ctrl.Result{}, nil
 	}
 
@@ -386,9 +392,9 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 		if err != nil {
 			log.V(baremetal.VerbosityLevelDebug).Info("Failed to update provisioned machine",
 				baremetal.LogFieldError, err.Error())
-			errType := capierrors.UpdateMachineError
 			return checkMachineError(machineMgr, err,
-				"Failed to update the Metal3Machine", errType)
+				infrav1.AssociateMetal3MachineMetaDataCondition, infrav1.UpdateMachineErrorReason,
+				"Failed to update the Metal3Machine")
 		}
 		log.V(baremetal.VerbosityLevelTrace).Info("reconcileNormal: provisioned machine updated successfully")
 		return ctrl.Result{}, nil
@@ -407,8 +413,6 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 		return ctrl.Result{}, nil
 	}
 
-	errType := capierrors.CreateMachineError
-
 	// Check if the metal3machine was associated with a baremetalhost
 	hasAnnotation := machineMgr.HasAnnotation()
 	log.V(baremetal.VerbosityLevelDebug).Info("Checking BMH association",
@@ -423,9 +427,9 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 			log.V(baremetal.VerbosityLevelDebug).Info("Association failed",
 				baremetal.LogFieldError, err.Error())
 			machineMgr.SetV1Beta1ConditionToFalse(infrav1.AssociateBMHV1Beta1Condition, infrav1.AssociateBMHFailedV1Beta1Reason, clusterv1.ConditionSeverityError, "%s", err.Error())
-			machineMgr.SetCondition(infrav1.AssociateBareMetalHostCondition, metav1.ConditionFalse, infrav1.AssociateBareMetalHostFailedReason, err.Error())
 			return checkMachineError(machineMgr, err,
-				"failed to associate the Metal3Machine to a BareMetalHost", errType)
+				infrav1.AssociateBareMetalHostCondition, infrav1.AssociateBareMetalHostFailedReason,
+				"failed to associate the Metal3Machine to a BareMetalHost")
 		}
 
 		// Check again if the annotation is set, if not return error as association failed
@@ -455,9 +459,9 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 		log.V(baremetal.VerbosityLevelDebug).Info("Metadata association failed",
 			baremetal.LogFieldError, err.Error())
 		machineMgr.SetV1Beta1ConditionToFalse(infrav1.KubernetesNodeReadyV1Beta1Condition, infrav1.AssociateM3MetaDataFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, "%s", err.Error())
-		machineMgr.SetCondition(infrav1.AssociateMetal3MachineMetaDataCondition, metav1.ConditionFalse, infrav1.AssociateMetal3MachineMetaDataFailedReason, err.Error())
 		return checkMachineError(machineMgr, err,
-			"Failed to get the Metal3Metadata", errType)
+			infrav1.AssociateMetal3MachineMetaDataCondition, infrav1.AssociateMetal3MachineMetaDataFailedReason,
+			"Failed to get the Metal3Metadata")
 	}
 	machineMgr.SetCondition(infrav1.AssociateMetal3MachineMetaDataCondition, metav1.ConditionTrue, infrav1.AssociateMetal3MachineMetaDataSuccessReason, "")
 
@@ -467,7 +471,8 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 		log.V(baremetal.VerbosityLevelDebug).Info("Failed to update BareMetalHost",
 			baremetal.LogFieldError, err.Error())
 		return checkMachineError(machineMgr, err,
-			"failed to update BareMetalHost", errType)
+			infrav1.AssociateMetal3MachineMetaDataCondition, infrav1.CreateMachineErrorReason,
+			"failed to update BareMetalHost")
 	}
 
 	log.V(baremetal.VerbosityLevelTrace).Info("Checking if BMH is provisioned")
@@ -495,7 +500,9 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 		if err != nil {
 			log.V(baremetal.VerbosityLevelDebug).Info("Failed to set ProviderID from cloud provider",
 				baremetal.LogFieldError, err.Error())
-			return checkMachineError(machineMgr, err, "failed to set ProviderID on Metal3Machine based on Cloud Provider Node ProviderID", errType)
+			return checkMachineError(machineMgr, err,
+				infrav1.AssociateMetal3MachineMetaDataCondition, infrav1.CreateMachineErrorReason,
+				"failed to set ProviderID on Metal3Machine based on Cloud Provider Node ProviderID")
 		}
 		return ctrl.Result{}, nil
 	}
@@ -508,7 +515,9 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 	if err != nil {
 		log.V(baremetal.VerbosityLevelDebug).Info("Failed to set ProviderID from node label",
 			baremetal.LogFieldError, err.Error())
-		return checkMachineError(machineMgr, err, "failed to set ProviderID on Metal3Machine based on Node label", errType)
+		return checkMachineError(machineMgr, err,
+			infrav1.AssociateMetal3MachineMetaDataCondition, infrav1.CreateMachineErrorReason,
+			"failed to set ProviderID on Metal3Machine based on Node label")
 	}
 
 	log.V(baremetal.VerbosityLevelDebug).Info("SetProviderIDFromNodeLabel result",
@@ -538,18 +547,19 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 			log.V(baremetal.VerbosityLevelDebug).Info("Failed to set default ProviderID",
 				baremetal.LogFieldError, err.Error())
 			return checkMachineError(machineMgr, err,
-				"Failed to set default ProviderID the Metal3Machine", errType)
+				infrav1.AssociateMetal3MachineMetaDataCondition, infrav1.CreateMachineErrorReason,
+				"Failed to set default ProviderID the Metal3Machine")
 		}
 		machineMgr.SetReadyTrue()
 
-		errType = capierrors.UpdateMachineError
 		log.V(baremetal.VerbosityLevelTrace).Info("Updating machine after setting default ProviderID")
 		err = machineMgr.Update(ctx)
 		if err != nil {
 			log.V(baremetal.VerbosityLevelDebug).Info("Failed to update Metal3Machine",
 				baremetal.LogFieldError, err.Error())
 			return checkMachineError(machineMgr, err,
-				"Failed to update the Metal3Machine", errType)
+				infrav1.AssociateMetal3MachineMetaDataCondition, infrav1.UpdateMachineErrorReason,
+				"Failed to update the Metal3Machine")
 		}
 	}
 
@@ -558,18 +568,19 @@ func (r *Metal3MachineReconciler) reconcileNormal(ctx context.Context,
 	if err != nil {
 		log.V(baremetal.VerbosityLevelDebug).Info("Failed to set node ProviderID by hostname",
 			baremetal.LogFieldError, err.Error())
-		errType = capierrors.UpdateMachineError
-		return checkMachineError(machineMgr, err, "unable to find Node by hostname, it may not be ready yet", errType)
+		return checkMachineError(machineMgr, err,
+			infrav1.AssociateMetal3MachineMetaDataCondition, infrav1.UpdateMachineErrorReason,
+			"unable to find Node by hostname, it may not be ready yet")
 	}
 
-	errType = capierrors.UpdateMachineError
 	log.V(baremetal.VerbosityLevelTrace).Info("Final machine update")
 	err = machineMgr.Update(ctx)
 	if err != nil {
 		log.V(baremetal.VerbosityLevelDebug).Info("Final update failed",
 			baremetal.LogFieldError, err.Error())
 		return checkMachineError(machineMgr, err,
-			"Failed to update the Metal3Machine", errType)
+			infrav1.AssociateMetal3MachineMetaDataCondition, infrav1.UpdateMachineErrorReason,
+			"Failed to update the Metal3Machine")
 	}
 
 	log.V(baremetal.VerbosityLevelTrace).Info("reconcileNormal: completed successfully")
@@ -588,18 +599,16 @@ func (r *Metal3MachineReconciler) reconcileDelete(ctx context.Context,
 	log.V(baremetal.VerbosityLevelDebug).Info("Deletion conditions set",
 		baremetal.LogFieldCondition, infrav1.AssociateMetal3MachineMetaDataCondition)
 
-	errType := capierrors.DeleteMachineError
-
 	// dissociate metadata if any
 	log.V(baremetal.VerbosityLevelTrace).Info("Dissociating M3Metadata from machine")
 	if err := machineMgr.DissociateM3Metadata(ctx); err != nil {
 		log.V(baremetal.VerbosityLevelDebug).Info("Failed to dissociate M3Metadata",
 			baremetal.LogFieldError, err.Error())
 		machineMgr.SetV1Beta1ConditionToFalse(infrav1.KubernetesNodeReadyV1Beta1Condition, infrav1.DisassociateM3MetaDataFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, "%s", err.Error())
-		machineMgr.SetCondition(infrav1.AssociateMetal3MachineMetaDataCondition, metav1.ConditionFalse, infrav1.DisassociateM3MetaDataFailedReason, err.Error())
 
 		return checkMachineError(machineMgr, err,
-			"failed to dissociate Metadata", errType)
+			infrav1.AssociateMetal3MachineMetaDataCondition, infrav1.DisassociateM3MetaDataFailedReason,
+			"failed to dissociate Metadata")
 	}
 	log.V(baremetal.VerbosityLevelDebug).Info("M3Metadata dissociated successfully")
 
@@ -609,10 +618,10 @@ func (r *Metal3MachineReconciler) reconcileDelete(ctx context.Context,
 		log.V(baremetal.VerbosityLevelDebug).Info("Failed to delete Metal3Machine resources",
 			baremetal.LogFieldError, err.Error())
 		machineMgr.SetV1Beta1ConditionToFalse(infrav1.KubernetesNodeReadyV1Beta1Condition, infrav1.DeletionFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, "%s", err.Error())
-		machineMgr.SetCondition(infrav1.AssociateMetal3MachineMetaDataCondition, metav1.ConditionFalse, infrav1.Metal3MachineDeletingFailedReason, err.Error())
 
 		return checkMachineError(machineMgr, err,
-			"failed to delete Metal3Machine", errType)
+			infrav1.AssociateMetal3MachineMetaDataCondition, infrav1.Metal3MachineDeletingFailedReason,
+			"failed to delete Metal3Machine")
 	}
 	log.V(baremetal.VerbosityLevelDebug).Info("Metal3Machine resources deleted successfully")
 
@@ -842,20 +851,42 @@ func setErrorM3Machine(m3m *infrav1.Metal3Machine, message string, reason capier
 }
 
 func checkMachineError(machineMgr baremetal.MachineManagerInterface, err error,
-	errMessage string, errType capierrors.MachineStatusError) (ctrl.Result, error) {
+	conditionType string, conditionReason string, conditionMessage string) (ctrl.Result, error) {
 	if err == nil {
 		return ctrl.Result{}, nil
 	}
 
+	message := fmt.Sprintf("%s: %v", conditionMessage, err)
 	var reconcileError baremetal.ReconcileError
 	if errors.As(err, &reconcileError) {
 		if reconcileError.IsTransient() {
+			machineMgr.SetCondition(conditionType, metav1.ConditionFalse, conditionReason, message)
 			return reconcile.Result{Requeue: true, RequeueAfter: reconcileError.GetRequeueAfter()}, nil
 		}
 		if reconcileError.IsTerminal() {
-			machineMgr.SetError(errMessage, errType)
+			machineMgr.SetCondition(conditionType, metav1.ConditionFalse, conditionReason, message)
+			// Deprecated: Remove this block when SetError is removed.
+			machineMgr.SetError(message, conditionReasonToMachineStatusError(conditionReason))
 			return reconcile.Result{}, nil
 		}
 	}
-	return ctrl.Result{}, fmt.Errorf("%s: %w", errMessage, err)
+	machineMgr.SetCondition(conditionType, metav1.ConditionFalse, conditionReason, message)
+	return ctrl.Result{}, fmt.Errorf("%s: %w", conditionMessage, err)
+}
+
+// conditionReasonToMachineStatusError maps v1beta2 condition reasons to the deprecated
+// capierrors.MachineStatusError values for backward compatibility with SetError.
+//
+// Deprecated: Remove this function when SetError is removed.
+func conditionReasonToMachineStatusError(reason string) capierrors.MachineStatusError {
+	switch reason {
+	case infrav1.UpdateMachineErrorReason:
+		return capierrors.UpdateMachineError
+	case infrav1.DeleteMachineErrorReason, infrav1.DisassociateM3MetaDataFailedReason, infrav1.Metal3MachineDeletingFailedReason:
+		return capierrors.DeleteMachineError
+	case infrav1.InvalidConfigurationMachineReason:
+		return capierrors.InvalidConfigurationMachineError
+	default:
+		return capierrors.CreateMachineError
+	}
 }

--- a/controllers/metal3machine_controller_integration_test.go
+++ b/controllers/metal3machine_controller_integration_test.go
@@ -375,6 +375,13 @@ var _ = Describe("Reconcile metal3machine", func() {
 				ErrorReasonExpected: true,
 				ErrorReason:         "",
 				RequeueExpected:     false,
+				ConditionsExpected: []metav1.Condition{
+					{
+						Type:   infrav1.AssociateBareMetalHostCondition,
+						Status: metav1.ConditionFalse,
+						Reason: infrav1.WaitingForClusterInfrastructureReadyReason,
+					},
+				},
 			},
 		),
 		//Given: Machine, Metal3Machine, Cluster. No Metal3Cluster. Cluster Infra not ready

--- a/controllers/metal3machine_controller_test.go
+++ b/controllers/metal3machine_controller_test.go
@@ -149,6 +149,8 @@ func setReconcileNormalExpectations(ctrl *gomock.Controller,
 		m.EXPECT().NodeWithMatchingProviderIDExists(context.TODO(), nil).Return(false)
 		if tc.SetProviderIDFromNodeLabelFails {
 			m.EXPECT().SetProviderIDFromNodeLabel(context.TODO(), nil).Return(false, errors.New("failed"))
+			m.EXPECT().SetCondition(infrav1.AssociateMetal3MachineMetaDataCondition,
+				metav1.ConditionFalse, infrav1.CreateMachineErrorReason, gomock.Any())
 		} else {
 			m.EXPECT().SetProviderIDFromNodeLabel(context.TODO(), nil).Return(true, nil)
 			m.EXPECT().GetMetal3Machine().Return(&infrav1.Metal3Machine{})


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures all error states in the Metal3Machine controller are surfaced through v1beta2 conditions, preparing for the eventual removal of `FailureReason`/`FailureMessage` fields.

The key change is refactoring `checkMachineError` to be condition-first: callers provide condition parameters, and the deprecated `SetError` is derived internally, making future removal easier.

Duplicates `MachineStatusError` and `ClusterStatusError` types locally with their constants. This allows CAPM3 to eventually remove the dependency on the deprecated CAPI errors package independently.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
