### PR TITLE
:sparkles: Fetch DNS servers from IPPool for CAPI IPAddressClaim path

### DIFF
--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"net/netip"
 	"regexp"
 	"strconv"
 	"strings"
@@ -454,6 +455,86 @@ func (m *DataManager) getAddressesFromPool(ctx context.Context,
 func isMetal3IPPoolRef(ref infrav1.IPPoolReference) bool {
 	return (ref.APIGroup == IPPoolAPIGroup && ref.Kind == IPPoolKind) ||
 		(ref.APIGroup == "" && ref.Kind == "")
+}
+
+// fetchDNSServersFromIPPool fetches DNS servers directly from the Metal3 IPPool object.
+// It resolves per-subnet DNS overrides by checking which subnet the allocated address belongs to,
+// falling back to pool-level DNSServers if no per-subnet override is found.
+// This is used instead of reading DNS from the IPAddress object, since CAPI IPAddress does not
+// carry DNS information.
+func (m *DataManager) fetchDNSServersFromIPPool(ctx context.Context, poolRef infrav1.IPPoolReference, allocatedAddress *capipamv1.IPAddress) ([]ipamv1.IPAddressStr, error) {
+	if !isMetal3IPPoolRef(poolRef) {
+		// Non-Metal3 pools might not have DNS servers in their spec. Return if metal3 IPPool is not referenced.
+		return nil, nil
+	}
+
+	if allocatedAddress == nil || allocatedAddress.Spec.Address == "" {
+		return nil, errors.New("allocated address is nil or empty, cannot fetch DNS servers from IPPool")
+	}
+
+	pool := &ipamv1.IPPool{}
+	poolNamespacedName := types.NamespacedName{
+		Name:      poolRef.Name,
+		Namespace: allocatedAddress.Namespace,
+	}
+
+	if err := m.client.Get(ctx, poolNamespacedName, pool); err != nil {
+		return nil, fmt.Errorf("failed to fetch IPPool %s: %w", poolRef.Name, err)
+	}
+
+	allocatedIP, err := netip.ParseAddr(allocatedAddress.Spec.Address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse allocated address %s: %w", allocatedAddress.Spec.Address, err)
+	}
+
+	for _, p := range pool.Spec.Pools {
+		if addressInPool(allocatedIP, p) {
+			if len(p.DNSServers) > 0 {
+				return p.DNSServers, nil
+			}
+			// Address matched this pool entry but it has no per-pool DNS override;
+			// fall back to spec-level DNSServers.
+			return pool.Spec.DNSServers, nil
+		}
+	}
+
+	return nil, fmt.Errorf("allocated address %s not contained in any pool entry of IPPool %s", allocatedAddress.Spec.Address, poolRef.Name)
+}
+
+// addressInPool checks if the given IP address falls within the pool entry's bounds.
+// The logic mirrors isAddressInBonds in ip-address-manager's IPPool webhook.
+func addressInPool(ip netip.Addr, p ipamv1.Pool) bool {
+	if p.Start != nil {
+		startIP, err := netip.ParseAddr(string(*p.Start))
+		if err != nil {
+			return false
+		}
+		if startIP.Compare(ip) > 0 {
+			return false
+		}
+	}
+
+	if p.End != nil {
+		endIP, err := netip.ParseAddr(string(*p.End))
+		if err != nil {
+			return false
+		}
+		if endIP.Compare(ip) < 0 {
+			return false
+		}
+	}
+
+	if p.Subnet != nil && *p.Subnet != "" {
+		_, subnet, err := net.ParseCIDR(string(*p.Subnet))
+		if err != nil {
+			return false
+		}
+		if !subnet.Contains(ip.AsSlice()) {
+			return false
+		}
+	}
+
+	return true
 }
 
 // releaseAddressesFromPool releases all addresses allocated by a [Metal3DataTemplate] by deleting the IP claims.
@@ -1013,7 +1094,7 @@ func (m *DataManager) ensureIPClaim(ctx context.Context, poolRef infrav1.IPPoolR
 }
 
 // addressFromClaim retrieves the IPAddress for a CAPI IPAddressClaim.
-func (m *DataManager) addressFromClaim(ctx context.Context, _ infrav1.IPPoolReference, claim *capipamv1.IPAddressClaim) (AddressFromPool, bool, error) {
+func (m *DataManager) addressFromClaim(ctx context.Context, poolRef infrav1.IPPoolReference, claim *capipamv1.IPAddressClaim) (AddressFromPool, bool, error) {
 	m.Log.V(VerbosityLevelTrace).Info("Getting address from IPAddressClaim")
 	if claim == nil {
 		return AddressFromPool{}, true, errors.New("no claim provided")
@@ -1041,11 +1122,17 @@ func (m *DataManager) addressFromClaim(ctx context.Context, _ infrav1.IPPoolRefe
 		return AddressFromPool{}, false, err
 	}
 
+	// CAPI IPAddress does not have a DNSServers field, so fetch DNS from the IPPool directly.
+	dnsServers, err := m.fetchDNSServersFromIPPool(ctx, poolRef, address)
+	if err != nil {
+		return AddressFromPool{}, false, err
+	}
+
 	a := AddressFromPool{
 		Address:    ipamv1.IPAddressStr(address.Spec.Address),
 		Prefix:     address.Spec.Prefix,
 		Gateway:    ipamv1.IPAddressStr(address.Spec.Gateway),
-		dnsServers: []ipamv1.IPAddressStr{},
+		dnsServers: dnsServers,
 	}
 	return a, false, nil
 }

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -2365,6 +2365,7 @@ var _ = Describe("Metal3Data manager", func() {
 		poolRef         infrav1.IPPoolReference
 		ipClaim         *capipamv1.IPAddressClaim
 		ipAddress       *capipamv1.IPAddress
+		ipPool          *ipamv1.IPPool
 		expectError     bool
 		expectRequeue   bool
 		expectedAddress AddressFromPool
@@ -2380,6 +2381,9 @@ var _ = Describe("Metal3Data manager", func() {
 			}
 			if tc.ipClaim != nil {
 				objects = append(objects, tc.ipClaim)
+			}
+			if tc.ipPool != nil {
+				objects = append(objects, tc.ipPool)
 			}
 			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
 			dataMgr, err := NewDataManager(fakeClient, tc.m3d,
@@ -2484,10 +2488,12 @@ var _ = Describe("Metal3Data manager", func() {
 			poolName: testPoolName,
 			poolRef:  infrav1.IPPoolReference{Name: testPoolName},
 			expectedAddress: AddressFromPool{
-				Address:    ipamv1.IPAddressStr("192.168.0.10"),
-				Prefix:     ptr.To(int32(26)),
-				Gateway:    ipamv1.IPAddressStr("192.168.0.1"),
-				dnsServers: []ipamv1.IPAddressStr{},
+				Address: ipamv1.IPAddressStr("192.168.0.10"),
+				Prefix:  ptr.To(int32(26)),
+				Gateway: ipamv1.IPAddressStr("192.168.0.1"),
+				dnsServers: []ipamv1.IPAddressStr{
+					"8.8.8.8",
+				},
 			},
 			ipClaim: &capipamv1.IPAddressClaim{
 				ObjectMeta: testObjectMeta(metal3DataName+"-"+testPoolName, namespaceName, ""),
@@ -2503,6 +2509,18 @@ var _ = Describe("Metal3Data manager", func() {
 					Address: "192.168.0.10",
 					Prefix:  ptr.To(int32(26)),
 					Gateway: "192.168.0.1",
+				},
+			},
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							Subnet: (*ipamv1.IPSubnetStr)(ptr.To("192.168.0.0/24")),
+						},
+					},
 				},
 			},
 		}),
@@ -5791,4 +5809,553 @@ var _ = Describe("When using BMH name based pre-allocation", func() {
 		}),
 	)
 
+})
+
+var _ = Describe("Metal3Data manager DNS from IPPool", func() {
+	type testCaseFetchDNS struct {
+		poolRef          infrav1.IPPoolReference
+		allocatedAddress *capipamv1.IPAddress
+		pool             *ipamv1.IPPool
+		expectedDNS      []ipamv1.IPAddressStr
+		expectError      bool
+	}
+
+	DescribeTable("Test fetchDNSServersFromIPPool",
+		func(tc testCaseFetchDNS) {
+			objects := []client.Object{}
+			if tc.pool != nil {
+				objects = append(objects, tc.pool)
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			m3d := &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
+			}
+			dataMgr, err := NewDataManager(fakeClient, m3d, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			dns, err := dataMgr.fetchDNSServersFromIPPool(context.TODO(), tc.poolRef, tc.allocatedAddress)
+			if tc.expectError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+			if tc.expectedDNS == nil {
+				Expect(dns).To(BeNil())
+			} else {
+				Expect(dns).To(Equal(tc.expectedDNS))
+			}
+		},
+		Entry("Metal3 IPPool found with DNS", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "192.168.0.50",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							Subnet: (*ipamv1.IPSubnetStr)(ptr.To("192.168.0.0/24")),
+						},
+					},
+				},
+			},
+			expectedDNS: []ipamv1.IPAddressStr{"8.8.8.8"},
+		}),
+		Entry("Metal3 IPPool not found", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: "nonexistent", APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "192.168.0.50",
+				},
+			},
+			expectError: true,
+		}),
+		Entry("Non-Metal3 pool ref returns nil", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "other.io", Kind: "OtherPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "192.168.0.50",
+				},
+			},
+			expectedDNS: nil,
+		}),
+		Entry("Pool-level DNS only", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "192.168.0.50",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8", "8.8.4.4"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							Start:  (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:    (*ipamv1.IPAddressStr)(ptr.To("192.168.0.100")),
+							Subnet: (*ipamv1.IPSubnetStr)(ptr.To("192.168.0.0/24")),
+						},
+					},
+				},
+			},
+			expectedDNS: []ipamv1.IPAddressStr{"8.8.8.8", "8.8.4.4"},
+		}),
+		Entry("Per-subnet DNS override", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "192.168.0.50",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							Start:      (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:        (*ipamv1.IPAddressStr)(ptr.To("192.168.0.100")),
+							Subnet:     (*ipamv1.IPSubnetStr)(ptr.To("192.168.0.0/24")),
+							DNSServers: []ipamv1.IPAddressStr{"1.1.1.1", "1.0.0.1"},
+						},
+					},
+				},
+			},
+			expectedDNS: []ipamv1.IPAddressStr{"1.1.1.1", "1.0.0.1"},
+		}),
+		Entry("Address not in any pool entry returns error", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "192.168.0.50",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							Start:      (*ipamv1.IPAddressStr)(ptr.To("10.0.0.10")),
+							End:        (*ipamv1.IPAddressStr)(ptr.To("10.0.0.100")),
+							Subnet:     (*ipamv1.IPSubnetStr)(ptr.To("10.0.0.0/24")),
+							DNSServers: []ipamv1.IPAddressStr{"1.1.1.1"},
+						},
+					},
+				},
+			},
+			expectError: true,
+		}),
+		Entry("Empty address expects error", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+					NamePrefix: "test",
+				},
+			},
+			expectError: true,
+		}),
+		Entry("No DNS servers anywhere", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "192.168.0.50",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							Start:  (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:    (*ipamv1.IPAddressStr)(ptr.To("192.168.0.100")),
+							Subnet: (*ipamv1.IPSubnetStr)(ptr.To("192.168.0.0/24")),
+						},
+					},
+				},
+			},
+			expectedDNS: nil,
+		}),
+		Entry("Multiple subnets, address in second subnet", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "192.168.1.50",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							Start:      (*ipamv1.IPAddressStr)(ptr.To("10.0.0.10")),
+							End:        (*ipamv1.IPAddressStr)(ptr.To("10.0.0.100")),
+							Subnet:     (*ipamv1.IPSubnetStr)(ptr.To("10.0.0.0/24")),
+							DNSServers: []ipamv1.IPAddressStr{"1.1.1.1"},
+						},
+						{
+							Start:      (*ipamv1.IPAddressStr)(ptr.To("192.168.1.10")),
+							End:        (*ipamv1.IPAddressStr)(ptr.To("192.168.1.100")),
+							Subnet:     (*ipamv1.IPSubnetStr)(ptr.To("192.168.1.0/24")),
+							DNSServers: []ipamv1.IPAddressStr{"9.9.9.9"},
+						},
+					},
+				},
+			},
+			expectedDNS: []ipamv1.IPAddressStr{"9.9.9.9"},
+		}),
+		Entry("Subnet match by start/end range without subnet CIDR", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "192.168.0.50",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							Start:      (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:        (*ipamv1.IPAddressStr)(ptr.To("192.168.0.100")),
+							DNSServers: []ipamv1.IPAddressStr{"1.1.1.1"},
+						},
+					},
+				},
+			},
+			expectedDNS: []ipamv1.IPAddressStr{"1.1.1.1"},
+		}),
+		Entry("IPv6 per-subnet DNS", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "fd00::10",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"2001:4860:4860::8888"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							Subnet:     (*ipamv1.IPSubnetStr)(ptr.To("fd00::/64")),
+							DNSServers: []ipamv1.IPAddressStr{"fd00::53"},
+						},
+					},
+				},
+			},
+			expectedDNS: []ipamv1.IPAddressStr{"fd00::53"},
+		}),
+		Entry("Address in subnet but outside start/end range returns error", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "192.168.0.200",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							Start:      (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:        (*ipamv1.IPAddressStr)(ptr.To("192.168.0.100")),
+							Subnet:     (*ipamv1.IPSubnetStr)(ptr.To("192.168.0.0/24")),
+							DNSServers: []ipamv1.IPAddressStr{"1.1.1.1"},
+						},
+					},
+				},
+			},
+			expectError: true,
+		}),
+		Entry("Nil allocated address returns error", testCaseFetchDNS{
+			poolRef:          infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: nil,
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							Subnet: (*ipamv1.IPSubnetStr)(ptr.To("192.168.0.0/24")),
+						},
+					},
+				},
+			},
+			expectError: true,
+		}),
+		Entry("Invalid allocated address string returns error", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "not-a-valid-ip",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							Subnet: (*ipamv1.IPSubnetStr)(ptr.To("192.168.0.0/24")),
+						},
+					},
+				},
+			},
+			expectError: true,
+		}),
+		Entry("Empty APIGroup and Kind treated as Metal3 pool ref", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "", Kind: ""},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "192.168.0.50",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							Subnet: (*ipamv1.IPSubnetStr)(ptr.To("192.168.0.0/24")),
+						},
+					},
+				},
+			},
+			expectedDNS: []ipamv1.IPAddressStr{"8.8.8.8"},
+		}),
+		Entry("Address at exact start boundary", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "192.168.0.10",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.100")),
+						},
+					},
+				},
+			},
+			expectedDNS: []ipamv1.IPAddressStr{"8.8.8.8"},
+		}),
+		Entry("Address at exact end boundary", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "192.168.0.100",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.100")),
+						},
+					},
+				},
+			},
+			expectedDNS: []ipamv1.IPAddressStr{"8.8.8.8"},
+		}),
+		Entry("Invalid start IP in pool entry skips that entry", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "192.168.0.50",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							Start:      (*ipamv1.IPAddressStr)(ptr.To("invalid")),
+							End:        (*ipamv1.IPAddressStr)(ptr.To("192.168.0.100")),
+							DNSServers: []ipamv1.IPAddressStr{"1.1.1.1"},
+						},
+						{
+							Subnet: (*ipamv1.IPSubnetStr)(ptr.To("192.168.0.0/24")),
+						},
+					},
+				},
+			},
+			expectedDNS: []ipamv1.IPAddressStr{"8.8.8.8"},
+		}),
+		Entry("Invalid end IP in pool entry skips that entry", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "192.168.0.50",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							Start:      (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:        (*ipamv1.IPAddressStr)(ptr.To("invalid")),
+							DNSServers: []ipamv1.IPAddressStr{"1.1.1.1"},
+						},
+						{
+							Subnet: (*ipamv1.IPSubnetStr)(ptr.To("192.168.0.0/24")),
+						},
+					},
+				},
+			},
+			expectedDNS: []ipamv1.IPAddressStr{"8.8.8.8"},
+		}),
+		Entry("Invalid subnet CIDR in pool entry skips that entry", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "192.168.0.50",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							Subnet:     (*ipamv1.IPSubnetStr)(ptr.To("not-a-cidr")),
+							DNSServers: []ipamv1.IPAddressStr{"1.1.1.1"},
+						},
+						{
+							Subnet: (*ipamv1.IPSubnetStr)(ptr.To("192.168.0.0/24")),
+						},
+					},
+				},
+			},
+			expectedDNS: []ipamv1.IPAddressStr{"8.8.8.8"},
+		}),
+		Entry("Pool with only start defined, address above start", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "192.168.0.50",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+						},
+					},
+				},
+			},
+			expectedDNS: []ipamv1.IPAddressStr{"8.8.8.8"},
+		}),
+		Entry("Pool with only end defined, address below end", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "192.168.0.50",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							End: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.100")),
+						},
+					},
+				},
+			},
+			expectedDNS: []ipamv1.IPAddressStr{"8.8.8.8"},
+		}),
+		Entry("Pool entry with no start, end, or subnet matches any address", testCaseFetchDNS{
+			poolRef: infrav1.IPPoolReference{Name: testPoolName, APIGroup: "ipam.metal3.io", Kind: "IPPool"},
+			allocatedAddress: &capipamv1.IPAddress{
+				ObjectMeta: testObjectMeta("test-ip", namespaceName, "test"),
+				Spec: capipamv1.IPAddressSpec{
+					Address: "10.99.99.99",
+				},
+			},
+			pool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+				Spec: ipamv1.IPPoolSpec{
+					DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+					NamePrefix: "test",
+					Pools: []ipamv1.Pool{
+						{
+							DNSServers: []ipamv1.IPAddressStr{"1.1.1.1"},
+						},
+					},
+				},
+			},
+			expectedDNS: []ipamv1.IPAddressStr{"1.1.1.1"},
+		}),
+	)
 })

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -164,7 +164,6 @@ rules:
   - watch
 - apiGroups:
   - ipam.cluster.x-k8s.io
