### PR TITLE
🌱 Drop mariadb from release notes, print full image

### DIFF
--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -51,6 +51,7 @@ const (
 	superseded      = ":recycle: Superseded or Reverted"
 	repoOwner       = "metal3-io"
 	repoName        = "cluster-api-provider-metal3"
+	imageRegistry   = "quay.io"
 	warningTemplate = ":rotating_light: This is a %s. Use it only for testing purposes.\nIf you find any bugs, file an [issue](https://github.com/metal3-io/cluster-api-provider-metal3/issues/new/).\n\n"
 )
 
@@ -268,7 +269,7 @@ func run() int {
 		fmt.Printf("</details>\n\n")
 	}
 
-	fmt.Printf("The image for this release is: %v\n", latestTag)
+	fmt.Printf("The image for this release is: %s/%s/%s:%s\n", imageRegistry, repoOwner, repoName, latestTag)
 	fmt.Println("\n_Thanks to all our contributors!_ 😊")
 
 	return 0

--- a/hack/verify-release.sh
+++ b/hack/verify-release.sh
@@ -87,7 +87,7 @@ declare -a release_note_strings=(
 
 # required strings that are postfixed with correct release number
 declare -a release_note_tag_strings=(
-    "The image for this release is: v${VERSION}"
+    "The image for this release is: ${REGISTRY}/${PROJECT}:v${VERSION}"
 )
 
 # release artefacts


### PR DESCRIPTION
The mariadb image is no longer part of a CAPM3 release, so remove it from the notes.

Print the full image reference instead of a tag in the "image for this release is:" line.

Update verify-release.sh to match the new notes string and to stop checking for the mariadb image.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes https://github.com/metal3-io/cluster-api-provider-metal3/issues/3587

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
