### PR TITLE
🌱 Add separate golangci and kube-api-lint make targets for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -447,8 +447,16 @@ lint: $(GOLANGCI_LINT) $(GOLANGCI_LINT_KAL) ## Lint codebase
 	cd $(FAKE_APISERVER_DIR) && $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=15m
 	cd $(APIS_DIR) && $(GOLANGCI_LINT_KAL) run -v --config $(ROOT_DIR)/.golangci-kal.yaml $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=15m
 
+.PHONY: kube-api-lint
 kube-api-lint: $(GOLANGCI_LINT) $(GOLANGCI_LINT_KAL) ## Run kube-api-linter on the codebase
 	cd $(APIS_DIR) && $(GOLANGCI_LINT_KAL) run -v --config $(ROOT_DIR)/.golangci-kal.yaml $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=15m
+
+.PHONY: golangci
+golangci: $(GOLANGCI_LINT) ## Run golangci-lint over all modules (CI)
+	$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=15m
+	cd $(APIS_DIR) && $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=15m
+	cd $(TEST_DIR) && $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=15m
+	cd $(FAKE_APISERVER_DIR) && $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=15m
 
 .PHONY: lint-fix
 lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter


### PR DESCRIPTION
Split linting into dedicated CI targets so Prow can run golangci-lint and kube-api-linter (KAL) as independent checks without duplicating work.

Adds a new `golangci` target that runs golangci-lint across all four modules (root, api, test, hack/fake-apiserver), and ensures `kube-api-lint` runs KAL only.

`make lint` is left unchanged as the conbined target for local use. Both CI targets are marked `.PHONY`.

**NOTE**: This is the first of three PRs.
- (2) project-infra - point the `golangci-lint` Prow job at `make golangci` and add a new `kube-api-lint` job calling `make kube-api-lint`.
- (3) CAPM3 - remove the now-redundant `golangci-lint` and `kube-api-lint` GH Actions workflows. No functional changes to CI until PR for (2) lands.

Fixes [#1459](https://github.com/metal3-io/project-infra/issues/1459)