### PR TITLE
🌱 e2e: fix scalability test for vbmctl-based setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -882,6 +882,8 @@ clean-e2e: ## Clean up e2e artifacts, kind clusters, and leftover resources
 	sudo rm -rf $(LIBVIRT_POOL_PATH)
 	# Remove vbmctl containers
 	docker rm -f vbmctl-image-server-e2e vbmctl-sushy-tools-e2e vbmctl-sushy-tools 2>/dev/null || true
+	# Remove the fake-ipa container used by the scalability (fake) scenario
+	docker rm -f fake-ipa 2>/dev/null || true
 	# Delete the management kind cluster created by this test suite only; do not
 	# touch other kind clusters that may be running on the host.
 	@if command -v kind &> /dev/null; then \

--- a/docs/scalability-test.md
+++ b/docs/scalability-test.md
@@ -1,0 +1,150 @@
+# Scalability e2e test
+
+This document explains how the `scalability` e2e scenario works: what it
+exercises, why it is "fully faked", and how the pieces fit together.
+
+## What it tests
+
+The scalability test measures how CAPM3 (and the surrounding Metal3 stack)
+behaves when creating **many workload clusters and BareMetalHosts (BMHs) at
+once**. It uses Cluster API's generic `capi_e2e.ScaleSpec` to create
+`NUM_NODES` clusters (default `30`) concurrently, each in its own namespace,
+and waits for the BMHs to become `Available` and the clusters to come up.
+
+It is labelled `scalability` and is skipped by every other run
+(`ci-e2e.sh` adds `scalability` to `GINKGO_SKIP` unless it is the focus).
+
+Run it with:
+
+```bash
+GINKGO_FOCUS=scalability ./scripts/ci-e2e.sh
+```
+
+## Why everything is faked
+
+Provisioning 30 real clusters on 30 real VMs would need enormous host resources
+and would mostly measure QEMU/boot time, not CAPM3. So the scenario fakes the
+three expensive, slow parts of the stack:
+
+| Real component | Fake replacement | What it removes |
+| -------------- | ---------------- | --------------- |
+| Workload Kubernetes API server | **FKAS** (fake API server) | Real control-plane boot |
+| BMC / Redfish + power/boot | **sushy-tools fake driver** | Real libvirt VMs |
+| Ironic Python Agent (IPA) ramdisk | **fake-ipa** container | Real PXE boot + inspection |
+
+The result: no libvirt VMs boot, yet BMHs still progress to `Available`/
+`Provisioned` and clusters still reconcile, so the test exercises CAPM3, BMO,
+Ironic and IPAM at scale.
+
+## The moving parts
+
+```mermaid
+flowchart TB
+    subgraph host["CI host"]
+        subgraph kind["kind management cluster"]
+            CAPM3["CAPM3 / BMO / Ironic / IPAM"]
+            FKAS["FKAS<br/>fake API server<br/>172.22.0.2:3333"]
+        end
+        SUSHY["sushy-tools (fake driver)<br/>serves Redfish /Systems/&lt;uuid&gt;<br/>with no backing VM"]
+        FIPA["fake-ipa container<br/>--net host<br/>fakes IPA callbacks to Ironic"]
+    end
+
+    CAPM3 -->|"register fake cluster"| FKAS
+    CAPM3 -->|"Ironic drives BMC"| SUSHY
+    FIPA -->|"heartbeat / inspection<br/>continue_inspection"| CAPM3
+    SUSHY -. "no real VM to boot" .- FIPA
+
+    classDef k fill:#bbdefb,stroke:#0d47a1,color:#0d47a1;
+    classDef s fill:#d1c4e9,stroke:#4527a0,color:#311b92;
+    class CAPM3,FKAS k;
+    class SUSHY,FIPA s;
+```
+
+### 1. FKAS — fake workload API servers
+
+Each workload cluster needs an API endpoint. Instead of booting a control
+plane, the test deploys **FKAS** into the management cluster
+(`createFKASResources()` in `test/e2e/scalability_test.go`) and, per cluster,
+calls its `/register` endpoint (`registerFKASCluster`). FKAS returns a
+host/port that is patched into the cluster template as the API endpoint, so CAPI
+believes the workload API server is up.
+
+### 2. sushy-tools fake driver — BMCs without VMs
+
+`hack/setup-bml.sh` runs `vbmctl create bml` but, because the scalability case
+sets `SKIP_VM_CREATION=true`, it defines only a single tiny placeholder VM
+(never started) — just enough to satisfy vbmctl, which rejects an empty
+`spec.vms` — so the networks, BMC emulator and image server come up **without a
+real VM per node**. It also generates a sushy-tools config
+(`_out/sushy.conf`) with:
+
+- `SUSHY_EMULATOR_FAKE_DRIVER = True`
+- `SUSHY_EMULATOR_FAKE_IPA = True`
+- `SUSHY_EMULATOR_FAKE_SYSTEMS = [ … ]` — one entry per node, each with a real
+  UUID as its id (sushy-tools parses the system id as a UUID, so a name like
+  `node-0` would 500). The same UUID is used in the BMH BMC address
+  (`.../redfish/v1/Systems/<uuid>`); the human-readable `name` stays `node-<i>`.
+
+vbmctl bind-mounts that file into the sushy-tools container (via
+`bmcEmulator.configFile`), so sushy-tools serves virtual Redfish systems that
+respond to power/boot without any real machine behind them.
+
+### 3. fake-ipa — completing inspection/provisioning
+
+A BMH only reaches `Available` after Ironic inspects it, which normally requires
+the node to PXE-boot the IPA ramdisk and call back. With no VM, nothing boots,
+so the test launches the **fake-ipa** container (`launchFakeIPA()` in
+`BeforeEach`). It runs on the host network and impersonates the agent, calling
+Ironic's inspection/heartbeat endpoints (`…/v1/continue_inspection`). Because
+fake-ipa talks plain HTTP, the scalability case also relaxes Ironic's agent TLS
+requirement (`OS_AGENT__REQUIRE_TLS=false`, injected via the Ironic CR
+`extraConfig`).
+
+## Test flow
+
+```mermaid
+sequenceDiagram
+    participant CI as ci-e2e.sh / setup-bml.sh
+    participant Suite as e2e BeforeSuite
+    participant Spec as ScaleSpec (per cluster)
+    participant Ironic
+    participant Sushy as sushy-tools (fake)
+    participant FIPA as fake-ipa
+
+    CI->>CI: SKIP_VM_CREATION=true → vbmctl create bml (no VMs) + sushy.conf
+    Suite->>Suite: BeforeEach: deploy FKAS + launch fake-ipa
+    loop for each of NUM_NODES clusters
+        Spec->>Spec: create namespace
+        Spec->>Ironic: apply BMHs (batch of BMH_BATCH_SIZE)
+        Ironic->>Sushy: power on / set boot (Redfish)
+        FIPA->>Ironic: fake IPA inspection callback
+        Ironic-->>Spec: BMH Available
+        Spec->>FKAS: register cluster → API endpoint
+        Spec->>Spec: apply cluster template, wait for cluster
+    end
+    Suite->>Suite: AfterEach: remove fake-ipa + FKAS
+```
+
+Key per-cluster logic lives in `postScaleClusterNamespaceCreated`
+(`test/e2e/scalability_test.go`), which applies the right slice of BMHs in
+batches of `BMH_BATCH_SIZE`, waits for them to become `Available`, registers the
+cluster with FKAS, and rewrites the template's API endpoint placeholders.
+
+## Relevant knobs
+
+| Variable | Default | Meaning |
+| -------- | ------- | ------- |
+| `NUM_NODES` | `30` | Number of clusters/BMHs to create |
+| `SCALE_SPEC_CONCURRENCY` | see e2e config | Parallel cluster creations |
+| `BMH_BATCH_SIZE` | `2` | BMHs applied per batch |
+| `CONTROL_PLANE_MACHINE_COUNT` | `1` | Control-plane machines per cluster |
+| `WORKER_MACHINE_COUNT` | `0` | Workers per cluster |
+| `SKIP_VM_CREATION` | `true` (scalability) | Skip real libvirt VMs |
+| `FAKE_IPA_IMAGE` | `quay.io/metal3-io/fake-ipa:latest` | fake-ipa container image |
+
+## Cleanup
+
+- `fake-ipa` is removed in the test `AfterEach` and by `make clean-e2e`.
+- FKAS is removed in `AfterEach`.
+- The generated `_out/sushy.conf` lives under `_out/`, which
+  `make clean-e2e` deletes.

