### PR TITLE
:sparkles: WIP: Enable capi claims for metal3 pools

### DIFF
--- a/baremetal/metal3data_manager.go
+++ b/baremetal/metal3data_manager.go
@@ -59,6 +59,11 @@ const (
 
 var (
 	EnableBMHNameBasedPreallocation bool
+	// EnableCAPIIPAddressClaims controls whether Metal3 IPPools use CAPI
+	// IPAddressClaims instead of Metal3 IPClaims for IP allocation. When true,
+	// the controller creates CAPI IPAddressClaims for Metal3 IPPool references,
+	// enabling the deprecation path from Metal3 IPClaim/IPAddress to CAPI variants.
+	EnableCAPIIPAddressClaims bool
 )
 
 // DataManagerInterface is an interface for a DataManager.
@@ -404,7 +409,7 @@ func (m *DataManager) getAddressesFromPool(ctx context.Context,
 
 	for pool, ref := range poolRefs {
 		var rc reconciledClaim
-		if isMetal3IPPoolRef(ref) {
+		if isMetal3IPPoolRef(ref) && !EnableCAPIIPAddressClaims {
 			rc, err = m.ensureM3IPClaim(ctx, ref)
 		} else {
 			rc, err = m.ensureIPClaim(ctx, ref)
@@ -546,7 +551,7 @@ func (m *DataManager) releaseAddressesFromPool(ctx context.Context, m3dt infrav1
 	for pool, ref := range poolRefs {
 		m.Log.Info("Releasing address from IPPool", LogFieldPool, pool)
 		var err error
-		if isMetal3IPPoolRef(ref) {
+		if isMetal3IPPoolRef(ref) && !EnableCAPIIPAddressClaims {
 			err = m.releaseAddressFromM3Pool(ctx, ref)
 		} else {
 			err = m.releaseAddressFromPool(ctx, ref)

--- a/baremetal/metal3data_manager_test.go
+++ b/baremetal/metal3data_manager_test.go
@@ -6359,3 +6359,284 @@ var _ = Describe("Metal3Data manager DNS from IPPool", func() {
 		}),
 	)
 })
+
+var _ = Describe("Metal3Data manager with EnableCAPIIPAddressClaims", func() {
+	BeforeEach(func() {
+		EnableCAPIIPAddressClaims = true
+	})
+
+	AfterEach(func() {
+		EnableCAPIIPAddressClaims = false
+	})
+
+	type testCaseCAPIClaimsRouting struct {
+		m3dtSpec        infrav1.Metal3DataTemplateSpec
+		ipClaims        []*capipamv1.IPAddressClaim
+		ipAddresses     []*capipamv1.IPAddress
+		ipPools         []*ipamv1.IPPool
+		expectError     bool
+		expectRequeue   bool
+		expectedAddress map[string]AddressFromPool
+	}
+
+	DescribeTable("Test getAddressesFromPool routes Metal3 pool refs through CAPI claims",
+		func(tc testCaseCAPIClaimsRouting) {
+			objects := make([]client.Object, 0, len(tc.ipClaims)+len(tc.ipAddresses)+len(tc.ipPools))
+			for _, claim := range tc.ipClaims {
+				objects = append(objects, claim)
+			}
+			for _, addr := range tc.ipAddresses {
+				objects = append(objects, addr)
+			}
+			for _, pool := range tc.ipPools {
+				objects = append(objects, pool)
+			}
+			m3d := &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
+				Spec: infrav1.Metal3DataSpec{
+					Template: testMetal3ObjectReference(metal3DataTemplateName),
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Metal3Data",
+					APIVersion: infrav1.GroupVersion.String(),
+				},
+			}
+			m3dt := infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta(metal3DataTemplateName, namespaceName, ""),
+				Spec:       tc.m3dtSpec,
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			dataMgr, err := NewDataManager(fakeClient, m3d,
+				logr.Discard(),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			poolAddresses, err := dataMgr.getAddressesFromPool(context.TODO(), m3dt, nil, nil, nil)
+			if tc.expectError {
+				Expect(err).To(HaveOccurred())
+				Expect(err).NotTo(BeAssignableToTypeOf(ReconcileError{}))
+			} else if tc.expectRequeue {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(BeAssignableToTypeOf(ReconcileError{}))
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+			if tc.expectedAddress != nil {
+				Expect(poolAddresses).To(Equal(tc.expectedAddress))
+			}
+		},
+		Entry("Metal3 pool ref creates CAPI claim and requeues when not fulfilled", testCaseCAPIClaimsRouting{
+			m3dtSpec: infrav1.Metal3DataTemplateSpec{
+				MetaData: &infrav1.MetaData{
+					IPAddressesFromPool: []infrav1.FromPool{
+						{
+							Key:  "Address-1",
+							Name: testPoolName,
+						},
+					},
+				},
+				NetworkData: &infrav1.NetworkData{},
+			},
+			expectRequeue: true,
+		}),
+		Entry("Metal3 pool ref with fulfilled CAPI claim returns address with DNS from IPPool", testCaseCAPIClaimsRouting{
+			m3dtSpec: infrav1.Metal3DataTemplateSpec{
+				MetaData: &infrav1.MetaData{
+					IPAddressesFromPool: []infrav1.FromPool{
+						{
+							Key:  "Address-1",
+							Name: testPoolName,
+						},
+					},
+				},
+				NetworkData: &infrav1.NetworkData{},
+			},
+			ipClaims: []*capipamv1.IPAddressClaim{
+				{
+					ObjectMeta: testObjectMeta(metal3DataName+"-"+testPoolName, namespaceName, ""),
+					Spec: capipamv1.IPAddressClaimSpec{
+						PoolRef: capipamv1.IPPoolReference{
+							Name:     testPoolName,
+							APIGroup: "ipam.metal3.io",
+							Kind:     "IPPool",
+						},
+					},
+					Status: capipamv1.IPAddressClaimStatus{
+						AddressRef: capipamv1.IPAddressReference{
+							Name: "test-ip-192.168.0.10",
+						},
+					},
+				},
+			},
+			ipAddresses: []*capipamv1.IPAddress{
+				{
+					ObjectMeta: testObjectMeta("test-ip-192.168.0.10", namespaceName, ""),
+					Spec: capipamv1.IPAddressSpec{
+						Address: "192.168.0.10",
+						Prefix:  ptr.To(int32(24)),
+						Gateway: "192.168.0.1",
+					},
+				},
+			},
+			ipPools: []*ipamv1.IPPool{
+				{
+					ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+					Spec: ipamv1.IPPoolSpec{
+						DNSServers: []ipamv1.IPAddressStr{"8.8.8.8", "8.8.4.4"},
+						NamePrefix: "test",
+						Pools: []ipamv1.Pool{
+							{
+								Subnet: (*ipamv1.IPSubnetStr)(ptr.To("192.168.0.0/24")),
+							},
+						},
+					},
+				},
+			},
+			expectedAddress: map[string]AddressFromPool{
+				testPoolName: {
+					Address:    ipamv1.IPAddressStr("192.168.0.10"),
+					Prefix:     ptr.To(int32(24)),
+					Gateway:    ipamv1.IPAddressStr("192.168.0.1"),
+					dnsServers: []ipamv1.IPAddressStr{"8.8.8.8", "8.8.4.4"},
+				},
+			},
+		}),
+		Entry("Metal3 pool ref with fulfilled CAPI claim returns per-subnet DNS override", testCaseCAPIClaimsRouting{
+			m3dtSpec: infrav1.Metal3DataTemplateSpec{
+				MetaData: &infrav1.MetaData{
+					IPAddressesFromPool: []infrav1.FromPool{
+						{
+							Key:  "Address-1",
+							Name: testPoolName,
+						},
+					},
+				},
+				NetworkData: &infrav1.NetworkData{},
+			},
+			ipClaims: []*capipamv1.IPAddressClaim{
+				{
+					ObjectMeta: testObjectMeta(metal3DataName+"-"+testPoolName, namespaceName, ""),
+					Spec: capipamv1.IPAddressClaimSpec{
+						PoolRef: capipamv1.IPPoolReference{
+							Name:     testPoolName,
+							APIGroup: "ipam.metal3.io",
+							Kind:     "IPPool",
+						},
+					},
+					Status: capipamv1.IPAddressClaimStatus{
+						AddressRef: capipamv1.IPAddressReference{
+							Name: "test-ip-10.0.1.50",
+						},
+					},
+				},
+			},
+			ipAddresses: []*capipamv1.IPAddress{
+				{
+					ObjectMeta: testObjectMeta("test-ip-10.0.1.50", namespaceName, ""),
+					Spec: capipamv1.IPAddressSpec{
+						Address: "10.0.1.50",
+						Prefix:  ptr.To(int32(24)),
+						Gateway: "10.0.1.1",
+					},
+				},
+			},
+			ipPools: []*ipamv1.IPPool{
+				{
+					ObjectMeta: testObjectMeta(testPoolName, namespaceName, ""),
+					Spec: ipamv1.IPPoolSpec{
+						DNSServers: []ipamv1.IPAddressStr{"8.8.8.8"},
+						NamePrefix: "test",
+						Pools: []ipamv1.Pool{
+							{
+								Start:      (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+								End:        (*ipamv1.IPAddressStr)(ptr.To("192.168.0.100")),
+								Subnet:     (*ipamv1.IPSubnetStr)(ptr.To("192.168.0.0/24")),
+								DNSServers: []ipamv1.IPAddressStr{"1.1.1.1"},
+							},
+							{
+								Start:      (*ipamv1.IPAddressStr)(ptr.To("10.0.1.10")),
+								End:        (*ipamv1.IPAddressStr)(ptr.To("10.0.1.100")),
+								Subnet:     (*ipamv1.IPSubnetStr)(ptr.To("10.0.1.0/24")),
+								DNSServers: []ipamv1.IPAddressStr{"9.9.9.9"},
+							},
+						},
+					},
+				},
+			},
+			expectedAddress: map[string]AddressFromPool{
+				testPoolName: {
+					Address:    ipamv1.IPAddressStr("10.0.1.50"),
+					Prefix:     ptr.To(int32(24)),
+					Gateway:    ipamv1.IPAddressStr("10.0.1.1"),
+					dnsServers: []ipamv1.IPAddressStr{"9.9.9.9"},
+				},
+			},
+		}),
+	)
+
+	DescribeTable("Test releaseAddressesFromPool routes Metal3 pool refs through CAPI release",
+		func(expectError bool, objects []client.Object, m3dtSpec infrav1.Metal3DataTemplateSpec) {
+			m3d := &infrav1.Metal3Data{
+				ObjectMeta: testObjectMeta(metal3DataName, namespaceName, ""),
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Metal3Data",
+					APIVersion: infrav1.GroupVersion.String(),
+				},
+			}
+			m3dt := infrav1.Metal3DataTemplate{
+				ObjectMeta: testObjectMeta(metal3DataTemplateName+"-abc", "", ""),
+				Spec:       m3dtSpec,
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			dataMgr, err := NewDataManager(fakeClient, m3d,
+				logr.Discard(),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = dataMgr.releaseAddressesFromPool(context.TODO(), m3dt)
+			if expectError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			// Verify the CAPI claim was deleted (not the Metal3 claim path)
+			claim := &capipamv1.IPAddressClaim{}
+			nn := types.NamespacedName{
+				Name:      metal3DataName + "-" + testPoolName,
+				Namespace: namespaceName,
+			}
+			err = fakeClient.Get(context.TODO(), nn, claim)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		},
+		Entry("Metal3 pool ref releases via CAPI claim path",
+			false,
+			[]client.Object{
+				&capipamv1.IPAddressClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       metal3DataName + "-" + testPoolName,
+						Namespace:  namespaceName,
+						Finalizers: []string{infrav1.DataFinalizer},
+					},
+					Spec: capipamv1.IPAddressClaimSpec{
+						PoolRef: capipamv1.IPPoolReference{
+							Name:     testPoolName,
+							APIGroup: "ipam.metal3.io",
+							Kind:     "IPPool",
+						},
+					},
+				},
+			},
+			infrav1.Metal3DataTemplateSpec{
+				MetaData: &infrav1.MetaData{
+					IPAddressesFromPool: []infrav1.FromPool{
+						{
+							Key:  "Address-1",
+							Name: testPoolName,
+						},
+					},
+				},
+				NetworkData: &infrav1.NetworkData{},
+			},
+		),
+	)
+})

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,6 +27,7 @@ spec:
         args:
         - "--webhook-port=9443"
         - "--enable-bmh-name-based-preallocation=${ENABLE_BMH_NAME_BASED_PREALLOCATION:=false}"
+        - "--enable-capi-ipaddress-claims=${ENABLE_CAPI_IPADDRESS_CLAIMS:=false}"
         - "--diagnostics-address=${CAPM3_DIAGNOSTICS_ADDRESS:=:8443}"
         - "--insecure-diagnostics=${CAPM3_INSECURE_DIAGNOSTICS:=false}"
         image: controller:latest

--- a/main.go
+++ b/main.go
@@ -108,6 +108,7 @@ var (
 	watchFilterValue                 string
 	logOptions                       = logs.NewOptions()
 	enableBMHNameBasedPreallocation  bool
+	enableCAPIIPAddressClaims        bool
 	managerOptions                   = flags.ManagerOptions{}
 	skipCRDMigrationPhases           []string
 )
@@ -229,6 +230,10 @@ func main() {
 	ctx := ctrl.SetupSignalHandler()
 
 	baremetal.EnableBMHNameBasedPreallocation = enableBMHNameBasedPreallocation
+	if v, ok := os.LookupEnv("ENABLE_CAPI_IPADDRESS_CLAIMS"); ok {
+		enableCAPIIPAddressClaims, _ = strconv.ParseBool(v)
+	}
+	baremetal.EnableCAPIIPAddressClaims = enableCAPIIPAddressClaims
 
 	setupChecks(mgr)
 	setupReconcilers(ctx, mgr)
@@ -264,6 +269,13 @@ func initFlags(fs *pflag.FlagSet) {
 		"enable-bmh-name-based-preallocation",
 		false,
 		"If set to true, it enables PreAllocation field to use Metal3IPClaim name structured with BaremetalHost and M3IPPool names",
+	)
+
+	fs.BoolVar(
+		&enableCAPIIPAddressClaims,
+		"enable-capi-ipaddress-claims",
+		false,
+		"If set to true, Metal3 IPPools will use CAPI IPAddressClaims instead of Metal3 IPClaims for IP allocation. This enables the deprecation path from Metal3 IPClaim/IPAddress to CAPI variants. Can also be set via ENABLE_CAPI_IPADDRESS_CLAIMS env var.",
 	)
 
 	fs.DurationVar(

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -10,6 +10,8 @@ FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-false}"
 
 export CAPM3RELEASEBRANCH="${CAPM3RELEASEBRANCH:-main}"
 export IPAMRELEASEBRANCH="${IPAMRELEASEBRANCH:-main}"
+#export ENABLE_CAPI_IPADDRESS_CLAIMS="${ENABLE_CAPI_IPADDRESS_CLAIMS:-false}"
+export ENABLE_CAPI_IPADDRESS_CLAIMS=true
 
 # Extract release version from release-branch name
 if [[ "${CAPM3RELEASEBRANCH}" == release-* ]]; then

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/utils/ptr"
 	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	capipamv1 "sigs.k8s.io/cluster-api/api/ipam/v1beta2"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	testexec "sigs.k8s.io/cluster-api/test/framework/exec"
@@ -687,6 +688,8 @@ func MachineToVMNamev1beta1(ctx context.Context, cli client.Client, m *clusterv1
 }
 
 // MachineToIPAddress gets IPAddress based on machine, from machine -> m3machine -> m3data -> IPAddress.
+// It supports both the Metal3 IPClaim path (ipam.metal3.io) and the CAPI IPAddressClaim path
+// (ipam.cluster.x-k8s.io). It tries the CAPI path first then falls back to the Metal3 IPClaim/IPAddress chain.
 func MachineToIPAddress(ctx context.Context, cli client.Client, m *clusterv1.Machine, ippool ipamv1.IPPool) (string, error) {
 	m3Machine := &infrav1.Metal3Machine{}
 	namespace := m.GetObjectMeta().GetNamespace()
@@ -715,7 +718,23 @@ func MachineToIPAddress(ctx context.Context, cli client.Client, m *clusterv1.Mac
 		return "", errors.New("couldn't find a matching Metal3Data object")
 	}
 
-	// Metal3Data owns IPClaim, and IPClaim owns IPAddress.
+	// Try CAPI IPAddressClaim path first: Metal3Data owns IPAddressClaim, IPAM controller
+	// creates a CAPI IPAddress and sets the claim's Status.AddressRef.
+	ipAddressClaims := &capipamv1.IPAddressClaimList{}
+	err = cli.List(ctx, ipAddressClaims)
+	if err != nil {
+		return "", fmt.Errorf("couldn't list IPAddressClaim objects: %w", err)
+	}
+	var ipAddressClaim *capipamv1.IPAddressClaim
+	for i, claim := range ipAddressClaims.Items {
+		for _, owner := range claim.OwnerReferences {
+			if owner.Name == m3Data.Name && claim.Spec.PoolRef.Name == ippool.Name {
+				ipAddressClaim = &ipAddressClaims.Items[i]
+			}
+		}
+	}
+
+	// Fallback: Metal3 IPClaim path. Metal3Data owns IPClaim, and IPClaim owns IPAddress.
 	// Find the IPClaim owned by the Metal3Data for the target pool.
 	ipClaims := &ipamv1.IPClaimList{}
 	err = cli.List(ctx, ipClaims)
@@ -730,8 +749,8 @@ func MachineToIPAddress(ctx context.Context, cli client.Client, m *clusterv1.Mac
 			}
 		}
 	}
-	if ipClaim == nil {
-		return "", errors.New("couldn't find a matching IPClaim object")
+	if ipClaim == nil && ipAddressClaim == nil {
+		return "", errors.New("couldn't find a matching IPClaim or IPAddressClaim object")
 	}
 
 	// Find the IPAddress owned by the IPClaim.


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->
Enable capi claims for metal3 pools. Let's see how e2e test react when CAPI CRDs are used in stead of the metal3 ones. 
<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
