### PR TITLE
🌱Bump golang version to 1.25.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.25.12@sha256:dd7d32e19b28621cd982082397fc0510d396805b717d5e77466aa2dd692340de
+ARG BUILD_IMAGE=docker.io/golang:1.25.13@sha256:cbff9d1a9041b316010f2da6b701b6c0d597718cb90928c85eb597334a0d23d4
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary on golang image

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SHELL:=/usr/bin/env bash
 
 .DEFAULT_GOAL:=help
 
-GO_VERSION ?= 1.25.12
+GO_VERSION ?= 1.25.13
 GO := $(shell type -P go)
 # Use GOPROXY environment variable if set
 ifneq ($(GO),)

--- a/hack/fake-apiserver/Dockerfile
+++ b/hack/fake-apiserver/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.25.12@sha256:d7912cedddfa15b2900a8dfb7187df0af5ec2cb424a371139b5b352fd3e6b740
+ARG BUILD_IMAGE=docker.io/golang:1.25.13@sha256:cbff9d1a9041b316010f2da6b701b6c0d597718cb90928c85eb597334a0d23d4
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the fkas binary on golang image

--- a/test/extension/Dockerfile
+++ b/test/extension/Dockerfile
@@ -1,5 +1,5 @@
 # Build the extension binary
-ARG BUILD_IMAGE=docker.io/golang:1.25.12@sha256:d7912cedddfa15b2900a8dfb7187df0af5ec2cb424a371139b5b352fd3e6b740
+ARG BUILD_IMAGE=docker.io/golang:1.25.13@sha256:cbff9d1a9041b316010f2da6b701b6c0d597718cb90928c85eb597334a0d23d4
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 FROM $BUILD_IMAGE AS builder


### PR DESCRIPTION
Bump go version to 1.25.13 to address the following CVEs
CVE-2026-56865
CVE-2026-56864 
CVE-2026-56859 
CVE-2026-56853 
CVE-2026-56860 
CVE-2026-46600
CVE-2026-56862 
CVE-2026-56858 
CVE-2026-39821
CVE-2026-33818