--- a/hack/setup-bml.sh
+++ b/hack/setup-bml.sh
@@ -46,12 +46,22 @@ generate_vbmctl_vms() {
   local i
 
   # The scalability scenario is fully faked (fakeIPA + FKAS): the guests never
-  # boot, so creating real libvirt VMs (NUM_NODES can be 30) would allocate a
-  # huge amount of host memory/CPU for nothing. Skip VM creation entirely and
-  # leave the vbmctl "vms" list empty; vbmctl still sets up the networks, BMC
-  # emulator and image server, and bmcs.yaml is still generated for the tests.
+  # boot, so creating a real libvirt VM per node (NUM_NODES can be 30) would
+  # allocate a huge amount of host memory/CPU for nothing. vbmctl's "create bml"
+  # rejects an empty spec.vms, yet it is the only command that also wires the
+  # veth pairs / docker networks needed for kind<->libvirt connectivity. So
+  # define a single tiny placeholder VM (defined, never started) to bring up the
+  # lab — networks, BMC emulator, image server — without 30 real guests. The
+  # BMHs reference sushy-tools' fake systems, not this VM.
+  # TODO: Drop this placeholder once vbmctl (in baremetal-operator) allows
+  # "create bml" with an empty spec.vms (create only networks/veth/BMC emulator).
   if [[ "${SKIP_VM_CREATION:-false}" == "true" ]]; then
-    export VBMCTL_VMS=""
+    export VBMCTL_VMS="  - name: fake-placeholder
+    memory: 512
+    vcpus: 1
+    volumes:
+    - name: \"1\"
+      size: 1"
     return
   fi
 
@@ -81,17 +91,49 @@ generate_vbmctl_vms() {
   export VBMCTL_VMS="${vm_entries%$'\n'}"
 }
 
+# Stable per-node Redfish system UUIDs, used only in fake mode. sushy-tools'
+# fake driver parses a system's id as a real UUID (uuid.UUID(id) in its storage
+# resource), so the id must be a proper UUID, not a name like "node-0" (which
+# makes GET /Systems/node-0 return HTTP 500). The same UUID is reused in the BMC
+# address so Ironic targets the right fake system. In real mode the BMC address
+# instead uses the libvirt domain name (see generate_bmcs_config). Populated once
+# and shared by the sushy and bmcs config generators.
+declare -a NODE_UUIDS
+generate_node_uuids() {
+  local i
+  for ((i=0; i<NUM_NODES; i++)); do
+    NODE_UUIDS[i]="$(cat /proc/sys/kernel/random/uuid)"
+  done
+}
+
 # Generate bmcs config dynamically based on NUM_NODES
 generate_bmcs_config() {
   local bmcs_entries=""
   local i
 
+  # In fake mode (scalability), use plain redfish so Ironic boots via ipxe and
+  # returns the agent token in the lookup response: fake-ipa has no access to a
+  # virtual-media boot ISO to extract a pregenerated token, so redfish-virtualmedia
+  # leaves it tokenless and its heartbeats are rejected (400, token required).
+  # Real-VM scenarios keep redfish-virtualmedia (the guests actually boot the ISO).
+  local bmc_scheme="redfish-virtualmedia+http"
+  if [[ "${SKIP_VM_CREATION:-false}" == "true" ]]; then
+    bmc_scheme="redfish+http"
+  fi
+
   for ((i=0; i<NUM_NODES; i++)); do
     local suffix
     suffix=$(printf "%02d" "$((i + 1))")
     local ip_last_octet=$((20 + i))
+    # Redfish system id in the BMC address. Fake mode targets a sushy FAKE_SYSTEM
+    # keyed by NODE_UUIDS; real mode targets the libvirt domain, which sushy's
+    # libvirt driver resolves by domain name (node-${i}).
+    local system_id="node-${i}"
+    if [[ "${SKIP_VM_CREATION:-false}" == "true" ]]; then
+      system_id="${NODE_UUIDS[i]}"
+    fi
     bmcs_entries+="- name: \"node-${i}\"
-  address: \"redfish-virtualmedia+http://${PROVISIONING_IP}:${BMC_EMULATOR_PORT}/redfish/v1/Systems/node-${i}\"
+  address: \"${bmc_scheme}://${PROVISIONING_IP}:${BMC_EMULATOR_PORT}/redfish/v1/Systems/${system_id}\"
   bootMacAddress: \"00:60:2f:31:81:${suffix}\"
   ipAddress: \"192.168.111.${ip_last_octet}\"
   user: admin
@@ -104,9 +146,61 @@ generate_bmcs_config() {
   echo -n "${bmcs_entries}" > "${E2E_BMCS_CONFIG}"
 }
 
+# Generate the sushy-tools config. In fake mode it enables the fake driver and
+# fake-IPA and defines virtual Redfish systems with no backing libvirt VM
+# (mirroring metal3-dev-env's NODES_PLATFORM=fake); each system's id is a real
+# UUID (NODE_UUIDS) reused in the BMC address in bmcs.yaml (.../Systems/<uuid>).
+# In real mode it only sets the listen address/port and sushy-tools uses its
+# default libvirt driver. vbmctl bind-mounts this file via bmcEmulator.configFile.
+generate_sushy_config() {
+  if [[ "${SKIP_VM_CREATION:-false}" != "true" ]]; then
+    # Real mode: only the listen address/port; sushy-tools uses its default
+    # libvirt driver to control the VMs.
+    cat > "${SUSHY_CONFIG}" <<EOF
+SUSHY_EMULATOR_LISTEN_IP = u"${PROVISIONING_IP}"
+SUSHY_EMULATOR_LISTEN_PORT = ${BMC_EMULATOR_PORT}
+EOF
+    return
+  fi
+
+  local systems="" i
+  for ((i=0; i<NUM_NODES; i++)); do
+    local suffix ext_octet
+    suffix=$(printf "%02d" "$((i + 1))")
+    ext_octet=$((20 + i))
+    systems+="    {
+        \"uuid\": \"${NODE_UUIDS[i]}\",
+        \"name\": \"node-${i}\",
+        \"power_state\": \"Off\",
+        \"external_notifier\": True,
+        \"nics\": [
+            {\"mac\": \"00:60:2f:31:81:${suffix}\", \"ip\": \"172.22.0.$((100 + i))\"},
+            {\"mac\": \"00:60:2f:32:81:${suffix}\", \"ip\": \"192.168.111.${ext_octet}\"}
+        ]
+    },
+"
+  done
+
+  cat > "${SUSHY_CONFIG}" <<EOF
+SUSHY_EMULATOR_LISTEN_IP = u"${PROVISIONING_IP}"
+SUSHY_EMULATOR_LISTEN_PORT = ${BMC_EMULATOR_PORT}
+SUSHY_EMULATOR_FAKE_DRIVER = True
+SUSHY_EMULATOR_FAKE_IPA = True
+SUSHY_EMULATOR_FAKE_SYSTEMS = [
+${systems%$'\n'}
+]
+EOF
+}
+
+# Path to the generated sushy-tools config. vbmctl bind-mounts it into the
+# container via bmcEmulator.configFile; the template references ${SUSHY_CONFIG}.
+export SUSHY_CONFIG="${REPO_ROOT}/_out/sushy.conf"
+
 # Generate vbmctl config from template
 export VBMCTL_CONFIG="${REPO_ROOT}/_out/vbmctl.yaml"
+generate_node_uuids
 generate_vbmctl_vms
+generate_sushy_config
 envsubst < "${REPO_ROOT}/test/e2e/config/vbmctl.yaml.tmpl" > "${VBMCTL_CONFIG}"
 
 # Generate bmcs config dynamically (consumed by Go tests to create BMH objects)

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -77,29 +77,30 @@ fi
 
 mkdir -p "${CAPI_CONFIG_FOLDER}"
 
-# Start fresh clusterctl.yaml each run
-: > "${CAPI_CONFIG_FOLDER}/clusterctl.yaml"
-
+# Feature-gate variables are exported (not written to clusterctl.yaml): the e2e
+# framework builds its own clusterctl config and does not read that file, but
+# clusterctl does merge OS environment variables when resolving components.
+#
+# USE_CLUSTERCLASS_TEMPLATES selects which template set the run builds/uses
+# (clusterclass vs normal). It is deliberately separate from CLUSTER_TOPOLOGY,
+# which only enables the ClusterTopology feature gate in the CAPI controller:
+# most tests enable the gate but still provision from normal templates.
+USE_CLUSTERCLASS_TEMPLATES=false
 case "${GINKGO_FOCUS:-}" in
   features)
-    echo "ENABLE_BMH_NAME_BASED_PREALLOCATION: true" >>"${CAPI_CONFIG_FOLDER}/clusterctl.yaml"
+    export ENABLE_BMH_NAME_BASED_PREALLOCATION=true
   ;;
 
   scalability)
