### PR TITLE
🌱 Block syncing of reserved kubernetes.io labels

### DIFF
--- a/baremetal/labelsync.go
+++ b/baremetal/labelsync.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2025 The Metal3 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package baremetal
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+const (
+	// PrefixAnnotationKey is the annotation key on Metal3Cluster that lists the label prefixes to sync.
+	PrefixAnnotationKey = "metal3.io/metal3-label-sync-prefixes"
+)
+
+// reservedLabelDomains are Kubernetes-reserved label domains that must never be used as sync prefixes.
+var reservedLabelDomains = []string{
+	"kubernetes.io",
+	"k8s.io",
+}
+
+// IsReservedLabelPrefix reports whether the given label prefix belongs to a
+// Kubernetes-reserved domain (kubernetes.io, k8s.io) or any of their subdomains.
+func IsReservedLabelPrefix(prefix string) bool {
+	for _, domain := range reservedLabelDomains {
+		if prefix == domain || strings.HasSuffix(prefix, "."+domain) {
+			return true
+		}
+	}
+	return false
+}
+
+// ParsePrefixAnnotation parses a comma-separated list of DNS-1123 subdomain prefixes.
+func ParsePrefixAnnotation(prefixStr string) (map[string]struct{}, error) {
+	entries := strings.Split(prefixStr, ",")
+	prefixSet := make(map[string]struct{})
+	for _, prefix := range entries {
+		prefix = strings.TrimSpace(prefix)
+		if prefix == "" {
+			// ignore empty prefix string (e.g. `, ,`)
+			continue
+		} else if errs := validation.IsDNS1123Subdomain(prefix); len(errs) > 0 {
+			return nil, fmt.Errorf("invalid prefix (%v): %s", prefix, strings.Join(errs, ", "))
+		}
+		prefixSet[prefix] = struct{}{}
+	}
+	return prefixSet, nil
+}

--- a/baremetal/labelsync_test.go
+++ b/baremetal/labelsync_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2025 The Metal3 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package baremetal
+
+import (
+	"reflect"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Label sync helpers", func() {
+	type testCaseIsReservedLabelPrefix struct {
+		Prefix   string
+		Expected bool
+	}
+
+	DescribeTable("IsReservedLabelPrefix",
+		func(tc testCaseIsReservedLabelPrefix) {
+			Expect(IsReservedLabelPrefix(tc.Prefix)).To(Equal(tc.Expected))
+		},
+		Entry("kubernetes.io is reserved", testCaseIsReservedLabelPrefix{
+			Prefix:   "kubernetes.io",
+			Expected: true,
+		}),
+		Entry("k8s.io is reserved", testCaseIsReservedLabelPrefix{
+			Prefix:   "k8s.io",
+			Expected: true,
+		}),
+		Entry("subdomain of kubernetes.io is reserved", testCaseIsReservedLabelPrefix{
+			Prefix:   "node.kubernetes.io",
+			Expected: true,
+		}),
+		Entry("subdomain of k8s.io is reserved", testCaseIsReservedLabelPrefix{
+			Prefix:   "foo.k8s.io",
+			Expected: true,
+		}),
+		Entry("metal3.io is not reserved", testCaseIsReservedLabelPrefix{
+			Prefix:   "foo.metal3.io",
+			Expected: false,
+		}),
+		Entry("lookalike suffix is not reserved", testCaseIsReservedLabelPrefix{
+			Prefix:   "notkubernetes.io",
+			Expected: false,
+		}),
+		Entry("empty prefix is not reserved", testCaseIsReservedLabelPrefix{
+			Prefix:   "",
+			Expected: false,
+		}),
+	)
+
+	type testCaseParsePrefixAnnotation struct {
+		PrefixStr      string
+		ExpectedErr    bool
+		ExpectedResult map[string]struct{}
+	}
+
+	DescribeTable("ParsePrefixAnnotation",
+		func(tc testCaseParsePrefixAnnotation) {
+			prefixSet, err := ParsePrefixAnnotation(tc.PrefixStr)
+			if tc.ExpectedErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(reflect.DeepEqual(prefixSet, tc.ExpectedResult)).To(BeTrue(), "Expected %v but got %v", tc.ExpectedResult, prefixSet)
+			}
+		},
+		Entry("single prefix", testCaseParsePrefixAnnotation{
+			PrefixStr:   "foo.metal3.io",
+			ExpectedErr: false,
+			ExpectedResult: map[string]struct{}{
+				"foo.metal3.io": {},
+			},
+		}),
+		Entry("multiple prefixes with whitespace and empties", testCaseParsePrefixAnnotation{
+			PrefixStr:   "foo.metal3.io, moo.myprefix,,bar",
+			ExpectedErr: false,
+			ExpectedResult: map[string]struct{}{
+				"foo.metal3.io": {},
+				"moo.myprefix":  {},
+				"bar":           {},
+			},
+		}),
+		Entry("empty string", testCaseParsePrefixAnnotation{
+			PrefixStr:      "",
+			ExpectedErr:    false,
+			ExpectedResult: map[string]struct{}{},
+		}),
+		Entry("only commas", testCaseParsePrefixAnnotation{
+			PrefixStr:      ",, ,,",
+			ExpectedErr:    false,
+			ExpectedResult: map[string]struct{}{},
+		}),
+		Entry("invalid DNS-1123 prefix", testCaseParsePrefixAnnotation{
+			PrefixStr:      "foo.io, @bar.io",
+			ExpectedErr:    true,
+			ExpectedResult: nil,
+		}),
+	)
+})

