### PR TITLE
🌱 test/e2e: fix in-place upgrade rollout on version-managed feature gates

### DIFF
--- a/docs/e2e-test.md
+++ b/docs/e2e-test.md
@@ -266,6 +266,25 @@ the actual upgrade via SSH.
 See [test/extension/handlers/inplaceupdate/handlers.go](../test/extension/handlers/inplaceupdate/handlers.go)
 for the detailed implementation.
 
+**Handling version-managed KubeadmConfig changes:**
+
+When the `CanUpdateMachine`/`CanUpdateMachineSet` hooks are called, the extension
+declares which fields it can reconcile in-place by mutating the current object to
+match the desired object. Any diff that remains between the (patched) current and
+the desired objects causes KubeadmControlPlane (KCP) to fall back to a rolling
+update (machine replacement) instead of an in-place upgrade.
+
+Besides `Machine.spec.version`, a Kubernetes upgrade also changes
+`KubeadmConfig.spec.clusterConfiguration.featureGates`, because KCP
+automatically manages version-dependent kubeadm feature gates. For example, KCP
+injects the `ControlPlaneKubeletLocalMode` feature gate for versions where it is
+not yet enabled by default and removes it once the feature graduates (as happens
+when upgrading from v1.35 to v1.36). The extension must therefore declare that it
+can update `ClusterConfiguration.FeatureGates` in-place; otherwise the leftover
+`featureGates` diff would trigger an unwanted rollout and the test would fail its
+"machine UID must not change" assertion. This is handled by
+`canUpdateKubeadmConfigSpec` in the handler.
+
 **Test flow:**
 
 1. Test starts 5 bmh, 3 CP nodes and 0 worker node

--- a/test/extension/handlers/inplaceupdate/handlers.go
+++ b/test/extension/handlers/inplaceupdate/handlers.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
 
@@ -73,8 +74,28 @@ func canUpdateMachineSpec(current, desired *clusterv1.MachineSpec) {
 	}
 }
 
-// canUpdateKubeadmConfigSpec declares that this extension can update.
-func canUpdateKubeadmConfigSpec(_, _ *bootstrapv1.KubeadmConfigSpec) {
+// canUpdateKubeadmConfigSpec declares which KubeadmConfigSpec fields this
+// extension can reconcile in-place.
+//
+// During a Kubernetes version upgrade, Cluster API's KubeadmControlPlane
+// automatically manages version-dependent kubeadm feature gates in
+// ClusterConfiguration.FeatureGates. For example, it injects the
+// "ControlPlaneKubeletLocalMode" feature gate for Kubernetes versions where it
+// is not yet enabled by default and drops it again once the feature graduates
+// (this happens when upgrading e.g. from v1.35 to v1.36). This produces a
+// KubeadmConfig diff in addition to the Machine version change.
+//
+// Because our in-place upgrade actually runs "kubeadm upgrade" on the node, this
+// configuration change is applied as part of the upgrade, so we declare that we
+// can update FeatureGates in-place. Without this, KCP sees the unresolved diff
+// after the extension's patches are applied and falls back to a rolling update
+// (replacing machines), which defeats the purpose of an in-place upgrade and
+// fails the in-place upgrade e2e test (machines get new UIDs).
+func canUpdateKubeadmConfigSpec(current, desired *bootstrapv1.KubeadmConfigSpec) {
+	// ClusterConfiguration.FeatureGates (version-managed by KCP, e.g. ControlPlaneKubeletLocalMode).
+	if !maps.Equal(current.ClusterConfiguration.FeatureGates, desired.ClusterConfiguration.FeatureGates) {
+		current.ClusterConfiguration.FeatureGates = desired.ClusterConfiguration.FeatureGates
+	}
 	// Todo: add more fields as needed.
 }
 


### PR DESCRIPTION
The in-place k8s upgrade e2e test failed because KubeadmControlPlane fell back to a rolling update (replacing machines) instead of upgrading nodes in-place, breaking the assertion that control-plane machine UIDs stay unchanged.

During a version upgrade (e.g. v1.35 -> v1.36) KCP automatically manages version-dependent kubeadm feature gates in
KubeadmConfig.spec.clusterConfiguration.featureGates. It injects ControlPlaneKubeletLocalMode for versions where it is not yet enabled by default and drops it once the feature graduates. This produces a KubeadmConfig diff in addition to the Machine version change.

The test-extension's canUpdateKubeadmConfigSpec was a no-op, so the CanUpdateMachine/CanUpdateMachineSet hooks left the featureGates diff unresolved. KCP then concluded an in-place update was not possible and triggered a rollout.

Declare that the extension can reconcile ClusterConfiguration.FeatureGates in-place (safe, since the handler runs "kubeadm upgrade" on the node), and document the behavior in docs/e2e-test.md.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