-    echo 'CLUSTER_TOPOLOGY: true' >>"${CAPI_CONFIG_FOLDER}/clusterctl.yaml"
-    # Build FKAS image from source so that the scalability test uses the latest code
-    FKAS_TAG=ci make docker-build-fkas
+    export CLUSTER_TOPOLOGY=true
   ;;
 
   in-place-upgrade)
-    # Enable Cluster Topology and in-place updates features
-    echo 'CLUSTER_TOPOLOGY: true' >>"${CAPI_CONFIG_FOLDER}/clusterctl.yaml"
-    echo 'EXP_RUNTIME_SDK: true' >>"${CAPI_CONFIG_FOLDER}/clusterctl.yaml"
-    echo 'EXP_IN_PLACE_UPDATES: true' >>"${CAPI_CONFIG_FOLDER}/clusterctl.yaml"
+    export CLUSTER_TOPOLOGY=true
+    export EXP_RUNTIME_SDK=true
+    export EXP_IN_PLACE_UPDATES=true
   ;;
 esac
-
-echo 'EXP_MACHINE_TAINT_PROPAGATION: true' >> "${CAPI_CONFIG_FOLDER}/clusterctl.yaml"
 
 if [[ ${GINKGO_FOCUS:-} != "scalability" ]]; then
   # Don't run scalability tests if not asked for.