--- a/controllers/metal3labelsync_controller.go
+++ b/controllers/metal3labelsync_controller.go
@@ -18,10 +18,7 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"regexp"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -52,9 +49,7 @@ var (
 )
 
 const (
-	labelSyncControllerName = metrics.ControllerMetal3LabelSync
-	// PrefixAnnotationKey is prefix for annotation key.
-	PrefixAnnotationKey = "metal3.io/metal3-label-sync-prefixes"
+	labelSyncControllerName = "metal3-label-sync-controller"
 )
 
 // Metal3LabelSyncReconciler reconciles label updates to BareMetalHost objects with the corresponding K Node objects in the workload cluster.
@@ -230,7 +225,7 @@ func (r *Metal3LabelSyncReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		controllerLog.V(baremetal.VerbosityLevelDebug).Info("No annotations on Metal3Cluster")
 		return ctrl.Result{}, nil
 	}
-	prefixStr, ok := annotations[PrefixAnnotationKey]
+	prefixStr, ok := annotations[baremetal.PrefixAnnotationKey]
 	if !ok {
 		controllerLog.V(baremetal.VerbosityLevelDebug).Info("No prefix annotation found on Metal3Cluster")
 		return ctrl.Result{}, nil
@@ -239,7 +234,7 @@ func (r *Metal3LabelSyncReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		"prefixes", prefixStr)
 
 	controllerLog.V(baremetal.VerbosityLevelTrace).Info("Parsing prefix annotation")
-	prefixSet, err := parsePrefixAnnotation(prefixStr)
+	prefixSet, err := baremetal.ParsePrefixAnnotation(prefixStr)
 	if err != nil {
 		controllerLog.V(baremetal.VerbosityLevelDebug).Info("Failed to parse prefix annotation",
 			baremetal.LogFieldError, err.Error())
@@ -418,53 +413,4 @@ func (r *Metal3LabelSyncReconciler) Metal3ClusterToBareMetalHosts(ctx context.Co
 		result = append(result, ctrl.Request{NamespacedName: hostObjKey})
 	}
 	return result
-}
-
-// parsePrefixAnnotation parses a string for prefixes. The string must be in the format: `prefix-1,prefix-2,...`
-// and each prefix must conform to the definition of a subdomain in DNS (RFC 1123).
-func parsePrefixAnnotation(prefixStr string) (map[string]struct{}, error) {
-	entries := strings.Split(prefixStr, ",")
-	prefixSet := make(map[string]struct{})
-	for _, prefix := range entries {
-		prefix = strings.TrimSpace(prefix)
-		if prefix == "" {
-			// ignore empty prefix string (e.g. `, ,`)
-			continue
-		} else if err := IsDNS1123Subdomain(prefix); err != nil {
-			return nil, fmt.Errorf("invalid prefix (%v): %w", prefix, err)
-		}
-		prefixSet[prefix] = struct{}{}
-	}
-	return prefixSet, nil
-}
-
-// The following code is also used by kubectl for label and prefix validation.
-// Reference: https://github.com/kubernetes/apimachinery/blob/master/pkg/util/validation/validation.go
-const dns1123LabelFmt string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
-const dns1123SubdomainFmt string = dns1123LabelFmt + "(\\." + dns1123LabelFmt + ")*"
-const dns1123SubdomainErrorMsg string = "a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"
-
-// DNS1123SubdomainMaxLength is a subdomain's max length in DNS (RFC 1123).
-const DNS1123SubdomainMaxLength int = 253
-
-var dns1123SubdomainRegexp = regexp.MustCompile("^" + dns1123SubdomainFmt + "$")
-
-// IsDNS1123Subdomain tests for a string that conforms to the definition of a
-// subdomain in DNS (RFC 1123).
-func IsDNS1123Subdomain(value string) error {
-	if len(value) > DNS1123SubdomainMaxLength {
-		return fmt.Errorf("%v must be no more than %d characters", value, DNS1123SubdomainMaxLength)
-	}
-	if !dns1123SubdomainRegexp.MatchString(value) {
-		return errors.New(RegexError(dns1123SubdomainErrorMsg, dns1123SubdomainFmt, "example.com"))
-	}
-	return nil
-}
-
-// RegexError returns a string explanation of a regex validation failure.
-func RegexError(msg string, fmt string, examples ...string) string {
-	if len(examples) == 0 {
-		return msg + " (regex used for validation is '" + fmt + "')"
-	}
-	return msg + " (e.g. '" + strings.Join(examples, "' or '") + "', regex used for validation is '" + fmt + "')"
 }

--- a/controllers/metal3labelsync_controller.go
+++ b/controllers/metal3labelsync_controller.go
@@ -293,6 +293,29 @@ func (r *Metal3LabelSyncReconciler) reconcileBMHLabels(ctx context.Context, host
 	return nil
 }
 
+// reservedLabelDomains lists the label key domains that are reserved by
+// Kubernetes. Labels under these domains (e.g. kubernetes.io/os,
+// node-role.kubernetes.io/...) must never be synced from a BareMetalHost to a
+// Node: they are interpreted by core Kubernetes and can affect pod scheduling
+// and other node behavior. This matches the label sync proposal, which excludes
+// the kubernetes.io and k8s.io domains from synchronization.
+var reservedLabelDomains = []string{
+	"kubernetes.io",
+	"k8s.io",
+}
+
+// isReservedLabelPrefix reports whether the given label prefix belongs to a
+// Kubernetes-reserved domain (kubernetes.io, k8s.io) or any of their
+// subdomains (e.g. node.kubernetes.io).
+func isReservedLabelPrefix(prefix string) bool {
+	for _, domain := range reservedLabelDomains {
+		if prefix == domain || strings.HasSuffix(prefix, "."+domain) {
+			return true
+		}
+	}
+	return false
+}
+
 func buildLabelSyncSet(prefixSet map[string]struct{}, labels map[string]string) map[string]string {
 	labelSyncSet := make(map[string]string)
 	for labelKey, labelVal := range labels {
@@ -301,6 +324,11 @@ func buildLabelSyncSet(prefixSet map[string]struct{}, labels map[string]string) 
 			continue
 		}
 		if _, ok := prefixSet[p]; !ok {
+			continue
+		}
+		// Never sync labels under Kubernetes-reserved domains, even if an
+		// admin explicitly added such a prefix to the sync annotation.
+		if isReservedLabelPrefix(p) {
 			continue
 		}
 		labelSyncSet[labelKey] = labelVal

--- a/controllers/metal3labelsync_controller_test.go
+++ b/controllers/metal3labelsync_controller_test.go
@@ -116,55 +116,6 @@ var _ = Describe("Metal3LabelSync controller", func() {
 		}),
 	)
 
-	type TestCaseParsePrefixAnnotation struct {
-		PrefixStr      string
-		ExpectedErr    bool
-		ExpectedResult map[string]struct{}
-	}
-
-	DescribeTable("Parse Prefix Annotation",
-		func(tc TestCaseParsePrefixAnnotation) {
-			prefixSet, err := parsePrefixAnnotation(tc.PrefixStr)
-			if tc.ExpectedErr {
-				Expect(err).To(HaveOccurred())
-			} else {
-				Expect(err).NotTo(HaveOccurred())
-				Expect(reflect.DeepEqual(prefixSet, tc.ExpectedResult)).To(BeTrue(), "Expected %v but got %v", tc.ExpectedResult, prefixSet)
-			}
-		},
-		Entry("Parse single prefix", TestCaseParsePrefixAnnotation{
-			PrefixStr:   "foo.metal3.io",
-			ExpectedErr: false,
-			ExpectedResult: map[string]struct{}{
-				"foo.metal3.io": {},
-			},
-		}),
-		Entry("Parse multiple prefixes", TestCaseParsePrefixAnnotation{
-			PrefixStr:   "foo.metal3.io, moo.myprefix,,bar",
-			ExpectedErr: false,
-			ExpectedResult: map[string]struct{}{
-				"foo.metal3.io": {},
-				"moo.myprefix":  {},
-				"bar":           {},
-			},
-		}),
-		Entry("Parse empty prefix string", TestCaseParsePrefixAnnotation{
-			PrefixStr:      "",
-			ExpectedErr:    false,
-			ExpectedResult: map[string]struct{}{},
-		}),
-		Entry("Parse empty prefix string with commas", TestCaseParsePrefixAnnotation{
-			PrefixStr:      ",, ,,",
-			ExpectedErr:    false,
-			ExpectedResult: map[string]struct{}{},
-		}),
-		Entry("Invalid prefix does not meet DNS (RFC 1123)", TestCaseParsePrefixAnnotation{
-			PrefixStr:      "foo.io, @bar.io",
-			ExpectedErr:    true,
-			ExpectedResult: nil,
-		}),
-	)
-
 	type TestCaseSynchronizeLabelSyncSetsOnNode struct {
 		PrefixSet      map[string]struct{}
 		Host           *bmov1alpha1.BareMetalHost

--- a/internal/webhooks/v1beta2/metal3cluster_webhook.go
+++ b/internal/webhooks/v1beta2/metal3cluster_webhook.go
@@ -15,8 +15,10 @@ package webhooks
 
 import (
 	"context"
+	"fmt"
 
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta2"
+	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
@@ -85,6 +87,27 @@ func (webhook *Metal3Cluster) validate(_ *infrav1.Metal3Cluster, newM3C *infrav1
 				"is required",
 			),
 		)
+	}
+
+	if prefixStr, ok := newM3C.Annotations[baremetal.PrefixAnnotationKey]; ok {
+		prefixSet, err := baremetal.ParsePrefixAnnotation(prefixStr)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("metadata", "annotations").Key(baremetal.PrefixAnnotationKey),
+				prefixStr,
+				fmt.Sprintf("invalid prefix annotation: %v", err),
+			))
+		} else {
+			for prefix := range prefixSet {
+				if baremetal.IsReservedLabelPrefix(prefix) {
+					allErrs = append(allErrs, field.Invalid(
+						field.NewPath("metadata", "annotations").Key(baremetal.PrefixAnnotationKey),
+						prefix,
+						"prefix belongs to a Kubernetes-reserved domain (kubernetes.io, k8s.io) and cannot be synced",
+					))
+				}
+			}
+		}
 	}
 
 	if len(allErrs) == 0 {

--- a/internal/webhooks/v1beta2/metal3cluster_webhook_test.go
+++ b/internal/webhooks/v1beta2/metal3cluster_webhook_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta2"
+	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -182,6 +183,99 @@ func TestMetal3ClusterValidation(t *testing.T) {
 				g.Expect(err).To(HaveOccurred())
 			} else {
 				_, err := webhook.ValidateUpdate(ctx, tt.oldCluster, tt.newCluster)
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+func clusterWithPrefixAnnotation(prefix string) *infrav1.Metal3Cluster {
+	return &infrav1.Metal3Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+			Annotations: map[string]string{
+				baremetal.PrefixAnnotationKey: prefix,
+			},
+		},
+		Spec: infrav1.Metal3ClusterSpec{
+			ControlPlaneEndpoint: infrav1.APIEndpoint{
+				Host: "abc.com",
+				Port: 443,
+			},
+		},
+	}
+}
+
+func TestMetal3ClusterPrefixAnnotationValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		prefix    string
+		expectErr bool
+	}{
+		{
+			name:      "valid prefix",
+			prefix:    "foo.metal3.io",
+			expectErr: false,
+		},
+		{
+			name:      "multiple valid prefixes",
+			prefix:    "foo.metal3.io, bar.example.com",
+			expectErr: false,
+		},
+		{
+			name:      "empty annotation",
+			prefix:    "",
+			expectErr: false,
+		},
+		{
+			name:      "kubernetes.io is reserved",
+			prefix:    "kubernetes.io",
+			expectErr: true,
+		},
+		{
+			name:      "k8s.io is reserved",
+			prefix:    "k8s.io",
+			expectErr: true,
+		},
+		{
+			name:      "subdomain of kubernetes.io is reserved",
+			prefix:    "node.kubernetes.io",
+			expectErr: true,
+		},
+		{
+			name:      "subdomain of k8s.io is reserved",
+			prefix:    "foo.k8s.io",
+			expectErr: true,
+		},
+		{
+			name:      "mix of valid and reserved rejects",
+			prefix:    "foo.metal3.io, kubernetes.io",
+			expectErr: true,
+		},
+		{
+			name:      "invalid DNS prefix",
+			prefix:    "@invalid",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			webhook := &Metal3Cluster{}
+			cluster := clusterWithPrefixAnnotation(tt.prefix)
+
+			_, err := webhook.ValidateCreate(ctx, cluster)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+
+			_, err = webhook.ValidateUpdate(ctx, cluster, cluster)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
 				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})


### PR DESCRIPTION
Filter out labels under the reserved kubernetes.io and k8s.io domains (and their subdomains) in buildLabelSyncSet, so they are never synced from a BareMetalHost to a Node even if an admin lists such a prefix in the label-sync annotation. Prevents scheduling issues from labels like kubernetes.io/os or kubernetes.io/arch.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
