### PR TITLE
🐛 Fix Metal3DataTemplate racing with clusterctl move

### DIFF
--- a/baremetal/metal3datatemplate_manager.go
+++ b/baremetal/metal3datatemplate_manager.go
@@ -31,6 +31,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -166,6 +168,7 @@ func (m *DataTemplateManager) UpdateDatas(ctx context.Context) (bool, bool, erro
 	}
 
 	hasClaims := false
+	pausedClaimSkipped := false
 	// Iterate over the Metal3DataClaim objects to find all indexes and objects
 	for _, dataClaim := range dataClaimObjects.Items {
 		// If DataTemplate does not point to this object, discard
@@ -177,6 +180,20 @@ func (m *DataTemplateManager) UpdateDatas(ctx context.Context) (bool, bool, erro
 			if dataClaim.Status.RenderedData != nil {
 				continue
 			}
+			// Skip Metal3Data creation while the claim's owning Cluster is paused,
+			// e.g. during `clusterctl move`. A Metal3DataTemplate is no longer owned
+			// by any single Cluster (it can be shared), so it is not paused together
+			// with the Cluster. Rendering data while the Cluster is paused would race
+			// with the move and can allocate an index/claim mapping that conflicts
+			// with the Metal3Data objects being moved, which the Metal3Data webhook
+			// then rejects because spec.index and spec.claim are immutable.
+			cluster, clusterErr := util.GetClusterFromMetadata(ctx, m.client, dataClaim.ObjectMeta)
+			if clusterErr == nil && cluster != nil && annotations.IsPaused(cluster, &dataClaim) {
+				m.Log.V(VerbosityLevelDebug).Info("Owning Cluster is paused, skipping Metal3Data creation for claim",
+					LogFieldMetal3DataClaim, dataClaim.Name, LogFieldMetal3DataTemplate, m.DataTemplate.Name)
+				pausedClaimSkipped = true
+				continue
+			}
 		}
 		m.Log.V(VerbosityLevelTrace).Info("Initiate updating data of claim", LogFieldMetal3DataClaim, dataClaim.Name, LogFieldMetal3DataTemplate, m.DataTemplate.Name)
 		indexes, err = m.updateData(ctx, &dataClaim, indexes)
@@ -186,6 +203,12 @@ func (m *DataTemplateManager) UpdateDatas(ctx context.Context) (bool, bool, erro
 		m.Log.V(VerbosityLevelDebug).Info("Success updating data of claim", LogFieldMetal3DataClaim, dataClaim.Name, LogFieldMetal3DataTemplate, m.DataTemplate.Name)
 	}
 	m.updateStatusTimestamp()
+	// If we skipped any claim because its owning Cluster is paused (e.g. during
+	// `clusterctl move`), requeue so the claim gets rendered once the Cluster is
+	// unpaused. The controller does not otherwise get re-triggered on unpause.
+	if pausedClaimSkipped {
+		return hasData, hasClaims, WithTransientError(errors.New("waiting for paused Cluster to be unpaused before rendering Metal3Data"), requeueAfter)
+	}
 	return hasData, hasClaims, nil
 }
 

--- a/baremetal/metal3datatemplate_manager_test.go
+++ b/baremetal/metal3datatemplate_manager_test.go
@@ -172,6 +172,8 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 		template          *infrav1.Metal3DataTemplate
 		dataClaims        []*infrav1.Metal3DataClaim
 		datas             []*infrav1.Metal3Data
+		clusters          []*clusterv1.Cluster
+		unrenderedClaims  map[string]bool
 		expectRequeue     bool
 		expectError       bool
 		expectedNbIndexes int
@@ -180,12 +182,15 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 
 	DescribeTable("Test UpdateDatas",
 		func(tc testCaseUpdateDatas) {
-			objects := make([]client.Object, 0, len(tc.datas)+len(tc.dataClaims))
+			objects := make([]client.Object, 0, len(tc.datas)+len(tc.dataClaims)+len(tc.clusters))
 			for _, address := range tc.datas {
 				objects = append(objects, address)
 			}
 			for _, claim := range tc.dataClaims {
 				objects = append(objects, claim)
+			}
+			for _, cluster := range tc.clusters {
+				objects = append(objects, cluster)
 			}
 			fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).WithStatusSubresource(objects...).Build()
 			templateMgr, err := NewDataTemplateManager(fakeClient, tc.template, logr.Discard())
@@ -217,6 +222,12 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 			// being deleted
 			for _, claim := range dataClaimObjects.Items {
 				if claim.DeletionTimestamp == nil || claim.DeletionTimestamp.IsZero() {
+					if tc.unrenderedClaims[claim.Name] {
+						// Claims whose owning Cluster is paused (e.g. during
+						// clusterctl move) must be left untouched.
+						Expect(claim.Status.RenderedData).To(BeNil())
+						continue
+					}
 					Expect(claim.Status.RenderedData).NotTo(BeNil())
 				}
 			}
@@ -546,6 +557,47 @@ var _ = Describe("Metal3DataTemplate manager", func() {
 				},
 			},
 			expectedNbIndexes: 2,
+		}),
+		// A Metal3DataTemplate is not owned by any single Cluster, so it is not
+		// paused together with the Cluster during `clusterctl move`. An unrendered
+		// claim whose owning Cluster is paused must be left untouched: rendering it
+		// would create a Metal3Data whose index/claim mapping can conflict with the
+		// objects being moved, which the (immutable) Metal3Data webhook rejects.
+		Entry("Claim from paused cluster is skipped", testCaseUpdateDatas{
+			template: &infrav1.Metal3DataTemplate{
+				ObjectMeta: templateMeta,
+				Spec:       infrav1.Metal3DataTemplateSpec{},
+			},
+			clusters: []*clusterv1.Cluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "paused-cluster",
+						Namespace: namespaceName,
+					},
+					Spec: clusterv1.ClusterSpec{
+						Paused: ptr.To(true),
+					},
+				},
+			},
+			dataClaims: []*infrav1.Metal3DataClaim{
+				{
+					ObjectMeta: func() metav1.ObjectMeta {
+						om := testObjectMetaWithOR("paused-claim", metal3machineName)
+						om.Labels = map[string]string{clusterv1.ClusterNameLabel: "paused-cluster"}
+						return om
+					}(),
+					Spec: infrav1.Metal3DataClaimSpec{
+						Template: &infrav1.Metal3ObjectRef{
+							Name:      templateMeta.Name,
+							Namespace: namespaceName,
+						},
+					},
+				},
+			},
+			unrenderedClaims:  map[string]bool{"paused-claim": true},
+			expectRequeue:     true,
+			expectedIndexes:   []infrav1.IndexEntry{},
+			expectedNbIndexes: 0,
 		}),
 	)
 


### PR DESCRIPTION
After #3520 the Metal3DataTemplate controller no longer derives its pause state from the owning Cluster; it only checks its own paused annotation. During `clusterctl move` the Cluster is paused but the template is not, so on the target cluster the controller keeps reconciling and re-creates Metal3Data objects with a freshly-computed claim/index mapping. When clusterctl then moves the original Metal3Data, the update is rejected by the webhook because spec.claim and spec.index are immutable ("cannot be modified"), which breaks (re)pivoting.

Skip rendering a claim whose owning Cluster is paused in UpdateDatas, mirroring the util.GetClusterFromMetadata + annotations.IsPaused pattern already used by the Metal3Data controller. This restores the pre-#3520 freeze during clusterctl move while keeping the template decoupled from a single Cluster (the check is per-claim via the ClusterNameLabel).

Added unit test verifying no Metal3Data is created for a claim whose Cluster is paused.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
