### PR TITLE
:seedling: register fake etcd members by pod name

### DIFF
--- a/hack/fake-apiserver/cmd/metal3-fkas/main.go
+++ b/hack/fake-apiserver/cmd/metal3-fkas/main.go
@@ -603,7 +603,15 @@ func setupEtcdMember(resourceName, clusterName, nodeName, namespace string, w ht
 		http.Error(w, "etcdKey is not *rsa.PrivateKey", http.StatusInternalServerError)
 		return errors.New("etcdKey is not *rsa.PrivateKey")
 	}
-	err = apiServerMux.AddEtcdMember(resourceName, nodeName, etcdCert, etcdPrivKey)
+	// Register the etcd member under the etcd pod name (e.g. "etcd-<nodeName>"),
+	// matching how CAPI's in-memory provider registers members. KCP's etcd health
+	// probe port-forwards to the etcd pod and sets the TLS ServerName to the pod
+	// name, and the mux only serves the etcd serving certificate (and routes gRPC
+	// to the etcd handler) when that ServerName matches a registered etcd member.
+	// Registering the bare node name here makes the SNI lookup miss, so the mux
+	// hands back the API-server certificate and the etcd connection never
+	// completes ("context deadline exceeded"), leaving EtcdMemberHealthy False.
+	err = apiServerMux.AddEtcdMember(resourceName, etcdPodMember, etcdCert, etcdPrivKey)
 	if err != nil {
 		setupLog.Error(err, "failed to add etcd member")
 		http.Error(w, "", http.StatusInternalServerError)


### PR DESCRIPTION
KCP probes etcd using the pod name as the TLS server name. Registering members by node name caused SNI lookup failures and unhealthy etcd members in scale tests.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
