### PR TITLE
 🌱 Warn against high timeoutSeconds in Metal3Remediation

### DIFF
--- a/api/v1beta2/metal3remediation_types.go
+++ b/api/v1beta2/metal3remediation_types.go
@@ -69,6 +69,9 @@ type RemediationStrategy struct {
 
 	// timeoutSeconds defines the timeout between remediation retries.
 	// The minimum allowed value is 100 seconds. The default is 600 seconds.
+	// Setting a very high value is discouraged: the controller waits this
+	// long between attempts, so a large timeout delays every retry and can
+	// effectively stall remediation for a very long time.
 	// +kubebuilder:validation:Minimum=100
 	// +kubebuilder:default=600
 	// +optional

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3remediations.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3remediations.yaml
@@ -169,6 +169,9 @@ spec:
                     description: |-
                       timeoutSeconds defines the timeout between remediation retries.
                       The minimum allowed value is 100 seconds. The default is 600 seconds.
+                      Setting a very high value is discouraged: the controller waits this
+                      long between attempts, so a large timeout delays every retry and can
+                      effectively stall remediation for a very long time.
                     format: int32
                     minimum: 100
                     type: integer

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3remediationtemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3remediationtemplates.yaml
@@ -160,6 +160,9 @@ spec:
                             description: |-
                               timeoutSeconds defines the timeout between remediation retries.
                               The minimum allowed value is 100 seconds. The default is 600 seconds.
+                              Setting a very high value is discouraged: the controller waits this
+                              long between attempts, so a large timeout delays every retry and can
+                              effectively stall remediation for a very long time.
                             format: int32
                             minimum: 100
                             type: integer


### PR DESCRIPTION
Document that a large spec.strategy.timeoutSeconds delays every retry and can stall remediation, and regenerate the CRDs.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