@@ -127,6 +128,11 @@ if [[ -z "${CAPM3_DOCKER_SG:-}" ]] && getent group docker &>/dev/null \
   echo "Activating 'docker' group membership for this session via sg (avoids logout/login)..."
   export CAPM3_DOCKER_SG=1
   exec sg docker -c "$(printf '%q ' "${BASH_SOURCE[0]}" "$@")"
+fi
+
+# Build FKAS image from source so the scalability test uses the latest code.
+if [[ "${GINKGO_FOCUS:-}" == "scalability" ]]; then
+  FKAS_TAG=ci make docker-build-fkas
 fi
 
 # If running in-place-upgrade tests, ensure extension namespace and ssh key secret exist
@@ -323,10 +329,12 @@ kind delete cluster --name "${MANAGEMENT_CLUSTER_NAME}" || true
 # The bootstrap cluster (kind) is created by the Go test framework
 # via CAPI's bootstrap package. VMs are already running from vbmctl above.
 export E2E_COPY_KUBECONFIG=true
-if [[ -n "${CLUSTER_TOPOLOGY:-}" ]]; then
-  export CLUSTER_TOPOLOGY=true
+export EXP_MACHINE_TAINT_PROPAGATION=true
+# USE_CLUSTERCLASS_TEMPLATES (set per-scenario above) decides the template set;
+# CLUSTER_TOPOLOGY only toggles the controller feature gate, so it does not
+# select the make target here.
+if [[ "${USE_CLUSTERCLASS_TEMPLATES}" == "true" ]]; then
   make e2e-clusterclass-tests
 else
