### PR TITLE
🌱 Bump CAPI to v1.14 in e2e tests and add v1.14 provider matrix for e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,7 @@ SKIP_CREATE_MGMT_CLUSTER ?= true
 .PHONY: e2e-substitutions
 e2e-substitutions: $(ENVSUBST)
 	mkdir -p $(E2E_OUT_DIR)/main
+	mkdir -p $(E2E_OUT_DIR)/v1.14
 	mkdir -p $(E2E_OUT_DIR)/v1.13
 	mkdir -p $(E2E_OUT_DIR)/v1.12
 	$(ENVSUBST) < $(E2E_CONF_FILE) > $(E2E_CONF_FILE_ENVSUBST)
@@ -212,13 +213,13 @@ e2e-substitutions: $(ENVSUBST)
 ## --------------------------------------
 ##@ templates
 E2E_TEMPLATES_DIR ?= $(ROOT_DIR)/test/e2e/data/infrastructure-metal3
-.PHONY: cluster-templates cluster-templates-main cluster-templates-main-v1beta1 cluster-templates-v1.13 cluster-templates-v1.12
-cluster-templates: cluster-templates-main cluster-templates-main-v1beta1 cluster-templates-v1.13 cluster-templates-v1.12
+.PHONY: cluster-templates cluster-templates-main cluster-templates-main-v1beta1 cluster-templates-v1.14 cluster-templates-v1.13 cluster-templates-v1.12
+cluster-templates: cluster-templates-main cluster-templates-main-v1beta1 cluster-templates-v1.14 cluster-templates-v1.13 cluster-templates-v1.12
 	mkdir -p $(ARTIFACTS)/templates
 	cp -r $(E2E_OUT_DIR)/. $(ARTIFACTS)/templates/
 
-.PHONY: clusterclass-templates clusterclass-templates-main clusterclass-templates-v1.13 clusterclass-templates-v1.12
-clusterclass-templates: clusterclass-templates-main clusterclass-templates-v1.13 clusterclass-templates-v1.12
+.PHONY: clusterclass-templates clusterclass-templates-main clusterclass-templates-v1.14 clusterclass-templates-v1.13 clusterclass-templates-v1.12
+clusterclass-templates: clusterclass-templates-main clusterclass-templates-v1.14 clusterclass-templates-v1.13 clusterclass-templates-v1.12
 	mkdir -p $(ARTIFACTS)/templates
 	cp -r $(E2E_OUT_DIR)/. $(ARTIFACTS)/templates/
 
@@ -256,6 +257,18 @@ clusterclass-templates-main: $(KUSTOMIZE) ## Generate cluster templates
 	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/main/clusterclass-template-upgrade-workload > $(E2E_OUT_DIR)/main/cluster-template-upgrade-workload.yaml
 	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/main/clusterclass > $(E2E_OUT_DIR)/main/clusterclass.yaml
 
+.PHONY: cluster-templates-v1.14
+cluster-templates-v1.14: $(KUSTOMIZE) ## Generate cluster templates
+	mkdir -p $(E2E_OUT_DIR)/v1.14
+	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/v1.14/cluster-template-ubuntu > $(E2E_OUT_DIR)/v1.14/cluster-template-ubuntu.yaml
+	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/v1.14/cluster-template-centos > $(E2E_OUT_DIR)/v1.14/cluster-template-centos.yaml
+	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/v1.14/cluster-template-centos-fake > $(E2E_OUT_DIR)/v1.14/cluster-template-centos-fake.yaml
+	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/v1.14/clusterclass-metal3 > $(E2E_OUT_DIR)/v1.14/clusterclass-metal3.yaml
+	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/v1.14/cluster-template-upgrade-workload > $(E2E_OUT_DIR)/v1.14/cluster-template-upgrade-workload.yaml
+	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/v1.14/cluster-template-centos-md-remediation > $(E2E_OUT_DIR)/v1.14/cluster-template-centos-md-remediation.yaml
+	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/v1.14/cluster-template-ubuntu-md-remediation > $(E2E_OUT_DIR)/v1.14/cluster-template-ubuntu-md-remediation.yaml
+	touch $(E2E_OUT_DIR)/v1.14/clusterclass.yaml
+
 .PHONY: cluster-templates-v1.13
 cluster-templates-v1.13: $(KUSTOMIZE) ## Generate cluster templates
 	mkdir -p $(E2E_OUT_DIR)/v1.13
@@ -279,6 +292,14 @@ cluster-templates-v1.12: $(KUSTOMIZE) ## Generate cluster templates
 	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/v1.12/cluster-template-centos-md-remediation > $(E2E_OUT_DIR)/v1.12/cluster-template-centos-md-remediation.yaml
 	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/v1.12/cluster-template-ubuntu-md-remediation > $(E2E_OUT_DIR)/v1.12/cluster-template-ubuntu-md-remediation.yaml
 	touch $(E2E_OUT_DIR)/v1.12/clusterclass.yaml
+
+.PHONY: clusterclass-templates-v1.14
+clusterclass-templates-v1.14: $(KUSTOMIZE) ## Generate cluster templates
+	mkdir -p $(E2E_OUT_DIR)/v1.14
+	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/v1.14/clusterclass-template-ubuntu > $(E2E_OUT_DIR)/v1.14/cluster-template-ubuntu.yaml
+	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/v1.14/clusterclass-template-centos > $(E2E_OUT_DIR)/v1.14/cluster-template-centos.yaml
+	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/v1.14/clusterclass-template-upgrade-workload > $(E2E_OUT_DIR)/v1.14/cluster-template-upgrade-workload.yaml
+	$(KUSTOMIZE) build $(E2E_TEMPLATES_DIR)/v1.14/clusterclass > $(E2E_OUT_DIR)/v1.14/clusterclass.yaml
 
 .PHONY: clusterclass-templates-v1.13
 clusterclass-templates-v1.13: $(KUSTOMIZE) ## Generate cluster templates

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,6 +2,9 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
 - major: 1
+  minor: 15
+  contract: v1beta2
+- major: 1
   minor: 14
   contract: v1beta2
 - major: 1

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -18,9 +18,9 @@ if [[ "${CAPM3RELEASEBRANCH}" == release-* ]]; then
     export IPAMRELEASE="v${CAPM3_RELEASE_PREFIX}.99"
     export CAPI_RELEASE_PREFIX="v${CAPM3_RELEASE_PREFIX}."
 else
-    export CAPM3RELEASE="v1.14.99"
-    export IPAMRELEASE="v1.14.99"
-    export CAPI_RELEASE_PREFIX="v1.13."
+    export CAPM3RELEASE="v1.15.99"
+    export IPAMRELEASE="v1.15.99"
+    export CAPI_RELEASE_PREFIX="v1.14."
 fi
 
 # Default CAPI_CONFIG_FOLDER to $HOME/.config folder if XDG_CONFIG_HOME not set
@@ -65,7 +65,7 @@ export DATE
 # If CAPI_NIGHTLY_BUILD is true, it means that the tests are run against the
 # nightly build of CAPI components which are built from CAPI's main branch.
 if [[ "${CAPI_NIGHTLY_BUILD:-false}" == "true" ]]; then
-  export CAPIRELEASE="v1.13.99"
+  export CAPIRELEASE="v1.15.99"
   echo 'export CAPI_NIGHTLY_BUILD="true"' >>"${M3_DEV_ENV_PATH}/config_${USER}.sh"
 fi
 
