### PR TITLE
WIP: 🌱 Remove BMO in the preCleanupManagementCluster function.

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -290,11 +290,32 @@ for overlay in "${BMO_OVERLAYS[@]}"; do
   fi
 done
 
+# While the management cluster is being torn down, CAPI's log collector keeps a
+# client-go informer watching it. The resulting "reflector.go ... failed to
+# list/watch *v1.Pod", "Unhandled Error" and BMO log-stream lines are benign
+# teardown noise that cannot be stopped from the test hooks (the informer runs
+# on the CAPI-owned suite context). Filter them out of the console log so they
+# don't drown the real output.
+# See https://github.com/metal3-io/cluster-api-provider-metal3/pull/3535
+E2E_LOG_FILTER='reflector\.go|Failed to watch \*v1\.Pod|failed to list \*v1\.Pod|watch of \*v1\.Pod ended|Unhandled Error|client connection lost|Error starting logs stream for pod'
+
+# Runs a make target and drops the benign teardown log lines, while preserving
+# the make target's real exit code (not grep's).
+run_e2e_make() {
+  local target="$1"
+  local status
+  set +e
+  make "${target}" 2>&1 | grep --line-buffered -vE "${E2E_LOG_FILTER}"
+  status=${PIPESTATUS[0]}
+  set -e
+  return "${status}"
+}
+
 # run e2e tests
 if [[ -n "${CLUSTER_TOPOLOGY:-}" ]]; then
   export CLUSTER_TOPOLOGY=true
-  make e2e-clusterclass-tests
+  run_e2e_make e2e-clusterclass-tests
 else
   export EXP_MACHINE_TAINT_PROPAGATION=true