-  export EXP_MACHINE_TAINT_PROPAGATION=true
   make e2e-tests
 fi

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -29,6 +29,10 @@ fi
 export CONTAINER_RUNTIME="docker"
 export BOOTSTRAP_CLUSTER="kind"
 
+# Extra Ironic config injected into the Ironic CR (spec.extraConfig) via envsubst.
+# Empty list by default; the scalability scenario overrides it below.
+export IRONIC_EXTRA_CONFIG="${IRONIC_EXTRA_CONFIG:-[]}"
+
 export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.37.0"}
 export KUBERNETES_VERSION_UPGRADE_FROM=${KUBERNETES_VERSION_UPGRADE_FROM:-"v1.36.2"}
 
@@ -80,6 +84,10 @@ case "${GINKGO_FOCUS:-}" in
     # so skip creating real libvirt VMs entirely (30 nodes would otherwise
     # allocate ~120 GiB / 60 vCPUs and exhaust the CI worker).
     export SKIP_VM_CREATION=${SKIP_VM_CREATION:-"true"}
+    # fake-ipa heartbeats to Ironic over plain HTTP, so relax the agent TLS
+    # requirement (OS_AGENT__REQUIRE_TLS=false). Injected into the Ironic CR
+    # spec.extraConfig via envsubst; other scenarios keep the empty default.
+    export IRONIC_EXTRA_CONFIG='[{group: "agent", name: "require_tls", value: "false"}]'
     # Note: Uses KUBERNETES_VERSION_UPGRADE_FROM directly now (no duplication needed)
   ;;
 

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -64,10 +64,13 @@ const (
 	other          vmState = "other"
 	artifactoryURL         = "https://artifactory.nordix.org/artifactory/metal3/images/k8s"
 	imagesURL              = "http://172.22.0.1/images"
-	osTypeCentos           = "centos"
-	osTypeUbuntu           = "ubuntu"
-	osTypeLeap             = "opensuse-leap"
-	ironicSuffix           = "-ironic"
+	// defaultClusterProvisioningIP is the fallback provisioning IP reachable from the
+	// cluster node (matches CLUSTER_PROVISIONING_IP / CLUSTER_BARE_METAL_PROVISIONER_IP).
+	defaultClusterProvisioningIP = "172.22.0.2"
+	osTypeCentos                 = "centos"
+	osTypeUbuntu                 = "ubuntu"
+	osTypeLeap                   = "opensuse-leap"
+	ironicSuffix                 = "-ironic"
 	// Out-of-service Taint test actions.
 	oostAdded   = "added"
 	oostRemoved = "removed"

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -13,6 +13,8 @@ images:
   loadBehavior: mustLoad
 - name: quay.io/metal3-io/ip-address-manager:latest
   loadBehavior: mustLoad
+- name: quay.io/metal3-io/metal3-fkas:ci
+  loadBehavior: tryLoad
 
 providers:
 - name: cluster-api
@@ -321,7 +323,6 @@ variables:
   # Default vars for the template, those values could be overridden by the env-vars.
   CAPI_VERSION: "v1beta2"
   CAPM3_VERSION: "${CAPM3_VERSION:-v1beta2}"
-  CONFIG_FILE_PATH: "${CAPI_CONFIG_FOLDER}/clusterctl.yaml"
   SERVICE_CIDR: "10.96.0.0/12"
   POD_CIDR: "192.168.0.0/18"
   BARE_METAL_PROVISIONER_CIDR: "24"
@@ -355,6 +356,7 @@ variables:
   BMO_RELEASE_PR_TEST: "data/bmo-deployment/overlays/pr-test"
   BMO_RELEASE_MAIN: "data/bmo-deployment/overlays/release-main"
   FKAS_RELEASE_LATEST: "data/fkas"
+  FAKE_IPA_IMAGE: "${FAKE_IPA_IMAGE:-registry.nordix.org/quay-io-proxy/metal3-io/fake-ipa}"
   REPO_NAME: "${REPO_NAME:-cluster-api-provider-metal3}"
   EXP_MACHINE_TAINT_PROPAGATION: "true"
 

--- a/test/e2e/config/vbmctl.yaml.tmpl
+++ b/test/e2e/config/vbmctl.yaml.tmpl
@@ -33,8 +33,7 @@ ${VBMCTL_VMS}
   bmcEmulator:
     type: "sushy-tools"
     image: "${BMC_EMULATOR_IMAGE}"
-    listenAddress: "${PROVISIONING_IP}"
-    listenPort: ${BMC_EMULATOR_PORT}
+    configFile: "${SUSHY_CONFIG}"
   imageServer:
     port: 80
     dataDir: "${IRONIC_DATA_DIR}/html"

--- a/test/e2e/data/ironic-standalone-operator/ironic/base/ironic.yaml
+++ b/test/e2e/data/ironic-standalone-operator/ironic/base/ironic.yaml
@@ -22,4 +22,5 @@ spec:
     extraKernelParams: "console=ttyS0"
   tls:
     certificateName: ironic-cert
+  extraConfig: ${IRONIC_EXTRA_CONFIG}
 ---

--- a/test/e2e/pivoting.go
+++ b/test/e2e/pivoting.go
@@ -354,7 +354,7 @@ func RePivoting(ctx context.Context, inputGetter func() RePivotingInput) {
 	By("Reconfiguring provisioning network on the bootstrap cluster before repivoting Ironic")
 	provisioningIP := os.Getenv("CLUSTER_PROVISIONING_IP")
 	if provisioningIP == "" {
-		provisioningIP = "172.22.0.2"
+		provisioningIP = defaultClusterProvisioningIP
 	}
 	provisioningInterface := input.E2EConfig.MustGetVariable("BARE_METAL_PROVISIONER_INTERFACE")
 	ConfigureProvisioningNetwork(ctx, input.E2EConfig.ManagementClusterName, provisioningIP, provisioningInterface)

--- a/test/e2e/scalability_test.go
+++ b/test/e2e/scalability_test.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -62,6 +64,7 @@ var _ = Describe("When testing scalability with fakeIPA and FKAS", Label("scalab
 		// We need to override clusterctl apply log folder to avoid getting our credentials exposed.
 		clusterctlLogFolder = filepath.Join(os.TempDir(), "clusters", bootstrapClusterProxy.GetName())
 		createFKASResources()
+		launchFakeIPA()
 		imageURL, imageChecksum := EnsureImage("v1.34.1")
 		os.Setenv("IMAGE_RAW_CHECKSUM", imageChecksum)
 		os.Setenv("IMAGE_RAW_URL", imageURL)
@@ -89,6 +92,11 @@ var _ = Describe("When testing scalability with fakeIPA and FKAS", Label("scalab
 	})
 
 	AfterEach(func() {
+		// Collect the host lab container logs before teardown; these run as docker
+		// containers (not pods) and are invisible to the in-cluster log collection.
+		CollectVbmctlContainerLogs(ctx, filepath.Join(artifactFolder, "vbmctl-container-logs"))
+		collectFakeIPAContainerLogs(filepath.Join(artifactFolder, "vbmctl-container-logs"))
+		removeFakeIPA()
 		FKASKustomization := e2eConfig.MustGetVariable("FKAS_RELEASE_LATEST")
 		By(fmt.Sprintf("Removing FKAS from kustomization %s from the bootsrap cluster", FKASKustomization))
 		err := BuildAndRemoveKustomization(ctx, FKASKustomization, bootstrapClusterProxy)
@@ -144,6 +152,91 @@ func createFKASResources() {
 		WaitIntervals:       e2eConfig.GetIntervals("default", "wait-deployment"),
 	})
 	Expect(err).NotTo(HaveOccurred())
+}
+
+// fakeIPAContainerName is the name of the host container running fake-ipa.
+const fakeIPAContainerName = "fake-ipa"
+
+// launchFakeIPA starts the fake Ironic Python Agent container on the host. Paired
+// with the sushy-tools fake driver (configured by hack/setup-bml.sh), it lets the
+// scalability BMHs reach Available/Provisioned without any real VM booting an IPA
+// ramdisk, mirroring metal3-dev-env's NODES_PLATFORM=fake.
+func launchFakeIPA() {
+	image := e2eConfig.MustGetVariable("FAKE_IPA_IMAGE")
+
+	provisionerIP := os.Getenv("CLUSTER_BARE_METAL_PROVISIONER_IP")
+	if provisionerIP == "" {
+		provisionerIP = defaultClusterProvisioningIP
+	}
+	ironicAPIPort := os.Getenv("IRONIC_API_PORT")
+	if ironicAPIPort == "" {
+		ironicAPIPort = "6385"
+	}
+	advertiseIP := os.Getenv("EXTERNAL_SUBNET_V4_HOST")
+	if advertiseIP == "" {
+		advertiseIP = "192.168.111.1"
+	}
+	ironicURL := "https://" + net.JoinHostPort(provisionerIP, ironicAPIPort)
+
+	certDir := filepath.Join(os.TempDir(), "fake-ipa")
+	Expect(os.MkdirAll(certDir, 0o750)).To(Succeed())
+	configPy := fmt.Sprintf(`FAKE_IPA_API_URL = "%s"
+FAKE_IPA_INSPECTION_CALLBACK_URL = "%s/v1/continue_inspection"
+FAKE_IPA_ADVERTISE_ADDRESS_IP = "%s"
+FAKE_IPA_INSECURE = True
+FAKE_IPA_MIN_BOOT_TIME = 20
+FAKE_IPA_MAX_BOOT_TIME = 30
+`, ironicURL, ironicURL, advertiseIP)
+	Expect(os.WriteFile(filepath.Join(certDir, "config.py"), []byte(configPy), 0o600)).To(Succeed())
+
+	By(fmt.Sprintf("Launching fake-ipa container (%s)", image))
+	// Remove any stale container left over from a previous run.
+	_ = exec.CommandContext(ctx, "docker", "rm", "-f", fakeIPAContainerName).Run() // #nosec G204
+	sshDir := filepath.Join(os.Getenv("HOME"), ".ssh")
+	cmd := exec.CommandContext(ctx, "docker", "run", "-d", "--net", "host", // #nosec G204
+		"--name", fakeIPAContainerName,
+		"-v", certDir+":/root/cert",
+		"-v", sshDir+":/root/ssh",
+		"-e", "CONFIG=/root/cert/config.py",
+		image,
+	)
+	out, err := cmd.CombinedOutput()
+	Expect(err).NotTo(HaveOccurred(), "failed to start fake-ipa container: %s", string(out))
+}
+
+// removeFakeIPA force-removes the fake-ipa container (best-effort).
+func removeFakeIPA() {
+	cmd := exec.CommandContext(context.Background(), "docker", "rm", "-f", fakeIPAContainerName) // #nosec G204
+	if out, err := cmd.CombinedOutput(); err != nil {
+		Logf("docker rm -f %s (may not exist): %v: %s", fakeIPAContainerName, err, string(out))
+	}
+}
+
+// collectFakeIPAContainerLogs captures the fake-ipa container's logs and inspect
+// metadata before teardown. fake-ipa runs as a host docker container (not a
+// vbmctl-managed container and not a Kubernetes pod), so it is otherwise never
+// collected. Best-effort: failures are logged, never fatal to cleanup.
+func collectFakeIPAContainerLogs(outputPath string) {
+	if err := os.MkdirAll(outputPath, 0o750); err != nil {
+		Logf("couldn't create fake-ipa log directory %q: %v", outputPath, err)
+		return
+	}
+	// docker logs writes to both stdout and stderr; capture both.
+	logs, err := exec.CommandContext(context.Background(), "docker", "logs", fakeIPAContainerName).CombinedOutput() // #nosec G204
+	if err != nil {
+		Logf("couldn't get logs for container %s: %v", fakeIPAContainerName, err)
+	}
+	if err = writeToFile(logs, fakeIPAContainerName+".log", outputPath); err != nil {
+		Logf("couldn't write logs for container %s: %v", fakeIPAContainerName, err)
+	}
+	inspect, err := exec.CommandContext(context.Background(), "docker", "inspect", fakeIPAContainerName).Output() // #nosec G204
+	if err != nil {
+		Logf("couldn't inspect container %s: %v", fakeIPAContainerName, err)
+		return
+	}
+	if err = writeToFile(inspect, fakeIPAContainerName+".inspect.json", outputPath); err != nil {
+		Logf("couldn't write inspect for container %s: %v", fakeIPAContainerName, err)
+	}
 }
 
 func LogToFile(logFile string, data []byte) {

--- a/test/e2e/upgrade_clusterctl_test.go
+++ b/test/e2e/upgrade_clusterctl_test.go
@@ -542,7 +542,7 @@ func preCleanupManagementCluster(clusterProxy framework.ClusterProxy, testName s
 	By("Reconfiguring provisioning network on the bootstrap cluster")
 	provisioningIP := os.Getenv("CLUSTER_PROVISIONING_IP")
 	if provisioningIP == "" {
-		provisioningIP = "172.22.0.2"
+		provisioningIP = defaultClusterProvisioningIP
 	}
 	provisioningInterface := e2eConfig.MustGetVariable("BARE_METAL_PROVISIONER_INTERFACE")
 	ConfigureProvisioningNetwork(ctx, e2eConfig.ManagementClusterName, provisioningIP, provisioningInterface)


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

The vbmctl migration dropped the old NODES_PLATFORM=fake path, so
scalability (NUM_NODES=30) booted a real VM per node and exhausted CI.

Restore the fully-faked setup, gated on SKIP_VM_CREATION so other
scenarios are unaffected:

- scripts/environment.sh: set SKIP_VM_CREATION=true for the scalability
  focus.
- hack/setup-bml.sh: skip the VMs and write a sushy-tools fake-driver
  config (_out/sushy.conf) with Redfish systems keyed by real per-node
  UUIDs, reused in the BMC addresses (bmcs config).
- test/e2e/config/vbmctl.yaml.tmpl: point bmcEmulator at ${SUSHY_CONFIG}
  so BMHs power on with no backing VM.
- test/e2e/scalability_test.go + Makefile: run and clean up a fake-ipa
  container that completes inspection over plain HTTP.
- ironic base CR + test/e2e/config/e2e_conf.yaml: accept the plain-HTTP
  agent via ${IRONIC_EXTRA_CONFIG} (OS_AGENT__REQUIRE_TLS=false) and add
  overridable FAKE_IPA_IMAGE.
- docs/scalability-test.md: document the flow.

NOTE: vbmctl currently does not allow "spec.vms" to be empty, but we need it to be empty for scale tests. So we are creating one small vm just to satisfy vbmctl, but we can remove it once we fix this issue in vbmctl. Created tracking issue in BMO https://github.com/metal3-io/baremetal-operator/issues/3602 

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
