### PR TITLE
 ⚠️  Add length validation to v1beta1 Metal3Machine string fields

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -84,6 +84,8 @@ type CustomDeploy struct {
 	// Custom deploy method name.
 	// This name is specific to the deploy ramdisk used. If you don't have
 	// a custom deploy ramdisk, you shouldn't use CustomDeploy.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=512
 	Method string `json:"method"`
 }
 

--- a/api/v1beta1/metal3machine_types.go
+++ b/api/v1beta1/metal3machine_types.go
@@ -119,6 +119,7 @@ type Metal3MachineSpec struct {
 	// The legacy format (metal3://<bmh-uuid>) will be deprecated in CAPM3 v1.13
 	// and removed in CAPM3 v1.14.
 	// +optional
+	// +kubebuilder:validation:MaxLength=512
 	ProviderID *string `json:"providerID,omitempty"`
 
 	// Image is the image to be provisioned.
@@ -164,6 +165,8 @@ type Metal3MachineSpec struct {
 	AutomatedCleaningMode *string `json:"automatedCleaningMode,omitempty"`
 
 	// FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API.
+	// +optional
+	// +kubebuilder:validation:MaxLength=256
 	FailureDomain string `json:"failureDomain,omitempty"`
 }
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machines.yaml
@@ -85,6 +85,8 @@ spec:
                       Custom deploy method name.
                       This name is specific to the deploy ramdisk used. If you don't have
                       a custom deploy ramdisk, you shouldn't use CustomDeploy.
+                    maxLength: 512
+                    minLength: 1
                     type: string
                 required:
                 - method
@@ -138,6 +140,7 @@ spec:
               failureDomain:
                 description: FailureDomain is the failure domain unique identifier
                   this Machine should be attached to, as defined in Cluster API.
+                maxLength: 256
                 type: string
               hostSelector:
                 description: |-
@@ -242,6 +245,7 @@ spec:
                   (metal3://<namespace>/<bmh-name>/<m3m-name>).
                   The legacy format (metal3://<bmh-uuid>) will be deprecated in CAPM3 v1.13
                   and removed in CAPM3 v1.14.
+                maxLength: 512
                 type: string
               userData:
                 description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metal3machinetemplates.yaml
@@ -84,6 +84,8 @@ spec:
                               Custom deploy method name.
                               This name is specific to the deploy ramdisk used. If you don't have
                               a custom deploy ramdisk, you shouldn't use CustomDeploy.
+                            maxLength: 512
+                            minLength: 1
                             type: string
                         required:
                         - method
@@ -138,6 +140,7 @@ spec:
                         description: FailureDomain is the failure domain unique identifier
                           this Machine should be attached to, as defined in Cluster
                           API.
+                        maxLength: 256
                         type: string
                       hostSelector:
                         description: |-
@@ -242,6 +245,7 @@ spec:
                           (metal3://<namespace>/<bmh-name>/<m3m-name>).
                           The legacy format (metal3://<bmh-uuid>) will be deprecated in CAPM3 v1.13
                           and removed in CAPM3 v1.14.
+                        maxLength: 512
                         type: string
                       userData:
                         description: |-


### PR DESCRIPTION
v1beta1 omitted length limits that v1beta2 already enforces. Since v1beta1 stays served, add maxLength bounds and regenerate CRDs:
- providerID:          maxLength 512
- failureDomain:       maxLength 256
- customDeploy.method: minLength 1, maxLength 512

minLength is applied only to customDeploy.method, where an empty value is meaningless; failureDomain and providerID keep empty as a valid (unset) state to avoid breaking existing objects.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