-  make e2e-tests
+  run_e2e_make e2e-tests
 fi

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -10,18 +10,15 @@ import (
 	"io"
 	"maps"
 	"net"
-	"net/http"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
 
-	"github.com/blang/semver"
 	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta2"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
@@ -830,71 +827,6 @@ func LabelCRD(ctx context.Context, c client.Client, crdName string, labels map[s
 func GetStableReleaseOfMinor(ctx context.Context, releaseMarkerPrefix string, minorRelease string) (string, error) {
 	releaseMarker := fmt.Sprintf(releaseMarkerPrefix, minorRelease)
 	return clusterctl.ResolveRelease(ctx, releaseMarker)
-}
-
-// GetLatestPatchRelease returns latest patch release against minor release.
-func GetLatestPatchRelease(goProxyPath string, minorReleaseVersion string) (string, error) {
-	if strings.EqualFold("main", minorReleaseVersion) || strings.EqualFold("latest", minorReleaseVersion) {
-		return strings.ToUpper(minorReleaseVersion), nil
-	}
-	semVersion, err := semver.Parse(minorReleaseVersion)
-	if err != nil {
-		return "", fmt.Errorf("parsing semver for %s: %w", minorReleaseVersion, err)
-	}
-	parsedTags, err := getVersions(goProxyPath)
-	if err != nil {
-		return "", err
-	}
-
-	var picked semver.Version
-	for i, tag := range parsedTags {
-		if tag.Major == semVersion.Major && tag.Minor == semVersion.Minor {
-			picked = parsedTags[i]
-		}
-	}
-	if picked.Major == 0 && picked.Minor == 0 && picked.Patch == 0 {
-		return "", fmt.Errorf("no suitable release available for path %s and version %s", goProxyPath, minorReleaseVersion)
-	}
-	return picked.String(), nil
-}
-
-// GetVersions returns the a sorted list of semantical versions which exist for a go module.
-func getVersions(gomodulePath string) (semver.Versions, error) {
-	// Get the data
-	/* #nosec G107 */
-	resp, err := http.Get(gomodulePath) //nolint:noctx
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to get versions from url %s got %d %s", gomodulePath, resp.StatusCode, http.StatusText(resp.StatusCode))
-	}
-	defer resp.Body.Close()
-
-	rawResponse, err := io.ReadAll(resp.Body)
-	if err != nil {
-		retryError := fmt.Errorf("failed to get versions: error reading goproxy response body: %w", err)
-		return nil, retryError
-	}
-	parsedVersions := semver.Versions{}
-	for s := range strings.SplitSeq(string(rawResponse), "\n") {
-		if s == "" {
-			continue
-		}
-		s = strings.TrimSuffix(s, "+incompatible")
-		parsedVersion, err := semver.ParseTolerant(s)
-		if err != nil {
-			// Discard releases with tags that are not a valid semantic versions (the user can point explicitly to such releases).
-			continue
-		}
-		parsedVersions = append(parsedVersions, parsedVersion)
-	}
-
-	if len(parsedVersions) == 0 {
-		return nil, fmt.Errorf("no versions found for go module %q", gomodulePath)
-	}
-	sort.Sort(parsedVersions)
-	return parsedVersions, nil
 }
 
 // BuildAndApplyKustomizationInput provides input for BuildAndApplyKustomize().

--- a/test/e2e/pivoting.go
+++ b/test/e2e/pivoting.go
@@ -40,6 +40,15 @@ const (
 	IRSOControllerManagerName    = "ironic-standalone-operator-controller-manager"
 )
 
+// targetClusterCacheCancel stops the controller-runtime cache backing the target
+// cluster proxy. That cache is shared (via GetCache's sync.Once) by the pod-log
+// watchers set up on the target cluster during Pivoting (BMO, Ironic). We
+// pre-warm it with a cancelable context in Pivoting so that RePivoting can stop
+// it before the target cluster is deleted; otherwise the informer keeps trying
+// to sync with the gone API server and spams the console with
+// "failed to list/watch *v1.Pod" errors.
+var targetClusterCacheCancel context.CancelFunc
+
 type PivotingInput struct {
 	E2EConfig             *clusterctl.E2EConfig
 	BootstrapClusterProxy framework.ClusterProxy
@@ -144,6 +153,15 @@ func Pivoting(ctx context.Context, inputGetter func() PivotingInput) {
 	labelBMOCRDs(ctx, input.BootstrapClusterProxy)
 	By("Add Labels to hardwareData CRDs")
 	labelHDCRDs(ctx, input.BootstrapClusterProxy)
+
+	// Pre-warm the target cluster proxy's controller-runtime cache with a context
+	// we own, before InstallIRSO/InstallBMO trigger GetCache and bind the shared
+	// cache to the uncancelable suite context. Owning the context lets RePivoting
+	// stop the cache before the target cluster is deleted, which is the only way
+	// to silence the informer's reflector spam during teardown.
+	targetCacheCtx, cancelTargetCache := context.WithCancel(ctx)
+	targetClusterCacheCancel = cancelTargetCache
+	input.TargetCluster.GetCache(targetCacheCtx)
 
 	By("Pivoting: Install IRSO in the target cluster")
 	irsoDeployLogFolder := filepath.Join(input.ArtifactFolder, input.TargetCluster.GetName(), "ironic-deploy-logs-pivoting")
@@ -302,9 +320,14 @@ type RemoveDeploymentInput struct {
 
 func RemoveDeployment(ctx context.Context, inputGetter func() RemoveDeploymentInput) {
 	input := inputGetter()
+	// Use foreground propagation so the deployment's pods are deleted as part of
+	// the delete instead of being orphaned and cleaned up asynchronously.
+	foregroundDeletion := metav1.DeletePropagationForeground
 	err := input.ClusterProxy.GetClientSet().AppsV1().
 		Deployments(input.Namespace).
-		Delete(ctx, input.Name, metav1.DeleteOptions{})
+		Delete(ctx, input.Name, metav1.DeleteOptions{
+			PropagationPolicy: &foregroundDeletion,
+		})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			Logf("RemoveDeployment: deployment %s/%s not found (already deleted), continuing", input.Namespace, input.Name)
@@ -356,6 +379,17 @@ func RePivoting(ctx context.Context, inputGetter func() RePivotingInput) {
 	err := FetchClusterLogs(input.TargetCluster, filepath.Join(clusterLogCollectionBasePath, "afterPivot"))
 	if err != nil {
 		Logf("Error: %v", err)
+	}
+
+	// Stop the shared controller-runtime cache on the target cluster proxy before
+	// the target cluster is torn down. The BMO/Ironic pod-log watchers set up
+	// during Pivoting all use this single cache; cancelling the context we
+	// pre-warmed it with makes the informers stop cleanly instead of endlessly
+	// retrying against the deleted API server and spamming the console.
+	By("Stop the target cluster proxy cache to shut down log watchers")
+	if targetClusterCacheCancel != nil {
+		targetClusterCacheCancel()
+		targetClusterCacheCancel = nil
 	}
 
 	By("Fetch manifest for workload cluster after pivot")
@@ -440,6 +474,17 @@ func RePivoting(ctx context.Context, inputGetter func() RePivotingInput) {
 	})
 
 	LogFromFile(filepath.Join(input.ArtifactFolder, "clusters", input.ClusterName+"-pivot", "logs", input.Namespace, "clusterctl-move.log"))
+
+	// Remove BMO from the target cluster so it is actually gone before the target
+	// cluster is deleted.
+	By("Remove BMO deployment from the target cluster")
+	RemoveDeployment(ctx, func() RemoveDeploymentInput {
+		return RemoveDeploymentInput{
+			ClusterProxy: input.TargetCluster,
+			Namespace:    input.E2EConfig.MustGetVariable(ironicNamespace),
+			Name:         input.E2EConfig.MustGetVariable(NamePrefix) + "-controller-manager",
+		}
+	})
 
 	By("Check that the re-pivoted cluster is up and running")
 	pivotingCluster := framework.DiscoveryAndWaitForCluster(ctx, framework.DiscoveryAndWaitForClusterInput{

--- a/test/e2e/upgrade_clusterctl_test.go
+++ b/test/e2e/upgrade_clusterctl_test.go
@@ -30,20 +30,27 @@ var (
 	providerCAPIPrefix    = "cluster-api:v%s"
 	providerKubeadmPrefix = "kubeadm:v%s"
 	providerMetal3Prefix  = "metal3:v%s"
-	ironicGoproxy         = "https://proxy.golang.org/github.com/metal3-io/ironic-image/@v/list"
-	bmoGoproxy            = "https://proxy.golang.org/github.com/metal3-io/baremetal-operator/@v/list"
 
 	k8sVersion                 string
 	managementClusterNamespace string
+
+	// managementClusterCacheCancel stops the controller-runtime cache backing the
+	// management cluster proxy. That cache is shared (via GetCache's sync.Once) by
+	// every pod-log watcher set up on the proxy, including CAPI's own controller
+	// log watchers. We pre-warm it with a cancelable context in preInitFunc so that
+	// preCleanupManagementCluster can stop it before the cluster is deleted;
+	// otherwise the informer keeps trying to sync with the gone API server and
+	// spams the console with "failed to list/watch *v1.Pod" errors.
+	managementClusterCacheCancel context.CancelFunc
 )
 
-// Ironic 35.0 -> latest image tag.
-var _ = Describe("When testing cluster upgrade from releases (v1.13=>current)", Label("clusterctl-upgrade"), func() {
-	minorVersion := "1.13"
-	bmoFromRelease := "0.13"
-	ironicFromRelease := "35.0"
-	bmoToRelease := "main"
-	ironicToRelease := "main"
+// Ironic 33.0 -> 35.0.
+var _ = Describe("When testing cluster upgrade from releases (v1.12=>current)", Label("clusterctl-upgrade"), func() {
+	minorVersion := "1.12"
+	bmoFromRelease := "0.12"
+	ironicFromRelease := "33.0"
+	bmoToRelease := "0.13"
+	ironicToRelease := "35.0"
 
 	// Use the .99 versions available in the local artifact repository (built from
 	// release branch kustomize overlays in e2e_conf.yaml). The old clusterctl binary
@@ -282,6 +289,16 @@ func preInitFunc(clusterProxy framework.ClusterProxy, bmoRelease string, ironicR
 		Expect(clusterProxy.GetClientSet().CoreV1().Namespaces().Delete(ctx, "test", metav1.DeleteOptions{})).To(Succeed())
 	}
 
+	// Pre-warm the management cluster proxy's controller-runtime cache with a
+	// context we own, before any log watcher (ours via InstallBMO/InstallIRSO, or
+	// CAPI's InitManagementClusterAndWatchControllerLogs) triggers GetCache and
+	// binds the shared cache to the uncancelable suite context. Owning the context
+	// lets preCleanupManagementCluster stop the cache before the cluster is torn
+	// down, which is the only way to silence the informer's reflector spam.
+	cacheCtx, cancel := context.WithCancel(ctx)
+	managementClusterCacheCancel = cancel
+	clusterProxy.GetCache(cacheCtx)
+
 	By("Fetch manifest for bootstrap cluster")
 	err := FetchManifests(clusterProxy, filepath.Join(artifactFolder, clusterProxy.GetName(), "preInit-manifest"))
 	if err != nil {
@@ -364,6 +381,17 @@ func preInitFunc(clusterProxy framework.ClusterProxy, bmoRelease string, ironicR
 	os.Setenv("IPAM_PROVISIONING_POOL_RANGE_END", "172.22.0.240")
 }
 
+// upgradeReleaseTag maps an upgrade-to release identifier to the suffix used by
+// the IRSO_IRONIC_* / BMO_RELEASE_* e2e config variables. "main"/"latest" are
+// upper-cased (e.g. IRSO_IRONIC_MAIN); pinned minor versions such as "35.0" are
+// used as-is (e.g. IRSO_IRONIC_35.0).
+func upgradeReleaseTag(release string) string {
+	if strings.EqualFold(release, "main") || strings.EqualFold(release, "latest") {
+		return strings.ToUpper(release)
+	}
+	return release
+}
+
 // preUpgrade hook should be called from ClusterctlUpgradeSpec before upgrading the management cluster
 // it upgrades Ironic and BMO before upgrading the providers.
 func preUpgrade(clusterProxy framework.ClusterProxy, bmoUpgradeToRelease string, ironicUpgradeToRelease string) {
@@ -372,12 +400,14 @@ func preUpgrade(clusterProxy framework.ClusterProxy, bmoUpgradeToRelease string,
 		Logf("Error fetching manifests for bootstrap cluster: %v", err)
 	}
 
-	ironicTag, err := GetLatestPatchRelease(ironicGoproxy, ironicUpgradeToRelease)
-	Expect(err).ToNot(HaveOccurred(), "Failed to fetch ironic version for release %s", ironicUpgradeToRelease)
+	// The IRSO_IRONIC_* / BMO_RELEASE_* e2e config variables are keyed by the
+	// release identifier itself (e.g. "35.0", "0.13", or "MAIN"), matching the
+	// overlay directories. Resolve the tag from the release directly, the same
+	// way preInitFunc does, instead of looking up a patch version.
+	ironicTag := upgradeReleaseTag(ironicUpgradeToRelease)
 	Logf("Ironic Tag %s\n", ironicTag)
 
-	bmoTag, err := GetLatestPatchRelease(bmoGoproxy, bmoUpgradeToRelease)
-	Expect(err).ToNot(HaveOccurred(), "Failed to fetch bmo version for release %s", bmoUpgradeToRelease)
+	bmoTag := upgradeReleaseTag(bmoUpgradeToRelease)
 	Logf("Bmo Tag %s\n", bmoTag)
 
 	Byf("Upgrade IRSO with ironic version %s in the target management cluster: %s", ironicTag, clusterProxy.GetName())
@@ -432,6 +462,29 @@ func preCleanupManagementCluster(clusterProxy framework.ClusterProxy, ironicRele
 	os.Unsetenv("KUBECONFIG_WORKLOAD")
 	os.Unsetenv("KUBECONFIG_BOOTSTRAP")
 	bmoIronicNamespace := e2eConfig.MustGetVariable(ironicNamespace)
+
+	// Stop the shared controller-runtime cache on the management cluster proxy
+	// before the cluster is torn down. Every pod-log watcher on this proxy (BMO,
+	// Ironic and CAPI's own controller log watchers) uses this single cache;
+	// cancelling the context we pre-warmed it with in preInitFunc makes the
+	// informers stop cleanly instead of endlessly retrying against the deleted
+	// API server and spamming the console with "failed to list/watch *v1.Pod".
+	By("Stop the management cluster proxy cache to shut down log watchers")
+	if managementClusterCacheCancel != nil {
+		managementClusterCacheCancel()
+		managementClusterCacheCancel = nil
+	}
+
+	// Remove BMO so it is actually gone before the cluster is deleted.
+	By("Remove BMO deployment from the management cluster")
+	RemoveDeployment(ctx, func() RemoveDeploymentInput {
+		return RemoveDeploymentInput{
+			ClusterProxy: clusterProxy,
+			Namespace:    bmoIronicNamespace,
+			Name:         e2eConfig.MustGetVariable(NamePrefix) + "-controller-manager",
+		}
+	})
+
 	// Reinstall ironic
 	reInstallIronic := func() {
 		By("Reinstate Ironic containers and BMH")

--- a/test/go.mod
+++ b/test/go.mod
@@ -3,7 +3,6 @@ module github.com/metal3-io/cluster-api-provider-metal3/test
 go 1.26.0
 
 require (
-	github.com/blang/semver v3.5.1+incompatible
 	github.com/blang/semver/v4 v4.0.0
 	github.com/go-logr/logr v1.4.3
 	github.com/jinzhu/copier v0.4.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -36,8 +36,6 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3d
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
-github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bshuster-repo/logrus-logstash-hook v1.1.0 h1:o2FzZifLg+z/DN1OFmzTWzZZx/roaqt8IPZCIVco8r4=


### PR DESCRIPTION


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**Prevents error spam in the console log when the log collectors are trying to get logs from the non-existing cluster in clusterctl-upgrade tests:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes https://github.com/metal3-io/cluster-api-provider-metal3/issues/2460

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
