### PR TITLE
🌱 Pin setup-envtest to go.mod version instead of release branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,6 @@ ENVSUBST_BIN := envsubst
 ENVSUBST := $(TOOLS_BIN_DIR)/$(ENVSUBST_BIN)-drone
 SETUP_ENVTEST_BIN := setup-envtest
 SETUP_ENVTEST = $(abspath $(TOOLS_BIN_DIR)/$(SETUP_ENVTEST_BIN))
-SETUP_ENVTEST_VER := release-0.19
 SETUP_ENVTEST_PKG := sigs.k8s.io/controller-runtime/tools/setup-envtest
 GINKGO_BIN := ginkgo
 GINKGO := $(TOOLS_BIN_DIR)/$(GINKGO_BIN)
@@ -78,6 +77,11 @@ GINKGO_PKG := github.com/onsi/ginkgo/v2/ginkgo
 get_go_version = $(shell $(GO) list -m $1 | awk '{print $$2}')
 ifneq ($(GO),)
 	GINKGO_VER := $(call get_go_version,github.com/onsi/ginkgo/v2)
+	# Pin setup-envtest to the controller-runtime version from go.mod rather than a
+	# mutable release branch. The tools/setup-envtest submodule is tagged in lockstep
+	# with controller-runtime, so this stays in sync and resolves to an immutable,
+	# checksum-verified semver tag.
+	SETUP_ENVTEST_VER := $(call get_go_version,sigs.k8s.io/controller-runtime)
 endif
 ENVTEST_K8S_VERSION := 1.36.x
 


### PR DESCRIPTION
Deriving SETUP_ENVTEST_VER from the controller-runtime version in go.mod resolves to an immutable, checksum-verified semver tag rather than the mutable release-0.19 branch, and keeps the tool in sync with the library the code uses.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