@@ -198,6 +198,7 @@ yaml_envsubst() {
 BMO_OVERLAYS=(
   "${REPO_ROOT}/test/e2e/data/bmo-deployment/overlays/release-0.12"
   "${REPO_ROOT}/test/e2e/data/bmo-deployment/overlays/release-0.13"
+  "${REPO_ROOT}/test/e2e/data/bmo-deployment/overlays/release-0.14"
   "${REPO_ROOT}/test/e2e/data/bmo-deployment/overlays/pr-test"
   "${REPO_ROOT}/test/e2e/data/bmo-deployment/overlays/release-main"
 )

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -17,8 +17,17 @@ providers:
 - name: cluster-api
   type: CoreProvider
   versions:
-  - name: "v1.14.99"
+  - name: "v1.15.99"
     value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_${DATE}/core-components.yaml"
+    type: "url"
+    contract: v1beta2
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+    files:
+    - sourcePath: "../data/shared/capi/v1.15/metadata.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.14}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.14}/core-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:
@@ -47,8 +56,17 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
-  - name: "v1.14.99"
+  - name: "v1.15.99"
     value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_${DATE}/bootstrap-components.yaml"
+    type: "url"
+    contract: v1beta2
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+    files:
+    - sourcePath: "../data/shared/capi/v1.15/metadata.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.14}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.14}/bootstrap-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:
@@ -77,8 +95,17 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
-  - name: "v1.14.99"
+  - name: "v1.15.99"
     value: "https://storage.googleapis.com/k8s-staging-cluster-api/components/nightly_main_${DATE}/control-plane-components.yaml"
+    type: "url"
+    contract: v1beta2
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+    files:
+    - sourcePath: "../data/shared/capi/v1.15/metadata.yaml"
+  - name: "{go://sigs.k8s.io/cluster-api@v1.14}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.14}/control-plane-components.yaml"
     type: "url"
     contract: v1beta2
     replacements:
@@ -107,9 +134,27 @@ providers:
 - name: metal3
   type: IPAMProvider
   versions:
+  - name: v1.15.99
+    value: "${PWD}/test/e2e/data/ipamprovider-metal3/overlays/main/"
+    contract: v1beta2
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+    files:
+    - sourcePath: "../data/shared/ipam-metal3/main/metadata.yaml"
+      targetName: "metadata.yaml"
+  - name: v1.14.99
+    value: "${PWD}/test/e2e/data/ipamprovider-metal3/overlays/release-1.14/"
+    contract: v1beta2
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+    files:
+    - sourcePath: "../data/shared/ipam-metal3/v1.14/metadata.yaml"
+      targetName: "metadata.yaml"
   - name: v1.13.99
     value: "${PWD}/test/e2e/data/ipamprovider-metal3/overlays/release-1.13/"
-    contract: v1beta1
+    contract: v1beta2
     replacements:
     - old: --metrics-addr=127.0.0.1:8080
       new: --metrics-addr=:8080
@@ -129,28 +174,6 @@ providers:
 - name: metal3
   type: InfrastructureProvider
   versions:
-  - name: "v1.13.99"
-    value: "${PWD}/test/e2e/data/infrastructure-metal3/overlays/release-1.13/"
-    contract: v1beta2
-    files:
-    - sourcePath: "../data/shared/infrastructure-metal3/v1.13/metadata.yaml"
-      targetName: "metadata.yaml"
-    - sourcePath: "../_out/v1.13/cluster-template-ubuntu.yaml"
-      targetName: "cluster-template-ubuntu.yaml"
-    - sourcePath: "../_out/v1.13/cluster-template-centos.yaml"
-      targetName: "cluster-template-centos.yaml"
-    - sourcePath: "../_out/v1.13/cluster-template-centos-fake.yaml"
-      targetName: "cluster-template-centos-fake.yaml"
-    - sourcePath: "../_out/v1.13/clusterclass-metal3.yaml"
-      targetName: "clusterclass-metal3.yaml"
-    - sourcePath: "../_out/v1.13/cluster-template-upgrade-workload.yaml"
-      targetName: "cluster-template-upgrade-workload.yaml"
-    - sourcePath: "../_out/v1.13/cluster-template-centos-md-remediation.yaml"
-      targetName: "cluster-template-centos-md-remediation.yaml"
-    - sourcePath: "../_out/v1.13/cluster-template-ubuntu-md-remediation.yaml"
-      targetName: "cluster-template-ubuntu-md-remediation.yaml"
-    - sourcePath: "../_out/v1.13/clusterclass.yaml"
-      targetName: "clusterclass-test-clusterclass.yaml"
   - name: "v1.12.99"
     value: "${PWD}/test/e2e/data/infrastructure-metal3/overlays/release-1.12/"
     contract: v1beta1
@@ -173,7 +196,51 @@ providers:
       targetName: "cluster-template-ubuntu-md-remediation.yaml"
     - sourcePath: "../_out/v1.12/clusterclass.yaml"
       targetName: "clusterclass-test-clusterclass.yaml"
+  - name: "v1.13.99"
+    value: "${PWD}/test/e2e/data/infrastructure-metal3/overlays/release-1.13/"
+    contract: v1beta2
+    files:
+    - sourcePath: "../data/shared/infrastructure-metal3/v1.13/metadata.yaml"
+      targetName: "metadata.yaml"
+    - sourcePath: "../_out/v1.13/cluster-template-ubuntu.yaml"
+      targetName: "cluster-template-ubuntu.yaml"
+    - sourcePath: "../_out/v1.13/cluster-template-centos.yaml"
+      targetName: "cluster-template-centos.yaml"
+    - sourcePath: "../_out/v1.13/cluster-template-centos-fake.yaml"
+      targetName: "cluster-template-centos-fake.yaml"
+    - sourcePath: "../_out/v1.13/clusterclass-metal3.yaml"
+      targetName: "clusterclass-metal3.yaml"
+    - sourcePath: "../_out/v1.13/cluster-template-upgrade-workload.yaml"
+      targetName: "cluster-template-upgrade-workload.yaml"
+    - sourcePath: "../_out/v1.13/cluster-template-centos-md-remediation.yaml"
+      targetName: "cluster-template-centos-md-remediation.yaml"
+    - sourcePath: "../_out/v1.13/cluster-template-ubuntu-md-remediation.yaml"
+      targetName: "cluster-template-ubuntu-md-remediation.yaml"
+    - sourcePath: "../_out/v1.13/clusterclass.yaml"
+      targetName: "clusterclass-test-clusterclass.yaml"
   - name: "v1.14.99"
+    value: "${PWD}/test/e2e/data/infrastructure-metal3/overlays/release-1.14/"
+    contract: v1beta2
+    files:
+    - sourcePath: "../data/shared/infrastructure-metal3/v1.14/metadata.yaml"
+      targetName: "metadata.yaml"
+    - sourcePath: "../_out/v1.14/cluster-template-ubuntu.yaml"
+      targetName: "cluster-template-ubuntu.yaml"
+    - sourcePath: "../_out/v1.14/cluster-template-centos.yaml"
+      targetName: "cluster-template-centos.yaml"
+    - sourcePath: "../_out/v1.14/cluster-template-centos-fake.yaml"
+      targetName: "cluster-template-centos-fake.yaml"
+    - sourcePath: "../_out/v1.14/clusterclass-metal3.yaml"
+      targetName: "clusterclass-metal3.yaml"
+    - sourcePath: "../_out/v1.14/cluster-template-upgrade-workload.yaml"
+      targetName: "cluster-template-upgrade-workload.yaml"
+    - sourcePath: "../_out/v1.14/cluster-template-centos-md-remediation.yaml"
+      targetName: "cluster-template-centos-md-remediation.yaml"
+    - sourcePath: "../_out/v1.14/cluster-template-ubuntu-md-remediation.yaml"
+      targetName: "cluster-template-ubuntu-md-remediation.yaml"
+    - sourcePath: "../_out/v1.14/clusterclass.yaml"
+      targetName: "clusterclass-test-clusterclass.yaml"
+  - name: "v1.15.99"
     value: "${PWD}/test/e2e/data/infrastructure-metal3/overlays/main/"
     contract: v1beta2
     files:
@@ -278,6 +345,7 @@ variables:
   IRSO_IRONIC_MAIN: "data/ironic-standalone-operator/ironic/overlays/main"
   BMO_RELEASE_0.12: "data/bmo-deployment/overlays/release-0.12"
   BMO_RELEASE_0.13: "data/bmo-deployment/overlays/release-0.13"
+  BMO_RELEASE_0.14: "data/bmo-deployment/overlays/release-0.14"
   BMO_RELEASE_PR_TEST: "data/bmo-deployment/overlays/pr-test"
   BMO_RELEASE_MAIN: "data/bmo-deployment/overlays/release-main"
   FKAS_RELEASE_LATEST: "data/fkas"

--- a/test/e2e/data/bmo-deployment/overlays/release-0.14/ironic.env
+++ b/test/e2e/data/bmo-deployment/overlays/release-0.14/ironic.env
@@ -1,0 +1,4 @@
+DEPLOY_KERNEL_URL=http://172.22.0.2:6180/images/ironic-python-agent.kernel
+DEPLOY_RAMDISK_URL=http://172.22.0.2:6180/images/ironic-python-agent.initramfs
+IRONIC_ENDPOINT=https://172.22.0.2:6385/v1/
+IRONIC_INSPECTOR_ENDPOINT=https://172.22.0.2:5050/v1/

--- a/test/e2e/data/bmo-deployment/overlays/release-0.14/kustomization.yaml
+++ b/test/e2e/data/bmo-deployment/overlays/release-0.14/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: baremetal-operator-system
+resources:
+- https://github.com/metal3-io/baremetal-operator/config/overlays/basic-auth_tls?ref=release-0.14&timeout=120s
+configMapGenerator:
+- name: ironic
+  behavior: create
+  envs:
+  - ironic.env
+patches:
+- patch: |
+    # Don't try to pull again the pre-loaded image
+    - op: replace
+      path: /spec/template/spec/containers/0/imagePullPolicy
+      value: IfNotPresent
+  target:
+    kind: Deployment
+    name: controller-manager
+images:
+- name: quay.io/metal3-io/baremetal-operator
+  newTag: release-0.14
+# We cannot use suffix hashes since the kustomizations we build on
+# cannot be aware of what suffixes we add.
+generatorOptions:
+  disableNameSuffixHash: true
+# NOTE: These credentials are generated automatically in scripts/ci-e2e.sh
+secretGenerator:
+- name: ironic-credentials
+  files:
+  - username=ironic-username
+  - password=ironic-password

--- a/test/e2e/data/infrastructure-metal3/overlays/release-1.14/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/overlays/release-1.14/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- https://github.com/metal3-io/cluster-api-provider-metal3/config/default?ref=release-1.14
+
+patches:
+- patch: |
+    # Extend default with TLS 1.3 hardening.
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-min-version=VersionTLS13"
+  target:
+    kind: Deployment
+    name: controller-manager

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/centos-kubeadm-config/centos-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/centos-kubeadm-config/centos-kubeadm-config.yaml
@@ -1,0 +1,225 @@
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  kubeadmConfigSpec:
+    files:
+    - content: |
+        #!/bin/bash
+        set -e
+        url="$1"
+        dst="$2"
+        filename="$(basename $url)"
+        tmpfile="/tmp/$filename"
+        curl -sSL -w "%{http_code}" "$url" | sed "s:/usr/bin:/usr/local/bin:g" > /tmp/"$filename"
+        http_status=$(cat "$tmpfile" | tail -n 1)
+        if [ "$http_status" != "200" ]; then
+          echo "Error: unable to retrieve $filename file";
+          exit 1;
+        else
+          cat "$tmpfile"| sed '$d' > "$dst";
+        fi
+      owner: root:root
+      path: /usr/local/bin/retrieve.configuration.files.sh
+      permissions: "0755"
+    - path: /etc/keepalived/keepalived.conf
+      content: |
+        ! Configuration File for keepalived
+        global_defs {
+            notification_email {
+            sysadmin@example.com
+            support@example.com
+            }
+            notification_email_from lb@example.com
+            smtp_server localhost
+            smtp_connect_timeout 30
+        }
+
+        vrrp_script k8s_api_check {
+            script "curl -sk https://127.0.0.1:6443/healthz"
+            interval 5
+            timeout 5
+            rise 3
+            fall 3
+        }
+
+        vrrp_instance VI_1 {
+            state MASTER
+            interface enp2s0
+            virtual_router_id 1
+            priority 101
+            advert_int 1
+            virtual_ipaddress {
+                ${CLUSTER_APIENDPOINT_HOST}
+            }
+            track_script {
+                k8s_api_check
+            }
+        }
+    - path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
+      owner: root:root
+      permissions: '0600'
+      content: |
+        [connection]
+        id=enp1s0
+        type=ethernet
+        interface-name=enp1s0
+        master=ironicendpoint
+        slave-type=bridge
+    - content: |
+        [connection]
+        id=ironicendpoint
+        type=bridge
+        interface-name=ironicendpoint
+        autoconnect=yes
+        autoconnect-priority=1
+
+        [bridge]
+        stp=false
+        interface-name=ironicendpoint
+
+        [ipv4]
+        address1={{ ds.meta_data.provisioningIP }}/{{ ds.meta_data.provisioningCIDR }}
+        method=manual
+
+        [ipv6]
+        addr-gen-mode=eui64
+        method=ignore
+      path: /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
+      owner: root:root
+      permissions: '0600'
+    - content: |
+        [registries.search]
+        registries = ['docker.io']
+
+        [registries.insecure]
+        registries = ['${REGISTRY}']
+      path: /etc/containers/registries.conf
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+        - name: cgroup-driver
+          value: systemd
+        - name: container-runtime-endpoint
+          value: unix:///var/run/crio/crio.sock
+        - name: feature-gates
+          value: AllAlpha=false
+        - name: node-labels
+          value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+        - name: provider-id
+          value: '${PROVIDER_ID_FORMAT}'
+        - name: runtime-request-timeout
+          value: '5m'
+        name: '{{ ds.meta_data.name }}'
+    joinConfiguration:
+      controlPlane: {}
+      nodeRegistration:
+        kubeletExtraArgs:
+        - name: cgroup-driver
+          value: systemd
+        - name: container-runtime-endpoint
+          value: unix:///var/run/crio/crio.sock
+        - name: feature-gates
+          value: AllAlpha=false
+        - name: node-labels
+          value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+        - name: provider-id
+          value: '${PROVIDER_ID_FORMAT}'
+        - name: runtime-request-timeout
+          value: '5m'
+        name: '{{ ds.meta_data.name }}'
+    preKubeadmCommands:
+    - rm /etc/cni/net.d/*
+    - systemctl restart NetworkManager.service
+    - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
+    - nmcli connection up ironicendpoint
+    - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+    - nmcli connection up enp1s0
+    - systemctl enable --now keepalived
+    - sleep 60
+    - systemctl enable --now crio kubelet
+    postKubeadmCommands:
+    - mkdir -p /home/${IMAGE_USERNAME}/.kube
+    - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube
+    - cp /etc/kubernetes/admin.conf /home/${IMAGE_USERNAME}/.kube/config
+    - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube/config
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      files:
+      - content: |
+          #!/bin/bash
+          set -e
+          url="$1"
+          dst="$2"
+          filename="$(basename $url)"
+          tmpfile="/tmp/$filename"
+          curl -sSL -w "%{http_code}" "$url" | sed "s:/usr/bin:/usr/local/bin:g" > /tmp/"$filename"
+          http_status=$(cat "$tmpfile" | tail -n 1)
+          if [ "$http_status" != "200" ]; then
+            echo "Error: unable to retrieve $filename file";
+            exit 1;
+          else
+            cat "$tmpfile"| sed '$d' > "$dst";
+          fi
+        owner: root:root
+        path: /usr/local/bin/retrieve.configuration.files.sh
+        permissions: "0755"
+      - content: |
+          [connection]
+          id=enp1s0
+          type=ethernet
+          interface-name=enp1s0
+          master=ironicendpoint
+          slave-type=bridge
+          autoconnect=yes
+          autoconnect-priority=999
+        path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
+        owner: root:root
+        permissions: '0600'
+      - path: /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
+        owner: root:root
+        permissions: '0600'
+        content: |
+          [connection]
+          id=ironicendpoint
+          type=bridge
+          interface-name=ironicendpoint
+
+          [bridge]
+          stp=false
+
+          [ipv4]
+          address1={{ ds.meta_data.provisioningIP }}/{{ ds.meta_data.provisioningCIDR }}
+          method=manual
+
+          [ipv6]
+          addr-gen-mode=eui64
+          method=ignore
+      - path: /etc/containers/registries.conf
+        owner: root:root
+        permissions: '0644'
+        content: |
+          [registries.search]
+          registries = ['docker.io']
+
+          [registries.insecure]
+          registries = ['${REGISTRY}']
+      preKubeadmCommands:
+      - rm /etc/cni/net.d/*
+      - systemctl restart NetworkManager.service
+      - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
+      - nmcli connection up ironicendpoint
+      - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+      - nmcli connection up enp1s0
+      - systemctl enable --now crio kubelet
+      - sleep 120

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/centos-kubeadm-config/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/centos-kubeadm-config/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- ../cluster
+patches:
+- path: centos-kubeadm-config.yaml

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/cluster-with-topology/cluster-with-topology.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/cluster-with-topology/cluster-with-topology.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  labels:
+    cni: ${CLUSTER_NAME}-crs-0
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: [ "${POD_CIDR}" ]
+    services:
+      cidrBlocks: [ "${SERVICE_CIDR}" ]
+  topology:
+    classRef:
+      name: metal3
+    version: ${KUBERNETES_VERSION}
+    controlPlane:
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+    workers:
+      machineDeployments:
+      - class: worker
+        name: ${CLUSTER_NAME}-machine
+        replicas: ${WORKER_MACHINE_COUNT}
+    variables:
+    - name: image
+      value:
+        checksum: ${IMAGE_RAW_CHECKSUM}
+        checksumType: ${IMAGE_CHECKSUM_TYPE}
+        diskFormat: raw
+        url: ${IMAGE_RAW_URL}
+    - name: controlPlaneEndpoint
+      value:
+        host: CLUSTER_APIENDPOINT_HOST_HOLDER
+        port: CLUSTER_APIENDPOINT_PORT_HOLDER
+    - name: controlPlaneDataTemplate
+      value: ${CLUSTER_NAME}-controlplane-template
+---
+apiVersion: ipam.metal3.io/v1alpha1
+kind: IPPool
+metadata:
+  name: ${CLUSTER_NAME}-baremetalv4-pool
+spec:
+  clusterName: ${CLUSTER_NAME}
+  gateway: 192.168.111.1
+  namePrefix: ${CLUSTER_NAME}-bmv4
+  pools:
+  - end: 192.168.111.240
+    start: 192.168.111.201
+  prefix: 24
+---
+apiVersion: ipam.metal3.io/v1alpha1
+kind: IPPool
+metadata:
+  name: ${CLUSTER_NAME}-provisioning-pool
+spec:
+  clusterName: ${CLUSTER_NAME}
+  namePrefix: ${CLUSTER_NAME}-prov
+  pools:
+  - end: 172.22.0.240
+    start: 172.22.0.201
+  prefix: 24
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3DataTemplate
+metadata:
+  name: ${CLUSTER_NAME}-controlplane-template
+spec:
+  clusterName: ${CLUSTER_NAME}
+  metaData:
+    ipAddressesFromPool:
+    - key: provisioningIP
+      name: ${CLUSTER_NAME}-provisioning-pool
+      apiGroup: "ipam.metal3.io"
+      kind: "IPPool"
+    objectNames:
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine
+    prefixesFromPool:
+    - key: provisioningCIDR
+      name: ${CLUSTER_NAME}-provisioning-pool
+      apiGroup: "ipam.metal3.io"
+      kind: "IPPool"
+  networkData:
+    links:
+      ethernets:
+      - id: enp1s0
+        macAddress:
+          fromHostInterface: enp1s0
+        type: phy
+      - id: enp2s0
+        macAddress:
+          fromHostInterface: enp2s0
+        type: phy
+    networks:
+      ipv4:
+      - id: baremetalv4
+        ipAddressFromIPPool: ${CLUSTER_NAME}-baremetalv4-pool
+        link: enp2s0
+        routes:
+        - gateway:
+            fromIPPool: ${CLUSTER_NAME}-baremetalv4-pool
+          network: 0.0.0.0
+          prefix: 0
+    services:
+      dns:
+      - 8.8.8.8

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/cluster-with-topology/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/cluster-with-topology/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- cluster-with-topology.yaml

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/cluster/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/cluster/cluster-with-kcp.yaml
@@ -1,0 +1,125 @@
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  labels:
+    cni: ${CLUSTER_NAME}-crs-0
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: [ "${POD_CIDR}" ]
+    services:
+      cidrBlocks: [ "${SERVICE_CIDR}" ]
+  controlPlaneRef:
+    apiGroup: controlplane.cluster.x-k8s.io
+    kind: KubeadmControlPlane
+    name: ${CLUSTER_NAME}
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: Metal3Cluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  controlPlaneEndpoint:
+    host: ${CLUSTER_APIENDPOINT_HOST}
+    port: ${CLUSTER_APIENDPOINT_PORT}
+  cloudProviderEnabled: false
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  machineTemplate:
+    spec:
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: Metal3MachineTemplate
+        name: ${CLUSTER_NAME}-controlplane
+      deletion:
+        nodeDrainTimeoutSeconds: ${NODE_DRAIN_TIMEOUT}
+  kubeadmConfigSpec:
+    users:
+    - name: ${IMAGE_USERNAME}
+      sshAuthorizedKeys:
+      - ${SSH_PUB_KEY_CONTENT}
+      sudo: ALL=(ALL) NOPASSWD:ALL
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  rollout:
+    strategy:
+      rollingUpdate:
+        maxSurge: 1
+  version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3MachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-controlplane
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      dataTemplate:
+        name: ${CLUSTER_NAME}-controlplane-template
+      image:
+        checksum: ${IMAGE_RAW_CHECKSUM}
+        checksumType: ${IMAGE_CHECKSUM_TYPE}
+        diskFormat: raw
+        url: ${IMAGE_RAW_URL}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3DataTemplate
+metadata:
+  name: ${CLUSTER_NAME}-controlplane-template
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}
+  metaData:
+    ipAddressesFromPool:
+    - key: provisioningIP
+      name: provisioning-pool
+      apiGroup: "ipam.metal3.io"
+      kind: "IPPool"
+    objectNames:
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine
+    prefixesFromPool:
+    - key: provisioningCIDR
+      name: provisioning-pool
+      apiGroup: "ipam.metal3.io"
+      kind: "IPPool"
+  networkData:
+    links:
+      ethernets:
+      - id: enp1s0
+        macAddress:
+          fromHostInterface: enp1s0
+        type: phy
+      - id: enp2s0
+        macAddress:
+          fromHostInterface: enp2s0
+        type: phy
+    networks:
+      ipv4:
+      - id: baremetalv4
+        ipAddressFromIPPool: baremetalv4-pool
+        link: enp2s0
+        routes:
+        - gateway:
+            fromIPPool: baremetalv4-pool
+          network: 0.0.0.0
+          prefix: 0
+    services:
+      dns:
+      - 8.8.8.8

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/cluster/crs.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/cluster/crs.yaml
@@ -1,0 +1,24 @@
+---
+# ConfigMap object referenced by the ClusterResourceSet object and with
+# the CNI resource defined in the test config file
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cni-${CLUSTER_NAME}-crs-0"
+data: ${CNI_RESOURCES}
+binaryData:
+---
+# ClusterResourceSet object with
+# a selector that targets all the Cluster with label cni=${CLUSTER_NAME}-crs-0
+apiVersion: addons.cluster.x-k8s.io/v1beta2
+kind: ClusterResourceSet
+metadata:
+  name: "${CLUSTER_NAME}-crs-0"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      cni: "${CLUSTER_NAME}-crs-0"
+  resources:
+  - name: "cni-${CLUSTER_NAME}-crs-0"
+    kind: ConfigMap

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/cluster/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/cluster/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- cluster-with-kcp.yaml
+- md.yaml
+- crs.yaml

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/cluster/md.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/cluster/md.yaml
@@ -1,0 +1,131 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+    nodepool: nodepool-0
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+      nodepool: nodepool-0
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+        nodepool: nodepool-0
+    spec:
+      bootstrap:
+        configRef:
+          apiGroup: bootstrap.cluster.x-k8s.io
+          kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-workers
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: Metal3MachineTemplate
+        name: ${CLUSTER_NAME}-workers
+      deletion:
+        nodeDrainTimeoutSeconds: 0
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3MachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      dataTemplate:
+        name: ${CLUSTER_NAME}-workers-template
+      image:
+        checksum: ${IMAGE_RAW_CHECKSUM}
+        checksumType: ${IMAGE_CHECKSUM_TYPE}
+        diskFormat: raw
+        url: ${IMAGE_RAW_URL}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3DataTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers-template
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}
+  metaData:
+    ipAddressesFromPool:
+    - key: provisioningIP
+      name: provisioning-pool
+      apiGroup: "ipam.metal3.io"
+      kind: "IPPool"
+    objectNames:
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine
+    prefixesFromPool:
+    - key: provisioningCIDR
+      name: provisioning-pool
+      apiGroup: "ipam.metal3.io"
+      kind: "IPPool"
+  networkData:
+    links:
+      ethernets:
+      - id: enp1s0
+        macAddress:
+          fromHostInterface: enp1s0
+        type: phy
+      - id: enp2s0
+        macAddress:
+          fromHostInterface: enp2s0
+        type: phy
+    networks:
+      ipv4:
+      - id: baremetalv4
+        ipAddressFromIPPool: baremetalv4-pool
+        link: enp2s0
+        routes:
+        - gateway:
+            fromIPPool: baremetalv4-pool
+          network: 0.0.0.0
+          prefix: 0
+    services:
+      dns:
+      - 8.8.8.8
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+          - name: cgroup-driver
+            value: systemd
+          - name: container-runtime-endpoint
+            value: unix:///var/run/crio/crio.sock
+          - name: feature-gates
+            value: AllAlpha=false
+          - name: node-labels
+            value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+          - name: provider-id
+            value: '${PROVIDER_ID_FORMAT}'
+          - name: runtime-request-timeout
+            value: '5m'
+          name: '{{ ds.meta_data.name }}'
+      users:
+      - name: metal3
+        sshAuthorizedKeys:
+        - ${SSH_PUB_KEY_CONTENT}
+        sudo: ALL=(ALL) NOPASSWD:ALL

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass-centos-kubeadm-config/clusterclass-centos-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass-centos-kubeadm-config/clusterclass-centos-kubeadm-config.yaml
@@ -1,0 +1,232 @@
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlaneTemplate
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      kubeadmConfigSpec:
+        users:
+        - name: ${IMAGE_USERNAME}
+          sshAuthorizedKeys:
+          - ${SSH_PUB_KEY_CONTENT}
+          sudo: ALL=(ALL) NOPASSWD:ALL
+        files:
+        - content: |
+            #!/bin/bash
+            set -e
+            url="$1"
+            dst="$2"
+            filename="$(basename $url)"
+            tmpfile="/tmp/$filename"
+            curl -sSL -w "%{http_code}" "$url" | sed "s:/usr/bin:/usr/local/bin:g" > /tmp/"$filename"
+            http_status=$(cat "$tmpfile" | tail -n 1)
+            if [ "$http_status" != "200" ]; then
+              echo "Error: unable to retrieve $filename file";
+              exit 1;
+            else
+              cat "$tmpfile"| sed '$d' > "$dst";
+            fi
+          owner: root:root
+          path: /usr/local/bin/retrieve.configuration.files.sh
+          permissions: "0755"
+        - path: /etc/keepalived/keepalived.conf
+          content: |
+            ! Configuration File for keepalived
+            global_defs {
+                notification_email {
+                sysadmin@example.com
+                support@example.com
+                }
+                notification_email_from lb@example.com
+                smtp_server localhost
+                smtp_connect_timeout 30
+            }
+
+            vrrp_script k8s_api_check {
+                script "curl -sk https://127.0.0.1:6443/healthz"
+                interval 5
+                timeout 5
+                rise 3
+                fall 3
+            }
+
+            vrrp_instance VI_1 {
+                state MASTER
+                interface enp2s0
+                virtual_router_id 1
+                priority 101
+                advert_int 1
+                virtual_ipaddress {
+                    ${CLUSTER_APIENDPOINT_HOST}
+                }
+                track_script {
+                    k8s_api_check
+                }
+            }
+        - path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
+          owner: root:root
+          permissions: '0600'
+          content: |
+            [connection]
+            id=enp1s0
+            type=ethernet
+            interface-name=enp1s0
+            master=ironicendpoint
+            slave-type=bridge
+        - content: |
+            [connection]
+            id=ironicendpoint
+            type=bridge
+            interface-name=ironicendpoint
+            autoconnect=yes
+            autoconnect-priority=1
+
+            [bridge]
+            stp=false
+            interface-name=ironicendpoint
+
+            [ipv4]
+            address1={{ ds.meta_data.provisioningIP }}/{{ ds.meta_data.provisioningCIDR }}
+            method=manual
+
+            [ipv6]
+            addr-gen-mode=eui64
+            method=ignore
+          path: /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
+          owner: root:root
+          permissions: '0600'
+        - content: |
+            [registries.search]
+            registries = ['docker.io']
+
+            [registries.insecure]
+            registries = ['${REGISTRY}']
+          path: /etc/containers/registries.conf
+        initConfiguration:
+          nodeRegistration:
+            kubeletExtraArgs:
+            - name: cgroup-driver
+              value: systemd
+            - name: container-runtime-endpoint
+              value: unix:///var/run/crio/crio.sock
+            - name: feature-gates
+              value: AllAlpha=false
+            - name: node-labels
+              value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+            - name: provider-id
+              value: '${PROVIDER_ID_FORMAT}'
+            - name: runtime-request-timeout
+              value: '5m'
+            name: '{{ ds.meta_data.name }}'
+        joinConfiguration:
+          controlPlane: {}
+          nodeRegistration:
+            kubeletExtraArgs:
+            - name: cgroup-driver
+              value: systemd
+            - name: container-runtime-endpoint
+              value: unix:///var/run/crio/crio.sock
+            - name: feature-gates
+              value: AllAlpha=false
+            - name: node-labels
+              value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+            - name: provider-id
+              value: '${PROVIDER_ID_FORMAT}'
+            - name: runtime-request-timeout
+              value: '5m'
+            name: '{{ ds.meta_data.name }}'
+        preKubeadmCommands:
+        - rm /etc/cni/net.d/*
+        - systemctl restart NetworkManager.service
+        - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
+        - nmcli connection up ironicendpoint
+        - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+        - nmcli connection up enp1s0
+        - systemctl enable --now keepalived
+        - sleep 60
+        - systemctl enable --now crio kubelet
+        postKubeadmCommands:
+        - mkdir -p /home/${IMAGE_USERNAME}/.kube
+        - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube
+        - cp /etc/kubernetes/admin.conf /home/${IMAGE_USERNAME}/.kube/config
+        - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube/config
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      files:
+      - content: |
+          #!/bin/bash
+          set -e
+          url="$1"
+          dst="$2"
+          filename="$(basename $url)"
+          tmpfile="/tmp/$filename"
+          curl -sSL -w "%{http_code}" "$url" | sed "s:/usr/bin:/usr/local/bin:g" > /tmp/"$filename"
+          http_status=$(cat "$tmpfile" | tail -n 1)
+          if [ "$http_status" != "200" ]; then
+            echo "Error: unable to retrieve $filename file";
+            exit 1;
+          else
+            cat "$tmpfile"| sed '$d' > "$dst";
+          fi
+        owner: root:root
+        path: /usr/local/bin/retrieve.configuration.files.sh
+        permissions: "0755"
+      - content: |
+          [connection]
+          id=enp1s0
+          type=ethernet
+          interface-name=enp1s0
+          master=ironicendpoint
+          slave-type=bridge
+          autoconnect=yes
+          autoconnect-priority=999
+        path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
+        owner: root:root
+        permissions: '0600'
+      - path: /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
+        owner: root:root
+        permissions: '0600'
+        content: |
+          [connection]
+          id=ironicendpoint
+          type=bridge
+          interface-name=ironicendpoint
+
+          [bridge]
+          stp=false
+
+          [ipv4]
+          address1={{ ds.meta_data.provisioningIP }}/{{ ds.meta_data.provisioningCIDR }}
+          method=manual
+
+          [ipv6]
+          addr-gen-mode=eui64
+          method=ignore
+      - path: /etc/containers/registries.conf
+        owner: root:root
+        permissions: '0644'
+        content: |
+          [registries.search]
+          registries = ['docker.io']
+
+          [registries.insecure]
+          registries = ['${REGISTRY}']
+      preKubeadmCommands:
+      - rm /etc/cni/net.d/*
+      - systemctl restart NetworkManager.service
+      - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
+      - nmcli connection up ironicendpoint
+      - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+      - nmcli connection up enp1s0
+      - systemctl enable --now crio kubelet
+      - sleep 120

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass-centos-kubeadm-config/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass-centos-kubeadm-config/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- ../clusterclass-cluster
+patchesStrategicMerge:
+- clusterclass-centos-kubeadm-config.yaml

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass-cluster/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass-cluster/cluster-with-kcp.yaml
@@ -1,0 +1,124 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlaneTemplate
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3ClusterTemplate
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      controlPlaneEndpoint:
+        host: ${CLUSTER_APIENDPOINT_HOST}
+        port: ${CLUSTER_APIENDPOINT_PORT}
+      cloudProviderEnabled: false
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3MachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-controlplane
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      dataTemplate:
+        name: ${CLUSTER_NAME}-controlplane-template
+      image:
+        checksum: ${IMAGE_RAW_CHECKSUM}
+        checksumType: ${IMAGE_CHECKSUM_TYPE}
+        diskFormat: raw
+        url: ${IMAGE_RAW_URL}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3DataTemplate
+metadata:
+  name: ${CLUSTER_NAME}-controlplane-template
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}
+  metaData:
+    ipAddressesFromPool:
+    - key: provisioningIP
+      name: provisioning-pool
+      apiGroup: "ipam.metal3.io"
+      kind: "IPPool"
+    objectNames:
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine
+    prefixesFromPool:
+    - key: provisioningCIDR
+      name: provisioning-pool
+      apiGroup: "ipam.metal3.io"
+      kind: "IPPool"
+  networkData:
+    links:
+      ethernets:
+      - id: enp1s0
+        macAddress:
+          fromHostInterface: enp1s0
+        type: phy
+      - id: enp2s0
+        macAddress:
+          fromHostInterface: enp2s0
+        type: phy
+    networks:
+      ipv4:
+      - id: baremetalv4
+        ipAddressFromIPPool: baremetalv4-pool
+        link: enp2s0
+        routes:
+        - gateway:
+            fromIPPool: baremetalv4-pool
+          network: 0.0.0.0
+          prefix: 0
+    services:
+      dns:
+      - 8.8.8.8
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  labels:
+    cni: ${CLUSTER_NAME}-crs-0
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: [ "${POD_CIDR}" ]
+    services:
+      cidrBlocks: [ "${SERVICE_CIDR}" ]
+  topology:
+    classRef:
+      name: test-clusterclass
+    version: ${KUBERNETES_VERSION}
+    controlPlane:
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+    workers:
+      machineDeployments:
+      - class: worker
+        name: ${CLUSTER_NAME}-machine
+        replicas: ${WORKER_MACHINE_COUNT}
+    variables:
+    - name: image
+      value:
+        checksum: ${IMAGE_RAW_CHECKSUM}
+        checksumType: ${IMAGE_CHECKSUM_TYPE}
+        diskFormat: raw
+        url: ${IMAGE_RAW_URL}
+    - name: controlPlaneEndpoint
+      value:
+        host: ${CLUSTER_APIENDPOINT_HOST}
+        port: ${CLUSTER_APIENDPOINT_PORT}
+    - name: workerDataTemplate
+      value: ${CLUSTER_NAME}-workers-template
+    - name: controlPlaneDataTemplate
+      value: ${CLUSTER_NAME}-controlplane-template

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass-cluster/crs.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass-cluster/crs.yaml
@@ -1,0 +1,24 @@
+---
+# ConfigMap object referenced by the ClusterResourceSet object and with
+# the CNI resource defined in the test config file
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cni-${CLUSTER_NAME}-crs-0"
+data: ${CNI_RESOURCES}
+binaryData:
+---
+# ClusterResourceSet object with
+# a selector that targets all the Cluster with label cni=${CLUSTER_NAME}-crs-0
+apiVersion: addons.cluster.x-k8s.io/v1beta2
+kind: ClusterResourceSet
+metadata:
+  name: "${CLUSTER_NAME}-crs-0"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      cni: "${CLUSTER_NAME}-crs-0"
+  resources:
+  - name: "cni-${CLUSTER_NAME}-crs-0"
+    kind: ConfigMap

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass-cluster/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass-cluster/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- cluster-with-kcp.yaml
+- md.yaml
+- crs.yaml

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass-cluster/md.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass-cluster/md.yaml
@@ -1,0 +1,95 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3MachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      dataTemplate:
+        name: ${CLUSTER_NAME}-workers-template
+      image:
+        checksum: ${IMAGE_RAW_CHECKSUM}
+        checksumType: ${IMAGE_CHECKSUM_TYPE}
+        diskFormat: raw
+        url: ${IMAGE_RAW_URL}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3DataTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers-template
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}
+  metaData:
+    ipAddressesFromPool:
+    - key: provisioningIP
+      name: provisioning-pool
+      apiGroup: "ipam.metal3.io"
+      kind: "IPPool"
+    objectNames:
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine
+    prefixesFromPool:
+    - key: provisioningCIDR
+      name: provisioning-pool
+      apiGroup: "ipam.metal3.io"
+      kind: "IPPool"
+  networkData:
+    links:
+      ethernets:
+      - id: enp1s0
+        macAddress:
+          fromHostInterface: enp1s0
+        type: phy
+      - id: enp2s0
+        macAddress:
+          fromHostInterface: enp2s0
+        type: phy
+    networks:
+      ipv4:
+      - id: baremetalv4
+        ipAddressFromIPPool: baremetalv4-pool
+        link: enp2s0
+        routes:
+        - gateway:
+            fromIPPool: baremetalv4-pool
+          network: 0.0.0.0
+          prefix: 0
+    services:
+      dns:
+      - 8.8.8.8
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+          - name: cgroup-driver
+            value: systemd
+          - name: container-runtime-endpoint
+            value: unix:///var/run/crio/crio.sock
+          - name: feature-gates
+            value: AllAlpha=false
+          - name: node-labels
+            value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+          - name: provider-id
+            value: '${PROVIDER_ID_FORMAT}'
+          - name: runtime-request-timeout
+            value: '5m'
+          name: '{{ ds.meta_data.name }}'
+      users:
+      - name: metal3
+        sshAuthorizedKeys:
+        - ${SSH_PUB_KEY_CONTENT}
+        sudo: ALL=(ALL) NOPASSWD:ALL

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass-ubuntu-kubeadm-config/clusterclass-ubuntu-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass-ubuntu-kubeadm-config/clusterclass-ubuntu-kubeadm-config.yaml
@@ -1,0 +1,144 @@
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlaneTemplate
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      kubeadmConfigSpec:
+        users:
+        - name: ${IMAGE_USERNAME}
+          sshAuthorizedKeys:
+          - ${SSH_PUB_KEY_CONTENT}
+          sudo: ALL=(ALL) NOPASSWD:ALL
+        files:
+        - content: |
+            ! Configuration File for keepalived
+            global_defs {
+                notification_email {
+                sysadmin@example.com
+                support@example.com
+                }
+                notification_email_from lb@example.com
+                smtp_server localhost
+                smtp_connect_timeout 30
+            }
+            vrrp_script k8s_api_check {
+                script "curl -sk https://127.0.0.1:6443/healthz"
+                interval 5
+                timeout 5
+                rise 3
+                fall 3
+            }
+
+            vrrp_instance VI_2 {
+                state MASTER
+                interface enp2s0
+                virtual_router_id 2
+                priority 101
+                advert_int 1
+                virtual_ipaddress {
+                    ${CLUSTER_APIENDPOINT_HOST}
+                }
+                track_script {
+                    k8s_api_check
+                }
+            }
+          path: /etc/keepalived/keepalived.conf
+        - content: |
+            network:
+              version: 2
+              renderer: networkd
+              bridges:
+                ${CLUSTER_PROVISIONING_INTERFACE}:
+                  interfaces: [enp1s0]
+                  addresses:
+                  - {{ ds.meta_data.provisioningIP }}/{{ ds.meta_data.provisioningCIDR }}
+          owner: root:root
+          path: /etc/netplan/52-ironicendpoint.yaml
+          permissions: "0644"
+        - content: |
+            [registries.search]
+            registries = ['docker.io']
+
+            [registries.insecure]
+            registries = ['${REGISTRY}']
+          path: /etc/containers/registries.conf
+        joinConfiguration:
+          controlPlane: {}
+          nodeRegistration:
+            kubeletExtraArgs:
+            - name: cgroup-driver
+              value: systemd
+            - name: container-runtime-endpoint
+              value: unix:///var/run/crio/crio.sock
+            - name: feature-gates
+              value: AllAlpha=false
+            - name: node-labels
+              value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+            - name: provider-id
+              value: '${PROVIDER_ID_FORMAT}'
+            - name: runtime-request-timeout
+              value: '5m'
+            name: '{{ ds.meta_data.name }}'
+        initConfiguration:
+          nodeRegistration:
+            kubeletExtraArgs:
+            - name: cgroup-driver
+              value: systemd
+            - name: container-runtime-endpoint
+              value: unix:///var/run/crio/crio.sock
+            - name: feature-gates
+              value: AllAlpha=false
+            - name: node-labels
+              value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+            - name: provider-id
+              value: '${PROVIDER_ID_FORMAT}'
+            - name: runtime-request-timeout
+              value: '5m'
+            name: '{{ ds.meta_data.name }}'
+        postKubeadmCommands:
+        - mkdir -p /home/${IMAGE_USERNAME}/.kube
+        - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube
+        - cp /etc/kubernetes/admin.conf /home/${IMAGE_USERNAME}/.kube/config
+        - systemctl enable --now keepalived
+        - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube/config
+        preKubeadmCommands:
+        - sed -i "s/MACAddressPolicy=persistent/MACAddressPolicy=none/g" /usr/lib/systemd/network/99-default.link
+        - netplan apply
+        - systemctl enable --now crio kubelet
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      files:
+      - content: |
+          network:
+            version: 2
+            renderer: networkd
+            bridges:
+              ${CLUSTER_PROVISIONING_INTERFACE}:
+                interfaces: [enp1s0]
+                addresses:
+                - {{ ds.meta_data.provisioningIP }}/{{ ds.meta_data.provisioningCIDR }}
+        owner: root:root
+        path: /etc/netplan/52-ironicendpoint.yaml
+        permissions: "0644"
+      - content: |
+          [registries.search]
+          registries = ['docker.io']
+
+          [registries.insecure]
+          registries = ['${REGISTRY}']
+        path: /etc/containers/registries.conf
+      preKubeadmCommands:
+      - sed -i "s/MACAddressPolicy=persistent/MACAddressPolicy=none/g" /usr/lib/systemd/network/99-default.link
+      - netplan apply
+      - systemctl enable --now crio kubelet

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass-ubuntu-kubeadm-config/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass-ubuntu-kubeadm-config/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- ../clusterclass-cluster
+patchesStrategicMerge:
+- clusterclass-ubuntu-kubeadm-config.yaml

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass/clusterclass.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass/clusterclass.yaml
@@ -1,0 +1,166 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: ClusterClass
+metadata:
+  name: test-clusterclass
+spec:
+  variables:
+  - name: controlPlaneEndpoint
+    required: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          host:
+            type: string
+          port:
+            type: integer
+  - name: image
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          checksum:
+            type: string
+          checksumType:
+            type: string
+          diskFormat:
+            type: string
+          url:
+            type: string
+  - name: workerDataTemplate
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: string
+  - name: controlPlaneDataTemplate
+    schema:
+      openAPIV3Schema:
+        type: string
+  patches:
+  - name: controlPlaneEndpointSub
+    description: Overrides controlPlaneEndpoint data of Metal3ClusterTemplate used by the cluster
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3ClusterTemplate
+        matchResources:
+          infrastructureCluster: true
+      jsonPatches:
+      - op: replace
+        path: /spec/template/spec/controlPlaneEndpoint
+        valueFrom:
+          variable: controlPlaneEndpoint
+  - name: imageSub
+    description: Overrides image data for worker nodes of example-worker class
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - worker
+      jsonPatches:
+      - op: replace
+        path: /spec/template/spec/image/checksum
+        valueFrom:
+          variable: image.checksum
+      - op: replace
+        path: /spec/template/spec/image/checksumType
+        valueFrom:
+          variable: image.checksumType
+      - op: replace
+        path: /spec/template/spec/image/diskFormat
+        valueFrom:
+          variable: image.diskFormat
+      - op: replace
+        path: /spec/template/spec/image/url
+        valueFrom:
+          variable: image.url
+  - name: workerDataTemplateSub
+    description: Overrides data-template for worker nodes
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - worker
+      jsonPatches:
+      - op: replace
+        path: /spec/template/spec/dataTemplate/name
+        valueFrom:
+          variable: workerDataTemplate
+  - name: controlPlaneImageSub
+    description: Overrides image data for worker nodes of control plane node
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: replace
+        path: /spec/template/spec/image/checksum
+        valueFrom:
+          variable: image.checksum
+      - op: replace
+        path: /spec/template/spec/image/checksumType
+        valueFrom:
+          variable: image.checksumType
+      - op: replace
+        path: /spec/template/spec/image/diskFormat
+        valueFrom:
+          variable: image.diskFormat
+      - op: replace
+        path: /spec/template/spec/image/url
+        valueFrom:
+          variable: image.url
+  - name: controlPlaneDataTemplateSub
+    description: Overrides data-template for control plane nodes
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: replace
+        path: /spec/template/spec/dataTemplate/name
+        valueFrom:
+          variable: controlPlaneDataTemplate
+  controlPlane:
+    templateRef:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+      kind: KubeadmControlPlaneTemplate
+      name: ${CLUSTER_NAME}
+    machineInfrastructure:
+      templateRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: ${CLUSTER_NAME}-controlplane
+  workers:
+    machineDeployments:
+    - class: worker
+      metadata:
+        labels:
+          cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+          nodepool: nodepool-0
+      bootstrap:
+        templateRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-workers
+      infrastructure:
+        templateRef:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+          kind: Metal3MachineTemplate
+          name: ${CLUSTER_NAME}-workers
+  infrastructure:
+    templateRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3ClusterTemplate
+      name: ${CLUSTER_NAME}

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/clusterclass/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- clusterclass.yaml

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/ippool/ippool.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/ippool/ippool.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: ipam.metal3.io/v1alpha1
+kind: IPPool
+metadata:
+  name: provisioning-pool
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}
+  namePrefix: ${CLUSTER_NAME}-prov
+  pools:
+  - start: ${IPAM_PROVISIONING_POOL_RANGE_START}
+    end: ${IPAM_PROVISIONING_POOL_RANGE_END}
+  prefix: ${BARE_METAL_PROVISIONER_CIDR}
+---
+apiVersion: ipam.metal3.io/v1alpha1
+kind: IPPool
+metadata:
+  name: baremetalv4-pool
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}
+  namePrefix: ${CLUSTER_NAME}-bmv4
+  pools:
+  - start: ${IPAM_EXTERNALV4_POOL_RANGE_START}
+    end: ${IPAM_EXTERNALV4_POOL_RANGE_END}
+  prefix: ${EXTERNAL_SUBNET_V4_PREFIX}
+  gateway: ${EXTERNAL_SUBNET_V4_HOST}

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/ippool/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/ippool/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- ippool.yaml

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/opensuse-leap-kubeadm-config/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/opensuse-leap-kubeadm-config/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- ../cluster
+patches:
+- path: opensuse-leap-kubeadm-config.yaml

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/opensuse-leap-kubeadm-config/opensuse-leap-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/opensuse-leap-kubeadm-config/opensuse-leap-kubeadm-config.yaml
@@ -1,0 +1,229 @@
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  kubeadmConfigSpec:
+    files:
+    - content: |
+        #!/bin/bash
+        while :; do
+          curl -sk https://127.0.0.1:6443/healthz 1>&2 > /dev/null
+          isOk=$?
+          isActive=$(systemctl show -p ActiveState keepalived.service | cut -d'=' -f2)
+          if [ $isOk == "0" ] &&  [ $isActive != "active" ]; then
+            logger 'API server is healthy, however keepalived is not running, starting keepalived'
+            echo 'API server is healthy, however keepalived is not running, starting keepalived'
+            sudo systemctl start keepalived.service
+          elif [ $isOk != "0" ] &&  [ $isActive == "active" ]; then
+            logger 'API server is not healthy, however keepalived running, stopping keepalived'
+            echo 'API server is not healthy, however keepalived running, stopping keepalived'
+            sudo systemctl stop keepalived.service
+          fi
+          sleep 5
+        done
+      owner: root:root
+      path: /usr/local/bin/monitor.keepalived.sh
+      permissions: "0755"
+    - content: |
+        [Unit]
+        Description=Monitors keepalived adjusts status with that of API server
+        After=syslog.target network-online.target
+
+        [Service]
+        Type=simple
+        Restart=always
+        ExecStart=/usr/local/bin/monitor.keepalived.sh
+
+        [Install]
+        WantedBy=multi-user.target
+      owner: root:root
+      path: /lib/systemd/system/monitor.keepalived.service
+    - content: |
+        ! Configuration File for keepalived
+        global_defs {
+            notification_email {
+            sysadmin@example.com
+            support@example.com
+            }
+            notification_email_from lb@example.com
+            smtp_server localhost
+            smtp_connect_timeout 30
+        }
+        vrrp_instance VI_2 {
+            state MASTER
+            interface enp2s0
+            virtual_router_id 2
+            priority 101
+            advert_int 1
+            virtual_ipaddress {
+                ${CLUSTER_APIENDPOINT_HOST}
+            }
+        }
+      path: /etc/keepalived/keepalived.conf
+    - path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
+      owner: root:root
+      permissions: '0600'
+      content: |
+        [connection]
+        id=enp1s0
+        type=ethernet
+        interface-name=enp1s0
+        master=ironicendpoint
+        slave-type=bridge
+    - content: |
+        [connection]
+        id=ironicendpoint
+        type=bridge
+        interface-name=ironicendpoint
+        autoconnect=yes
+        autoconnect-priority=1
+
+        [bridge]
+        stp=false
+        interface-name=ironicendpoint
+
+        [ipv4]
+        address1={{ ds.meta_data.provisioningIP }}/{{ ds.meta_data.provisioningCIDR }}
+        method=manual
+
+        [ipv6]
+        addr-gen-mode=eui64
+        method=ignore
+      path: /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
+      owner: root:root
+      permissions: '0600'
+    - content: |
+        [registries.search]
+        registries = ['docker.io']
+
+        [registries.insecure]
+        registries = ['${REGISTRY}']
+      path: /etc/containers/registries.conf
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+        - name: cgroup-driver
+          value: systemd
+        - name: container-runtime-endpoint
+          value: unix:///var/run/crio/crio.sock
+        - name: feature-gates
+          value: AllAlpha=false
+        - name: node-labels
+          value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+        - name: provider-id
+          value: '${PROVIDER_ID_FORMAT}'
+        - name: runtime-request-timeout
+          value: '5m'
+        name: '{{ ds.meta_data.name }}'
+    joinConfiguration:
+      controlPlane: {}
+      nodeRegistration:
+        kubeletExtraArgs:
+        - name: cgroup-driver
+          value: systemd
+        - name: container-runtime-endpoint
+          value: unix:///var/run/crio/crio.sock
+        - name: feature-gates
+          value: AllAlpha=false
+        - name: node-labels
+          value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+        - name: provider-id
+          value: '${PROVIDER_ID_FORMAT}'
+        - name: runtime-request-timeout
+          value: '5m'
+        name: '{{ ds.meta_data.name }}'
+    preKubeadmCommands:
+    - rm /etc/cni/net.d/*
+    - systemctl restart NetworkManager.service
+    - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
+    - nmcli connection up ironicendpoint
+    - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+    - nmcli connection up enp1s0
+    - systemctl enable --now keepalived
+    - sleep 60
+    - systemctl enable --now crio kubelet
+    postKubeadmCommands:
+    - mkdir -p /home/${IMAGE_USERNAME}/.kube
+    - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube
+    - cp /etc/kubernetes/admin.conf /home/${IMAGE_USERNAME}/.kube/config
+    - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube/config
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      files:
+      - content: |
+          #!/bin/bash
+          set -e
+          url="$1"
+          dst="$2"
+          filename="$(basename $url)"
+          tmpfile="/tmp/$filename"
+          curl -sSL -w "%{http_code}" "$url" | sed "s:/usr/bin:/usr/local/bin:g" > /tmp/"$filename"
+          http_status=$(cat "$tmpfile" | tail -n 1)
+          if [ "$http_status" != "200" ]; then
+            echo "Error: unable to retrieve $filename file";
+            exit 1;
+          else
+            cat "$tmpfile"| sed '$d' > "$dst";
+          fi
+        owner: root:root
+        path: /usr/local/bin/retrieve.configuration.files.sh
+        permissions: "0755"
+      - content: |
+          [connection]
+          id=enp1s0
+          type=ethernet
+          interface-name=enp1s0
+          master=ironicendpoint
+          slave-type=bridge
+          autoconnect=yes
+          autoconnect-priority=999
+        path: /etc/NetworkManager/system-connections/enp1s0.nmconnection
+        owner: root:root
+        permissions: '0600'
+      - path: /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
+        owner: root:root
+        permissions: '0600'
+        content: |
+          [connection]
+          id=ironicendpoint
+          type=bridge
+          interface-name=ironicendpoint
+
+          [bridge]
+          stp=false
+
+          [ipv4]
+          address1={{ ds.meta_data.provisioningIP }}/{{ ds.meta_data.provisioningCIDR }}
+          method=manual
+
+          [ipv6]
+          addr-gen-mode=eui64
+          method=ignore
+      - path: /etc/containers/registries.conf
+        owner: root:root
+        permissions: '0644'
+        content: |
+          [registries.search]
+          registries = ['docker.io']
+
+          [registries.insecure]
+          registries = ['${REGISTRY}']
+      preKubeadmCommands:
+      - rm /etc/cni/net.d/*
+      - systemctl restart NetworkManager.service
+      - nmcli connection load /etc/NetworkManager/system-connections/ironicendpoint.nmconnection
+      - nmcli connection up ironicendpoint
+      - nmcli connection load /etc/NetworkManager/system-connections/enp1s0.nmconnection
+      - nmcli connection up enp1s0
+      - systemctl enable --now crio kubelet
+      - sleep 120

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/ubuntu-kubeadm-config/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/ubuntu-kubeadm-config/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- ../cluster
+patches:
+- path: ubuntu-kubeadm-config.yaml

--- a/test/e2e/data/infrastructure-metal3/v1.14/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/bases/ubuntu-kubeadm-config/ubuntu-kubeadm-config.yaml
@@ -1,0 +1,137 @@
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  kubeadmConfigSpec:
+    files:
+    - content: |
+        ! Configuration File for keepalived
+        global_defs {
+            notification_email {
+            sysadmin@example.com
+            support@example.com
+            }
+            notification_email_from lb@example.com
+            smtp_server localhost
+            smtp_connect_timeout 30
+        }
+        vrrp_script k8s_api_check {
+            script "curl -sk https://127.0.0.1:6443/healthz"
+            interval 5
+            timeout 5
+            rise 3
+            fall 3
+        }
+
+        vrrp_instance VI_2 {
+            state MASTER
+            interface enp2s0
+            virtual_router_id 2
+            priority 101
+            advert_int 1
+            virtual_ipaddress {
+                ${CLUSTER_APIENDPOINT_HOST}
+            }
+            track_script {
+                k8s_api_check
+            }
+        }
+      path: /etc/keepalived/keepalived.conf
+    - content: |
+        network:
+          version: 2
+          renderer: networkd
+          bridges:
+            ${CLUSTER_PROVISIONING_INTERFACE}:
+              interfaces: [enp1s0]
+              addresses:
+              - {{ ds.meta_data.provisioningIP }}/{{ ds.meta_data.provisioningCIDR }}
+      owner: root:root
+      path: /etc/netplan/52-ironicendpoint.yaml
+      permissions: "0644"
+    - content: |
+        [registries.search]
+        registries = ['docker.io']
+
+        [registries.insecure]
+        registries = ['${REGISTRY}']
+      path: /etc/containers/registries.conf
+    joinConfiguration:
+      controlPlane: {}
+      nodeRegistration:
+        kubeletExtraArgs:
+        - name: cgroup-driver
+          value: systemd
+        - name: container-runtime-endpoint
+          value: unix:///var/run/crio/crio.sock
+        - name: feature-gates
+          value: AllAlpha=false
+        - name: node-labels
+          value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+        - name: provider-id
+          value: '${PROVIDER_ID_FORMAT}'
+        - name: runtime-request-timeout
+          value: '5m'
+        name: '{{ ds.meta_data.name }}'
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+        - name: cgroup-driver
+          value: systemd
+        - name: container-runtime-endpoint
+          value: unix:///var/run/crio/crio.sock
+        - name: feature-gates
+          value: AllAlpha=false
+        - name: node-labels
+          value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+        - name: provider-id
+          value: '${PROVIDER_ID_FORMAT}'
+        - name: runtime-request-timeout
+          value: '5m'
+        name: '{{ ds.meta_data.name }}'
+    postKubeadmCommands:
+    - mkdir -p /home/${IMAGE_USERNAME}/.kube
+    - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube
+    - cp /etc/kubernetes/admin.conf /home/${IMAGE_USERNAME}/.kube/config
+    - systemctl enable --now keepalived
+    - chown ${IMAGE_USERNAME}:${IMAGE_USERNAME} /home/${IMAGE_USERNAME}/.kube/config
+    preKubeadmCommands:
+    - sed -i "s/MACAddressPolicy=persistent/MACAddressPolicy=none/g" /usr/lib/systemd/network/99-default.link
+    - netplan apply
+    - systemctl enable --now crio kubelet
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      files:
+      - content: |
+          network:
+            version: 2
+            renderer: networkd
+            bridges:
+              ${CLUSTER_PROVISIONING_INTERFACE}:
+                interfaces: [enp1s0]
+                addresses:
+                - {{ ds.meta_data.provisioningIP }}/{{ ds.meta_data.provisioningCIDR }}
+        owner: root:root
+        path: /etc/netplan/52-ironicendpoint.yaml
+        permissions: "0644"
+      - content: |
+          [registries.search]
+          registries = ['docker.io']
+
+          [registries.insecure]
+          registries = ['${REGISTRY}']
+        path: /etc/containers/registries.conf
+      preKubeadmCommands:
+      - sed -i "s/MACAddressPolicy=persistent/MACAddressPolicy=none/g" /usr/lib/systemd/network/99-default.link
+      - netplan apply
+      - systemctl enable --now crio kubelet

--- a/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-centos-fake/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-centos-fake/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- ../bases/cluster-with-topology

--- a/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-centos-md-remediation/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-centos-md-remediation/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- ../bases/ippool
+- ../bases/centos-kubeadm-config
+
+- mhc.yaml
+patchesStrategicMerge:
+- md.yaml

--- a/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-centos-md-remediation/md.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-centos-md-remediation/md.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+    nodepool: nodepool-0
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    metadata:
+      labels:
+        "e2e.remediation.label": ""

--- a/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-centos-md-remediation/mhc.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-centos-md-remediation/mhc.yaml
@@ -1,0 +1,22 @@
+---
+# MachineHealthCheck object with
+# - a selector that targets all the machines with label e2e.remediation.label=""
+# - unhealthyNodeConditions triggering remediation after 10s the condition is set
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-mhc-0"
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  remediation:
+    triggerIf:
+      unhealthyLessThanOrEqualTo: 100%
+  selector:
+    matchLabels:
+      e2e.remediation.label: ""
+  checks:
+    unhealthyNodeConditions:
+    - type: e2e.remediation.condition
+      status: "False"
+      timeoutSeconds: 10

--- a/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-centos-md-taints/kcp-taints.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-centos-md-taints/kcp-taints.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  machineTemplate:
+    spec:
+      taints:
+      - key: "pre-existing-on-initialization-taint"
+        value: "on-initialization-value"
+        effect: PreferNoSchedule
+        propagation: OnInitialization
+      - key: "pre-existing-always-taint"
+        value: "always-value"
+        effect: PreferNoSchedule
+        propagation: Always

--- a/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-centos-md-taints/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-centos-md-taints/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- ../bases/ippool
+- ../bases/centos-kubeadm-config
+
+patches:
+- path: md-taints.yaml
+- path: kcp-taints.yaml

--- a/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-centos-md-taints/md-taints.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-centos-md-taints/md-taints.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+    nodepool: nodepool-0
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      taints:
+      - key: "pre-existing-on-initialization-taint"
+        value: "on-initialization-value"
+        effect: PreferNoSchedule
+        propagation: OnInitialization
+      - key: "pre-existing-always-taint"
+        value: "always-value"
+        effect: PreferNoSchedule
+        propagation: Always

--- a/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-centos/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-centos/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- ../bases/ippool
+- ../bases/centos-kubeadm-config

--- a/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-opensuse-leap/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-opensuse-leap/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- ../bases/ippool
+- ../bases/opensuse-leap-kubeadm-config

--- a/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-ubuntu-md-remediation/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-ubuntu-md-remediation/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- ../bases/ippool
+- ../bases/ubuntu-kubeadm-config
+
+- mhc.yaml
+patchesStrategicMerge:
+- md.yaml

--- a/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-ubuntu-md-remediation/md.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-ubuntu-md-remediation/md.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+    nodepool: nodepool-0
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    metadata:
+      labels:
+        "e2e.remediation.label": ""

--- a/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-ubuntu-md-remediation/mhc.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-ubuntu-md-remediation/mhc.yaml
@@ -1,0 +1,22 @@
+---
+# MachineHealthCheck object with
+# - a selector that targets all the machines with label e2e.remediation.label=""
+# - unhealthyNodeConditions triggering remediation after 10s the condition is set
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-mhc-0"
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  remediation:
+    triggerIf:
+      unhealthyLessThanOrEqualTo: "100%"
+  selector:
+    matchLabels:
+      e2e.remediation.label: ""
+  checks:
+    unhealthyNodeConditions:
+    - type: e2e.remediation.condition
+      status: "False"
+      timeoutSeconds: 10

--- a/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-ubuntu-md-taints/kcp-taints.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-ubuntu-md-taints/kcp-taints.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  machineTemplate:
+    spec:
+      taints:
+      - key: "pre-existing-on-initialization-taint"
+        value: "on-initialization-value"
+        effect: PreferNoSchedule
+        propagation: OnInitialization
+      - key: "pre-existing-always-taint"
+        value: "always-value"
+        effect: PreferNoSchedule
+        propagation: Always

--- a/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-ubuntu-md-taints/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-ubuntu-md-taints/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- ../bases/ippool
+- ../bases/ubuntu-kubeadm-config
+
+patches:
+- path: md-taints.yaml
+- path: kcp-taints.yaml

--- a/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-ubuntu-md-taints/md-taints.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-ubuntu-md-taints/md-taints.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+    nodepool: nodepool-0
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      taints:
+      - key: "pre-existing-on-initialization-taint"
+        value: "on-initialization-value"
+        effect: PreferNoSchedule
+        propagation: OnInitialization
+      - key: "pre-existing-always-taint"
+        value: "always-value"
+        effect: PreferNoSchedule
+        propagation: Always

--- a/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-ubuntu/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-ubuntu/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- ../bases/ippool
+- ../bases/ubuntu-kubeadm-config

--- a/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-upgrade-workload/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/cluster-template-upgrade-workload/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- ../bases/ubuntu-kubeadm-config

--- a/test/e2e/data/infrastructure-metal3/v1.14/clusterclass-metal3/clusterclass-metal3.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/clusterclass-metal3/clusterclass-metal3.yaml
@@ -1,0 +1,228 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: ClusterClass
+metadata:
+  name: metal3
+spec:
+  variables:
+  - name: controlPlaneEndpoint
+    required: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          host:
+            type: string
+          port:
+            type: integer
+  - name: image
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          checksum:
+            type: string
+          checksumType:
+            type: string
+          diskFormat:
+            type: string
+          url:
+            type: string
+  - name: controlPlaneDataTemplate
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: string
+  patches:
+  - name: controlPlaneEndpointSub
+    description: Overrides controlPlaneEndpoint data of Metal3ClusterTemplate used by the cluster
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3ClusterTemplate
+        matchResources:
+          infrastructureCluster: true
+      jsonPatches:
+      - op: replace
+        path: /spec/template/spec/controlPlaneEndpoint
+        valueFrom:
+          variable: controlPlaneEndpoint
+  - name: controlPlaneImageSub
+    description: Overrides image data for worker nodes of control plane node
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: replace
+        path: /spec/template/spec/image/checksum
+        valueFrom:
+          variable: image.checksum
+      - op: replace
+        path: /spec/template/spec/image/checksumType
+        valueFrom:
+          variable: image.checksumType
+      - op: replace
+        path: /spec/template/spec/image/diskFormat
+        valueFrom:
+          variable: image.diskFormat
+      - op: replace
+        path: /spec/template/spec/image/url
+        valueFrom:
+          variable: image.url
+  - name: controlPlaneDataTemplateSub
+    description: Overrides data-template for control plane nodes
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: replace
+        path: /spec/template/spec/dataTemplate/name
+        valueFrom:
+          variable: controlPlaneDataTemplate
+  controlPlane:
+    templateRef:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+      kind: KubeadmControlPlaneTemplate
+      name: metal3-control-plane
+    machineInfrastructure:
+      templateRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: metal3-control-plane
+  infrastructure:
+    templateRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3ClusterTemplate
+      name: metal3-cluster
+  workers:
+    machineDeployments:
+    - class: worker
+      metadata:
+        labels:
+          cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+          nodepool: nodepool-0
+      bootstrap:
+        templateRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          kind: KubeadmConfigTemplate
+          name: metal3-default-worker-bootstraptemplate
+      infrastructure:
+        templateRef:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+          kind: Metal3MachineTemplate
+          name: metal3-default-worker-machinetemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3ClusterTemplate
+metadata:
+  name: metal3-cluster
+spec:
+  template:
+    spec:
+      controlPlaneEndpoint:
+        host: ${CLUSTER_APIENDPOINT_HOST}
+        port: ${CLUSTER_APIENDPOINT_PORT}
+      cloudProviderEnabled: false
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlaneTemplate
+metadata:
+  name: metal3-control-plane
+spec:
+  template:
+    spec:
+      kubeadmConfigSpec:
+        initConfiguration:
+          nodeRegistration:
+            kubeletExtraArgs:
+            - name: cgroup-driver
+              value: systemd
+            - name: container-runtime-endpoint
+              value: unix:///var/run/crio/crio.sock
+            - name: feature-gates
+              value: AllAlpha=false
+            - name: node-labels
+              value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+            - name: provider-id
+              value: '${PROVIDER_ID_FORMAT}'
+            - name: runtime-request-timeout
+              value: '5m'
+            name: '{{ ds.meta_data.name }}'
+        joinConfiguration:
+          controlPlane: {}
+          nodeRegistration:
+            kubeletExtraArgs:
+            - name: cgroup-driver
+              value: systemd
+            - name: container-runtime-endpoint
+              value: unix:///var/run/crio/crio.sock
+            - name: feature-gates
+              value: AllAlpha=false
+            - name: node-labels
+              value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+            - name: provider-id
+              value: '${PROVIDER_ID_FORMAT}'
+            - name: runtime-request-timeout
+              value: '5m'
+            name: '{{ ds.meta_data.name }}'
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3MachineTemplate
+metadata:
+  name: metal3-control-plane
+spec:
+  template:
+    spec:
+      dataTemplate:
+        name: metal3-controlplane-template
+      image:
+        checksum: ${IMAGE_RAW_CHECKSUM}
+        checksumType: ${IMAGE_CHECKSUM_TYPE}
+        diskFormat: raw
+        url: ${IMAGE_RAW_URL}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KubeadmConfigTemplate
+metadata:
+  name: metal3-default-worker-bootstraptemplate
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+          - name: cgroup-driver
+            value: systemd
+          - name: container-runtime-endpoint
+            value: unix:///var/run/crio/crio.sock
+          - name: feature-gates
+            value: AllAlpha=false
+          - name: node-labels
+            value: 'metal3.io/uuid={{ ds.meta_data.uuid }}'
+          - name: provider-id
+            value: '${PROVIDER_ID_FORMAT}'
+          - name: runtime-request-timeout
+            value: '5m'
+          name: '{{ ds.meta_data.name }}'
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: Metal3MachineTemplate
+metadata:
+  name: metal3-default-worker-machinetemplate
+spec:
+  template:
+    spec:
+      dataTemplate:
+        name: metal3-controlplane-template
+      image:
+        checksum: ${IMAGE_RAW_CHECKSUM}
+        checksumType: ${IMAGE_CHECKSUM_TYPE}
+        diskFormat: raw
+        url: ${IMAGE_RAW_URL}

--- a/test/e2e/data/infrastructure-metal3/v1.14/clusterclass-metal3/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/clusterclass-metal3/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- clusterclass-metal3.yaml

--- a/test/e2e/data/infrastructure-metal3/v1.14/clusterclass-template-centos/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/clusterclass-template-centos/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- ../bases/ippool
+- ../bases/clusterclass-centos-kubeadm-config

--- a/test/e2e/data/infrastructure-metal3/v1.14/clusterclass-template-ubuntu/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/clusterclass-template-ubuntu/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- ../bases/ippool
+- ../bases/clusterclass-ubuntu-kubeadm-config

--- a/test/e2e/data/infrastructure-metal3/v1.14/clusterclass-template-upgrade-workload/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/clusterclass-template-upgrade-workload/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- ../bases/clusterclass-ubuntu-kubeadm-config

--- a/test/e2e/data/infrastructure-metal3/v1.14/clusterclass/kustomization.yaml
+++ b/test/e2e/data/infrastructure-metal3/v1.14/clusterclass/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- ../bases/clusterclass

--- a/test/e2e/data/ipamprovider-metal3/overlays/release-1.14/kustomization.yaml
+++ b/test/e2e/data/ipamprovider-metal3/overlays/release-1.14/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- https://github.com/metal3-io/ip-address-manager/config/default?ref=release-1.14
+
+patches:
+- patch: |
+    # Extend default with TLS 1.3 hardening.
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-min-version=VersionTLS13"
+  target:
+    kind: Deployment
+    name: controller-manager

--- a/test/e2e/data/shared/capi/v1.15/metadata.yaml
+++ b/test/e2e/data/shared/capi/v1.15/metadata.yaml
@@ -1,3 +1,8 @@
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# update this file only when a new major or minor version is released
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
@@ -12,10 +17,10 @@ releaseSeries:
   contract: v1beta2
 - major: 1
   minor: 12
-  contract: v1beta1
+  contract: v1beta2
 - major: 1
   minor: 11
-  contract: v1beta1
+  contract: v1beta2
 - major: 1
   minor: 10
   contract: v1beta1

--- a/test/e2e/data/shared/infrastructure-metal3/v1.14/metadata.yaml
+++ b/test/e2e/data/shared/infrastructure-metal3/v1.14/metadata.yaml
@@ -2,9 +2,6 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
 - major: 1
-  minor: 15
-  contract: v1beta2
-- major: 1
   minor: 14
   contract: v1beta2
 - major: 1

--- a/test/e2e/data/shared/ipam-metal3/main/metadata.yaml
+++ b/test/e2e/data/shared/ipam-metal3/main/metadata.yaml
@@ -31,21 +31,3 @@ releaseSeries:
 - major: 1
   minor: 6
   contract: v1beta1
-- major: 1
-  minor: 5
-  contract: v1beta1
-- major: 1
-  minor: 4
-  contract: v1beta1
-- major: 1
-  minor: 3
-  contract: v1beta1
-- major: 1
-  minor: 2
-  contract: v1beta1
-- major: 1
-  minor: 1
-  contract: v1beta1
-- major: 1
-  minor: 0
-  contract: v1beta1

--- a/test/e2e/data/shared/ipam-metal3/v1.14/metadata.yaml
+++ b/test/e2e/data/shared/ipam-metal3/v1.14/metadata.yaml
@@ -2,9 +2,6 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
 - major: 1
-  minor: 15
-  contract: v1beta2
-- major: 1
   minor: 14
   contract: v1beta2
 - major: 1


### PR DESCRIPTION
Bump the e2e management-cluster CAPI to the v1.14 stable release and shift the nightly/main labels to v1.15.99. This makes the management cluster CRDs support newer fields (e.g. KubeadmConfigTemplate contentFormat) that only exist in CAPI v1.14+.

- e2e_conf.yaml: nightly main v1.14.99 -> v1.15.99 for core/bootstrap/ control-plane; add stable {go://...@v1.14} entries; add metal3 IPAM/infra v1.14.99 provider blocks and shift main infra to v1.15.99
- ci-e2e.sh: CAPI_RELEASE_PREFIX v1.13. -> v1.14.; CAPM3RELEASE and IPAMRELEASE v1.14.99 -> v1.15.99; nightly CAPIRELEASE -> v1.15.99
- Makefile: add cluster-templates-v1.14 and clusterclass-templates-v1.14 targets and wire v1.14 into the aggregate template targets
- Add shared metadata (capi/v1.15, capi/v1.14, infra/v1.14, ipam/v1.14), v1.14 template sources, and release-1.14/release-0.14 overlays

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Part of https://github.com/metal3-io/project-infra/issues/1335 

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
