### PR TITLE
🌱Align ubuntu kubeadm e2e config with the centos approach that is using vrrp script.

### DIFF
--- a/test/e2e/data/infrastructure-metal3/main-v1beta1/bases/clusterclass-ubuntu-kubeadm-config/clusterclass-ubuntu-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/main-v1beta1/bases/clusterclass-ubuntu-kubeadm-config/clusterclass-ubuntu-kubeadm-config.yaml
@@ -15,40 +15,6 @@ spec:
           sudo: ALL=(ALL) NOPASSWD:ALL
         files:
         - content: |
-            #!/bin/bash
-            while :; do
-              curl -sk https://127.0.0.1:6443/healthz 1>&2 > /dev/null
-              isOk=$?
-              isActive=$(systemctl show -p ActiveState keepalived.service | cut -d'=' -f2)
-              if [ $isOk == "0" ] &&  [ $isActive != "active" ]; then
-                logger 'API server is healthy, however keepalived is not running, starting keepalived'
-                echo 'API server is healthy, however keepalived is not running, starting keepalived'
-                sudo systemctl start keepalived.service
-              elif [ $isOk != "0" ] &&  [ $isActive == "active" ]; then
-                logger 'API server is not healthy, however keepalived running, stopping keepalived'
-                echo 'API server is not healthy, however keepalived running, stopping keepalived'
-                sudo systemctl stop keepalived.service
-              fi
-              sleep 5
-            done
-          owner: root:root
-          path: /usr/local/bin/monitor.keepalived.sh
-          permissions: "0755"
-        - content: |
-            [Unit]
-            Description=Monitors keepalived adjusts status with that of API server
-            After=syslog.target network-online.target
-
-            [Service]
-            Type=simple
-            Restart=always
-            ExecStart=/usr/local/bin/monitor.keepalived.sh
-
-            [Install]
-            WantedBy=multi-user.target
-          owner: root:root
-          path: /lib/systemd/system/monitor.keepalived.service
-        - content: |
             ! Configuration File for keepalived
             global_defs {
                 notification_email {
@@ -59,6 +25,14 @@ spec:
                 smtp_server localhost
                 smtp_connect_timeout 30
             }
+            vrrp_script k8s_api_check {
+                script "curl -sk https://127.0.0.1:6443/healthz"
+                interval 5
+                timeout 5
+                rise 3
+                fall 3
+            }
+
             vrrp_instance VI_2 {
                 state MASTER
                 interface enp2s0
@@ -67,6 +41,9 @@ spec:
                 advert_int 1
                 virtual_ipaddress {
                     ${CLUSTER_APIENDPOINT_HOST}
+                }
+                track_script {
+                    k8s_api_check
                 }
             }
           path: /etc/keepalived/keepalived.conf
@@ -132,8 +109,6 @@ spec:
         - sed -i "s/MACAddressPolicy=persistent/MACAddressPolicy=none/g" /usr/lib/systemd/network/99-default.link
         - netplan apply
         - systemctl enable --now crio kubelet
-        - if (curl -sk --max-time 10 https://${CLUSTER_APIENDPOINT_HOST}:${CLUSTER_APIENDPOINT_PORT}/healthz); then echo "keepalived already running";else systemctl start keepalived; fi
-        - systemctl enable --now /lib/systemd/system/monitor.keepalived.service
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-metal3/main-v1beta1/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/main-v1beta1/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
@@ -8,40 +8,6 @@ spec:
   kubeadmConfigSpec:
     files:
     - content: |
-        #!/bin/bash
-        while :; do
-          curl -sk https://127.0.0.1:6443/healthz 1>&2 > /dev/null
-          isOk=$?
-          isActive=$(systemctl show -p ActiveState keepalived.service | cut -d'=' -f2)
-          if [ $isOk == "0" ] &&  [ $isActive != "active" ]; then
-            logger 'API server is healthy, however keepalived is not running, starting keepalived'
-            echo 'API server is healthy, however keepalived is not running, starting keepalived'
-            sudo systemctl start keepalived.service
-          elif [ $isOk != "0" ] &&  [ $isActive == "active" ]; then
-            logger 'API server is not healthy, however keepalived running, stopping keepalived'
-            echo 'API server is not healthy, however keepalived running, stopping keepalived'
-            sudo systemctl stop keepalived.service
-          fi
-          sleep 5
-        done
-      owner: root:root
-      path: /usr/local/bin/monitor.keepalived.sh
-      permissions: "0755"
-    - content: |
-        [Unit]
-        Description=Monitors keepalived adjusts status with that of API server
-        After=syslog.target network-online.target
-
-        [Service]
-        Type=simple
-        Restart=always
-        ExecStart=/usr/local/bin/monitor.keepalived.sh
-
-        [Install]
-        WantedBy=multi-user.target
-      owner: root:root
-      path: /lib/systemd/system/monitor.keepalived.service
-    - content: |
         ! Configuration File for keepalived
         global_defs {
             notification_email {
@@ -52,6 +18,14 @@ spec:
             smtp_server localhost
             smtp_connect_timeout 30
         }
+        vrrp_script k8s_api_check {
+            script "curl -sk https://127.0.0.1:6443/healthz"
+            interval 5
+            timeout 5
+            rise 3
+            fall 3
+        }
+
         vrrp_instance VI_2 {
             state MASTER
             interface enp2s0
@@ -60,6 +34,9 @@ spec:
             advert_int 1
             virtual_ipaddress {
                 ${CLUSTER_APIENDPOINT_HOST}
+            }
+            track_script {
+                k8s_api_check
             }
         }
       path: /etc/keepalived/keepalived.conf
@@ -125,8 +102,6 @@ spec:
     - sed -i "s/MACAddressPolicy=persistent/MACAddressPolicy=none/g" /usr/lib/systemd/network/99-default.link
     - netplan apply
     - systemctl enable --now crio kubelet
-    - if (curl -sk --max-time 10 https://${CLUSTER_APIENDPOINT_HOST}:${CLUSTER_APIENDPOINT_PORT}/healthz); then echo "keepalived already running";else systemctl start keepalived; fi
-    - systemctl enable --now /lib/systemd/system/monitor.keepalived.service
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-metal3/main/bases/clusterclass-ubuntu-kubeadm-config/clusterclass-ubuntu-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/main/bases/clusterclass-ubuntu-kubeadm-config/clusterclass-ubuntu-kubeadm-config.yaml
@@ -15,40 +15,6 @@ spec:
           sudo: ALL=(ALL) NOPASSWD:ALL
         files:
         - content: |
-            #!/bin/bash
-            while :; do
-              curl -sk https://127.0.0.1:6443/healthz 1>&2 > /dev/null
-              isOk=$?
-              isActive=$(systemctl show -p ActiveState keepalived.service | cut -d'=' -f2)
-              if [ $isOk == "0" ] &&  [ $isActive != "active" ]; then
-                logger 'API server is healthy, however keepalived is not running, starting keepalived'
-                echo 'API server is healthy, however keepalived is not running, starting keepalived'
-                sudo systemctl start keepalived.service
-              elif [ $isOk != "0" ] &&  [ $isActive == "active" ]; then
-                logger 'API server is not healthy, however keepalived running, stopping keepalived'
-                echo 'API server is not healthy, however keepalived running, stopping keepalived'
-                sudo systemctl stop keepalived.service
-              fi
-              sleep 5
-            done
-          owner: root:root
-          path: /usr/local/bin/monitor.keepalived.sh
-          permissions: "0755"
-        - content: |
-            [Unit]
-            Description=Monitors keepalived adjusts status with that of API server
-            After=syslog.target network-online.target
-
-            [Service]
-            Type=simple
-            Restart=always
-            ExecStart=/usr/local/bin/monitor.keepalived.sh
-
-            [Install]
-            WantedBy=multi-user.target
-          owner: root:root
-          path: /lib/systemd/system/monitor.keepalived.service
-        - content: |
             ! Configuration File for keepalived
             global_defs {
                 notification_email {
@@ -59,6 +25,14 @@ spec:
                 smtp_server localhost
                 smtp_connect_timeout 30
             }
+            vrrp_script k8s_api_check {
+                script "curl -sk https://127.0.0.1:6443/healthz"
+                interval 5
+                timeout 5
+                rise 3
+                fall 3
+            }
+
             vrrp_instance VI_2 {
                 state MASTER
                 interface enp2s0
@@ -67,6 +41,9 @@ spec:
                 advert_int 1
                 virtual_ipaddress {
                     ${CLUSTER_APIENDPOINT_HOST}
+                }
+                track_script {
+                    k8s_api_check
                 }
             }
           path: /etc/keepalived/keepalived.conf
@@ -132,8 +109,6 @@ spec:
         - sed -i "s/MACAddressPolicy=persistent/MACAddressPolicy=none/g" /usr/lib/systemd/network/99-default.link
         - netplan apply
         - systemctl enable --now crio kubelet
-        - if (curl -sk --max-time 10 https://${CLUSTER_APIENDPOINT_HOST}:${CLUSTER_APIENDPOINT_PORT}/healthz); then echo "keepalived already running";else systemctl start keepalived; fi
-        - systemctl enable --now /lib/systemd/system/monitor.keepalived.service
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-metal3/main/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/main/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
@@ -8,40 +8,6 @@ spec:
   kubeadmConfigSpec:
     files:
     - content: |
-        #!/bin/bash
-        while :; do
-          curl -sk https://127.0.0.1:6443/healthz 1>&2 > /dev/null
-          isOk=$?
-          isActive=$(systemctl show -p ActiveState keepalived.service | cut -d'=' -f2)
-          if [ $isOk == "0" ] &&  [ $isActive != "active" ]; then
-            logger 'API server is healthy, however keepalived is not running, starting keepalived'
-            echo 'API server is healthy, however keepalived is not running, starting keepalived'
-            sudo systemctl start keepalived.service
-          elif [ $isOk != "0" ] &&  [ $isActive == "active" ]; then
-            logger 'API server is not healthy, however keepalived running, stopping keepalived'
-            echo 'API server is not healthy, however keepalived running, stopping keepalived'
-            sudo systemctl stop keepalived.service
-          fi
-          sleep 5
-        done
-      owner: root:root
-      path: /usr/local/bin/monitor.keepalived.sh
-      permissions: "0755"
-    - content: |
-        [Unit]
-        Description=Monitors keepalived adjusts status with that of API server
-        After=syslog.target network-online.target
-
-        [Service]
-        Type=simple
-        Restart=always
-        ExecStart=/usr/local/bin/monitor.keepalived.sh
-
-        [Install]
-        WantedBy=multi-user.target
-      owner: root:root
-      path: /lib/systemd/system/monitor.keepalived.service
-    - content: |
         ! Configuration File for keepalived
         global_defs {
             notification_email {
@@ -52,6 +18,14 @@ spec:
             smtp_server localhost
             smtp_connect_timeout 30
         }
+        vrrp_script k8s_api_check {
+            script "curl -sk https://127.0.0.1:6443/healthz"
+            interval 5
+            timeout 5
+            rise 3
+            fall 3
+        }
+
         vrrp_instance VI_2 {
             state MASTER
             interface enp2s0
@@ -60,6 +34,9 @@ spec:
             advert_int 1
             virtual_ipaddress {
                 ${CLUSTER_APIENDPOINT_HOST}
+            }
+            track_script {
+                k8s_api_check
             }
         }
       path: /etc/keepalived/keepalived.conf
@@ -125,8 +102,6 @@ spec:
     - sed -i "s/MACAddressPolicy=persistent/MACAddressPolicy=none/g" /usr/lib/systemd/network/99-default.link
     - netplan apply
     - systemctl enable --now crio kubelet
-    - if (curl -sk --max-time 10 https://${CLUSTER_APIENDPOINT_HOST}:${CLUSTER_APIENDPOINT_PORT}/healthz); then echo "keepalived already running";else systemctl start keepalived; fi
-    - systemctl enable --now /lib/systemd/system/monitor.keepalived.service
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-metal3/v1.12/bases/clusterclass-ubuntu-kubeadm-config/clusterclass-ubuntu-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.12/bases/clusterclass-ubuntu-kubeadm-config/clusterclass-ubuntu-kubeadm-config.yaml
@@ -15,40 +15,6 @@ spec:
           sudo: ALL=(ALL) NOPASSWD:ALL
         files:
         - content: |
-            #!/bin/bash
-            while :; do
-              curl -sk https://127.0.0.1:6443/healthz 1>&2 > /dev/null
-              isOk=$?
-              isActive=$(systemctl show -p ActiveState keepalived.service | cut -d'=' -f2)
-              if [ $isOk == "0" ] &&  [ $isActive != "active" ]; then
-                logger 'API server is healthy, however keepalived is not running, starting keepalived'
-                echo 'API server is healthy, however keepalived is not running, starting keepalived'
-                sudo systemctl start keepalived.service
-              elif [ $isOk != "0" ] &&  [ $isActive == "active" ]; then
-                logger 'API server is not healthy, however keepalived running, stopping keepalived'
-                echo 'API server is not healthy, however keepalived running, stopping keepalived'
-                sudo systemctl stop keepalived.service
-              fi
-              sleep 5
-            done
-          owner: root:root
-          path: /usr/local/bin/monitor.keepalived.sh
-          permissions: "0755"
-        - content: |
-            [Unit]
-            Description=Monitors keepalived adjusts status with that of API server
-            After=syslog.target network-online.target
-
-            [Service]
-            Type=simple
-            Restart=always
-            ExecStart=/usr/local/bin/monitor.keepalived.sh
-
-            [Install]
-            WantedBy=multi-user.target
-          owner: root:root
-          path: /lib/systemd/system/monitor.keepalived.service
-        - content: |
             ! Configuration File for keepalived
             global_defs {
                 notification_email {
@@ -59,6 +25,14 @@ spec:
                 smtp_server localhost
                 smtp_connect_timeout 30
             }
+            vrrp_script k8s_api_check {
+                script "curl -sk https://127.0.0.1:6443/healthz"
+                interval 5
+                timeout 5
+                rise 3
+                fall 3
+            }
+
             vrrp_instance VI_2 {
                 state MASTER
                 interface enp2s0
@@ -67,6 +41,9 @@ spec:
                 advert_int 1
                 virtual_ipaddress {
                     ${CLUSTER_APIENDPOINT_HOST}
+                }
+                track_script {
+                    k8s_api_check
                 }
             }
           path: /etc/keepalived/keepalived.conf
@@ -132,8 +109,6 @@ spec:
         - sed -i "s/MACAddressPolicy=persistent/MACAddressPolicy=none/g" /usr/lib/systemd/network/99-default.link
         - netplan apply
         - systemctl enable --now crio kubelet
-        - if (curl -sk --max-time 10 https://${CLUSTER_APIENDPOINT_HOST}:${CLUSTER_APIENDPOINT_PORT}/healthz); then echo "keepalived already running";else systemctl start keepalived; fi
-        - systemctl enable --now /lib/systemd/system/monitor.keepalived.service
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-metal3/v1.12/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.12/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
@@ -8,40 +8,6 @@ spec:
   kubeadmConfigSpec:
     files:
     - content: |
-        #!/bin/bash
-        while :; do
-          curl -sk https://127.0.0.1:6443/healthz 1>&2 > /dev/null
-          isOk=$?
-          isActive=$(systemctl show -p ActiveState keepalived.service | cut -d'=' -f2)
-          if [ $isOk == "0" ] &&  [ $isActive != "active" ]; then
-            logger 'API server is healthy, however keepalived is not running, starting keepalived'
-            echo 'API server is healthy, however keepalived is not running, starting keepalived'
-            sudo systemctl start keepalived.service
-          elif [ $isOk != "0" ] &&  [ $isActive == "active" ]; then
-            logger 'API server is not healthy, however keepalived running, stopping keepalived'
-            echo 'API server is not healthy, however keepalived running, stopping keepalived'
-            sudo systemctl stop keepalived.service
-          fi
-          sleep 5
-        done
-      owner: root:root
-      path: /usr/local/bin/monitor.keepalived.sh
-      permissions: "0755"
-    - content: |
-        [Unit]
-        Description=Monitors keepalived adjusts status with that of API server
-        After=syslog.target network-online.target
-
-        [Service]
-        Type=simple
-        Restart=always
-        ExecStart=/usr/local/bin/monitor.keepalived.sh
-
-        [Install]
-        WantedBy=multi-user.target
-      owner: root:root
-      path: /lib/systemd/system/monitor.keepalived.service
-    - content: |
         ! Configuration File for keepalived
         global_defs {
             notification_email {
@@ -52,6 +18,14 @@ spec:
             smtp_server localhost
             smtp_connect_timeout 30
         }
+        vrrp_script k8s_api_check {
+            script "curl -sk https://127.0.0.1:6443/healthz"
+            interval 5
+            timeout 5
+            rise 3
+            fall 3
+        }
+
         vrrp_instance VI_2 {
             state MASTER
             interface enp2s0
@@ -60,6 +34,9 @@ spec:
             advert_int 1
             virtual_ipaddress {
                 ${CLUSTER_APIENDPOINT_HOST}
+            }
+            track_script {
+                k8s_api_check
             }
         }
       path: /etc/keepalived/keepalived.conf
@@ -125,8 +102,6 @@ spec:
     - sed -i "s/MACAddressPolicy=persistent/MACAddressPolicy=none/g" /usr/lib/systemd/network/99-default.link
     - netplan apply
     - systemctl enable --now crio kubelet
-    - if (curl -sk --max-time 10 https://${CLUSTER_APIENDPOINT_HOST}:${CLUSTER_APIENDPOINT_PORT}/healthz); then echo "keepalived already running";else systemctl start keepalived; fi
-    - systemctl enable --now /lib/systemd/system/monitor.keepalived.service
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-metal3/v1.13/bases/clusterclass-ubuntu-kubeadm-config/clusterclass-ubuntu-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.13/bases/clusterclass-ubuntu-kubeadm-config/clusterclass-ubuntu-kubeadm-config.yaml
@@ -15,40 +15,6 @@ spec:
           sudo: ALL=(ALL) NOPASSWD:ALL
         files:
         - content: |
-            #!/bin/bash
-            while :; do
-              curl -sk https://127.0.0.1:6443/healthz 1>&2 > /dev/null
-              isOk=$?
-              isActive=$(systemctl show -p ActiveState keepalived.service | cut -d'=' -f2)
-              if [ $isOk == "0" ] &&  [ $isActive != "active" ]; then
-                logger 'API server is healthy, however keepalived is not running, starting keepalived'
-                echo 'API server is healthy, however keepalived is not running, starting keepalived'
-                sudo systemctl start keepalived.service
-              elif [ $isOk != "0" ] &&  [ $isActive == "active" ]; then
-                logger 'API server is not healthy, however keepalived running, stopping keepalived'
-                echo 'API server is not healthy, however keepalived running, stopping keepalived'
-                sudo systemctl stop keepalived.service
-              fi
-              sleep 5
-            done
-          owner: root:root
-          path: /usr/local/bin/monitor.keepalived.sh
-          permissions: "0755"
-        - content: |
-            [Unit]
-            Description=Monitors keepalived adjusts status with that of API server
-            After=syslog.target network-online.target
-
-            [Service]
-            Type=simple
-            Restart=always
-            ExecStart=/usr/local/bin/monitor.keepalived.sh
-
-            [Install]
-            WantedBy=multi-user.target
-          owner: root:root
-          path: /lib/systemd/system/monitor.keepalived.service
-        - content: |
             ! Configuration File for keepalived
             global_defs {
                 notification_email {
@@ -59,6 +25,14 @@ spec:
                 smtp_server localhost
                 smtp_connect_timeout 30
             }
+            vrrp_script k8s_api_check {
+                script "curl -sk https://127.0.0.1:6443/healthz"
+                interval 5
+                timeout 5
+                rise 3
+                fall 3
+            }
+
             vrrp_instance VI_2 {
                 state MASTER
                 interface enp2s0
@@ -67,6 +41,9 @@ spec:
                 advert_int 1
                 virtual_ipaddress {
                     ${CLUSTER_APIENDPOINT_HOST}
+                }
+                track_script {
+                    k8s_api_check
                 }
             }
           path: /etc/keepalived/keepalived.conf
@@ -132,8 +109,6 @@ spec:
         - sed -i "s/MACAddressPolicy=persistent/MACAddressPolicy=none/g" /usr/lib/systemd/network/99-default.link
         - netplan apply
         - systemctl enable --now crio kubelet
-        - if (curl -sk --max-time 10 https://${CLUSTER_APIENDPOINT_HOST}:${CLUSTER_APIENDPOINT_PORT}/healthz); then echo "keepalived already running";else systemctl start keepalived; fi
-        - systemctl enable --now /lib/systemd/system/monitor.keepalived.service
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-metal3/v1.13/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.13/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
@@ -8,40 +8,6 @@ spec:
   kubeadmConfigSpec:
     files:
     - content: |
-        #!/bin/bash
-        while :; do
-          curl -sk https://127.0.0.1:6443/healthz 1>&2 > /dev/null
-          isOk=$?
-          isActive=$(systemctl show -p ActiveState keepalived.service | cut -d'=' -f2)
-          if [ $isOk == "0" ] &&  [ $isActive != "active" ]; then
-            logger 'API server is healthy, however keepalived is not running, starting keepalived'
-            echo 'API server is healthy, however keepalived is not running, starting keepalived'
-            sudo systemctl start keepalived.service
-          elif [ $isOk != "0" ] &&  [ $isActive == "active" ]; then
-            logger 'API server is not healthy, however keepalived running, stopping keepalived'
-            echo 'API server is not healthy, however keepalived running, stopping keepalived'
-            sudo systemctl stop keepalived.service
-          fi
-          sleep 5
-        done
-      owner: root:root
-      path: /usr/local/bin/monitor.keepalived.sh
-      permissions: "0755"
-    - content: |
-        [Unit]
-        Description=Monitors keepalived adjusts status with that of API server
-        After=syslog.target network-online.target
-
-        [Service]
-        Type=simple
-        Restart=always
-        ExecStart=/usr/local/bin/monitor.keepalived.sh
-
-        [Install]
-        WantedBy=multi-user.target
-      owner: root:root
-      path: /lib/systemd/system/monitor.keepalived.service
-    - content: |
         ! Configuration File for keepalived
         global_defs {
             notification_email {
@@ -52,6 +18,14 @@ spec:
             smtp_server localhost
             smtp_connect_timeout 30
         }
+        vrrp_script k8s_api_check {
+            script "curl -sk https://127.0.0.1:6443/healthz"
+            interval 5
+            timeout 5
+            rise 3
+            fall 3
+        }
+
         vrrp_instance VI_2 {
             state MASTER
             interface enp2s0
@@ -60,6 +34,9 @@ spec:
             advert_int 1
             virtual_ipaddress {
                 ${CLUSTER_APIENDPOINT_HOST}
+            }
+            track_script {
+                k8s_api_check
             }
         }
       path: /etc/keepalived/keepalived.conf
@@ -125,8 +102,6 @@ spec:
     - sed -i "s/MACAddressPolicy=persistent/MACAddressPolicy=none/g" /usr/lib/systemd/network/99-default.link
     - netplan apply
     - systemctl enable --now crio kubelet
-    - if (curl -sk --max-time 10 https://${CLUSTER_APIENDPOINT_HOST}:${CLUSTER_APIENDPOINT_PORT}/healthz); then echo "keepalived already running";else systemctl start keepalived; fi
-    - systemctl enable --now /lib/systemd/system/monitor.keepalived.service
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate


### PR DESCRIPTION


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**: Replace the bash based keepalived script in the Ubuntu
e2e kubeadm configuration with a native VRRP script, similar to
CentOS.

This ensures consistency across distributions, removes the extra complexity of external bash script, and uses the domain-specific scripting for VRRP health checks that keepalived has.


<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
