### PR TITLE
🌱 Add warning about setting high values for retrylimit

### DIFF
--- a/api/v1beta2/metal3remediation_types.go
+++ b/api/v1beta2/metal3remediation_types.go
@@ -62,6 +62,10 @@ type RemediationStrategy struct {
 
 	// retryLimit sets maximum number of remediation retries.
 	// retryLimit must be a positive integer. The default is 1.
+	// Setting a very high value is discouraged: the controller waits at
+	// least timeoutSeconds (minimum 100s) between attempts, so a large
+	// retryLimit keeps the host in a reboot loop for a very long time
+	// before remediation is allowed to fail.
 	// +optional
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:default=1

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3remediations.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3remediations.yaml
@@ -161,6 +161,10 @@ spec:
                     description: |-
                       retryLimit sets maximum number of remediation retries.
                       retryLimit must be a positive integer. The default is 1.
+                      Setting a very high value is discouraged: the controller waits at
+                      least timeoutSeconds (minimum 100s) between attempts, so a large
+                      retryLimit keeps the host in a reboot loop for a very long time
+                      before remediation is allowed to fail.
                     format: int32
                     minimum: 1
                     type: integer

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3remediationtemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3remediationtemplates.yaml
@@ -152,6 +152,10 @@ spec:
                             description: |-
                               retryLimit sets maximum number of remediation retries.
                               retryLimit must be a positive integer. The default is 1.
+                              Setting a very high value is discouraged: the controller waits at
+                              least timeoutSeconds (minimum 100s) between attempts, so a large
+                              retryLimit keeps the host in a reboot loop for a very long time
+                              before remediation is allowed to fail.
                             format: int32
                             minimum: 1
                             type: integer


### PR DESCRIPTION
Document that a large spec.strategy.retryLimit keeps the host in a reboot loop for a long time, and regenerate the CRDs.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
