### PR TITLE
📖 Use descriptive link text in docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -299,8 +299,8 @@ The fields are:
   ensure that the secret belongs to the cluster ownerReference tree (see
   [doc](https://cluster-api.sigs.k8s.io/developer/providers/contracts/clusterctl.html#ownerreferences-chain)).
   The content of the secret should be a yaml equivalent of a json object that
-  follows the format definition that can be found
-  [here](https://docs.openstack.org/nova/latest/_downloads/4e8fe1ae7db6dd6eebca372db68fe63e/network_data.json).
+  follows the format definition that can be found in the
+  [OpenStack network_data.json reference](https://docs.openstack.org/nova/latest/_downloads/4e8fe1ae7db6dd6eebca372db68fe63e/network_data.json).
 
 - **hostSelector** -- Specify criteria for matching labels on `BareMetalHost`
   objects. This can be used to limit the set of available `BareMetalHost`
@@ -767,8 +767,8 @@ The `metaData` field will be rendered into a map of strings in yaml format,
 while `networkData` will be rendered into a map equivalent of
 [Nova network_data.json](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata).
 On the target node, the network data will be rendered as a json object that
-follows the format definition that can be found
-[here](https://docs.openstack.org/nova/latest/_downloads/4e8fe1ae7db6dd6eebca372db68fe63e/network_data.json).
+follows the format definition that can be found in the
+[OpenStack network_data.json reference](https://docs.openstack.org/nova/latest/_downloads/4e8fe1ae7db6dd6eebca372db68fe63e/network_data.json).
 
 ### Metadata Specifications
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,8 +28,8 @@ section for additional information on the `move` process.
 
 CAPM3 provides a cluster template. This requires some environment variables
 properly set. You can find an example file containing the environment variables
-`example_variables.rc`in the release or
-[here](https://github.com/metal3-io/cluster-api-provider-metal3/tree/main/examples/clusterctl-templates/example_variables.rc).
+`example_variables.rc`in the release or in the
+[example_variables.rc template](https://github.com/metal3-io/cluster-api-provider-metal3/tree/main/examples/clusterctl-templates/example_variables.rc).
 The examples provided there or below assume that you are deploying the target
 node using an off-the-shelf Ubuntu image (18.04), served locally in the
 metal3-dev-env. They must be adapted for any deployment.


### PR DESCRIPTION
Replace non-descriptive "[here]" link text flagged by the MD059 markdownlint rule with text that describes the link target:

- docs/api.md (x2): "[OpenStack network_data.json reference]"
- docs/getting-started.md: "[example_variables.rc template]"

This makes the docs more accessible and clears the markdownlint descriptive-link-text warnings.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