-  - ipam.metal3.io
   resources:
   - ipaddresses
   verbs:
@@ -178,6 +177,15 @@ rules:
   - ipaddresses/status
   verbs:
   - get
+- apiGroups:
+  - ipam.metal3.io
+  resources:
+  - ipaddresses
+  - ippools
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - ipam.metal3.io
   resources:

--- a/controllers/metal3datatemplate_controller.go
+++ b/controllers/metal3datatemplate_controller.go
@@ -60,6 +60,7 @@ type Metal3DataTemplateReconciler struct {
 // +kubebuilder:rbac:groups=ipam.metal3.io,resources=ipclaims/status,verbs=get;watch
 // +kubebuilder:rbac:groups=ipam.metal3.io,resources=ipaddresses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=ipam.metal3.io,resources=ipaddresses/status,verbs=get
+// +kubebuilder:rbac:groups=ipam.metal3.io,resources=ippools,verbs=get;list;watch
 // +kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddressclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddressclaims/status,verbs=get;watch
 // +kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddresses,verbs=get;list;watch


### PR DESCRIPTION
Add DNS server resolution from the Metal3 IPPool object in `addressFromClaim`, so that the CAPI IPAddressClaim IPAddress path returns DNS servers in `AddressFromPool`. This is needed because the CAPI `IPAddress` (`ipam.cluster.x-k8s.io/v1beta2`) does not have a `DNSServers` field. Only the Metal3 `IPAddress` carries it.

This is a prerequisite for deprecating Metal3 IPClaim/IPAddress in favor of CAPI variants (where Metal3 IPPool remains the pool backend).

### Changes

- **`baremetal/metal3data_manager.go`**: `addressFromClaim` now fetches DNS servers from the Metal3 IPPool and includes them in the returned `AddressFromPool`

- **`controllers/metal3datatemplate_controller.go`**
  - Added RBAC: `+kubebuilder:rbac:groups=ipam.metal3.io,resources=ippools,verbs=get;list;watch`

- **`baremetal/metal3data_manager_test.go`**
  - Updated `addressFromClaim` "IPAddress found" test to include an IPPool and expect DNS servers in the result
  - Added comprehensive `fetchDNSServersFromIPPool` test table

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
