### PR TITLE
🐛 Run the controller with ReadOnlyRootFilesystem

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,6 +56,7 @@ spec:
             drop:
             - ALL
           privileged: false
+          readOnlyRootFilesystem: true
           runAsUser: 65532
           runAsGroup: 65532
         terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
Running containers with ReadOnlyRootFilesystem true is defence in depth
in case there of a vulnerability. It minimizes what an intruder can do.

It's probably very minor for a Go controller like CAPM3, but on the other
hand there is no cost to doing so, so let's just do it. At the very least,
it will stop AI systems from reporting this as a weakness..

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
